### PR TITLE
bugFix: Add custom unmarshaler for json config

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -45,34 +45,34 @@ func (c *Config) ProviderExists(providerName string) bool {
 //
 // Function assumes config keys are lowercase
 func (c *Config) UnmarshalJSON(data []byte) error {
-	var v map[string][]map[string]interface{}
+	var conf map[string][]map[string]interface{}
 
-	if err := json.Unmarshal(data, &v); err != nil {
+	if err := json.Unmarshal(data, &conf); err != nil {
 		return err
 	}
 
-	for _, d := range v["providers"] {
+	for _, provMap := range conf["providers"] {
 		prov := Provider{}
 		var ok bool
 		numKnownKeys := 0
 
-		if _, ok := d["name"]; ok {
+		if _, ok := provMap["name"]; ok {
 			numKnownKeys++
 		}
-		if _, ok := d["version"]; ok {
+		if _, ok := provMap["version"]; ok {
 			numKnownKeys++
 		}
 
-		rest := make(map[string]interface{}, len(d) - numKnownKeys)
+		rest := make(map[string]interface{}, len(provMap) - numKnownKeys)
 
-		if prov.Name, ok = d["name"].(string); !ok {
+		if prov.Name, ok = provMap["name"].(string); !ok {
 			return fmt.Errorf("Could not parse provider config")
 		}
-		if prov.Version, ok = d["version"].(string); !ok {
+		if prov.Version, ok = provMap["version"].(string); !ok {
 			prov.Version = "latest"
 		}
 
-		for key, value := range d {
+		for key, value := range provMap {
 			if key == "name" || key == "version" { continue }
 			rest[key] = value
 		}

--- a/config/config.go
+++ b/config/config.go
@@ -1,6 +1,8 @@
 package config
 
 import (
+	"encoding/json"
+	"fmt"
 	"github.com/creasty/defaults"
 )
 
@@ -35,4 +37,49 @@ func (c *Config) ProviderExists(providerName string) bool {
 		}
 	}
 	return false
+}
+
+// Default JSON unmarshaler will not populate the Rest field
+// and there are no type annotations that make this happen.
+// See https://github.com/golang/go/issues/6213
+//
+// Function assumes config keys are lowercase
+func (c *Config) UnmarshalJSON(data []byte) error {
+	var v map[string][]map[string]interface{}
+
+	if err := json.Unmarshal(data, &v); err != nil {
+		return err
+	}
+
+	for _, d := range v["providers"] {
+		prov := Provider{}
+		var ok bool
+		numKnownKeys := 0
+
+		if _, ok := d["name"]; ok {
+			numKnownKeys++
+		}
+		if _, ok := d["version"]; ok {
+			numKnownKeys++
+		}
+
+		rest := make(map[string]interface{}, len(d) - numKnownKeys)
+
+		if prov.Name, ok = d["name"].(string); !ok {
+			return fmt.Errorf("Could not parse provider config")
+		}
+		if prov.Version, ok = d["version"].(string); !ok {
+			prov.Version = "latest"
+		}
+
+		for key, value := range d {
+			if key == "name" || key == "version" { continue }
+			rest[key] = value
+		}
+		prov.Rest = rest
+		c.Providers = append(c.Providers, prov)
+
+	}
+
+	return nil
 }

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -1,0 +1,93 @@
+package config
+
+import "testing"
+
+const test1 =
+`
+{"providers": 
+	[
+		{
+			"name": "aws",
+			"regions": ["us-east-1"],
+			"resources": 
+				[
+					{
+					  "name": "ec2.images"
+					},
+					{
+					  "name": "ec2.instances"
+					},
+					{
+					  "name": "s3.buckets"
+					}
+				]
+		}
+	]
+}
+`
+const test2 =
+`
+{"providers": 
+	[
+		{
+			"name": true,
+			"regions": ["us-east-1"],
+			"resources": 
+				[
+					{
+					  "name": "ec2.images"
+					},
+					{
+					  "name": "ec2.instances"
+					},
+					{
+					  "name": "s3.buckets"
+					}
+				]
+		}
+	]
+}
+`
+
+func TestConfig_UnmarshalJSON(t *testing.T) {
+	type args struct {
+		data []byte
+	}
+	tests := []struct {
+		name    string
+		args    args
+		wantErr bool
+	}{
+		{
+			name: "basicUnmarshal",
+			args: args{[]byte(test1)},
+			wantErr: false,
+		},
+		{
+			name: "basicUnmarshalFail",
+			args: args{[]byte(test2)},
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := &Config{}
+			var err error
+			if err = c.UnmarshalJSON(tt.args.data); (err != nil) != tt.wantErr {
+				t.Errorf("UnmarshalJSON() error = %v, wantErr %v", err, tt.wantErr)
+			}
+			if err == nil {
+				// probably a better way to test for proper parsing but this will do for now
+				if len(c.Providers) != 1 {
+					t.Errorf("Did not parse any providers")
+				}
+				if c.Providers[0].Rest == nil {
+					t.Errorf("Did not parse Rest")
+				}
+				if _, ok := c.Providers[0].Rest["resources"]; !ok {
+					t.Errorf("resources key is not in Rest")
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Description

Currently the native Json unmarshaling will not parse out the `Rest` portion of each of the providers. 
`encoding/json` does not have an `inline` struct tag similar to `yaml` so there is no way to parse the extra data from json without a custom unmarshaler.

I'm proposing an implementation of a custom json unmarshaler here, also added some basic tests.