### PR TITLE
Handle subresources

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -100,6 +100,9 @@ require (
 	github.com/spf13/pflag v1.0.5 // indirect
 	github.com/stretchr/objx v0.3.0 // indirect
 	github.com/subosito/gotenv v1.2.0 // indirect
+	github.com/tidwall/gjson v1.11.0 // indirect
+	github.com/tidwall/match v1.1.1 // indirect
+	github.com/tidwall/pretty v1.2.0 // indirect
 	github.com/vmihailenco/msgpack/v5 v5.3.4 // indirect
 	github.com/vmihailenco/tagparser/v2 v2.0.0 // indirect
 	github.com/xanzy/ssh-agent v0.3.0 // indirect

--- a/go.mod
+++ b/go.mod
@@ -118,4 +118,5 @@ require (
 	gopkg.in/warnings.v0 v0.1.2 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect
 	gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b // indirect
+	gotest.tools v2.2.0+incompatible // indirect
 )

--- a/go.mod
+++ b/go.mod
@@ -34,9 +34,14 @@ require (
 )
 
 require (
+	github.com/aws/aws-sdk-go v1.42.1
 	github.com/doug-martin/goqu/v9 v9.17.0
 	github.com/georgysavva/scany v0.2.9
+	github.com/google/go-cmp v0.5.6
+	github.com/jackc/pgconn v1.10.0
+	github.com/jackc/pgerrcode v0.0.0-20201024163028-a0d42d470451
 	github.com/olekukonko/tablewriter v0.0.5
+	github.com/tidwall/gjson v1.11.0
 )
 
 require (
@@ -54,7 +59,6 @@ require (
 	github.com/go-git/go-billy/v5 v5.3.1 // indirect
 	github.com/gofrs/uuid v4.0.0+incompatible // indirect
 	github.com/golang/protobuf v1.5.2 // indirect
-	github.com/google/go-cmp v0.5.6 // indirect
 	github.com/google/go-querystring v1.0.0 // indirect
 	github.com/google/uuid v1.3.0 // indirect
 	github.com/hashicorp/errwrap v1.1.0 // indirect
@@ -67,8 +71,6 @@ require (
 	github.com/imdario/mergo v0.3.12 // indirect
 	github.com/inconshreveable/mousetrap v1.0.0 // indirect
 	github.com/jackc/chunkreader/v2 v2.0.1 // indirect
-	github.com/jackc/pgconn v1.10.0 // indirect
-	github.com/jackc/pgerrcode v0.0.0-20201024163028-a0d42d470451 // indirect
 	github.com/jackc/pgio v1.0.0 // indirect
 	github.com/jackc/pgpassfile v1.0.0 // indirect
 	github.com/jackc/pgproto3/v2 v2.1.1 // indirect
@@ -100,7 +102,6 @@ require (
 	github.com/spf13/pflag v1.0.5 // indirect
 	github.com/stretchr/objx v0.3.0 // indirect
 	github.com/subosito/gotenv v1.2.0 // indirect
-	github.com/tidwall/gjson v1.11.0 // indirect
 	github.com/tidwall/match v1.1.1 // indirect
 	github.com/tidwall/pretty v1.2.0 // indirect
 	github.com/vmihailenco/msgpack/v5 v5.3.4 // indirect
@@ -108,9 +109,10 @@ require (
 	github.com/xanzy/ssh-agent v0.3.0 // indirect
 	github.com/xo/dburl v0.8.4 // indirect
 	go.uber.org/atomic v1.6.0 // indirect
-	golang.org/x/net v0.0.0-20210520170846-37e1c6afe023 // indirect
+	golang.org/x/net v0.0.0-20210614182718-04defd469f4e // indirect
 	golang.org/x/sys v0.0.0-20210927094055-39ccf1dd6fa6 // indirect
 	golang.org/x/text v0.3.6 // indirect
+	golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1 // indirect
 	google.golang.org/genproto v0.0.0-20211005153810-c76a74d43a8e // indirect
 	google.golang.org/grpc v1.41.0 // indirect
 	google.golang.org/protobuf v1.27.1 // indirect
@@ -118,5 +120,4 @@ require (
 	gopkg.in/warnings.v0 v0.1.2 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect
 	gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b // indirect
-	gotest.tools v2.2.0+incompatible // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -1109,7 +1109,13 @@ github.com/syndtr/gocapability v0.0.0-20200815063812-42c35b437635/go.mod h1:hkRG
 github.com/tchap/go-patricia v2.2.6+incompatible/go.mod h1:bmLyhP68RS6kStMGxByiQ23RP/odRBOTVjwp2cDyi6I=
 github.com/thoas/go-funk v0.9.1 h1:O549iLZqPpTUQ10ykd26sZhzD+rmR5pWhuElrhbC20M=
 github.com/thoas/go-funk v0.9.1/go.mod h1:+IWnUfUmFO1+WVYQWQtIJHeRRdaIyyYglZN7xzUPe4Q=
+github.com/tidwall/gjson v1.11.0 h1:C16pk7tQNiH6VlCrtIXL1w8GaOsi1X3W8KDkE1BuYd4=
+github.com/tidwall/gjson v1.11.0/go.mod h1:/wbyibRr2FHMks5tjHJ5F8dMZh3AcwJEMf5vlfC0lxk=
+github.com/tidwall/match v1.1.1 h1:+Ho715JplO36QYgwN9PGYNhgZvoUSc9X2c80KVTi+GA=
+github.com/tidwall/match v1.1.1/go.mod h1:eRSPERbgtNPcGhD8UCthc6PmLEQXEWd3PRB5JTxsfmM=
 github.com/tidwall/pretty v1.0.0/go.mod h1:XNkn88O1ChpSDQmQeStsy+sBenx6DDtFZJxhVysOjyk=
+github.com/tidwall/pretty v1.2.0 h1:RWIZEg2iJ8/g6fDDYzMpobmaoGh5OLl4AXtGUGPcqCs=
+github.com/tidwall/pretty v1.2.0/go.mod h1:ITEVvHYasfjBbM0u2Pg8T2nJnzm8xPwvNhhsoaGGjNU=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20170815181823-89b8d40f7ca8/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20190109142713-0ad062ec5ee5/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=
 github.com/tmccombs/hcl2json v0.3.3/go.mod h1:Y2chtz2x9bAeRTvSibVRVgbLJhLJXKlUeIvjeVdnm4w=

--- a/go.sum
+++ b/go.sum
@@ -138,6 +138,8 @@ github.com/aws/aws-lambda-go v1.23.0/go.mod h1:jJmlefzPfGnckuHdXX7/80O3BvUUi12XO
 github.com/aws/aws-sdk-go v1.15.11/go.mod h1:mFuSZ37Z9YOHbQEwBWztmVzqXrEkub65tZoCYDt7FT0=
 github.com/aws/aws-sdk-go v1.15.78/go.mod h1:E3/ieXAlvM0XWO57iftYVDLLvQ824smPP3ATZkfNZeM=
 github.com/aws/aws-sdk-go v1.17.7/go.mod h1:KmX6BPdI08NWTb3/sm4ZGu5ShLoqVDhKgpiN924inxo=
+github.com/aws/aws-sdk-go v1.42.1 h1:KJkhVJ2g2iHjznmQjeJ1J+z2IK5gOwXKikG1YOD7Meg=
+github.com/aws/aws-sdk-go v1.42.1/go.mod h1:585smgzpB/KqRA+K3y/NL/oYRqQvpNJYvLm+LY1U59Q=
 github.com/aws/aws-sdk-go-v2 v1.3.2/go.mod h1:7OaACgj2SX3XGWnrIjGlJM22h6yD6MEWKvm7levnnM8=
 github.com/aws/aws-sdk-go-v2 v1.6.0/go.mod h1:tI4KhsR5VkzlUa2DZAdwx7wCAYGwkZZ1H31PYrBFx1w=
 github.com/aws/aws-sdk-go-v2/config v1.1.5/go.mod h1:P3F1hku7qzC81txjwXnwOM6Ex6ezkU6+/557Teyb64E=
@@ -199,8 +201,6 @@ github.com/cilium/ebpf v0.4.0/go.mod h1:4tRaxcgiL706VnOzHOdBlY8IEAIdxINsQBcU4xJJ
 github.com/cilium/ebpf v0.6.2/go.mod h1:4tRaxcgiL706VnOzHOdBlY8IEAIdxINsQBcU4xJJXRs=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
 github.com/cloudflare/golz4 v0.0.0-20150217214814-ef862a3cdc58/go.mod h1:EOBUe0h4xcZ5GoxqC5SDxFQ8gwyZPKQoEzownBlhI80=
-github.com/cloudquery/cq-provider-sdk v0.5.0 h1:oSae/a4zMYLD7EIBzJs1ZzJFq+R/cY3djqHeWt15nXc=
-github.com/cloudquery/cq-provider-sdk v0.5.0/go.mod h1:R9dd0bLv9GM4KH+ckxRpvkzSYoWAE3Z0me2v2w5uCJA=
 github.com/cloudquery/cq-provider-sdk v0.5.1 h1:nRR4Pa1HTFrlTABKSxxclgiQNKktw0tJMHZbD79HLIg=
 github.com/cloudquery/cq-provider-sdk v0.5.1/go.mod h1:R9dd0bLv9GM4KH+ckxRpvkzSYoWAE3Z0me2v2w5uCJA=
 github.com/cloudquery/faker/v3 v3.7.4 h1:cCcU3r0yHpS0gqKj9rRKAGS0/hY33fBxbqCNFtDD4ec=
@@ -1325,8 +1325,9 @@ golang.org/x/net v0.0.0-20210316092652-d523dce5a7f4/go.mod h1:RBQZq4jEuRlivfhVLd
 golang.org/x/net v0.0.0-20210326060303-6b1517762897/go.mod h1:uSPa2vr4CLtc/ILN5odXGNXS6mhrKVzTaCXzk9m6W3k=
 golang.org/x/net v0.0.0-20210405180319-a5a99cb37ef4/go.mod h1:p54w0d4576C0XHj96bSt6lcn1PtDYWL6XObtHCRCNQM=
 golang.org/x/net v0.0.0-20210503060351-7fd8e65b6420/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
-golang.org/x/net v0.0.0-20210520170846-37e1c6afe023 h1:ADo5wSpq2gqaCGQWzk7S5vd//0iyyLeAratkEoG5dLE=
 golang.org/x/net v0.0.0-20210520170846-37e1c6afe023/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
+golang.org/x/net v0.0.0-20210614182718-04defd469f4e h1:XpT3nA5TvE525Ne3hInMh6+GETgn27Zfm9dxsThnX2Q=
+golang.org/x/net v0.0.0-20210614182718-04defd469f4e/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
 golang.org/x/oauth2 v0.0.0-20180227000427-d7d64896b5ff/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
 golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
 golang.org/x/oauth2 v0.0.0-20181106182150-f42d05182288/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
@@ -1734,7 +1735,6 @@ gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b/go.mod h1:K4uyk7z7BCEPqu6E+C
 gorm.io/driver/postgres v1.0.8/go.mod h1:4eOzrI1MUfm6ObJU/UcmbXyiHSs8jSwH95G5P5dxcAg=
 gorm.io/gorm v1.20.12/go.mod h1:0HFTzE/SqkGTzK6TlDPPQbAYCluiVvhzoA1+aVyzenw=
 gorm.io/gorm v1.21.4/go.mod h1:0HFTzE/SqkGTzK6TlDPPQbAYCluiVvhzoA1+aVyzenw=
-gotest.tools v2.2.0+incompatible h1:VsBPFP1AI068pPrMxtb/S8Zkgf9xEmTLJjfM+P5UIEo=
 gotest.tools v2.2.0+incompatible/go.mod h1:DsYFclhRJ6vuDpmuTbkuFWG+y2sxOXAzmJt81HFBacw=
 gotest.tools/v3 v3.0.2/go.mod h1:3SzNCllyD9/Y+b5r9JIKQ474KzkZyqLqEfYqMsX94Bk=
 gotest.tools/v3 v3.0.3/go.mod h1:Z7Lb0S5l+klDB31fvDQX8ss/FlKDxtlFlw3Oa8Ymbl8=

--- a/go.sum
+++ b/go.sum
@@ -1734,6 +1734,7 @@ gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b/go.mod h1:K4uyk7z7BCEPqu6E+C
 gorm.io/driver/postgres v1.0.8/go.mod h1:4eOzrI1MUfm6ObJU/UcmbXyiHSs8jSwH95G5P5dxcAg=
 gorm.io/gorm v1.20.12/go.mod h1:0HFTzE/SqkGTzK6TlDPPQbAYCluiVvhzoA1+aVyzenw=
 gorm.io/gorm v1.21.4/go.mod h1:0HFTzE/SqkGTzK6TlDPPQbAYCluiVvhzoA1+aVyzenw=
+gotest.tools v2.2.0+incompatible h1:VsBPFP1AI068pPrMxtb/S8Zkgf9xEmTLJjfM+P5UIEo=
 gotest.tools v2.2.0+incompatible/go.mod h1:DsYFclhRJ6vuDpmuTbkuFWG+y2sxOXAzmJt81HFBacw=
 gotest.tools/v3 v3.0.2/go.mod h1:3SzNCllyD9/Y+b5r9JIKQ474KzkZyqLqEfYqMsX94Bk=
 gotest.tools/v3 v3.0.3/go.mod h1:Z7Lb0S5l+klDB31fvDQX8ss/FlKDxtlFlw3Oa8Ymbl8=

--- a/modules/configs/drift.hcl
+++ b/modules/configs/drift.hcl
@@ -312,6 +312,7 @@ module "drift" {
 
         resource "aws_cloudfront_distribution_cache_behaviours" {
             identifiers = [ "parent.id", "path_pattern", "target_origin_id", "viewer_protocol_policy" ]
+            sets = [ "allowed_methods", "cached_methods" ]
 
             iac {
                 terraform {
@@ -361,7 +362,7 @@ module "drift" {
         }
 
         resource "aws_cloudtrail_trail_event_selectors" {
-            identifiers = [ "parent.name", sql("CASE WHEN include_management_events THEN 'true' ELSE 'false' END"), "read_write_type" ]
+            identifiers = [ "parent.name", sql("include_management_events::varchar"), "read_write_type" ]
 
             iac {
                 terraform {

--- a/modules/configs/drift.hcl
+++ b/modules/configs/drift.hcl
@@ -154,7 +154,19 @@ module "drift" {
             }
         }
 
-        # TODO: aws_apigateway_usage_plan_api_stages (tf row with type="aws_api_gateway_usage_plan".attributes->"api_stages")
+        resource "aws_apigateway_usage_plan_api_stages" {
+            identifiers = [ "usage_plan_id", "api_id", "stage" ]
+            iac {
+                terraform {
+                    type = "aws_api_gateway_usage_plan"
+                    path = "api_stages"
+                    identifiers = [ "root.id", "api_id", "stage" ]
+                    attribute_map = [
+                        "usage_plan_id=root.id"
+                    ]
+                }
+            }
+        }
 
         resource "aws_apigateway_usage_plan_keys" {
             iac {
@@ -268,7 +280,17 @@ module "drift" {
             }
         }
 
-       # TODO: aws_autoscaling_launch_configuration_block_device_mappings (tf row with type="aws_launch_configuration".attributes->"ebs_block_device")
+        resource "aws_autoscaling_launch_configuration_block_device_mappings" {
+            identifiers = [ "parent.launch_configuration_name", "device_name" ]
+
+            iac {
+                terraform {
+                    type = "aws_launch_configuration"
+                    path = "ebs_block_device"
+                    identifiers = [ "root.id", "device_name" ]
+                }
+            }
+        }
 
         resource "cloudfront.cache_policies" {
             iac {
@@ -288,11 +310,31 @@ module "drift" {
             }
         }
 
-        # TODO: aws_cloudfront_distribution_cache_behaviours (tf row with type="aws_cloudfront_distribution".attributes->"ordered_cache_behavior")
+        resource "aws_cloudfront_distribution_cache_behaviours" {
+            identifiers = [ "parent.id", "path_pattern", "target_origin_id", "viewer_protocol_policy" ]
+
+            iac {
+                terraform {
+                    type = "aws_cloudfront_distribution"
+                    path = "ordered_cache_behavior"
+                    identifiers = [ "root.id", "path_pattern", "target_origin_id", "viewer_protocol_policy" ]
+                }
+            }
+        }
 
         # TODO: aws_cache_behaviour_lambda_function_associations (no data in tests)
 
-        # TODO: aws_cloudfront_distribution_custom_error_responses (tf row with type="aws_cloudfront_distribution".attributes->"custom_error_responses")
+        resource "aws_cloudfront_distribution_custom_error_responses" {
+            identifiers = [ "parent.id", "error_code", "response_code", "response_page_path" ]
+
+            iac {
+                terraform {
+                    type = "aws_cloudfront_distribution"
+                    path = "custom_error_response"
+                    identifiers = [ "root.id", "error_code", "response_code", "response_page_path" ]
+                }
+            }
+        }
 
         resource "aws_cloudfront_distribution_origins" {
             identifiers = [ sql("SPLIT_PART(c.s3_origin_config_origin_access_identity,'/', 3)") ]
@@ -318,7 +360,17 @@ module "drift" {
             }
         }
 
-        # TODO: aws_cloudtrail_trail_event_selectors (tf row with type="aws_cloudtrail".attributes->"event_selector")
+        resource "aws_cloudtrail_trail_event_selectors" {
+            identifiers = [ "parent.name", sql("CASE WHEN include_management_events THEN 'true' ELSE 'false' END"), "read_write_type" ]
+
+            iac {
+                terraform {
+                    type = "aws_cloudtrail"
+                    path = "event_selector"
+                    identifiers = [ "root.id", "include_management_events", "read_write_type" ]
+                }
+            }
+        }
 
         resource "cloudwatch.alarms" {
             identifiers = [ "name" ]
@@ -330,7 +382,17 @@ module "drift" {
             }
         }
 
-        # TODO: aws_cloudwatch_alarm_metrics (tf row with type="aws_cloudwatch_metric_alarm".attributes->"metric_query")
+        resource "aws_cloudwatch_alarm_metrics" {
+            identifiers = [ "parent.name", "id" ]
+
+            iac {
+                terraform {
+                    type = "aws_cloudwatch_metric_alarm"
+                    path = "metric_query"
+                    identifiers = [ "root.id", "id" ]
+                }
+            }
+        }
 
         resource "cloudwatchlogs.filters" {
             identifiers = [ "name" ] # TODO: ignored "log_group_name" ?
@@ -341,7 +403,22 @@ module "drift" {
             }
         }
 
-        # TODO: aws_cloudwatchlogs_filter_metric_transformations (tf row with type="aws_cloudwatch_log_metric_filter".attributes->"metric_transformation")
+        resource "aws_cloudwatchlogs_filter_metric_transformations" {
+            identifiers = [ "parent.name", "metric_namespace", "metric_name" ]
+
+            iac {
+                terraform {
+                    type = "aws_cloudwatch_log_metric_filter"
+                    path = "metric_transformation"
+                    identifiers = [ "root.id", "namespace", "name" ]
+                    attribute_map = [
+                        "metric_namespace=namespace",
+                        "metric_name=name",
+                        "metric_value=value",
+                    ]
+                }
+            }
+        }
 
         resource "cognito.identity_pools" {
             iac {

--- a/pkg/module/drift/config.go
+++ b/pkg/module/drift/config.go
@@ -33,6 +33,7 @@ type ResourceConfig struct {
 	IgnoreAttributes  []string `hcl:"ignore_attributes,optional"`
 	Deep              *bool    `hcl:"deep,optional"`    // Check attributes if true, otherwise just match identifiers
 	Filters           []string `hcl:"filters,optional"` // SQL filters to exclude cloud providers default resources
+	Sets              []string `hcl:"sets,optional"`    // Unordered list-attributes where item order doesn't matter
 
 	IAC map[iacProvider]*IACConfig
 
@@ -83,6 +84,7 @@ func (res *ResourceConfig) applyWildResource(wild *ResourceConfig) {
 	res.IgnoreIdentifiers = mergeDedupSlices(res.IgnoreIdentifiers, wild.IgnoreIdentifiers)
 	res.IgnoreAttributes = mergeDedupSlices(res.IgnoreAttributes, wild.IgnoreAttributes)
 	res.Filters = mergeDedupSlices(res.Filters, wild.Filters)
+	res.Sets = mergeDedupSlices(res.Sets, wild.Sets)
 
 	if len(res.IAC) == 0 {
 		res.IAC = wild.IAC
@@ -242,6 +244,7 @@ func (d *Drift) applyProvider(cfg *ProviderConfig, p *cqproto.GetProviderSchemaR
 			res.IgnoreIdentifiers = replacePlaceholderInSlice(k, v, res.IgnoreIdentifiers)
 			res.Attributes = replacePlaceholderInSlice(k, v, res.Attributes)
 			res.IgnoreAttributes = replacePlaceholderInSlice(k, v, res.IgnoreAttributes)
+			res.Sets = replacePlaceholderInSlice(k, v, res.Sets)
 		}
 
 		// {$sql:*} identifiers are still not replaced

--- a/pkg/module/drift/config.go
+++ b/pkg/module/drift/config.go
@@ -40,7 +40,9 @@ type ResourceConfig struct {
 }
 
 type IACConfig struct {
-	Type string `hcl:"type,optional"`
+	Type        string   `hcl:"type,optional"`
+	Path        string   `hcl:"path,optional"`
+	Identifiers []string `hcl:"identifiers,optional"`
 
 	AttributeMap []string `hcl:"attribute_map,optional"`
 

--- a/pkg/module/drift/config_parser.go
+++ b/pkg/module/drift/config_parser.go
@@ -217,6 +217,10 @@ var (
 				Name:     "filters",
 				Required: false,
 			},
+			{
+				Name:     "sets",
+				Required: false,
+			},
 		},
 		Blocks: []hcl.BlockHeaderSchema{
 			{
@@ -305,6 +309,9 @@ func (p *Parser) decodeResourceBlock(b *hcl.Block, ctx *hcl.EvalContext) (*Resou
 	}
 	if filtersAttr, ok := content.Attributes["filters"]; ok {
 		diags = append(diags, gohcl.DecodeExpression(filtersAttr.Expr, ctx, &res.Filters)...)
+	}
+	if setsAttr, ok := content.Attributes["sets"]; ok {
+		diags = append(diags, gohcl.DecodeExpression(setsAttr.Expr, ctx, &res.Sets)...)
 	}
 
 	for _, block := range content.Blocks {

--- a/pkg/module/drift/config_parser.go
+++ b/pkg/module/drift/config_parser.go
@@ -331,7 +331,7 @@ func (p *Parser) decodeResourceBlock(b *hcl.Block, ctx *hcl.EvalContext) (*Resou
 				ia.attributeMap = make(map[string]string, len(ia.AttributeMap))
 
 				for _, v := range ia.AttributeMap {
-					parts := strings.Split(v, "=")
+					parts := strings.SplitN(v, "=", 2)
 					if len(parts) != 2 {
 						diags = append(diags, &hcl.Diagnostic{
 							Severity: hcl.DiagError,

--- a/pkg/module/drift/config_parser.go
+++ b/pkg/module/drift/config_parser.go
@@ -178,10 +178,6 @@ var (
 				Type:       "resource",
 				LabelNames: []string{"name"},
 			},
-			{
-				Type:       "subresource",
-				LabelNames: []string{"name", "sub_name"},
-			},
 		},
 		Attributes: []hcl.AttributeSchema{
 			{

--- a/pkg/module/drift/drift.go
+++ b/pkg/module/drift/drift.go
@@ -270,7 +270,7 @@ func handleIdentifiers(identifiers []string) (exp.Expression, error) {
 		}
 
 		if !usingVariable && !strings.Contains(id, ".") {
-			id = "c." + id
+			id = "c." + `"` + id + `"`
 		}
 
 		concatArgs = append(concatArgs, id, "'"+idSeparator+"'")

--- a/pkg/module/drift/drift.go
+++ b/pkg/module/drift/drift.go
@@ -150,7 +150,7 @@ func queryIntoResourceList(ctx context.Context, logger hclog.Logger, conn *pgxpo
 		var pgErr *pgconn.PgError
 		if errors.As(err, &pgErr) && pgErr.Code == pgerrcode.UndefinedTable {
 			// ERROR: relation %q does not exist
-			return nil, fmt.Errorf("cloud provider tables don't exist: Did you run `cloudquery fetch`?%q", pgErr.TableName)
+			return nil, fmt.Errorf("cloud provider tables don't exist: Did you run `cloudquery fetch`? %w", pgErr)
 		}
 
 		logger.Warn("query failed with error", "query", query, "args", args, "error", err)
@@ -248,30 +248,39 @@ func handleFilters(sel *goqu.SelectDataset, res *ResourceConfig) *goqu.SelectDat
 
 var idRegEx = regexp.MustCompile(`(?ms)^\$\{sql:(.+?)\}$`)
 
-func handleIdentifier(identifiers []string) (exp.Expression, error) {
-	switch l := len(identifiers); {
-	case l == 0:
+const idSeparator = "|"
+
+func handleIdentifiers(identifiers []string) (exp.Expression, error) {
+	idLen := len(identifiers)
+	if idLen == 0 {
 		return nil, fmt.Errorf("no identifiers to match")
-	case l > 1:
-		return nil, fmt.Errorf("multiple identifiers not supported yet")
 	}
 
-	usingVariable := false
+	concatArgs := make([]string, 0, len(identifiers)*2)
+	for i, id := range identifiers {
+		usingVariable := false
 
-	if ma := idRegEx.FindStringSubmatch(identifiers[0]); len(ma) == 2 {
-		identifiers[0] = ma[1]
-		usingVariable = true
+		if ma := idRegEx.FindStringSubmatch(id); len(ma) == 2 {
+			id = ma[1]
+			usingVariable = true
+		}
+
+		if strings.Contains(id, "${") {
+			return nil, fmt.Errorf("identifier %d still contains variable", i)
+		}
+
+		if !usingVariable && !strings.Contains(id, ".") {
+			id = "c." + id
+		}
+
+		concatArgs = append(concatArgs, id, "'"+idSeparator+"'")
 	}
 
-	if strings.Contains(identifiers[0], "${") {
-		return nil, fmt.Errorf("identifier still contains variable")
+	if idLen == 1 {
+		return goqu.L(concatArgs[0] + " AS id"), nil
 	}
 
-	if usingVariable {
-		return goqu.L("(" + identifiers[0] + ") AS id"), nil
-	}
-
-	return goqu.I("c." + identifiers[0]).As("id"), nil
+	return goqu.L("CONCAT(" + strings.Join(concatArgs[:len(concatArgs)-1], ",") + ") AS id"), nil
 }
 
 func readIACStates(iacID string, stateFiles []string) (iacProvider, interface{}, error) {

--- a/pkg/module/drift/drift.go
+++ b/pkg/module/drift/drift.go
@@ -250,6 +250,8 @@ var idRegEx = regexp.MustCompile(`(?ms)^\$\{sql:(.+?)\}$`)
 
 const idSeparator = "|"
 
+// handleIdentifiers returns an SQL expression given one or multiple identifiers. the `sql(<query>)` is also handled here.
+// Given multiple identifiers, each of them are concatenated using the idSeparator
 func handleIdentifiers(identifiers []string) (exp.Expression, error) {
 	idLen := len(identifiers)
 	if idLen == 0 {


### PR DESCRIPTION
Subresources are (often multiple) related resources contained in a terraform.Instance as attributes, under an array-typed key.

Issues:
- Some arrays are in fact "sets", ie. the order doesn't matter. We currently can't include them as PKs (identifiers) ~and can't reliably match them in deep mode either~. To fix this I tried sorting them handling TF values, but Postgres returns them unsorted so that didn't help... Looked for a function to sort an `ARRAY` type in PG, but what's recommended is to use `UNNEST()` and then do a subquery to order and `ARRAY_AGG`, which seemed to be too much. (`aws_cloudfront_distribution_cache_behaviours`)
- "root." syntax and handling in `parseTerraformInstance` is not very nice, need better handling/jsonpath to do this for us ideally...
- ~Some type issues (int vs. string typed int) throws off the deep mode comparisons, can be seen in `aws_cloudfront_distribution_custom_error_responses.response_code` (not handled) and `aws_cloudtrail_trail_event_selectors.include_management_events` (handled using `CASE WHEN`)~ fixed