### PR TITLE
Optionally read in provider dir from environment

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -48,7 +48,11 @@ func init() {
 	rootCmd.PersistentFlags().IntVar(&loggerConfig.MaxSize, "maxSize", 30, "MaxSize the max size in MB of the logfile before it's rolled")
 	rootCmd.PersistentFlags().IntVar(&loggerConfig.MaxBackups, "maxBackups", 3, "MaxBackups the max number of rolled files to keep")
 	rootCmd.PersistentFlags().IntVar(&loggerConfig.MaxAge, "maxAge", 3, "MaxAge the max age in days to keep a logfile")
-	rootCmd.PersistentFlags().String( "plugin-dir", ".", "Directory to save and load Cloudquery plugins from (env: CQ_PLUGIN_DIR)")
+	workingDir, err := os.Getwd()
+	if err != nil {
+		workingDir = "."
+	}
+	rootCmd.PersistentFlags().String( "plugin-dir", workingDir, "Directory to save and load Cloudquery plugins from (env: CQ_PLUGIN_DIR)")
 	_ = viper.BindPFlag("plugin-dir", rootCmd.PersistentFlags().Lookup("plugin-dir"))
 	cobra.OnInitialize(initConfig, initLogging)
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -48,6 +48,8 @@ func init() {
 	rootCmd.PersistentFlags().IntVar(&loggerConfig.MaxSize, "maxSize", 30, "MaxSize the max size in MB of the logfile before it's rolled")
 	rootCmd.PersistentFlags().IntVar(&loggerConfig.MaxBackups, "maxBackups", 3, "MaxBackups the max number of rolled files to keep")
 	rootCmd.PersistentFlags().IntVar(&loggerConfig.MaxAge, "maxAge", 3, "MaxAge the max age in days to keep a logfile")
+	rootCmd.PersistentFlags().String( "plugin-dir", ".", "Directory to save and load Cloudquery plugins from (env: CQ_PLUGIN_DIR)")
+	_ = viper.BindPFlag("plugin-dir", rootCmd.PersistentFlags().Lookup("plugin-dir"))
 	cobra.OnInitialize(initConfig, initLogging)
 }
 

--- a/plugin/hub/hub.go
+++ b/plugin/hub/hub.go
@@ -71,14 +71,21 @@ type Hub struct {
 }
 
 func NewHub(skipRegistry bool) *Hub {
-	dir, err := os.Getwd()
-	if err != nil {
-		dir = "."
+
+	var pluginDir string
+	var err error
+	pluginDir = os.Getenv("CQ_PLUGIN_DIR")
+	if pluginDir == "" {
+		pluginDir, err = os.Getwd()
+		if err != nil {
+			pluginDir = "."
+		}
 	}
+
 	return &Hub{
 		registryURL:     defaultHub,
 		skipRegistry:    skipRegistry,
-		pluginDirectory: dir,
+		pluginDirectory: pluginDir,
 	}
 }
 
@@ -107,7 +114,7 @@ func (h Hub) DownloadPlugin(organization, pluginName, version string, overrideEx
 	}
 
 
-	// build fully qualified plugin directory for givien plugin
+	// build fully qualified plugin directory for given plugin
 	pluginDir := filepath.Join(h.pluginDirectory, ".cq", "providers", organization, pluginName)
 	if err := os.MkdirAll(pluginDir, os.ModePerm); err != nil {
 		return err

--- a/plugin/hub/hub.go
+++ b/plugin/hub/hub.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"github.com/cloudquery/cloudquery/plugin"
 	"github.com/rs/zerolog/log"
+	"github.com/spf13/viper"
 	"golang.org/x/crypto/openpgp"
 	"io"
 	"net/http"
@@ -71,16 +72,7 @@ type Hub struct {
 }
 
 func NewHub(skipRegistry bool) *Hub {
-
-	var pluginDir string
-	var err error
-	pluginDir = os.Getenv("CQ_PLUGIN_DIR")
-	if pluginDir == "" {
-		pluginDir, err = os.Getwd()
-		if err != nil {
-			pluginDir = "."
-		}
-	}
+	pluginDir := viper.GetString("plugin-dir")
 
 	return &Hub{
 		registryURL:     defaultHub,

--- a/plugin/plugin.go
+++ b/plugin/plugin.go
@@ -5,6 +5,7 @@ import (
 	"github.com/cloudquery/cloudquery/logging"
 	"github.com/hashicorp/go-plugin"
 	"github.com/rs/zerolog/log"
+	"github.com/spf13/viper"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -111,15 +112,8 @@ func GetProviderPath(name string, version string) (string, error) {
 		org = split[0]
 		name = split[1]
 	}
-	var pluginDir string
-	var err error
-	pluginDir = os.Getenv("CQ_PLUGIN_DIR")
-	if pluginDir == "" {
-		pluginDir, err = os.Getwd()
-		if err != nil {
-			return "", err
-		}
-	}
+
+	pluginDir := viper.GetString("plugin-dir")
 
 	extension := ""
 	if runtime.GOOS == "windows" {

--- a/plugin/plugin.go
+++ b/plugin/plugin.go
@@ -111,14 +111,19 @@ func GetProviderPath(name string, version string) (string, error) {
 		org = split[0]
 		name = split[1]
 	}
-
-	workingDir, err := os.Getwd()
-	if err != nil {
-		return "", err
+	var pluginDir string
+	var err error
+	pluginDir = os.Getenv("CQ_PLUGIN_DIR")
+	if pluginDir == "" {
+		pluginDir, err = os.Getwd()
+		if err != nil {
+			return "", err
+		}
 	}
+
 	extension := ""
 	if runtime.GOOS == "windows" {
 		extension = ".exe"
 	}
-	return filepath.Join(workingDir, ".cq", "providers", org, name, fmt.Sprintf("%s-%s-%s%s", version, runtime.GOOS, runtime.GOARCH, extension)), nil
+	return filepath.Join(pluginDir, ".cq", "providers", org, name, fmt.Sprintf("%s-%s-%s%s", version, runtime.GOOS, runtime.GOARCH, extension)), nil
 }


### PR DESCRIPTION
## Description

It may be desirable in some environments to use a different directory for plugins. This change adds an environment variable `CQ_PLUGIN_DIR` that if present will be used as the directory for plugins.

If the environment variable is not set, the default behavior of using the current script directory is preserved.