### PR TITLE
fix lambda json conversion

### DIFF
--- a/deploy/lambda.go
+++ b/deploy/lambda.go
@@ -2,7 +2,6 @@ package deploy
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"os"
 
@@ -12,8 +11,8 @@ import (
 )
 
 type Request struct {
-	TaskName string      `json:"taskName"`
-	Config   interface{} `json:"config"`
+	TaskName string `json:"taskName"`
+	HCL      string `json:"hcl"`
 }
 
 func LambdaHandler(ctx context.Context, req Request) (string, error) {
@@ -32,14 +31,10 @@ func TaskExecutor(ctx context.Context, req Request) (string, error) {
 		policyDir = "."
 	}
 	viper.Set("policy-dir", policyDir)
-	b, err := json.Marshal(req.Config)
 
-	if err != nil {
-		return "", err
-	}
 	cfg, diags := config.NewParser(
 		config.WithEnvironmentVariables(config.EnvVarPrefix, os.Environ()),
-	).LoadConfigFromJson("config.json", b)
+	).LoadConfigFromSource("config.hcl", []byte(req.HCL))
 	if diags != nil {
 		return "", fmt.Errorf("bad configuration: %s", diags)
 	}

--- a/pkg/config/config_parser.go
+++ b/pkg/config/config_parser.go
@@ -3,6 +3,7 @@ package config
 import (
 	"fmt"
 	"os"
+	"strings"
 
 	"github.com/cloudquery/cloudquery/pkg/policy"
 
@@ -13,6 +14,14 @@ import (
 )
 
 func (p *Parser) LoadConfigFromSource(name string, data []byte) (*Config, hcl.Diagnostics) {
+	if strings.HasSuffix(name, ".json") {
+		// we dropped support for json so error out with an explainable message
+		return nil, hcl.Diagnostics{{
+			Severity: hcl.DiagError,
+			Summary:  `json is not supported please use hcl format`,
+			Detail:   `json is not supported please use hcl format`,
+		}}
+	}
 	body, diags := p.LoadFromSource(name, data)
 	if body == nil {
 		return nil, diags

--- a/pkg/config/config_parser.go
+++ b/pkg/config/config_parser.go
@@ -13,7 +13,7 @@ import (
 )
 
 func (p *Parser) LoadConfigFromSource(name string, data []byte) (*Config, hcl.Diagnostics) {
-	body, diags := p.loadFromSource(name, data)
+	body, diags := p.LoadFromSource(name, data)
 	if body == nil {
 		return nil, diags
 	}

--- a/pkg/config/config_parser.go
+++ b/pkg/config/config_parser.go
@@ -24,10 +24,6 @@ func (p *Parser) LoadConfigFromSource(name string, data []byte) (*Config, hcl.Di
 	return p.loadConfigFromSource(name, data, SourceHCL)
 }
 
-func (p *Parser) LoadConfigFromJson(name string, data []byte) (*Config, hcl.Diagnostics) {
-	return p.loadConfigFromSource(name, data, SourceJSON)
-}
-
 func (p *Parser) LoadConfigFile(path string) (*Config, hcl.Diagnostics) {
 	body, diags := p.LoadHCLFile(path)
 	if body == nil {

--- a/pkg/config/config_parser.go
+++ b/pkg/config/config_parser.go
@@ -12,16 +12,12 @@ import (
 	"github.com/spf13/viper"
 )
 
-func (p *Parser) loadConfigFromSource(name string, data []byte, source SourceType) (*Config, hcl.Diagnostics) {
-	body, diags := p.loadFromSource(name, data, source)
+func (p *Parser) LoadConfigFromSource(name string, data []byte) (*Config, hcl.Diagnostics) {
+	body, diags := p.loadFromSource(name, data)
 	if body == nil {
 		return nil, diags
 	}
 	return p.decodeConfig(body, diags)
-}
-
-func (p *Parser) LoadConfigFromSource(name string, data []byte) (*Config, hcl.Diagnostics) {
-	return p.loadConfigFromSource(name, data, SourceHCL)
 }
 
 func (p *Parser) LoadConfigFile(path string) (*Config, hcl.Diagnostics) {

--- a/pkg/config/parser.go
+++ b/pkg/config/parser.go
@@ -16,8 +16,7 @@ import (
 type SourceType string
 
 const (
-	SourceJSON = "json"
-	SourceHCL  = "hcl"
+	SourceHCL = "hcl"
 )
 
 // EnvVarPrefix is a prefix for environment variable names to be exported for HCL substitution.
@@ -103,8 +102,10 @@ func (p *Parser) loadFromSource(name string, data []byte, ext SourceType) (hcl.B
 	var file *hcl.File
 	var diags hcl.Diagnostics
 	switch ext {
-	case SourceJSON:
-		file, diags = p.p.ParseJSON(data, name)
+	// currently we support only hcl and not json as it has numerous complexities in supporting both.
+	// especially around dynamic hcl reading like done in provider block to send configuration over the wire
+	case SourceHCL:
+		file, diags = p.p.ParseHCL(data, name)
 	default:
 		file, diags = p.p.ParseHCL(data, name)
 	}

--- a/pkg/config/parser.go
+++ b/pkg/config/parser.go
@@ -3,7 +3,6 @@ package config
 import (
 	"fmt"
 	"io/fs"
-	"path/filepath"
 	"strings"
 
 	"github.com/hashicorp/hcl/v2"
@@ -78,8 +77,7 @@ func NewParser(options ...Option) *Parser {
 // callers may wish to ignore the provided error diagnostics and produce
 // a more context-sensitive error instead.
 //
-// The file will be parsed using the HCL native syntax unless the filename
-// ends with ".json", in which case the HCL JSON syntax will be used.
+// The file will be parsed using the HCL native syntax
 func (p *Parser) LoadHCLFile(path string) (hcl.Body, hcl.Diagnostics) {
 	src, err := p.fs.ReadFile(path)
 
@@ -95,20 +93,11 @@ func (p *Parser) LoadHCLFile(path string) (hcl.Body, hcl.Diagnostics) {
 			},
 		}
 	}
-	return p.loadFromSource(path, src, SourceType(filepath.Ext(path)))
+	return p.LoadFromSource(path, src)
 }
 
-func (p *Parser) loadFromSource(name string, data []byte, ext SourceType) (hcl.Body, hcl.Diagnostics) {
-	var file *hcl.File
-	var diags hcl.Diagnostics
-	switch ext {
-	// currently we support only hcl and not json as it has numerous complexities in supporting both.
-	// especially around dynamic hcl reading like done in provider block to send configuration over the wire
-	case SourceHCL:
-		file, diags = p.p.ParseHCL(data, name)
-	default:
-		file, diags = p.p.ParseHCL(data, name)
-	}
+func (p *Parser) LoadFromSource(name string, data []byte) (hcl.Body, hcl.Diagnostics) {
+	file, diags := p.p.ParseHCL(data, name)
 	// If the returned file or body is nil, then we'll return a non-nil empty
 	// body so we'll meet our contract that nil means an error reading the file.
 	if file == nil || file.Body == nil {
@@ -116,10 +105,6 @@ func (p *Parser) loadFromSource(name string, data []byte, ext SourceType) (hcl.B
 	}
 
 	return file.Body, diags
-}
-
-func (p *Parser) LoadFromSource(name string, data []byte, ext SourceType) (hcl.Body, hcl.Diagnostics) {
-	return p.loadFromSource(name, data, ext)
 }
 
 func EnvToHCLContext(evalContext *hcl.EvalContext, prefix string, vars []string) {


### PR DESCRIPTION
Description is still wip:


As we removed the jsonconverter we didn't update the lambda correctly yet.

Related to https://github.com/cloudquery/terraform-aws-cloudquery/pull/9

Also relates to this - https://github.com/hashicorp/hcl/issues/294

Supporting both json and HCL is possible but it's a real hassle and room for edge-cases so I suggest dropping this for not completly sticking to HCL unless in the future this will be requested somehow again. 