### PR TITLE
Always debug telemetry

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -114,14 +114,12 @@ func init() {
 	rootCmd.PersistentFlags().Bool("skip-build-tables", false, "Skip building tables on run, this should only be true if tables already exist.")
 	rootCmd.PersistentFlags().Bool("no-telemetry", false, "NoTelemetry is true telemetry collection will be disabled")
 	rootCmd.PersistentFlags().Bool("inspect-telemetry", false, "Enable telemetry inspection")
-	rootCmd.PersistentFlags().Bool("debug-telemetry", false, "DebugTelemetry is true telemetry collection will be in debug level") // Backwards compat only
-	rootCmd.PersistentFlags().Bool("no-debug-telemetry", false, "NoDebugTelemetry is true telemetry collection will not be in debug level")
+	rootCmd.PersistentFlags().Bool("debug-telemetry", false, "DebugTelemetry is true to debug telemetry logging")
 	rootCmd.PersistentFlags().String("telemetry-endpoint", "telemetry.cloudquery.io:443", "Telemetry endpoint")
 	rootCmd.PersistentFlags().Bool("insecure-telemetry-endpoint", false, "Allow insecure connection to telemetry endpoint")
 
 	_ = rootCmd.PersistentFlags().MarkHidden("telemetry-endpoint")
 	_ = rootCmd.PersistentFlags().MarkHidden("insecure-telemetry-endpoint")
-	_ = rootCmd.PersistentFlags().MarkHidden("debug-telemetry")
 
 	_ = viper.BindPFlag("plugin-dir", rootCmd.PersistentFlags().Lookup("plugin-dir"))
 	_ = viper.BindPFlag("policy-dir", rootCmd.PersistentFlags().Lookup("policy-dir"))
@@ -133,7 +131,6 @@ func init() {
 	_ = viper.BindPFlag("no-telemetry", rootCmd.PersistentFlags().Lookup("no-verify"))
 	_ = viper.BindPFlag("inspect-telemetry", rootCmd.PersistentFlags().Lookup("inspect-telemetry"))
 	_ = viper.BindPFlag("debug-telemetry", rootCmd.PersistentFlags().Lookup("debug-telemetry"))
-	_ = viper.BindPFlag("no-debug-telemetry", rootCmd.PersistentFlags().Lookup("no-debug-telemetry"))
 	_ = viper.BindPFlag("telemetry-endpoint", rootCmd.PersistentFlags().Lookup("telemetry-endpoint"))
 	_ = viper.BindPFlag("insecure-telemetry-endpoint", rootCmd.PersistentFlags().Lookup("insecure-telemetry-endpoint"))
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -114,12 +114,14 @@ func init() {
 	rootCmd.PersistentFlags().Bool("skip-build-tables", false, "Skip building tables on run, this should only be true if tables already exist.")
 	rootCmd.PersistentFlags().Bool("no-telemetry", false, "NoTelemetry is true telemetry collection will be disabled")
 	rootCmd.PersistentFlags().Bool("inspect-telemetry", false, "Enable telemetry inspection")
-	rootCmd.PersistentFlags().Bool("debug-telemetry", false, "DebugTelemetry is true telemetry collection will be in debug level")
+	rootCmd.PersistentFlags().Bool("debug-telemetry", false, "DebugTelemetry is true telemetry collection will be in debug level") // Backwards compat only
+	rootCmd.PersistentFlags().Bool("no-debug-telemetry", false, "NoDebugTelemetry is true telemetry collection will not be in debug level")
 	rootCmd.PersistentFlags().String("telemetry-endpoint", "telemetry.cloudquery.io:443", "Telemetry endpoint")
 	rootCmd.PersistentFlags().Bool("insecure-telemetry-endpoint", false, "Allow insecure connection to telemetry endpoint")
 
 	_ = rootCmd.PersistentFlags().MarkHidden("telemetry-endpoint")
 	_ = rootCmd.PersistentFlags().MarkHidden("insecure-telemetry-endpoint")
+	_ = rootCmd.PersistentFlags().MarkHidden("debug-telemetry")
 
 	_ = viper.BindPFlag("plugin-dir", rootCmd.PersistentFlags().Lookup("plugin-dir"))
 	_ = viper.BindPFlag("policy-dir", rootCmd.PersistentFlags().Lookup("policy-dir"))
@@ -131,6 +133,7 @@ func init() {
 	_ = viper.BindPFlag("no-telemetry", rootCmd.PersistentFlags().Lookup("no-verify"))
 	_ = viper.BindPFlag("inspect-telemetry", rootCmd.PersistentFlags().Lookup("inspect-telemetry"))
 	_ = viper.BindPFlag("debug-telemetry", rootCmd.PersistentFlags().Lookup("debug-telemetry"))
+	_ = viper.BindPFlag("no-debug-telemetry", rootCmd.PersistentFlags().Lookup("no-debug-telemetry"))
 	_ = viper.BindPFlag("telemetry-endpoint", rootCmd.PersistentFlags().Lookup("telemetry-endpoint"))
 	_ = viper.BindPFlag("insecure-telemetry-endpoint", rootCmd.PersistentFlags().Lookup("insecure-telemetry-endpoint"))
 

--- a/cmd/telemetry.go
+++ b/cmd/telemetry.go
@@ -21,7 +21,7 @@ func telemetryOpts() []telemetry.Option {
 		opts = append(opts, telemetry.WithDisabled())
 	}
 
-	if viper.GetBool("debug-telemetry") {
+	if !viper.GetBool("no-debug-telemetry") {
 		opts = append(opts, telemetry.WithDebug())
 	}
 

--- a/cmd/telemetry.go
+++ b/cmd/telemetry.go
@@ -21,7 +21,7 @@ func telemetryOpts() []telemetry.Option {
 		opts = append(opts, telemetry.WithDisabled())
 	}
 
-	if !viper.GetBool("no-debug-telemetry") {
+	if viper.GetBool("debug-telemetry") {
 		opts = append(opts, telemetry.WithDebug())
 	}
 

--- a/internal/telemetry/error.go
+++ b/internal/telemetry/error.go
@@ -1,8 +1,6 @@
 package telemetry
 
 import (
-	"fmt"
-
 	"go.opentelemetry.io/otel/codes"
 	otrace "go.opentelemetry.io/otel/trace"
 )
@@ -15,12 +13,6 @@ func RecordError(span otrace.Span, err error, opts ...otrace.EventOption) {
 
 	//  TODO for fetch get table name / error type
 
-	if isDebugSpan(span) {
-		span.RecordError(err, opts...)
-		span.SetStatus(codes.Error, err.Error())
-		return
-	}
-
-	span.RecordError(fmt.Errorf("error"), opts...)
-	span.SetStatus(codes.Error, "error")
+	span.RecordError(err, opts...)
+	span.SetStatus(codes.Error, err.Error())
 }

--- a/internal/telemetry/telemetry.go
+++ b/internal/telemetry/telemetry.go
@@ -50,7 +50,7 @@ type Client struct {
 	// Build info. These are set as resource attributes in the default resource.
 	version, commit, buildDate string
 
-	// Whether we're in debug mode or not. In debug mode, error strings are sent as-is.
+	// Whether we're in debug mode or not. In debug mode, error messages from the OpenTelemetry SDK is bumped to a higher level
 	debug bool
 
 	// Whether telemetry collection is disabled. If so, a NoopTracerProvider is set, and we don't initialize the default resource
@@ -172,7 +172,6 @@ func New(ctx context.Context, options ...Option) *Client {
 func (c *Client) Tracer(ctx context.Context) (context.Context, Tracer) {
 	tw := &wrappedTracer{
 		Tracer: c.tp.Tracer("cloudquery.io/internal/telemetry"),
-		debug:  c.debug,
 	}
 	return ContextWithTracer(ctx, tw), tw
 }

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -1006,13 +1006,12 @@ func collectFetchSummaryStats(span otrace.Span, fetchSummaries map[string]Provid
 	for _, ps := range fetchSummaries {
 		totalFetched += ps.TotalResourcesFetched
 		totalWarnings += ps.Diagnostics().Warnings()
-		totalErrors += ps.Diagnostics().Errors() + uint64(len(ps.PartialFetchErrors))
+		totalErrors += ps.Diagnostics().Errors()
 
 		span.SetAttributes(
 			attribute.Int64("fetch.resources."+ps.ProviderName, int64(ps.TotalResourcesFetched)),
 			attribute.Int64("fetch.warnings."+ps.ProviderName, int64(ps.Diagnostics().Warnings())),
 			attribute.Int64("fetch.errors."+ps.ProviderName, int64(ps.Diagnostics().Errors())),
-			attribute.Int("fetch.partial_errors."+ps.ProviderName, len(ps.PartialFetchErrors)),
 		)
 		span.SetAttributes(telemetry.MapToAttributes(ps.Metrics())...)
 	}


### PR DESCRIPTION
~Keeping `--debug-telemetry` to not break any defaults, could also remove that.~

Remove error redaction from telemetry, count fixes. `--debug-telemetry` now just changes the log level for the OTEL SDK.