### PR TITLE
Use account authorization details to fetch policy documents

### DIFF
--- a/providers/aws/iam/policies.go
+++ b/providers/aws/iam/policies.go
@@ -49,9 +49,13 @@ func (c *Client) transformPolicyVersionList(values []*iam.PolicyVersion) ([]*Pol
 	var tValues []*PolicyVersion
 
 	for _, value := range values {
-		decodedDocument, err := url.QueryUnescape(*value.Document)
-		if err != nil {
-			return nil, err
+		var decodedDocument string = ""
+		var err error = nil
+		if value.Document != nil {
+			decodedDocument, err = url.QueryUnescape(*value.Document)
+			if err != nil {
+				return nil, err
+			}
 		}
 
 		tValues = append(tValues, &PolicyVersion{

--- a/providers/aws/iam/roles.go
+++ b/providers/aws/iam/roles.go
@@ -88,9 +88,13 @@ func (c *Client) transformRoleTags(values []*iam.Tag) []*RoleTag {
 func (c *Client) transformRoles(values []*iam.Role) ([]*Role, error) {
 	var tValues []*Role
 	for _, value := range values {
-		decodedDocument, err := url.QueryUnescape(*value.AssumeRolePolicyDocument)
-		if err != nil {
-			return nil, err
+		var decodedDocument string = ""
+		var err error = nil
+		if value.AssumeRolePolicyDocument != nil {
+			decodedDocument, err = url.QueryUnescape(*value.AssumeRolePolicyDocument)
+			if err != nil {
+				return nil, err
+			}
 		}
 
 		tValue := Role{

--- a/providers/aws/iam/roles.go
+++ b/providers/aws/iam/roles.go
@@ -1,6 +1,7 @@
 package iam
 
 import (
+	"net/url"
 	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
@@ -87,10 +88,15 @@ func (c *Client) transformRoleTags(values []*iam.Tag) []*RoleTag {
 func (c *Client) transformRoles(values []*iam.Role) ([]*Role, error) {
 	var tValues []*Role
 	for _, value := range values {
+		decodedDocument, err := url.QueryUnescape(*value.AssumeRolePolicyDocument)
+		if err != nil {
+			return nil, err
+		}
+
 		tValue := Role{
 			AccountID:                c.accountID,
 			Arn:                      value.Arn,
-			AssumeRolePolicyDocument: value.AssumeRolePolicyDocument,
+			AssumeRolePolicyDocument: &decodedDocument,
 			CreateDate:               value.CreateDate,
 			Description:              value.Description,
 			MaxSessionDuration:       value.MaxSessionDuration,


### PR DESCRIPTION
I wanted to fetch the actual policy documents so that I can query the contents of them, for example filter on all policies that have AssumeRole in them. Since we have 17k+ policies in our accounts doing a call for each of them is probably not practical.

The solution for this the `get-account-authorization-details` call that allows you to fetch all the users, groups, roles and policies of an account in a single call. (https://docs.aws.amazon.com/cli/latest/reference/iam/get-account-authorization-details.html)

I've implemented this in this PR for just the policies call, since all the fields matched perfectly, but of course it can be used to replace (parts of) the users, groups and roles implementations too. It will probably make it faster. The issue is there are slight differences in the fields returned. For example for the policies call it returns more fields, but for others resources it returns less, so this will take a bit more time and research.

I've also implemented urldecode for the contents of documents to make it easier to parse.

Let me know what you think!