### PR TITLE
Clean up module profile handling

### DIFF
--- a/cmd/drift.go
+++ b/cmd/drift.go
@@ -13,14 +13,11 @@ import (
 	"github.com/cloudquery/cloudquery/pkg/ui/console"
 )
 
-const driftModuleID = "drift"
-
 var (
 	driftCmd = &cobra.Command{
 		Use:   "drift",
 		Short: "Drift Module",
 		Long:  "Drift Module",
-		Args:  cobra.MinimumNArgs(1),
 	}
 
 	driftScanCmd = &cobra.Command{
@@ -39,8 +36,9 @@ var (
 			driftParams.StateFiles = args
 
 			return c.CallModule(ctx, console.ModuleCallRequest{
-				Name:       driftModuleID,
+				Name:       "drift",
 				Params:     driftParams,
+				Profile:    driftProfile,
 				OutputPath: driftOutputPath,
 			})
 		}),
@@ -48,7 +46,7 @@ var (
 
 	driftParams drift.RunParams
 
-	driftOutputPath string
+	driftProfile, driftOutputPath string
 )
 
 func init() {
@@ -56,13 +54,13 @@ func init() {
 
 	// generic flags
 	flags.StringVar(&driftOutputPath, "output", "", "Generate a new file at the given path with the output")
+	flags.StringVar(&driftProfile, "profile", "", "Specify drift profile")
 
 	// flags handled by the drift package
 	flags.BoolVar(&driftParams.Debug, "debug", false, "Show debug output")
 	flags.StringVar(&driftParams.TfMode, "tf-mode", "managed", "Set Terraform mode")
 	flags.BoolVar(&driftParams.ForceDeep, "deep", false, "Force deep mode")
 	flags.BoolVar(&driftParams.ListManaged, "list-managed", false, "List managed resources in output")
-	flags.StringVar(&driftParams.Profile, "profile", "", "Specify drift profile")
 
 	driftCmd.SetUsageTemplate(usageTemplateWithFlags)
 	driftCmd.AddCommand(driftScanCmd)

--- a/pkg/config/config_parser.go
+++ b/pkg/config/config_parser.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"fmt"
 	"os"
 
 	"github.com/hashicorp/hcl/v2"
@@ -91,4 +92,40 @@ func (p *Parser) decodeConfig(body hcl.Body, diags hcl.Diagnostics) (*Config, hc
 		}
 	}
 	return config, diags
+}
+
+// ReadModuleConfigProfiles separates the module config from the modules block, where block identifier is the module name.
+func ReadModuleConfigProfiles(module string, block hcl.Body) (map[string]hcl.Body, error) {
+	if block == nil {
+		return nil, nil
+	}
+
+	content, _, diags := block.PartialContent(&hcl.BodySchema{
+		Blocks: []hcl.BlockHeaderSchema{
+			{
+				Type:       module,
+				LabelNames: []string{"name"},
+			},
+		},
+	})
+	if diags.HasErrors() {
+		return nil, diags
+	}
+
+	ret := make(map[string]hcl.Body, len(content.Blocks))
+	for i := range content.Blocks {
+		if _, ok := ret[content.Blocks[i].Labels[0]]; ok {
+			return nil, hcl.Diagnostics{
+				{
+					Severity: hcl.DiagError,
+					Summary:  "Duplicate profile name",
+					Detail:   fmt.Sprintf("Profile name %q already defined", content.Blocks[i].Labels[0]),
+					Subject:  content.Blocks[i].DefRange.Ptr(),
+				},
+			}
+		}
+
+		ret[content.Blocks[i].Labels[0]] = content.Blocks[i].Body
+	}
+	return ret, nil
 }

--- a/pkg/module/drift/drift.hcl
+++ b/pkg/module/drift/drift.hcl
@@ -982,6 +982,8 @@ config {
             }
         }
 
+        # TODO: route53.domains ("aws_route53_record" but no data in tests)
+
         resource "route53.health_checks" {
             iac {
                 terraform {

--- a/pkg/module/drift/model.go
+++ b/pkg/module/drift/model.go
@@ -15,8 +15,6 @@ type RunParams struct {
 
 	IACName    string
 	StateFiles []string
-
-	Profile string
 }
 
 type Resource struct {

--- a/pkg/module/types.go
+++ b/pkg/module/types.go
@@ -3,17 +3,17 @@ package module
 import (
 	"context"
 
-	"github.com/cloudquery/cq-provider-sdk/cqproto"
-
 	"github.com/hashicorp/hcl/v2"
 	"github.com/jackc/pgx/v4/pgxpool"
+
+	"github.com/cloudquery/cq-provider-sdk/cqproto"
 )
 
 type Module interface {
 	// ID returns the name of the module
 	ID() string
 	// Configure configures the module to run
-	Configure(context.Context, map[string]hcl.Body, ModuleRunParams) error
+	Configure(context.Context, hcl.Body, ModuleRunParams) error
 	// Execute executes the module, using given args in ExecuteRequest
 	Execute(context.Context, *ExecuteRequest) *ExecutionResult
 	// ExampleConfig returns an example configuration to be put in config.hcl
@@ -24,7 +24,7 @@ type ModuleRunParams interface{}
 
 type ExecuteRequest struct {
 	// Params are the invocation parameters specific to the module
-	Params interface{}
+	Params ModuleRunParams
 
 	// Providers is the list of providers to process
 	Providers []*cqproto.GetProviderSchemaResponse

--- a/pkg/ui/console/model.go
+++ b/pkg/ui/console/model.go
@@ -10,6 +10,9 @@ type ModuleCallRequest struct {
 	// Params are the invocation parameters specific to the module
 	Params interface{}
 
+	// Profile is the selected/overridden name of the profile
+	Profile string
+
 	// OutputPath is the filename to save output to
 	OutputPath string
 }


### PR DESCRIPTION
`--profile` and profile selection is now done by the console client. (Still, we don't load/parse it unless we're invoking a module)