### PR TITLE
Fail provider download on Not Found http error

### DIFF
--- a/pkg/plugin/registry/hub.go
+++ b/pkg/plugin/registry/hub.go
@@ -195,7 +195,7 @@ func (h Hub) downloadProvider(ctx context.Context, organization, providerName, p
 	providerURL := fmt.Sprintf("https://github.com/%s/cq-provider-%s/releases/download/%s/%s", organization, providerName, providerVersion, getPluginBinaryName(providerName))
 	providerPath := h.getProviderPath(organization, providerName, providerVersion)
 	if err := h.downloadFile(ctx, providerName, providerVersion, providerPath, providerURL, true); err != nil {
-		return ProviderDetails{}, err
+		return ProviderDetails{}, fmt.Errorf("plugin %s/%s@%s failed to download: %s", organization, providerName, providerVersion, err)
 	}
 
 	if ok := h.VerifyProvider(ctx, organization, providerName, providerVersion); !ok {
@@ -238,6 +238,10 @@ func (h Hub) downloadFile(ctx context.Context, providerName, version, filepath, 
 		return err
 	}
 	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("got %d http code instead expected %d", resp.StatusCode, http.StatusOK)
+	}
 
 	var reader io.Reader = resp.Body
 	if h.ProgressUpdater != nil && updateProgress {

--- a/pkg/plugin/registry/hub.go
+++ b/pkg/plugin/registry/hub.go
@@ -195,7 +195,7 @@ func (h Hub) downloadProvider(ctx context.Context, organization, providerName, p
 	providerURL := fmt.Sprintf("https://github.com/%s/cq-provider-%s/releases/download/%s/%s", organization, providerName, providerVersion, getPluginBinaryName(providerName))
 	providerPath := h.getProviderPath(organization, providerName, providerVersion)
 	if err := h.downloadFile(ctx, providerName, providerVersion, providerPath, providerURL, true); err != nil {
-		return ProviderDetails{}, fmt.Errorf("plugin %s/%s@%s failed to download: %s", organization, providerName, providerVersion, err)
+		return ProviderDetails{}, fmt.Errorf("plugin %s/%s@%s failed to download: %w", organization, providerName, providerVersion, err)
 	}
 
 	if ok := h.VerifyProvider(ctx, organization, providerName, providerVersion); !ok {


### PR DESCRIPTION
Without checking the HTTP code, an empty file is always created. And only the next time the CQ is launched, the provider's validation error occurs (the file of the same name is on the disk, but of zero length). 