### PR TITLE
Fix ECS list services call

### DIFF
--- a/providers/aws/ecs/services.go
+++ b/providers/aws/ecs/services.go
@@ -332,6 +332,7 @@ func (c *Client) services(clusters []*string) error {
 	var listInput ecs.ListServicesInput
 	for _, cluster := range clusters {
 		listInput.Cluster = cluster
+		listInput.NextToken = nil
 		for {
 			listOutput, err := c.svc.ListServices(&listInput)
 			if err != nil {


### PR DESCRIPTION
Before this change, the `NextToken` field is not reset for each cluster which can cause `ListServices` to return incomplete results. This change resets the `NextToken` field for each cluster.