### PR TITLE
Enable environment variables in drift config

### DIFF
--- a/pkg/config/parser.go
+++ b/pkg/config/parser.go
@@ -46,12 +46,7 @@ func WithFS(fs afero.Fs) Option {
 // the name is lower cased then.
 func WithEnvironmentVariables(prefix string, vars []string) Option {
 	return func(p *Parser) {
-		for _, e := range vars {
-			pair := strings.SplitN(e, "=", 2)
-			if strings.HasPrefix(pair[0], prefix) {
-				p.HCLContext.Variables[strings.TrimPrefix(pair[0], prefix)] = cty.StringVal(pair[1])
-			}
-		}
+		EnvToHCLContext(&p.HCLContext, prefix, vars)
 	}
 }
 
@@ -116,4 +111,13 @@ func (p *Parser) loadFromSource(name string, data []byte, ext SourceType) (hcl.B
 	}
 
 	return file.Body, diags
+}
+
+func EnvToHCLContext(evalContext *hcl.EvalContext, prefix string, vars []string) {
+	for _, e := range vars {
+		pair := strings.SplitN(e, "=", 2)
+		if strings.HasPrefix(pair[0], prefix) {
+			evalContext.Variables[strings.TrimPrefix(pair[0], prefix)] = cty.StringVal(pair[1])
+		}
+	}
 }

--- a/pkg/module/drift/config_parser.go
+++ b/pkg/module/drift/config_parser.go
@@ -2,8 +2,10 @@ package drift
 
 import (
 	"fmt"
+	"os"
 	"strings"
 
+	"github.com/cloudquery/cloudquery/pkg/config"
 	"github.com/cloudquery/cloudquery/pkg/config/convert"
 	"github.com/hashicorp/go-version"
 	"github.com/hashicorp/hcl/v2"
@@ -37,6 +39,8 @@ func NewParser(basePath string) *Parser {
 			return cty.StringVal("${sql:" + args[0].AsString() + "}"), nil
 		},
 	})
+
+	config.EnvToHCLContext(ctx, config.EnvVarPrefix, os.Environ())
 
 	return &Parser{
 		p:          hclparse.NewParser(),

--- a/pkg/module/drift/config_parser_test.go
+++ b/pkg/module/drift/config_parser_test.go
@@ -1,0 +1,23 @@
+package drift
+
+import (
+	"os"
+	"testing"
+
+	"github.com/cloudquery/cloudquery/pkg/config"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestEnvVars(t *testing.T) {
+	const (
+		varName = "TEST_VARIABLE"
+		val     = "VALUE"
+	)
+	_ = os.Setenv(config.EnvVarPrefix+varName, val)
+
+	p := NewParser("")
+
+	varVal, ok := p.HCLContext.Variables[varName]
+	assert.True(t, ok)
+	assert.Equal(t, val, varVal.AsString())
+}


### PR DESCRIPTION
ie. set `CQ_VAR_ACCOUNT_ID=123` and use `ACCOUNT_ID` in the `aws` block as the variable.