### PR TITLE
Lambda: add cloud watch trigger, migrate to postgres, allow plugins

### DIFF
--- a/deploy/aws/terraform/bucket.tf
+++ b/deploy/aws/terraform/bucket.tf
@@ -1,0 +1,8 @@
+resource "aws_s3_bucket" "deploy_bucket" {
+  bucket = var.bucket
+  acl    = "private"
+
+  tags = {
+    Name        = var.bucket
+  }
+}

--- a/deploy/aws/terraform/cloudwatch.tf
+++ b/deploy/aws/terraform/cloudwatch.tf
@@ -1,5 +1,5 @@
 resource "aws_cloudwatch_event_rule" "scan_schedule" {
-  name = "Cloudquery us-east-1 scan"
+  name = "Cloudquery-us-east-1-scan"
   description = "Run cloudquery everyday on us-east-1 resources"
 
   schedule_expression = "rate(1 day)"

--- a/deploy/aws/terraform/cloudwatch.tf
+++ b/deploy/aws/terraform/cloudwatch.tf
@@ -1,0 +1,12 @@
+resource "aws_cloudwatch_event_rule" "scan_schedule" {
+  name = "Cloudquery us-east-1 scan"
+  description = "Run cloudquery everyday on us-east-1 resources"
+
+  schedule_expression = "rate(1 day)"
+}
+
+resource "aws_cloudwatch_event_target" "sns" {
+  rule      = aws_cloudwatch_event_rule.scan_schedule.name
+  arn       = aws_lambda_function.cloudquery.arn
+  input     = file("tasks/us-east-1/input.json")
+}

--- a/deploy/aws/terraform/database.tf
+++ b/deploy/aws/terraform/database.tf
@@ -13,6 +13,7 @@ resource "aws_rds_cluster" "cloudquery" {
 
   skip_final_snapshot = true
   apply_immediately = true
+  enable_http_endpoint = true
 
   scaling_configuration {
     auto_pause               = true

--- a/deploy/aws/terraform/database.tf
+++ b/deploy/aws/terraform/database.tf
@@ -1,7 +1,7 @@
 resource "aws_rds_cluster" "cloudquery" {
   cluster_identifier = "cloudquery"
-  engine             = "aurora-mysql"
-  engine_version     = "5.7.mysql_aurora.2.07.1"
+  engine             = "aurora-postgresql"
+  engine_version     = "10.12"
   engine_mode        = "serverless"
   master_username    = "cloudquery"
   database_name      = "cloudquery"
@@ -9,7 +9,7 @@ resource "aws_rds_cluster" "cloudquery" {
 
   db_subnet_group_name = aws_db_subnet_group.rds_subnet_group.name
 
-  vpc_security_group_ids = [aws_security_group.allow_mysql.id]
+  vpc_security_group_ids = [aws_security_group.allow_postgresql.id]
 
   skip_final_snapshot = true
   apply_immediately = true
@@ -17,7 +17,7 @@ resource "aws_rds_cluster" "cloudquery" {
   scaling_configuration {
     auto_pause               = true
     max_capacity             = 4
-    min_capacity             = 1
+    min_capacity             = 2
     seconds_until_auto_pause = 300
     timeout_action           = "ForceApplyCapacityChange"
   }

--- a/deploy/aws/terraform/function.tf
+++ b/deploy/aws/terraform/function.tf
@@ -40,11 +40,15 @@ resource "aws_s3_bucket_object" "file_upload" {
   key    = "lambda-functions/cloudquery.zip"
   source = data.archive_file.zip.output_path
 
+  etag   = filemd5(data.archive_file.zip.output_path)
+
+  depends_on = [aws_s3_bucket.deploy_bucket]
+
 }
 
 data "archive_file" "zip" {
   type        = "zip"
-  source_dir = "../../../bin"
+  source_file = "../../../bin/cloudquery"
   output_path = "cloudquery.zip"
 }
 
@@ -88,7 +92,8 @@ resource "aws_lambda_function" "cloudquery" {
   environment {
     variables = {
       CQ_DRIVER= "mysql",
-      CQ_DSN = "${aws_rds_cluster.cloudquery.master_username}:${aws_rds_cluster.cloudquery.master_password}@tcp(${aws_rds_cluster.cloudquery.endpoint}:3306)/cloudquery"
+      CQ_DSN = "${aws_rds_cluster.cloudquery.master_username}:${aws_rds_cluster.cloudquery.master_password}@tcp(${aws_rds_cluster.cloudquery.endpoint}:3306)/cloudquery",
+      CQ_PLUGIN_DIR = "/tmp"
     }
   }
 }

--- a/deploy/aws/terraform/function.tf
+++ b/deploy/aws/terraform/function.tf
@@ -27,6 +27,20 @@ data "aws_iam_policy_document" "policy_document" {
       "arn:aws:s3:::${var.bucket}"
     ]
   }
+
+  statement {
+    effect  = "Allow"
+    actions = ["lambda:InvokeFunction"]
+
+    principals {
+      type        = "Service"
+      identifiers = ["events.amazonaws.com"]
+    }
+
+    resources = [
+      aws_lambda_function.cloudquery.arn
+    ]
+  }
 }
 
 resource "aws_iam_policy" "policy" {

--- a/deploy/aws/terraform/function.tf
+++ b/deploy/aws/terraform/function.tf
@@ -17,28 +17,20 @@ resource "aws_iam_role" "iam_for_cloudquery" {
 EOF
 }
 
+resource "aws_lambda_permission" "allow_cloudwatch" {
+  statement_id  = "AllowExecutionFromCloudWatch"
+  action        = "lambda:InvokeFunction"
+  function_name = aws_lambda_function.cloudquery.function_name
+  principal     = "events.amazonaws.com"
+}
+
 data "aws_iam_policy_document" "policy_document" {
   statement {
-    sid = "1"
     actions = [
       "s3:GetObject"
     ]
     resources = [
       "arn:aws:s3:::${var.bucket}"
-    ]
-  }
-
-  statement {
-    effect  = "Allow"
-    actions = ["lambda:InvokeFunction"]
-
-    principals {
-      type        = "Service"
-      identifiers = ["events.amazonaws.com"]
-    }
-
-    resources = [
-      aws_lambda_function.cloudquery.arn
     ]
   }
 }

--- a/deploy/aws/terraform/function.tf
+++ b/deploy/aws/terraform/function.tf
@@ -86,13 +86,13 @@ resource "aws_lambda_function" "cloudquery" {
 
   vpc_config {
     subnet_ids         = [aws_subnet.rds_subnet_a.id, aws_subnet.rds_subnet_b.id]
-    security_group_ids = [aws_security_group.allow_mysql.id, aws_security_group.allow_egress.id]
+    security_group_ids = [aws_security_group.allow_postgresql.id, aws_security_group.allow_egress.id]
   }
 
   environment {
     variables = {
-      CQ_DRIVER= "mysql",
-      CQ_DSN = "${aws_rds_cluster.cloudquery.master_username}:${aws_rds_cluster.cloudquery.master_password}@tcp(${aws_rds_cluster.cloudquery.endpoint}:3306)/cloudquery",
+      CQ_DRIVER= "postgresql",
+      CQ_DSN = "user=${aws_rds_cluster.cloudquery.master_username} password=${aws_rds_cluster.cloudquery.master_password} host=${aws_rds_cluster.cloudquery.endpoint} port=5432 dbname=cloudquery",
       CQ_PLUGIN_DIR = "/tmp"
     }
   }

--- a/deploy/aws/terraform/tasks/us-east-1/input.json
+++ b/deploy/aws/terraform/tasks/us-east-1/input.json
@@ -1,0 +1,24 @@
+{
+  "taskName": "fetch",
+  "config": {
+    "providers": [
+      {
+        "name": "aws",
+        "regions": [
+          "us-east-1"
+        ],
+        "resources": [
+          {
+            "name": "ec2.images"
+          },
+          {
+            "name": "ec2.instances"
+          },
+          {
+            "name": "s3.buckets"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/deploy/aws/terraform/vpc.tf
+++ b/deploy/aws/terraform/vpc.tf
@@ -50,28 +50,28 @@ resource "aws_nat_gateway" "nat_gw" {
   subnet_id     = aws_subnet.rds_subnet_pub.id
 }
 
-resource "aws_security_group" "allow_mysql" {
-  name        = "allow_mysql"
-  description = "Allow inbound mysql connections"
+resource "aws_security_group" "allow_postgresql" {
+  name        = "allow_postgresql"
+  description = "Allow inbound postresql connections"
   vpc_id      = aws_vpc.rds_vpc.id
 
   ingress {
-    description = "Mysql from security group"
-    from_port   = 3306
-    to_port     = 3306
+    description = "Postgresql from security group"
+    from_port   = 5432
+    to_port     = 5432
     protocol    = "tcp"
     self        = true
   }
 
   egress {
-    from_port   = 3306
-    to_port     = 3306
+    from_port   = 5432
+    to_port     = 5432
     protocol    = "tcp"
     self        = true
   }
 
   tags = {
-    Name = "allow_tls"
+    Name = "Allow Postgresql"
   }
 }
 

--- a/deploy/lambda.go
+++ b/deploy/lambda.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"github.com/cloudquery/cloudquery/client"
 	"github.com/cloudquery/cloudquery/config"
+	"github.com/spf13/viper"
 	"log"
 	"os"
 )
@@ -23,6 +24,11 @@ func LambdaHandler(ctx context.Context, req Request) (string, error) {
 func TaskExecutor(req Request) (string, error) {
 	driver := os.Getenv("CQ_DRIVER")
 	dsn := os.Getenv("CQ_DSN")
+	pluginDir, present := os.LookupEnv("CQ_PLUGIN_DIR")
+	if !present {
+		pluginDir = "."
+	}
+	viper.Set("plugin-dir", pluginDir)
 	switch req.TaskName {
 	case "fetch":
 		Fetch(driver, dsn, req.Config)

--- a/deploy/lambda.go
+++ b/deploy/lambda.go
@@ -3,9 +3,10 @@ package deploy
 import (
 	"context"
 	"fmt"
-	"github.com/spf13/viper"
 	"log"
 	"os"
+
+	"github.com/spf13/viper"
 
 	"github.com/cloudquery/cloudquery/client"
 	"github.com/cloudquery/cloudquery/config"


### PR DESCRIPTION
## Description

This PR includes three changes to the AWS Lambda deployment.

1. Adds a cloudwatch trigger
    _This shows an example of how one can schedule and run multiple Cloudquery configs in parallel on Lambda_
2. Migrates the Aurora database to Postgres
3. Uses the new `CQ_PLUGIN_DIR` environment variable to allow the plugin architecture to work in Lambda


It also adds an S3 bucket in terraform for use with the lambda function deployment