### PR TITLE
Report panics to Sentry

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -139,7 +139,6 @@ func init() {
 	rootCmd.SetHelpCommand(&cobra.Command{Hidden: true})
 	rootCmd.SetUsageTemplate(usageTemplate)
 	cobra.OnInitialize(initConfig, initLogging, initSentry)
-	rootCmd.PersistentPostRun = flushSentry
 }
 
 func initConfig() {

--- a/cmd/util.go
+++ b/cmd/util.go
@@ -10,6 +10,7 @@ import (
 	"github.com/cloudquery/cloudquery/internal/telemetry"
 	"github.com/cloudquery/cloudquery/pkg/ui"
 	"github.com/cloudquery/cloudquery/pkg/ui/console"
+	"github.com/getsentry/sentry-go"
 	"github.com/rs/zerolog/log"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
@@ -22,9 +23,16 @@ func handleCommand(f func(context.Context, *console.Client, *cobra.Command, []st
 		var exitWithCode int
 		defer func() {
 			if exitWithCode > 0 {
-				flushSentry(nil, nil)
 				os.Exit(exitWithCode)
 			}
+		}()
+		defer func() {
+			err := recover()
+			if err == nil {
+				return
+			}
+			sentry.CurrentHub().Recover(err)
+			panic(err)
 		}()
 
 		tele := telemetry.New(cmd.Context(), telemetryOpts()...)

--- a/internal/telemetry/error.go
+++ b/internal/telemetry/error.go
@@ -12,7 +12,10 @@ func RecordError(span otrace.Span, err error, opts ...otrace.EventOption) {
 		return
 	}
 
-	sentry.CaptureException(err)
+	sentry.WithScope(func(scope *sentry.Scope) {
+		scope.SetFingerprint([]string{span.SpanContext().TraceID().String()})
+		sentry.CaptureException(err)
+	})
 
 	span.RecordError(err, opts...)
 	span.SetStatus(codes.Error, err.Error())

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -1052,6 +1052,7 @@ func reportFetchSummaryErrors(span otrace.Span, fetchSummaries map[string]Provid
 			}
 
 			sentry.WithScope(func(scope *sentry.Scope) {
+				scope.SetFingerprint([]string{span.SpanContext().TraceID().String()})
 				scope.SetTags(map[string]string{
 					"diag_type":        e.Type().String(),
 					"provider":         ps.ProviderName,


### PR DESCRIPTION
To keep the panic in the console (`sentry.Recover()` swallows it) needed to take custom recovery actions.
Switched to Sentry's sync HTTP transport in the meantime to get rid of `flushSentry` nuances.

Closes #345.


Oh also added fingerprinting (traceID from otel) so that fetch errors are hopefully grouped.