### PR TITLE
Apply ...zapcore.Option during logger creation

### DIFF
--- a/cloudqueryclient/client.go
+++ b/cloudqueryclient/client.go
@@ -3,6 +3,9 @@ package cloudqueryclient
 import (
 	"database/sql"
 	"fmt"
+	"io/ioutil"
+	"os"
+
 	"github.com/cloudquery/cloudquery/providers/aws"
 	"github.com/cloudquery/cloudquery/providers/azure"
 	"github.com/cloudquery/cloudquery/providers/gcp"
@@ -18,8 +21,6 @@ import (
 	"gorm.io/driver/sqlserver"
 	"gorm.io/gorm"
 	"gorm.io/gorm/logger"
-	"io/ioutil"
-	"os"
 )
 
 var ProviderMap = map[string]func(*gorm.DB, *zap.Logger) (provider.Interface, error){
@@ -66,7 +67,7 @@ func NewLogger(verbose bool, options ...zap.Option) (*zap.Logger, error) {
 		EncoderConfig:    zap.NewDevelopmentEncoderConfig(),
 		OutputPaths:      []string{"stderr"},
 		ErrorOutputPaths: []string{"stderr"},
-	}.Build()
+	}.Build(options...)
 }
 
 func New(driver string, dsn string, verbose bool) (*Client, error) {


### PR DESCRIPTION
Prior to this fix, functional options were dropped in the constructor `NewLogger`.  Now they are applied to the logger post-configuration.  Note that verbose could be implemented as a zap.Option to create a uniform interface.