### PR TITLE
BugFix/panic on empty configuration

### DIFF
--- a/cmd/init.go
+++ b/cmd/init.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+
 	"github.com/cloudquery/cloudquery/internal/logging"
 	"github.com/cloudquery/cloudquery/internal/signalcontext"
 	"github.com/cloudquery/cloudquery/pkg/config"

--- a/cmd/init.go
+++ b/cmd/init.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"context"
 	"fmt"
-
 	"github.com/cloudquery/cloudquery/internal/logging"
 	"github.com/cloudquery/cloudquery/internal/signalcontext"
 	"github.com/cloudquery/cloudquery/pkg/config"
@@ -45,7 +44,6 @@ func Initialize(providers []string) {
 	for i, p := range providers {
 		requiredProviders[i] = &config.RequiredProvider{
 			Name:    p,
-			Source:  viper.GetString("source"),
 			Version: "latest",
 		}
 	}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -72,6 +72,10 @@ func init() {
 	_ = viper.BindPFlag("dsn", rootCmd.PersistentFlags().Lookup("dsn"))
 	_ = viper.BindPFlag("configPath", rootCmd.PersistentFlags().Lookup("config"))
 	_ = viper.BindPFlag("no-verify", rootCmd.PersistentFlags().Lookup("no-verify"))
+
+	initCmd.Flags().String("source", "cloudquery", "Name of organization the provider belongs too, defaults to cloudquery")
+	_ = viper.BindPFlag("source", initCmd.Flags().Lookup("source"))
+
 	rootCmd.AddCommand(initCmd, fetchCmd)
 	cobra.OnInitialize(initConfig, initLogging)
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -73,9 +73,6 @@ func init() {
 	_ = viper.BindPFlag("configPath", rootCmd.PersistentFlags().Lookup("config"))
 	_ = viper.BindPFlag("no-verify", rootCmd.PersistentFlags().Lookup("no-verify"))
 
-	initCmd.Flags().String("source", "cloudquery", "Name of organization the provider belongs too, defaults to cloudquery")
-	_ = viper.BindPFlag("source", initCmd.Flags().Lookup("source"))
-
 	rootCmd.AddCommand(initCmd, fetchCmd)
 	cobra.OnInitialize(initConfig, initLogging)
 }

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.16
 require (
 	github.com/VividCortex/ewma v1.2.0 // indirect
 	github.com/aws/aws-lambda-go v1.23.0
-	github.com/cloudquery/cq-provider-sdk v0.2.0
+	github.com/cloudquery/cq-provider-sdk v0.2.2
 	github.com/fatih/color v1.10.0
 	github.com/fsnotify/fsnotify v1.4.7
 	github.com/google/go-github/v35 v35.1.0

--- a/go.sum
+++ b/go.sum
@@ -65,8 +65,8 @@ github.com/cespare/xxhash v1.1.0/go.mod h1:XrSqR1VqqWfGrhpAt58auRo0WTKS1nRRg3ghf
 github.com/cespare/xxhash/v2 v2.1.1/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/clbanning/x2j v0.0.0-20191024224557-825249438eec/go.mod h1:jMjuTZXRI4dUb/I5gc9Hdhagfvm9+RyrPryS/auMzxE=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
-github.com/cloudquery/cq-provider-sdk v0.2.0 h1:gzM/sAZ4lEB3ylG0EqTLBN5Mtz5LgjFBo/bm6kbK11w=
-github.com/cloudquery/cq-provider-sdk v0.2.0/go.mod h1:cdn/dDr5A1zfmSFmW2qDmwD5J+8v/o33glMt2+u36KM=
+github.com/cloudquery/cq-provider-sdk v0.2.2 h1:60IxgiMadSQK6gBTdQlNmtr7LjYQZ7jIrqk7qKdnIxg=
+github.com/cloudquery/cq-provider-sdk v0.2.2/go.mod h1:cdn/dDr5A1zfmSFmW2qDmwD5J+8v/o33glMt2+u36KM=
 github.com/cloudquery/faker/v3 v3.7.4/go.mod h1:1b8WVG9Gh0T2hVo1a8dWeXfu0AhqSB6J/mmJaesqOeo=
 github.com/cncf/udpa/go v0.0.0-20201120205902-5459f2c99403/go.mod h1:WmhPx2Nbnhtbo57+VJT5O0JRkEi1Wbu0z5j0R8u5Hbk=
 github.com/cockroachdb/apd v1.1.0 h1:3LFP3629v+1aKXU5Q37mxmRxX/pIu1nijXydLShEq5I=

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -149,8 +149,11 @@ func (c *Client) Initialize(ctx context.Context) error {
 	c.Logger.Info("Initializing required providers")
 	for _, p := range c.config.CloudQuery.Providers {
 		c.Logger.Info("Initializing provider", "name", p.Name, "version", p.Version)
-		// TODO: when we will support multiple organization use the source attribute
-		details, err := c.Hub.GetProvider(ctx, p.Source, p.Name, p.Version)
+		org, name, err := registry.ParseProviderName(p.Name)
+		if err != nil {
+			return err
+		}
+		details, err := c.Hub.GetProvider(ctx, org, name, p.Version)
 		if err != nil {
 			return err
 		}
@@ -181,7 +184,7 @@ func (c *Client) Fetch(ctx context.Context, request FetchRequest) error {
 		errGroup.Go(func() error {
 			var cfg []byte
 			if provider.Configuration != nil {
-				cfg, err = convert.Body(providerCfg.Configuration, convert.Options{Simplify: false})
+				cfg, err = convert.Body(providerCfg.Configuration, convert.Options{Simplify: true})
 				if err != nil {
 					return err
 				}

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -19,12 +19,6 @@ import (
 	"gopkg.in/yaml.v3"
 )
 
-// UpgradeRequest is provided to the Client to execute an upgrade of one or more providers
-type UpgradeRequest struct {
-	Provider string
-	Version  string
-}
-
 // FetchRequest is provided to the Client to execute a fetch on one or more providers
 type FetchRequest struct {
 	// UpdateCallback allows gets called when the client receives updates on fetch.
@@ -50,8 +44,6 @@ type PolicyExecutionResult struct {
 	// Map of all query result sets
 	Results map[string]*PolicyResult
 }
-
-type Option func(options *Client)
 
 type FetchUpdate struct {
 	Provider string
@@ -93,6 +85,8 @@ type FetchDoneResult struct {
 type FetchUpdateCallback func(update FetchUpdate)
 
 type PolicyExecutionCallback func(name string, passed bool, resultCount int)
+
+type Option func(options *Client)
 
 // Client is the client for executing providers, fetching data and running queries and polices
 type Client struct {
@@ -156,7 +150,7 @@ func (c *Client) Initialize(ctx context.Context) error {
 	for _, p := range c.config.CloudQuery.Providers {
 		c.Logger.Info("Initializing provider", "name", p.Name, "version", p.Version)
 		// TODO: when we will support multiple organization use the source attribute
-		details, err := c.Hub.GetProvider(ctx, plugin.DefaultOrganization, p.Name, p.Version)
+		details, err := c.Hub.GetProvider(ctx, p.Source, p.Name, p.Version)
 		if err != nil {
 			return err
 		}
@@ -185,9 +179,12 @@ func (c *Client) Fetch(ctx context.Context, request FetchRequest) error {
 		}
 		provider := provider
 		errGroup.Go(func() error {
-			cfg, err := convert.Body(providerCfg.Configuration, convert.Options{Simplify: false})
-			if err != nil {
-				return err
+			var cfg []byte
+			if provider.Configuration != nil {
+				cfg, err = convert.Body(providerCfg.Configuration, convert.Options{Simplify: false})
+				if err != nil {
+					return err
+				}
 			}
 			c.Logger.Info("requesting provider to configure", "provider", provider.Name, "version", details.Version)
 			_, err = cqProvider.ConfigureProvider(gctx, &cqproto.ConfigureProviderRequest{

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -34,7 +34,7 @@ type Connection struct {
 
 type RequiredProvider struct {
 	Name    string `hcl:"name,label"`
-	Source  string `hcl:"source"`
+	Source  string `hcl:"source,optional"`
 	Version string `hcl:"version"`
 }
 

--- a/pkg/config/parser_test.go
+++ b/pkg/config/parser_test.go
@@ -1,9 +1,10 @@
 package config
 
 import (
+	"testing"
+
 	"github.com/cloudquery/cloudquery/pkg/config/convert"
 	"github.com/hashicorp/hcl/v2/hclsimple"
-	"testing"
 
 	"github.com/stretchr/testify/assert"
 )
@@ -32,7 +33,6 @@ provider "aws" {
   resources = ["slow_resource"]
 }`
 
-
 type Account struct {
 	ID      string `hcl:",label"`
 	RoleARN string `hcl:"role_arn,optional"`
@@ -45,7 +45,6 @@ type AwsConfig struct {
 	MaxRetries int       `hcl:"max_retries,optional" default:"5"`
 	MaxBackoff int       `hcl:"max_backoff,optional" default:"30"`
 }
-
 
 func TestParser_LoadConfigFromSource(t *testing.T) {
 	p := NewParser(nil)
@@ -85,6 +84,5 @@ func TestProviderLoadConfiguration(t *testing.T) {
 	c := AwsConfig{}
 	errs := hclsimple.Decode("res.json", res, nil, &c)
 	assert.Nil(t, errs)
-
 
 }

--- a/pkg/config/parser_test.go
+++ b/pkg/config/parser_test.go
@@ -22,13 +22,9 @@ const testConfig = `cloudquery {
 provider "aws" {
   configuration {
 	account "dev" {
-		regions = ["us-east1"]
-		resources = ["ec2"]
+		role_arn ="12312312"
 	}
-	account "ron" {
-		regions = ["us-east1"]
-		resources = ["ec2"]
-	}
+	account "ron" {}
   }
   resources = ["slow_resource"]
 }`

--- a/pkg/plugin/registry/organization.go
+++ b/pkg/plugin/registry/organization.go
@@ -1,0 +1,25 @@
+package registry
+
+import (
+	"fmt"
+	"strings"
+)
+
+const (
+	defaultOrganization = "cloudquery"
+
+)
+
+// ParseProviderName parses a name of a provider which can be just a name or a name + organization
+// For example aws <-> cloudquery/aws will download the cq-provider-aws in cloudquery organization
+// The organization defaults to cloudquery, if you want to download from a different repo set the name <your_org_name>/<provider_name>
+func ParseProviderName(name string) (string, string, error) {
+	names := strings.Split(name, "/")
+	if len(names) == 2 {
+		return names[0], names[1], nil
+	}
+	if len(names) == 1 {
+		return defaultOrganization, name, nil
+	}
+	return "", "", fmt.Errorf("invalid provider name %s", name)
+}

--- a/pkg/plugin/registry/organization.go
+++ b/pkg/plugin/registry/organization.go
@@ -7,7 +7,6 @@ import (
 
 const (
 	defaultOrganization = "cloudquery"
-
 )
 
 // ParseProviderName parses a name of a provider which can be just a name or a name + organization


### PR DESCRIPTION
- allowed to use source based on the provider config source=cloudquery previously was hard coded as cloudquery,  although it defaults to cloudquery as well.
-  fix panic when not adding a configuration block to a provider, that means provider uses the defaults values.