### PR TITLE
Implement file HCL function

### DIFF
--- a/internal/file/file.go
+++ b/internal/file/file.go
@@ -107,6 +107,16 @@ func (o *OsFs) Stat(path string) (os.FileInfo, error) {
 	return o.fs.Stat(path)
 }
 
+// Open is a wrapper around afero.Open that opens a file.
+func (o *OsFs) Open(path string) (afero.File, error) {
+	return o.fs.Open(path)
+}
+
+// Create is a wrapper around afero.Create that creates a file.
+func (o *OsFs) Create(path string) (afero.File, error) {
+	return o.fs.Create(path)
+}
+
 // SetFSInstance sets the FS instance. Should be only used for testing purpose.
 func (o *OsFs) SetFSInstance(fs afero.Fs) {
 	o.fs = fs

--- a/pkg/config/convert/converter.go
+++ b/pkg/config/convert/converter.go
@@ -193,7 +193,7 @@ func (c *converter) convertAttributes(attributes hcl.Attributes) (jsonObj, error
 	var out = make(jsonObj)
 
 	for _, attr := range attributes {
-		val, err := attr.Expr.Value(&evalContext)
+		val, err := attr.Expr.Value(evalContext)
 		if err != nil {
 			return nil, fmt.Errorf("convert expression: %w", err)
 		}
@@ -204,7 +204,7 @@ func (c *converter) convertAttributes(attributes hcl.Attributes) (jsonObj, error
 
 func (c *converter) convertExpression(expr hclsyntax.Expression) (interface{}, error) {
 	if c.options.Simplify {
-		value, err := expr.Value(&evalContext)
+		value, err := expr.Value(evalContext)
 		if err == nil {
 			return ctyjson.SimpleJSONValue{Value: value}, nil
 		}

--- a/pkg/config/convert/stdlib.go
+++ b/pkg/config/convert/stdlib.go
@@ -2,6 +2,7 @@ package convert
 
 import (
 	"io/ioutil"
+	"path/filepath"
 
 	"github.com/cloudquery/cloudquery/internal/file"
 	hcl "github.com/hashicorp/hcl/v2"
@@ -12,57 +13,62 @@ import (
 
 // a subset of functions used in terraform
 // that can be used when simplifying during conversion
-var evalContext = hcl.EvalContext{
-	Functions: map[string]function.Function{
-		// numeric
-		"abs":      stdlib.AbsoluteFunc,
-		"ceil":     stdlib.CeilFunc,
-		"floor":    stdlib.FloorFunc,
-		"log":      stdlib.LogFunc,
-		"max":      stdlib.MaxFunc,
-		"min":      stdlib.MinFunc,
-		"parseint": stdlib.ParseIntFunc,
-		"pow":      stdlib.PowFunc,
-		"signum":   stdlib.SignumFunc,
+var evalContext = GetEvalContext("")
 
-		// string
-		"chomp":      stdlib.ChompFunc,
-		"format":     stdlib.FormatFunc,
-		"formatlist": stdlib.FormatListFunc,
-		"indent":     stdlib.IndentFunc,
-		"join":       stdlib.JoinFunc,
-		"split":      stdlib.SplitFunc,
-		"strrev":     stdlib.ReverseFunc,
-		"trim":       stdlib.TrimFunc,
-		"trimprefix": stdlib.TrimPrefixFunc,
-		"trimsuffix": stdlib.TrimSuffixFunc,
-		"trimspace":  stdlib.TrimSpaceFunc,
+// GetEvalContext returns the hcl eval context.
+func GetEvalContext(basePath string) *hcl.EvalContext {
+	return &hcl.EvalContext{
+		Functions: map[string]function.Function{
+			// numeric
+			"abs":      stdlib.AbsoluteFunc,
+			"ceil":     stdlib.CeilFunc,
+			"floor":    stdlib.FloorFunc,
+			"log":      stdlib.LogFunc,
+			"max":      stdlib.MaxFunc,
+			"min":      stdlib.MinFunc,
+			"parseint": stdlib.ParseIntFunc,
+			"pow":      stdlib.PowFunc,
+			"signum":   stdlib.SignumFunc,
 
-		// collections
-		"chunklist": stdlib.ChunklistFunc,
-		"concat":    stdlib.ConcatFunc,
-		"distinct":  stdlib.DistinctFunc,
-		"flatten":   stdlib.FlattenFunc,
-		"length":    stdlib.LengthFunc,
-		"merge":     stdlib.MergeFunc,
-		"reverse":   stdlib.ReverseListFunc,
-		"sort":      stdlib.SortFunc,
+			// string
+			"chomp":      stdlib.ChompFunc,
+			"format":     stdlib.FormatFunc,
+			"formatlist": stdlib.FormatListFunc,
+			"indent":     stdlib.IndentFunc,
+			"join":       stdlib.JoinFunc,
+			"split":      stdlib.SplitFunc,
+			"strrev":     stdlib.ReverseFunc,
+			"trim":       stdlib.TrimFunc,
+			"trimprefix": stdlib.TrimPrefixFunc,
+			"trimsuffix": stdlib.TrimSuffixFunc,
+			"trimspace":  stdlib.TrimSpaceFunc,
 
-		// encoding
-		"csvdecode":  stdlib.CSVDecodeFunc,
-		"jsondecode": stdlib.JSONDecodeFunc,
-		"jsonencode": stdlib.JSONEncodeFunc,
+			// collections
+			"chunklist": stdlib.ChunklistFunc,
+			"concat":    stdlib.ConcatFunc,
+			"distinct":  stdlib.DistinctFunc,
+			"flatten":   stdlib.FlattenFunc,
+			"length":    stdlib.LengthFunc,
+			"merge":     stdlib.MergeFunc,
+			"reverse":   stdlib.ReverseListFunc,
+			"sort":      stdlib.SortFunc,
 
-		// time
-		"formatdate": stdlib.FormatDateFunc,
-		"timeadd":    stdlib.TimeAddFunc,
+			// encoding
+			"csvdecode":  stdlib.CSVDecodeFunc,
+			"jsondecode": stdlib.JSONDecodeFunc,
+			"jsonencode": stdlib.JSONEncodeFunc,
 
-		// file
-		"file": MakeFileFunc(),
-	},
+			// time
+			"formatdate": stdlib.FormatDateFunc,
+			"timeadd":    stdlib.TimeAddFunc,
+
+			// file
+			"file": MakeFileFunc(basePath),
+		},
+	}
 }
 
-func MakeFileFunc() function.Function {
+func MakeFileFunc(basePath string) function.Function {
 	return function.New(&function.Spec{
 		Params: []function.Parameter{
 			{
@@ -74,6 +80,16 @@ func MakeFileFunc() function.Function {
 		Impl: func(args []cty.Value, retType cty.Type) (cty.Value, error) {
 			path := args[0].AsString()
 			osFs := file.NewOsFs()
+
+			// Check if the given path is complete or is it relative?
+			if _, err := osFs.Stat(path); err != nil {
+				path = filepath.Join(basePath, path)
+				if _, err = osFs.Stat(path); err != nil {
+					err = function.NewArgError(0, err)
+					return cty.UnknownVal(cty.String), err
+				}
+			}
+
 			f, err := osFs.Open(path)
 			if err != nil {
 				err = function.NewArgError(0, err)

--- a/pkg/config/convert/stdlib_test.go
+++ b/pkg/config/convert/stdlib_test.go
@@ -12,7 +12,7 @@ import (
 func TestFileFunc(t *testing.T) {
 	osFs := file.NewOsFs()
 	osFs.SetFSInstance(afero.NewMemMapFs())
-	fileFunc := MakeFileFunc()
+	fileFunc := MakeFileFunc("")
 
 	// Create file with content
 	testFilePath := "/testfile"

--- a/pkg/config/convert/stdlib_test.go
+++ b/pkg/config/convert/stdlib_test.go
@@ -1,0 +1,30 @@
+package convert
+
+import (
+	"testing"
+
+	"github.com/cloudquery/cloudquery/internal/file"
+	"github.com/spf13/afero"
+	"github.com/stretchr/testify/assert"
+	"github.com/zclconf/go-cty/cty"
+)
+
+func TestFileFunc(t *testing.T) {
+	osFs := file.NewOsFs()
+	osFs.SetFSInstance(afero.NewMemMapFs())
+	fileFunc := MakeFileFunc()
+
+	// Create file with content
+	testFilePath := "/testfile"
+	f, err := osFs.Create(testFilePath)
+	assert.NoError(t, err)
+	fileContent := "teststring"
+	_, err = f.WriteString(fileContent)
+	assert.NoError(t, err)
+
+	val, err := fileFunc.Call([]cty.Value{
+		cty.StringVal(testFilePath),
+	})
+	assert.NoError(t, err)
+	assert.Equal(t, fileContent, val.AsString())
+}

--- a/pkg/config/policy_parser.go
+++ b/pkg/config/policy_parser.go
@@ -1,12 +1,13 @@
 package config
 
 import (
+	"github.com/cloudquery/cloudquery/pkg/config/convert"
 	"github.com/hashicorp/hcl/v2"
 	"github.com/hashicorp/hcl/v2/gohcl"
 )
 
-func (p *Parser) DecodePolicies(body hcl.Body, diags hcl.Diagnostics) (*PolicyWrapper, hcl.Diagnostics) {
+func (p *Parser) DecodePolicies(body hcl.Body, diags hcl.Diagnostics, basePath string) (*PolicyWrapper, hcl.Diagnostics) {
 	policyWrapper := &PolicyWrapper{}
-	contentDiags := gohcl.DecodeBody(body, nil, policyWrapper)
+	contentDiags := gohcl.DecodeBody(body, convert.GetEvalContext(basePath), policyWrapper)
 	return policyWrapper, append(diags, contentDiags...)
 }

--- a/pkg/config/policy_parser_test.go
+++ b/pkg/config/policy_parser_test.go
@@ -47,7 +47,7 @@ func TestPolicyParser_LoadConfigFromSource(t *testing.T) {
 	if diags != nil && diags.HasErrors() {
 		t.Fatal(diags.Errs())
 	}
-	policiesWrapper, diags := p.DecodePolicies(policiesRaw, diags)
+	policiesWrapper, diags := p.DecodePolicies(policiesRaw, diags, "")
 	assert.Nil(t, diags)
 
 	// Only one module should be defined for this test case

--- a/pkg/policy/manager_test.go
+++ b/pkg/policy/manager_test.go
@@ -83,11 +83,6 @@ func TestManagerImpl_RunPolicy(t *testing.T) {
 		RepositoryPath string
 	}{
 		{
-			Name:           "aws-cis-v1.20",
-			PolicyPath:     "michelvocks/cq-policy-core",
-			RepositoryPath: "aws/cis-v1.20",
-		},
-		{
 			Name:           "policy_hub_policy",
 			PolicyPath:     "cq-policy-core",
 			RepositoryPath: "test",

--- a/pkg/policy/manager_test.go
+++ b/pkg/policy/manager_test.go
@@ -83,6 +83,11 @@ func TestManagerImpl_RunPolicy(t *testing.T) {
 		RepositoryPath string
 	}{
 		{
+			Name:           "aws-cis-v1.20",
+			PolicyPath:     "michelvocks/cq-policy-core",
+			RepositoryPath: "aws/cis-v1.20",
+		},
+		{
 			Name:           "policy_hub_policy",
 			PolicyPath:     "cq-policy-core",
 			RepositoryPath: "test",


### PR DESCRIPTION
This PR implements the `file` function into the HCL parser that allows policies to specify an external path.
It also fixes two small issues with the policy execution that I noticed (error output malformed and repository path is evaluated before repository checkout).