### PR TITLE
Add support for CQ_ env variable via viper

### DIFF
--- a/cmd/fetch.go
+++ b/cmd/fetch.go
@@ -3,31 +3,36 @@ package cmd
 import (
 	"github.com/cloudquery/cloudquery/cloudqueryclient"
 	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
 )
 
-var dsn string
-var driver string
 var verbose bool
-var fetchConfigPath string
 
 var fetchCmd = &cobra.Command{
 	Use:     "fetch",
 	Short:   "Fetch data from configured cloud APIs to specified SQL database",
 	Version: Version,
 	RunE: func(cmd *cobra.Command, args []string) error {
+		driver := viper.GetString("driver")
+		dsn := viper.GetString("dsn")
+		configPath := viper.GetString("config_path")
 		client, err := cloudqueryclient.New(driver, dsn, verbose)
 		if err != nil {
 			return err
 		}
-		return client.Run(fetchConfigPath)
+		return client.Run(configPath)
 
 	},
 }
 
 func init() {
-	rootCmd.AddCommand(fetchCmd)
-	fetchCmd.Flags().StringVar(&dsn, "dsn", "./cloudquery.db", "database connection string or filepath if driver is sqlite")
-	fetchCmd.Flags().StringVar(&driver, "driver", "sqlite", "database driver sqlite/postgresql/mysql/sqlserver/neo4j")
-	fetchCmd.Flags().StringVar(&fetchConfigPath, "path", "./config.yml", "path to configuration file. can be generated with 'gen config' command")
+	fetchCmd.Flags().String( "dsn", "./cloudquery.db", "database connection string or filepath if driver is sqlite (env: CQ_DSN)")
+	fetchCmd.Flags().String("driver", "sqlite", "database driver sqlite/postgresql/mysql/sqlserver/neo4j (env: CQ_DRIVER)")
+	fetchCmd.Flags().String("path", "./config.yml", "path to configuration file. can be generated with 'gen config' command (env: CQ_CONFIG_PATH)")
 	fetchCmd.Flags().BoolVarP(&verbose, "verbose", "v", false, "verbose output")
+	viper.BindPFlag("dsn", fetchCmd.Flags().Lookup("dsn"))
+	viper.BindPFlag("driver", fetchCmd.Flags().Lookup("driver"))
+	viper.BindPFlag("config_path", fetchCmd.Flags().Lookup("path"))
+
+	rootCmd.AddCommand(fetchCmd)
 }

--- a/cmd/query.go
+++ b/cmd/query.go
@@ -3,18 +3,18 @@ package cmd
 import (
 	"github.com/cloudquery/cloudquery/cloudqueryclient"
 	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
 )
-
-var queryDSN string
-var queryDriver string
-var queryConfigPath string
-var queryOutputJsonPath string
 
 var queryCmd = &cobra.Command{
 	Use:     "query",
 	Short:   "Run queries specified in a policy file",
 	Version: Version,
 	RunE: func(cmd *cobra.Command, args []string) error {
+		driver := viper.GetString("driver")
+		dsn := viper.GetString("dsn")
+		queryConfigPath := viper.GetString("policy_path")
+		queryOutputJsonPath := viper.GetString("output")
 		client, err := cloudqueryclient.New(driver, dsn, verbose)
 		if err != nil {
 			return err
@@ -25,9 +25,14 @@ var queryCmd = &cobra.Command{
 }
 
 func init() {
+	queryCmd.Flags().String("dsn", "./cloudquery.db", "database connection string or filepath if driver is sqlite (env CQ_DSN)")
+	queryCmd.Flags().String("driver", "sqlite", "database driver sqlite/postgresql/mysql/sqlserver (env CQ_DRIVER)")
+	queryCmd.Flags().String("path", "./policy.yml", "path to a policy file. can be generated with 'gen policy' command (env CQ_POLICY_PATH)")
+	queryCmd.Flags().String("output", "", "output path to store results as json file (env CQ_OUTPUT)")
+	viper.BindPFlag("dsn", queryCmd.Flags().Lookup("dsn"))
+	viper.BindPFlag("driver", queryCmd.Flags().Lookup("driver"))
+	viper.BindPFlag("policy_path", queryCmd.Flags().Lookup("path"))
+	viper.BindPFlag("output", queryCmd.Flags().Lookup("output"))
+
 	rootCmd.AddCommand(queryCmd)
-	queryCmd.Flags().StringVar(&queryDSN, "dsn", "./cloudquery.db", "database connection string or filepath if driver is sqlite")
-	queryCmd.Flags().StringVar(&queryDriver, "driver", "sqlite", "database driver sqlite/postgresql/mysql/sqlserver")
-	queryCmd.Flags().StringVar(&queryConfigPath, "path", "./policy.yml", "path to a policy file. can be generated with 'gen policy' command")
-	queryCmd.Flags().StringVar(&queryOutputJsonPath, "output", "", "output path to store results as json file")
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -2,8 +2,10 @@ package cmd
 
 import (
 	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
 	"log"
 	"os"
+	"strings"
 	"time"
 )
 
@@ -23,4 +25,14 @@ func Execute() {
 		log.Println(err)
 		os.Exit(1)
 	}
+}
+
+func init() {
+	cobra.OnInitialize(initConfig)
+}
+
+func initConfig() {
+	viper.AutomaticEnv()
+	viper.SetEnvPrefix("CQ")
+	viper.SetEnvKeyReplacer(strings.NewReplacer("-", "_"))
 }

--- a/go.mod
+++ b/go.mod
@@ -19,6 +19,7 @@ require (
 	github.com/satori/go.uuid v1.2.0
 	github.com/shopspring/decimal v1.2.0 // indirect
 	github.com/spf13/cobra v1.1.1
+	github.com/spf13/viper v1.7.0
 	go.uber.org/zap v1.10.0
 	golang.org/x/tools v0.0.0-20201014231627-1610a49f37af // indirect
 	google.golang.org/api v0.35.0


### PR DESCRIPTION
This adds support for environment variables with `CQ_` prefix to cloudquery.

Currently supports:

```
CQ_DSN
CQ_DRIVER
CQ_CONFIG_PATH
CQ_QUERY_PATH
``` 