### PR TITLE
Improve Logging For Errors

### DIFF
--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -635,8 +635,8 @@ func (c *Client) RunPolicies(ctx context.Context, req *PoliciesRunRequest) ([]*p
 		result, err := c.runPolicy(ctx, policyConfig, req)
 
 		c.Logger.Debug("Policy execution finished", "name", policyConfig.Name, "err", err)
-
 		if err != nil {
+			c.Logger.Error("Policy execution finished with error", "name", policyConfig.Name, "err", err)
 			// update the ui with the error
 			if req.RunCallback != nil {
 				req.RunCallback(policy.Update{

--- a/pkg/policy/execute.go
+++ b/pkg/policy/execute.go
@@ -252,7 +252,7 @@ func (e *Executor) ExecutePolicies(ctx context.Context, req *ExecuteRequest, pol
 		}
 	}
 	if !found && len(selector) > 0 {
-		return nil, errPolicyOrQueryNotFound
+		return nil, fmt.Errorf("policy not found with provided selector: %s", selector)
 	}
 	return &total, nil
 }

--- a/pkg/policy/execute.go
+++ b/pkg/policy/execute.go
@@ -255,7 +255,7 @@ func (e *Executor) ExecutePolicies(ctx context.Context, req *ExecuteRequest, pol
 	}
 	if !found && len(selector) > 0 {
 		e.log.Error("policy not found with provided selector", "selector", selector, "policy names", pnames)
-		return nil, fmt.Errorf("policy not found with provided selector: %s", selector)
+		return nil, errPolicyOrQueryNotFound
 	}
 	return &total, nil
 }

--- a/pkg/policy/execute.go
+++ b/pkg/policy/execute.go
@@ -239,7 +239,7 @@ func (e *Executor) ExecutePolicies(ctx context.Context, req *ExecuteRequest, pol
 	var found bool
 	total := ExecutionResult{PolicyName: req.Policy.Name, Passed: true, Results: make([]*QueryResult, 0)}
 	for _, p := range policies {
-		pnames = append(pnames, p.Name)
+		pnames[i] = p.Name
 		if len(selector) == 0 || selector[0] == p.Name {
 			found = true
 			r, err := e.executePolicy(ctx, e.progressUpdate, req, p, rest)

--- a/pkg/policy/execute.go
+++ b/pkg/policy/execute.go
@@ -232,7 +232,7 @@ func (e *Executor) createView(ctx context.Context, v *View) error {
 
 func (e *Executor) ExecutePolicies(ctx context.Context, req *ExecuteRequest, policies Policies, selector []string) (*ExecutionResult, error) {
 	var rest []string
-	var pnames []string
+	pnames := make([]string, len(policies))
 	if len(selector) > 0 {
 		rest = selector[1:]
 	}

--- a/pkg/policy/execute.go
+++ b/pkg/policy/execute.go
@@ -232,12 +232,14 @@ func (e *Executor) createView(ctx context.Context, v *View) error {
 
 func (e *Executor) ExecutePolicies(ctx context.Context, req *ExecuteRequest, policies Policies, selector []string) (*ExecutionResult, error) {
 	var rest []string
+	var pnames []string
 	if len(selector) > 0 {
 		rest = selector[1:]
 	}
 	var found bool
 	total := ExecutionResult{PolicyName: req.Policy.Name, Passed: true, Results: make([]*QueryResult, 0)}
 	for _, p := range policies {
+		pnames = append(pnames, p.Name)
 		if len(selector) == 0 || selector[0] == p.Name {
 			found = true
 			r, err := e.executePolicy(ctx, e.progressUpdate, req, p, rest)
@@ -252,6 +254,7 @@ func (e *Executor) ExecutePolicies(ctx context.Context, req *ExecuteRequest, pol
 		}
 	}
 	if !found && len(selector) > 0 {
+		e.log.Error("policy not found with provided selector", "selector", selector, "policy names", pnames)
 		return nil, fmt.Errorf("policy not found with provided selector: %s", selector)
 	}
 	return &total, nil

--- a/pkg/policy/execute.go
+++ b/pkg/policy/execute.go
@@ -238,7 +238,7 @@ func (e *Executor) ExecutePolicies(ctx context.Context, req *ExecuteRequest, pol
 	}
 	var found bool
 	total := ExecutionResult{PolicyName: req.Policy.Name, Passed: true, Results: make([]*QueryResult, 0)}
-	for _, p := range policies {
+	for i, p := range policies {
 		pnames[i] = p.Name
 		if len(selector) == 0 || selector[0] == p.Name {
 			found = true


### PR DESCRIPTION
Addresses #304 
Addresses #318 

Before fix:
``` bash
% go run main.go policy run --enable-console-log
11:31AM INF logging configured consoleLog=true fileLogging=true fileName=cloudquery.log jsonLogOutput=false logDirectory=. maxAgeInDays=3 maxBackups=3 maxSizeMB=30 verbose=false
11:31AM INF Policies to run policies=[{"Name":"public-ips","Source":"../aws/foundational_security/policy.hcl","SubPath":"","Type":"local","Version":"latest"}]
11:31AM INF Starting policies run...
11:31AM INF Loading policy args={"Name":"public-ips","Source":"../aws/foundational_security/policy.hcl","SubPath":"","Type":"local","Version":"latest"}
11:31AM INF Finished policies run...
```
after fix:
``` bash
% go run main.go policy run --enable-console-log
11:31AM INF logging configured consoleLog=true fileLogging=true fileName=cloudquery.log jsonLogOutput=false logDirectory=. maxAgeInDays=3 maxBackups=3 maxSizeMB=30 verbose=false
11:31AM INF Policies to run policies=[{"Name":"public-ips","Source":"../aws/foundational_security/policy.hcl","SubPath":"","Type":"local","Version":"latest"}]
11:31AM INF Starting policies run...
11:31AM INF Loading policy args={"Name":"public-ips","Source":"../aws/foundational_security/policy.hcl","SubPath":"","Type":"local","Version":"latest"}
11:31AM ERR Policy execution finished with error err="provider aws doesn't exist" name=public-ips
11:31AM INF Finished policies run...
```



after selector issue fix:
```
 go run main.go policy run aws --sub-path cis-v1.2.0 --enable-console-log     
12:20PM INF logging configured consoleLog=true fileLogging=true fileName=cloudquery.log jsonLogOutput=false logDirectory=. maxAgeInDays=3 maxBackups=3 maxSizeMB=30 verbose=false
12:20PM INF Policies to run policies=[{"Name":"cloudquery-policies-aws","Source":"https://github.com/cloudquery-policies/aws.git","SubPath":"cis-v1.2.0","Type":"remote","Version":""}]
12:20PM INF Starting policies run...
12:20PM INF Loading policy args={"Name":"cloudquery-policies-aws","Source":"https://github.com/cloudquery-policies/aws.git","SubPath":"cis-v1.2.0","Type":"remote","Version":""}
12:20PM INF Loading the policy args={"Name":"cloudquery-policies-aws","Source":"https://github.com/cloudquery-policies/aws.git","SubPath":"cis-v1.2.0","Type":"remote","Version":""}
12:20PM INF Cloning Policy cloudquery-policies/aws
12:20PM INF Running policy args={"Name":"cloudquery-policies-aws","Source":"https://github.com/cloudquery-policies/aws.git","SubPath":"cis-v1.2.0","Type":"remote","Version":""}
12:20PM ERR policy not found with provided selector policy names=["aws"] selector=["cis-v1.2.0"]
12:20PM ERR Policy execution finished with error err="policy not found with provided selector: [cis-v1.2.0]" name=cloudquery-policies-aws
12:20PM INF Finished policies run...
```


