### PR TITLE
fix table name in sample code

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,8 +145,8 @@ You need to set `OKTA_TOKEN` environment variable
 SELECT gcp_storage_buckets.name
 FROM gcp_storage_buckets
          JOIN gcp_storage_bucket_policy_bindings ON gcp_storage_bucket_policy_bindings.bucket_id = gcp_storage_buckets.id
-         JOIN gcp_storage_bucket_policy_bindings_members ON gcp_storage_bucket_policy_bindings_members.bucket_policy_binding_id = gcp_storage_bucket_policy_bindings.id
-WHERE gcp_storage_bucket_policy_bindings_members.name = 'allUsers' AND gcp_storage_bucket_policy_bindings.role = 'roles/storage.objectViewer';
+         JOIN gcp_storage_bucket_policy_binding_members ON gcp_storage_bucket_policy_binding_members.bucket_policy_binding_id = gcp_storage_bucket_policy_bindings.id
+WHERE gcp_storage_bucket_policy_binding_members.name = 'allUsers' AND gcp_storage_bucket_policy_bindings.role = 'roles/storage.objectViewer';
 ```
 
 ##### Find all public facing AWS load balancers


### PR DESCRIPTION
It's `gcp_storage_bucket_policy_binding_members` not `gcp_storage_bucket_policy_bindings_members`.