### PR TITLE
Fixes #250 - Do not print unrelated help string on cmd error

### DIFF
--- a/cmd/completion.go
+++ b/cmd/completion.go
@@ -67,7 +67,7 @@ PS> cloudquery completion powershell > cloudquery.ps1
 	DisableFlagsInUseLine: true,
 	ValidArgs:             []string{"bash", "zsh", "fish", "powershell"},
 	Args:                  cobra.ExactValidArgs(1),
-	RunE: func(cmd *cobra.Command, args []string) error {
+	Run: handleError(func(cmd *cobra.Command, args []string) error {
 		var err error
 		switch args[0] {
 		case "bash":
@@ -80,7 +80,7 @@ PS> cloudquery completion powershell > cloudquery.ps1
 			err = cmd.Root().GenPowerShellCompletion(os.Stdout)
 		}
 		return err
-	},
+	}),
 }
 
 func init() {

--- a/cmd/drift.go
+++ b/cmd/drift.go
@@ -3,14 +3,15 @@ package cmd
 import (
 	"context"
 
-	"github.com/cloudquery/cloudquery/internal/logging"
-	"github.com/cloudquery/cloudquery/internal/signalcontext"
-	"github.com/cloudquery/cloudquery/pkg/module/drift"
-	"github.com/cloudquery/cloudquery/pkg/ui/console"
 	"github.com/rs/zerolog/log"
 	"github.com/spf13/afero"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
+
+	"github.com/cloudquery/cloudquery/internal/logging"
+	"github.com/cloudquery/cloudquery/internal/signalcontext"
+	"github.com/cloudquery/cloudquery/pkg/module/drift"
+	"github.com/cloudquery/cloudquery/pkg/ui/console"
 )
 
 const driftModuleID = "drift"
@@ -27,7 +28,7 @@ var (
 		Use:   "init",
 		Short: "Generate config for drift",
 		Long:  "Generate config for drift",
-		RunE: func(cmd *cobra.Command, args []string) error {
+		Run: handleError(func(cmd *cobra.Command, args []string) error {
 			configPath := viper.GetString("configPath")
 			ctx, _ := signalcontext.WithInterrupt(context.Background(), logging.NewZHcLog(&log.Logger, ""))
 			c, err := console.CreateClient(ctx, configPath)
@@ -37,14 +38,14 @@ var (
 			defer c.Client().Close()
 			c.GenModuleConfig(ctx, driftModuleID)
 			return nil
-		},
+		}),
 	}
 
 	driftScanCmd = &cobra.Command{
 		Use:   "scan",
 		Short: "Scan for drifts",
 		Long:  "Scan for drifts between cloud provider and IaC",
-		RunE: func(cmd *cobra.Command, args []string) error {
+		Run: handleError(func(cmd *cobra.Command, args []string) error {
 			configPath := viper.GetString("configPath")
 			ctx, _ := signalcontext.WithInterrupt(context.Background(), logging.NewZHcLog(&log.Logger, ""))
 			c, err := console.CreateClient(ctx, configPath)
@@ -59,7 +60,7 @@ var (
 				ModConfigPath: driftConfigPath,
 				OutputPath:    driftOutputPath,
 			})
-		},
+		}),
 	}
 
 	driftParams drift.RunParams

--- a/cmd/fetch.go
+++ b/cmd/fetch.go
@@ -3,12 +3,13 @@ package cmd
 import (
 	"context"
 
-	"github.com/cloudquery/cloudquery/internal/logging"
-	"github.com/cloudquery/cloudquery/internal/signalcontext"
-	"github.com/cloudquery/cloudquery/pkg/ui/console"
 	"github.com/rs/zerolog/log"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
+
+	"github.com/cloudquery/cloudquery/internal/logging"
+	"github.com/cloudquery/cloudquery/internal/signalcontext"
+	"github.com/cloudquery/cloudquery/pkg/ui/console"
 )
 
 var fetchCmd = &cobra.Command{
@@ -20,7 +21,7 @@ var fetchCmd = &cobra.Command{
 	`,
 	Example: `  # Fetch configured providers to PostgreSQL as configured in config.hcl
   cloudquery fetch`,
-	RunE: func(cmd *cobra.Command, args []string) error {
+	Run: handleError(func(cmd *cobra.Command, args []string) error {
 		configPath := viper.GetString("configPath")
 		failOnError := viper.GetBool("fail-on-error")
 
@@ -31,7 +32,7 @@ var fetchCmd = &cobra.Command{
 		}
 		defer c.Client().Close()
 		return c.Fetch(ctx, failOnError)
-	},
+	}),
 }
 
 func init() {

--- a/cmd/options.go
+++ b/cmd/options.go
@@ -18,9 +18,9 @@ Use "{{.CommandPath}} [command] --help" for more information about a command.{{e
 var optionsCmd = &cobra.Command{
 	Use:   "options",
 	Short: "Prints list of global CLI options (applies to all commands)",
-	RunE: func(cmd *cobra.Command, args []string) error {
+	Run: handleError(func(cmd *cobra.Command, args []string) error {
 		return cmd.UsageFunc()(cmd)
-	},
+	}),
 }
 
 func init() {

--- a/cmd/policy_download.go
+++ b/cmd/policy_download.go
@@ -3,12 +3,13 @@ package cmd
 import (
 	"context"
 
-	"github.com/cloudquery/cloudquery/internal/logging"
-	"github.com/cloudquery/cloudquery/internal/signalcontext"
-	"github.com/cloudquery/cloudquery/pkg/ui/console"
 	"github.com/rs/zerolog/log"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
+
+	"github.com/cloudquery/cloudquery/internal/logging"
+	"github.com/cloudquery/cloudquery/internal/signalcontext"
+	"github.com/cloudquery/cloudquery/pkg/ui/console"
 )
 
 const policyDownloadHelpMsg = "Download a policy from the CloudQuery Policy Hub"
@@ -31,7 +32,7 @@ var (
 
   # See https://hub.cloudquery.io for additional policies.`,
 		Args: cobra.ExactArgs(1),
-		RunE: func(cmd *cobra.Command, args []string) error {
+		Run: handleError(func(cmd *cobra.Command, args []string) error {
 			configPath := viper.GetString("configPath")
 			ctx, _ := signalcontext.WithInterrupt(context.Background(), logging.NewZHcLog(&log.Logger, ""))
 			c, err := console.CreateClient(ctx, configPath)
@@ -41,7 +42,7 @@ var (
 			defer c.Client().Close()
 			_ = c.DownloadPolicy(ctx, args)
 			return nil
-		},
+		}),
 	}
 )
 

--- a/cmd/policy_run.go
+++ b/cmd/policy_run.go
@@ -3,12 +3,13 @@ package cmd
 import (
 	"context"
 
-	"github.com/cloudquery/cloudquery/internal/logging"
-	"github.com/cloudquery/cloudquery/internal/signalcontext"
-	"github.com/cloudquery/cloudquery/pkg/ui/console"
 	"github.com/rs/zerolog/log"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
+
+	"github.com/cloudquery/cloudquery/internal/logging"
+	"github.com/cloudquery/cloudquery/internal/signalcontext"
+	"github.com/cloudquery/cloudquery/pkg/ui/console"
 )
 
 const policyRunHelpMsg = "Executes a policy on CloudQuery database"
@@ -35,7 +36,7 @@ var (
 
   # See https://hub.cloudquery.io for additional policies.`,
 		Args: cobra.MinimumNArgs(1),
-		RunE: func(cmd *cobra.Command, args []string) error {
+		Run: handleError(func(cmd *cobra.Command, args []string) error {
 			configPath := viper.GetString("configPath")
 			ctx, _ := signalcontext.WithInterrupt(context.Background(), logging.NewZHcLog(&log.Logger, ""))
 			c, err := console.CreateClient(ctx, configPath)
@@ -49,7 +50,7 @@ var (
 				}
 			}
 			return c.RunPolicy(ctx, args, localPath, subPath, outputPath, stopOnFailure, skipVersioning)
-		},
+		}),
 	}
 	skipDownload   bool
 	localPath      string

--- a/cmd/provider.go
+++ b/cmd/provider.go
@@ -4,13 +4,14 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/rs/zerolog/log"
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+
 	"github.com/cloudquery/cloudquery/internal/logging"
 	"github.com/cloudquery/cloudquery/internal/signalcontext"
 	"github.com/cloudquery/cloudquery/pkg/client"
 	"github.com/cloudquery/cloudquery/pkg/ui/console"
-	"github.com/rs/zerolog/log"
-	"github.com/spf13/cobra"
-	"github.com/spf13/viper"
 )
 
 var (
@@ -43,7 +44,7 @@ var (
 		Use:   "upgrade [providers,...]",
 		Short: providerUpgradeHelpMsg,
 		Long:  providerUpgradeHelpMsg,
-		RunE: func(cmd *cobra.Command, args []string) error {
+		Run: handleError(func(cmd *cobra.Command, args []string) error {
 			configPath := viper.GetString("configPath")
 			ctx, _ := signalcontext.WithInterrupt(context.Background(), logging.NewZHcLog(&log.Logger, ""))
 			c, err := console.CreateClient(ctx, configPath)
@@ -52,7 +53,7 @@ var (
 			}
 			defer c.Client().Close()
 			return c.UpgradeProviders(ctx, args)
-		},
+		}),
 	}
 
 	providerDowngradeHelpMsg = "Downgrades one or more providers schema version based on config.hcl"
@@ -60,7 +61,7 @@ var (
 		Use:   "downgrade [providers,...]",
 		Short: providerDowngradeHelpMsg,
 		Long:  providerDowngradeHelpMsg,
-		RunE: func(cmd *cobra.Command, args []string) error {
+		Run: handleError(func(cmd *cobra.Command, args []string) error {
 			configPath := viper.GetString("configPath")
 			ctx, _ := signalcontext.WithInterrupt(context.Background(), logging.NewZHcLog(&log.Logger, ""))
 			c, err := console.CreateClient(ctx, configPath)
@@ -69,7 +70,7 @@ var (
 			}
 			defer c.Client().Close()
 			return c.DowngradeProviders(ctx, args)
-		},
+		}),
 	}
 
 	providerDropHelpMsg = "Drops provider schema from database"
@@ -77,7 +78,7 @@ var (
 		Use:   "drop [provider]",
 		Short: providerDropHelpMsg,
 		Long:  providerDropHelpMsg,
-		RunE: func(cmd *cobra.Command, args []string) error {
+		Run: handleError(func(cmd *cobra.Command, args []string) error {
 			if len(args) != 1 {
 				return fmt.Errorf("missing provider name")
 			}
@@ -90,7 +91,7 @@ var (
 			defer c.Client().Close()
 			_ = c.DropProvider(ctx, args[0])
 			return nil
-		},
+		}),
 	}
 
 	providerBuildSchemaHelpMsg = "Builds provider schema on database"
@@ -98,7 +99,7 @@ var (
 		Use:   "build-schema [provider]",
 		Short: providerBuildSchemaHelpMsg,
 		Long:  providerBuildSchemaHelpMsg,
-		RunE: func(cmd *cobra.Command, args []string) error {
+		Run: handleError(func(cmd *cobra.Command, args []string) error {
 			if len(args) != 1 {
 				return fmt.Errorf("missing provider name")
 			}
@@ -110,7 +111,7 @@ var (
 			}
 			defer c.Client().Close()
 			return c.BuildProviderTables(ctx, args[0])
-		},
+		}),
 	}
 
 	providerDownloadHelpMsg = "Downloads all providers specified in config.hcl."
@@ -122,7 +123,7 @@ var (
   # Downloads all providers specified in config.hcl:
   ./cloudquery provider download
 `,
-		RunE: func(cmd *cobra.Command, args []string) error {
+		Run: handleError(func(cmd *cobra.Command, args []string) error {
 			configPath := viper.GetString("configPath")
 			ctx, _ := signalcontext.WithInterrupt(context.Background(), logging.NewZHcLog(&log.Logger, ""))
 			c, err := console.CreateClient(ctx, configPath)
@@ -131,7 +132,7 @@ var (
 			}
 			defer c.Client().Close()
 			return c.DownloadProviders(ctx)
-		},
+		}),
 	}
 )
 

--- a/cmd/util.go
+++ b/cmd/util.go
@@ -1,0 +1,16 @@
+package cmd
+
+import (
+	"os"
+
+	"github.com/spf13/cobra"
+)
+
+func handleError(f func(cmd *cobra.Command, args []string) error) func(cmd *cobra.Command, args []string) {
+	return func(cmd *cobra.Command, args []string) {
+		if err := f(cmd, args); err != nil {
+			cmd.PrintErrln(err)
+			os.Exit(1)
+		}
+	}
+}


### PR DESCRIPTION
IMHO the `SilenceUsage` option isn't the real solution to this kind of problem as it bringt other drawbacks.