### PR TITLE
Improve a bit misleading help message for cloudquery init

### DIFF
--- a/cmd/init.go
+++ b/cmd/init.go
@@ -20,7 +20,7 @@ const initHelpMsg = "Generate initial config.hcl for fetch command"
 
 var (
 	initCmd = &cobra.Command{
-		Use:   "init [choose one or more providers (aws,gcp,azure,okta,...)]",
+		Use:   "init [choose one or more providers (aws gcp azure okta ...)]",
 		Short: initHelpMsg,
 		Long:  initHelpMsg,
 		Example: `


### PR DESCRIPTION
The cloudquery init supports:

cloudquery aws
cloudquery aws gcp

though in one of the examples is:
cloudquery aws,gcp,azure which will result an error