### PR TITLE
fix name and logic for AWS CIS 1.10

### DIFF
--- a/example.aws_cis.policy.yml
+++ b/example.aws_cis.policy.yml
@@ -38,10 +38,10 @@ queries:
     query: >
       SELECT account_id, minimum_password_length FROM aws_iam_password_policies
        WHERE minimum_password_length < 14
-  - name: "AWS CIS check 1.10. Ensure IAM password policy requires minimum length of 14 or greater"
+  - name: "AWS CIS check 1.10. Ensure IAM password policy prevents password reuse"
     query: >
       SELECT account_id, password_reuse_prevention FROM aws_iam_password_policies
-       WHERE password_reuse_prevention is NULL or password_reuse_prevention != 1
+       WHERE password_reuse_prevention is NULL or password_reuse_prevention > 24
   - name: "AWS CIS check 1.11. Ensure IAM password policy expires passwords within 90 days or less"
     query: >
       SELECT account_id, max_password_age FROM aws_iam_password_policies


### PR DESCRIPTION
CIS 1.10 is titled `Ensure IAM password policy prevents password reuse` and the benchmark from AWS should pass as long as there are fewer than 24 remembered passwords.

https://docs.aws.amazon.com/securityhub/latest/userguide/securityhub-cis-controls.html#securityhub-cis-controls-1.10