### PR TITLE
Warn instead of throwing fatal error if specific resource collection fails

### DIFF
--- a/providers/aws/provider.go
+++ b/providers/aws/provider.go
@@ -213,6 +213,6 @@ func (p *Provider) collectResource(wg *sync.WaitGroup, fullResourceName string, 
 
 	err := p.resourceClients[service].CollectResource(resourceName, config)
 	if err != nil {
-		log.Fatal(err)
+		p.log.Sugar().Warnf("Skipping %s resources due to an error when querying: %v", fullResourceName, err)
 	}
 }


### PR DESCRIPTION
When querying a complex AWS or GCP environment with a service user / service role, it is common that the service user or service role does not have permissions to view all of the cloud environment. In AWS it is also possible for [resource policies to deny access to certain resources](https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_policies_evaluation-logic.html#policy-eval-denyallow) for the service user or service role before IAM policies even apply.

Even if resource collection for a subset of resources fail (e.g. some S3 buckets and some KMS keys cannot be collected due to explicit Deny in their resource policies), other resources collected from the same account (e.g. EC2 instances) should still be useful for querying, and it shouldn't be the case that we abandon the entire fetch run. Therefore in this PR I suggest that we log a warning instead of a fatal error if specific resources fail to be collected.