### PR TITLE
Exclude context Cancelled

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -44,6 +44,7 @@ require (
 	github.com/jackc/pgconn v1.10.0
 	github.com/jackc/pgerrcode v0.0.0-20201024163028-a0d42d470451
 	github.com/jackc/pgtype v1.8.1
+	github.com/lib/pq v1.10.3
 	github.com/olekukonko/tablewriter v0.0.5
 	github.com/spf13/cast v1.4.1
 	github.com/tidwall/gjson v1.11.0
@@ -94,7 +95,6 @@ require (
 	github.com/kylelemons/godebug v1.1.0 // indirect
 	github.com/lann/builder v0.0.0-20180802200727-47ae307949d0 // indirect
 	github.com/lann/ps v0.0.0-20150810152359-62de8c46ede0 // indirect
-	github.com/lib/pq v1.10.3 // indirect
 	github.com/magiconair/properties v1.8.1 // indirect
 	github.com/mattn/go-colorable v0.1.11 // indirect
 	github.com/mattn/go-runewidth v0.0.10 // indirect

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -461,25 +461,26 @@ func (c *Client) Fetch(ctx context.Context, request FetchRequest) (res *FetchRes
 			)
 			for {
 				resp, err := stream.Recv()
-				st, ok := status.FromError(err)
 
-				if (ok && st.Code() == gcodes.Canceled) || err == io.EOF {
-
-					pLog.Info("provider finished fetch", "execution", time.Since(fetchStart).String())
-					for _, fetchError := range partialFetchResults {
-						pLog.Warn("received partial fetch error", parsePartialFetchKV(fetchError)...)
-					}
-					fetchSummaries <- ProviderFetchSummary{
-						ProviderName:          providerConfig.Name,
-						Version:               providerPlugin.Version(),
-						TotalResourcesFetched: totalResources,
-						PartialFetchErrors:    partialFetchResults,
-						FetchErrors:           fetchErrors,
-						FetchResources:        fetchedResources,
-					}
-					return nil
-				}
 				if err != nil {
+					st, ok := status.FromError(err)
+					if (ok && st.Code() == gcodes.Canceled) || err == io.EOF {
+
+						pLog.Info("provider finished fetch", "execution", time.Since(fetchStart).String())
+						for _, fetchError := range partialFetchResults {
+							pLog.Warn("received partial fetch error", parsePartialFetchKV(fetchError)...)
+						}
+						fetchSummaries <- ProviderFetchSummary{
+							ProviderName:          providerConfig.Name,
+							Version:               providerPlugin.Version(),
+							TotalResourcesFetched: totalResources,
+							PartialFetchErrors:    partialFetchResults,
+							FetchErrors:           fetchErrors,
+							FetchResources:        fetchedResources,
+						}
+						return nil
+					}
+
 					pLog.Error("received provider fetch error", "error", err)
 					return err
 				}

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -480,7 +480,6 @@ func (c *Client) Fetch(ctx context.Context, request FetchRequest) (res *FetchRes
 						}
 						return nil
 					}
-
 					pLog.Error("received provider fetch error", "error", err)
 					return err
 				}

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -471,7 +471,7 @@ func (c *Client) Fetch(ctx context.Context, request FetchRequest) (res *FetchRes
 						status := "Finished"
 						if ok && st.Code() == gcodes.Canceled {
 							message = "provider fetch canceled"
-							status = "canceled"
+							status = "Canceled"
 						}
 
 						pLog.Info(message, "execution", time.Since(fetchStart).String())

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -288,7 +288,7 @@ func New(ctx context.Context, options ...Option) (*Client, error) {
 			return nil, err
 		}
 		if err := ValidatePostgresVersion(ctx, c.pool, MinPostgresVersion); err != nil {
-			c.Logger.Warn("postgrest validation warning", "err", err)
+			c.Logger.Warn("postgres validation warning", "err", err)
 		}
 	}
 	if err := c.setupTableCreator(ctx); err != nil {
@@ -460,7 +460,7 @@ func (c *Client) Fetch(ctx context.Context, request FetchRequest) (res *FetchRes
 			)
 			for {
 				resp, err := stream.Recv()
-				if err == io.EOF {
+				if err == io.EOF || (err != nil && err.Error() == "rpc error: code = Canceled desc = context canceled") {
 					pLog.Info("provider finished fetch", "execution", time.Since(fetchStart).String())
 					for _, fetchError := range partialFetchResults {
 						pLog.Warn("received partial fetch error", parsePartialFetchKV(fetchError)...)

--- a/pkg/ui/console/client.go
+++ b/pkg/ui/console/client.go
@@ -124,8 +124,8 @@ func (c Client) Fetch(ctx context.Context, failOnError bool) error {
 	response, err := c.c.Fetch(ctx, request)
 	if err != nil {
 		// Ignore context cancelled error
-		st, ok := status.FromError(err)
-		if !ok || st.Code() != gcodes.Canceled {
+		
+		if st, ok := status.FromError(err); !ok || st.Code() != gcodes.Canceled {
 			return err
 		}
 

--- a/pkg/ui/console/client.go
+++ b/pkg/ui/console/client.go
@@ -139,8 +139,12 @@ func (c Client) Fetch(ctx context.Context, failOnError bool) error {
 
 	ui.ColorizedOutput(ui.ColorProgress, "Provider fetch complete.\n\n")
 	for _, summary := range response.ProviderFetchSummary {
-		ui.ColorizedOutput(ui.ColorHeader, "Provider %s fetch summary:  %s Total Resources fetched: %d\t ⚠️ Warnings: %d\t ❌ Errors: %d\n",
-			summary.ProviderName, emojiStatus[ui.StatusOK], summary.TotalResourcesFetched,
+		status := emojiStatus[ui.StatusOK]
+		if summary.Status == "canceled" {
+			status = emojiStatus[ui.StatusError] + " (canceled)"
+		}
+		ui.ColorizedOutput(ui.ColorHeader, "Provider %s fetch summary: %s Total Resources fetched: %d\t ⚠️ Warnings: %d\t ❌ Errors: %d\n",
+			summary.ProviderName, status, summary.TotalResourcesFetched,
 			summary.Diagnostics().Warnings(), summary.Diagnostics().Errors())
 		if failOnError && summary.HasErrors() {
 			err = fmt.Errorf("provider fetch has one or more errors")

--- a/pkg/ui/console/client.go
+++ b/pkg/ui/console/client.go
@@ -120,7 +120,7 @@ func (c Client) Fetch(ctx context.Context, failOnError bool) error {
 		DisableDataDelete: viper.GetBool("disable-delete"),
 	}
 	response, err := c.c.Fetch(ctx, request)
-	if err != nil {
+	if err != nil && err.Error() != "rpc error: code = Canceled desc = context canceled" {
 		return err
 	}
 

--- a/pkg/ui/console/client.go
+++ b/pkg/ui/console/client.go
@@ -140,7 +140,7 @@ func (c Client) Fetch(ctx context.Context, failOnError bool) error {
 	ui.ColorizedOutput(ui.ColorProgress, "Provider fetch complete.\n\n")
 	for _, summary := range response.ProviderFetchSummary {
 		status := emojiStatus[ui.StatusOK]
-		if summary.Status == "canceled" {
+		if summary.Status == "Canceled" {
 			status = emojiStatus[ui.StatusError] + " (canceled)"
 		}
 		ui.ColorizedOutput(ui.ColorHeader, "Provider %s fetch summary: %s Total Resources fetched: %d\t ⚠️ Warnings: %d\t ❌ Errors: %d\n",

--- a/pkg/ui/console/client.go
+++ b/pkg/ui/console/client.go
@@ -124,7 +124,7 @@ func (c Client) Fetch(ctx context.Context, failOnError bool) error {
 	response, err := c.c.Fetch(ctx, request)
 	if err != nil {
 		// Ignore context cancelled error
-		
+
 		if st, ok := status.FromError(err); !ok || st.Code() != gcodes.Canceled {
 			return err
 		}


### PR DESCRIPTION
Closes: #364 

Output:

```
cloudquery % go run main.go fetch
Initializing CloudQuery Providers...

✓ cq-provider-aws@v0.8.4 verified    0s  100 %

Finished provider initialization...

Upgrading CloudQuery providers [aws]

✓ Upgraded provider aws to v0.8.4 successfully.

Finished upgrading providers...

Starting provider fetch...

⚠️ cq-provider-aws@latest diagnostics: 18    3s [===========>--------------------------------------------------|  Finished Resources: 23/120
^C2021/12/27 12:26:22 28 Ctrl-c
⚠️ cq-provider-aws@latest diagnostics: 47    3s [============================>---------------------------------|  Finished Resources: 57/120

Fetch Diagnostics for provider aws:

Resource: emr.clusters Type: Access Severity: Warning
        Summary: EMR: ListClusters - User: arn:aws:sts::7049xxxxxxxx:assumed-role/NoPermissions/aws-go-sdk-1640625979772028000 is not authorized to perform: elasticmapreduce:ListClusters on resource: * because no identity-based policy allows the elasticmapreduce:ListClusters action
        Remediation: You are not authorized to perform this operation. Check your IAM policies, and ensure that you are using the correct access keys.
Resource: sns.subscriptions Type: Access Severity: Warning
        Summary: SNS: ListSubscriptions - User: arn:aws:sts::7049xxxxxxxx:assumed-role/NoPermissions/aws-go-sdk-1640625979772028000 is not authorized to perform: SNS:ListSubscriptions on resource: arn:aws:sns:us-east-1:7049xxxxxxxx:* because no identity-based policy allows the SNS:ListSubscriptions action
        Remediation: You are not authorized to perform this operation. Check your IAM policies, and ensure that you are using the correct access keys.

.
.
.

Provider fetch complete.

Provider aws fetch summary:  ✓ Total Resources fetched: 64       ⚠️ Warnings: 48  ❌ Errors: 0
```