### PR TITLE
add AWS multi account.id fetch capability

### DIFF
--- a/providers/aws/provider.go
+++ b/providers/aws/provider.go
@@ -210,7 +210,8 @@ func (p *Provider) Run(config interface{}) error {
 	for _, account := range p.config.Accounts {
 
 		if account.ID != "default" && account.RoleARN != "" {
-			// assume role if different account
+			// assume role if specified (SDK takes it from default or env var: AWS_PROFILE)
+			p.session, err = session.NewSession()
 			cred := stscreds.NewCredentials(p.session, account.RoleARN)
 			p.session, err = session.NewSession(&aws.Config{
 				Credentials: cred,

--- a/providers/aws/provider.go
+++ b/providers/aws/provider.go
@@ -2,6 +2,10 @@ package aws
 
 import (
 	"fmt"
+	"log"
+	"strings"
+	"sync"
+
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/aws/aws-sdk-go/aws/credentials"
@@ -33,9 +37,6 @@ import (
 	"github.com/cloudquery/cloudquery/providers/provider"
 	"github.com/mitchellh/mapstructure"
 	"go.uber.org/zap"
-	"log"
-	"strings"
-	"sync"
 )
 
 type Provider struct {
@@ -78,8 +79,8 @@ var globalServices = map[string]ServiceNewFunction{
 var regionalServices = map[string]ServiceNewFunction{
 	"autoscaling":      autoscaling.NewClient,
 	"cloudtrail":       cloudtrail.NewClient,
-	"cloudwatchlogs":       cloudwatchlogs.NewClient,
-	"cloudwatch": cloudwatch.NewClient,
+	"cloudwatchlogs":   cloudwatchlogs.NewClient,
+	"cloudwatch":       cloudwatch.NewClient,
 	"directconnect":    directconnect.NewClient,
 	"ec2":              ec2.NewClient,
 	"ecr":              ecr.NewClient,
@@ -92,7 +93,7 @@ var regionalServices = map[string]ServiceNewFunction{
 	"kms":              kms.NewClient,
 	"rds":              rds.NewClient,
 	"redshift":         redshift.NewClient,
-	"sns": sns.NewClient,
+	"sns":              sns.NewClient,
 }
 
 var tablesArr = [][]interface{}{
@@ -207,11 +208,8 @@ func (p *Provider) Run(config interface{}) error {
 	p.parseLogLevel()
 
 	for _, account := range p.config.Accounts {
-		p.session, err = session.NewSession()
-		if err != nil {
-			return err
-		}
-		if account.ID != "default" {
+
+		if account.ID != "default" && account.RoleARN != "" {
 			// assume role if different account
 			cred := stscreds.NewCredentials(p.session, account.RoleARN)
 			p.session, err = session.NewSession(&aws.Config{
@@ -220,7 +218,15 @@ func (p *Provider) Run(config interface{}) error {
 			if err != nil {
 				return err
 			}
+		} else if account.ID != "default" {
+			p.session, err = session.NewSession(&aws.Config{Credentials: credentials.NewSharedCredentials("", account.ID)})
+		} else {
+			p.session, err = session.NewSession()
 		}
+		if err != nil {
+			return err
+		}
+
 		for _, region := range regions {
 			p.region = region
 


### PR DESCRIPTION
I wanted to be able to fetch all my accounts at the same time with such config.yml :
```
providers:
  - name: aws
    accounts: # Optional. if you want to assume role to multiple account and fetch data from them
      - id: production
      - id: sharedstorage
      - id: test-us
      - id: test-eu
      - id: test-rds
      - id: prod-kms
      - id: uballot
      - id: mmkpm
```

Working like a charm, however with sqlite when fetching the eighth account I've encountered io limits or concurrency issue. I will open a proper issue for this.