### PR TITLE
Fix AWS/ECR Repository duplicate entries

### DIFF
--- a/providers/aws/ecr/images.go
+++ b/providers/aws/ecr/images.go
@@ -24,7 +24,7 @@ type Repository struct {
 	ARN                                  *string
 	Name                                 *string
 	URI                                  *string
-	Images []*Image
+	Images []*Image `gorm:"constraint:OnDelete:CASCADE;"`
 }
 
 func (Repository) TableName() string {


### PR DESCRIPTION
Hi,

There's three fixes here, firstly adding the constraint on delete cascade to resolve when deleting the existing data;
```
2021/01/09 01:40:13 /go/pkg/mod/github.com/cloudquery/cloudquery@v0.7.7/database/database.go:97 pq: update or delete on table "aws_ecr_repositories" violates foreign key constraint "fk_aws_ecr_repositories_images" on table "aws_ecr_images"
```

Secondly, refactoring the processing loop so that `c.db.InsertOne(tRepo)` is only called once per repository.  Previously, if there were multiple pages of images, this would create a new repository entry in the database.

Finally, resetting `describeImagesInput.NextToken = nil` as the NextToken for the next repo used the previous repositories images last token which would cause a `InvalidParameterException`.