### PR TITLE
Add list of accounts

### DIFF
--- a/cmd/config.go
+++ b/cmd/config.go
@@ -2,10 +2,11 @@ package cmd
 
 import (
 	"fmt"
-	"github.com/spf13/cobra"
 	"io/ioutil"
 	"os"
 	"strings"
+
+	"github.com/spf13/cobra"
 )
 
 var headerConfig = `providers:`
@@ -52,6 +53,7 @@ var awsConfig = `
       - name: iam.users
       - name: iam.virtual_mfa_devices
       - name: kms.keys
+      - name: organizations.accounts
       - name: rds.certificates
       - name: rds.clusters
       - name: rds.db_subnet_groups

--- a/providers/aws/organizations/accounts.go
+++ b/providers/aws/organizations/accounts.go
@@ -1,0 +1,74 @@
+package organizations
+
+import (
+	"time"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/organizations"
+	"github.com/mitchellh/mapstructure"
+	"go.uber.org/zap"
+)
+
+type Account struct {
+	ID              uint    `gorm:"primarykey"`
+	AccountID       *string `neo:"unique"`
+	Arn             *string `neo:"unique"`
+	Email           *string
+	JoinedMethod    *string
+	JoinedTimestamp *time.Time
+	name            *string
+	status          *string
+}
+
+func (Account) TableName() string {
+	return "aws_organizations_accounts"
+}
+
+func (c *Client) transformAccounts(values []*organizations.Account) ([]*Account, error) {
+	var tValues []*Account
+	for _, value := range values {
+		tValues = append(tValues, &Account{
+			AccountID:       value.Id,
+			Arn:             value.Arn,
+			Email:           value.Email,
+			JoinedMethod:    value.JoinedMethod,
+			JoinedTimestamp: value.JoinedTimestamp,
+			name:            value.Name,
+			status:          value.Status,
+		})
+	}
+	return tValues, nil
+}
+
+var AccountTables = []interface{}{
+	&Account{},
+}
+
+func (c *Client) accounts(gConfig interface{}) error {
+	var config organizations.ListAccountsInput
+	err := mapstructure.Decode(gConfig, &config)
+	if err != nil {
+		return err
+	}
+
+	// TODO: This doesn't work, since the account ids are not coming from the client but from the sdk call
+	c.db.Where("account_id", c.accountID).Delete(AccountTables...)
+
+	for {
+		output, err := c.svc.ListAccounts(&config)
+		if err != nil {
+			return err
+		}
+		tValues, err := c.transformAccounts(output.Accounts)
+		if err != nil {
+			return err
+		}
+		c.db.ChunkedCreate(tValues)
+		c.log.Info("Fetched resources", zap.String("resource", "organizations.accounts"), zap.Int("count", len(output.Accounts)))
+		if aws.StringValue(output.NextToken) == "" {
+			break
+		}
+		config.NextToken = output.NextToken
+	}
+	return nil
+}

--- a/providers/aws/organizations/client.go
+++ b/providers/aws/organizations/client.go
@@ -1,0 +1,40 @@
+package organizations
+
+import (
+	"fmt"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/aws/aws-sdk-go/service/organizations"
+	"github.com/cloudquery/cloudquery/database"
+	"github.com/cloudquery/cloudquery/providers/aws/resource"
+	"go.uber.org/zap"
+)
+
+type Client struct {
+	session   *session.Session
+	db        *database.Database
+	log       *zap.Logger
+	accountID string
+	svc       *organizations.Organizations
+}
+
+func NewClient(session *session.Session, awsConfig *aws.Config, db *database.Database, log *zap.Logger,
+	accountID string, _ string) resource.ClientInterface {
+	return &Client{
+		session:   session,
+		db:        db,
+		log:       log,
+		accountID: accountID,
+		svc:       organizations.New(session, awsConfig),
+	}
+}
+
+func (c *Client) CollectResource(resource string, config interface{}) error {
+	switch resource {
+	case "accounts":
+		return c.accounts(config)
+	default:
+		return fmt.Errorf("unsupported resource organizations.%s", resource)
+	}
+}

--- a/providers/aws/provider.go
+++ b/providers/aws/provider.go
@@ -2,6 +2,10 @@ package aws
 
 import (
 	"fmt"
+	"log"
+	"strings"
+	"sync"
+
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/aws/aws-sdk-go/aws/credentials"
@@ -25,6 +29,7 @@ import (
 	"github.com/cloudquery/cloudquery/providers/aws/fsx"
 	"github.com/cloudquery/cloudquery/providers/aws/iam"
 	"github.com/cloudquery/cloudquery/providers/aws/kms"
+	"github.com/cloudquery/cloudquery/providers/aws/organizations"
 	"github.com/cloudquery/cloudquery/providers/aws/rds"
 	"github.com/cloudquery/cloudquery/providers/aws/redshift"
 	"github.com/cloudquery/cloudquery/providers/aws/resource"
@@ -33,9 +38,6 @@ import (
 	"github.com/cloudquery/cloudquery/providers/provider"
 	"github.com/mitchellh/mapstructure"
 	"go.uber.org/zap"
-	"log"
-	"strings"
-	"sync"
 )
 
 type Provider struct {
@@ -71,15 +73,16 @@ var globalCollectedResources = map[string]bool{}
 type ServiceNewFunction func(session *session.Session, awsConfig *aws.Config, db *database.Database, log *zap.Logger, accountID string, region string) resource.ClientInterface
 
 var globalServices = map[string]ServiceNewFunction{
-	"iam": iam.NewClient,
-	"s3":  s3.NewClient,
+	"iam":           iam.NewClient,
+	"s3":            s3.NewClient,
+	"organizations": organizations.NewClient,
 }
 
 var regionalServices = map[string]ServiceNewFunction{
 	"autoscaling":      autoscaling.NewClient,
 	"cloudtrail":       cloudtrail.NewClient,
-	"cloudwatchlogs":       cloudwatchlogs.NewClient,
-	"cloudwatch": cloudwatch.NewClient,
+	"cloudwatchlogs":   cloudwatchlogs.NewClient,
+	"cloudwatch":       cloudwatch.NewClient,
 	"directconnect":    directconnect.NewClient,
 	"ec2":              ec2.NewClient,
 	"ecr":              ecr.NewClient,
@@ -92,7 +95,7 @@ var regionalServices = map[string]ServiceNewFunction{
 	"kms":              kms.NewClient,
 	"rds":              rds.NewClient,
 	"redshift":         redshift.NewClient,
-	"sns": sns.NewClient,
+	"sns":              sns.NewClient,
 }
 
 var tablesArr = [][]interface{}{
@@ -129,6 +132,7 @@ var tablesArr = [][]interface{}{
 	iam.UserTables,
 	iam.VirtualMFADeviceTables,
 	kms.KeyTables,
+	organizations.AccountTables,
 	rds.ClusterTables,
 	rds.CertificateTables,
 	rds.DBSubnetGroupTables,


### PR DESCRIPTION
I tried adding a list of accounts call to cloudquery. The use case that I have is that I want to join this from the other resources by accountId to provide a human readable name for the account instead of the id.

I'm running into some trouble, but I can't really finish it on my own, which is why I'm submitting the PR a bit incomplete, there are three issues:

- Deleting the tables doesn't work, since it depends on the accountId being in the where clause. I tried removing the where clause but that doesn't work. I see a lot of stuff about neo4j in the database layer, and I have no knowledge of neo4j so I'm not confident in changing that part of the code.
- This call only works from an account that can actually access the organizations resources. If not it will throw an access denied warning when running cloudquery, in my case it throws many of these. I'm not sure how to approach suppressing these warnings.
- When you have multiple accounts that can access the organizations resources they will both fetch the same accounts and create duplicate rows in the accounts table. I'm not sure how to solve this.

I hope this PR helps and you can pick it up further since I'm running into my limits here.