### PR TITLE
Fix policy source tests using existing tag

### DIFF
--- a/pkg/policy/source_test.go
+++ b/pkg/policy/source_test.go
@@ -50,13 +50,13 @@ func TestLoadSource(t *testing.T) {
 		},
 		{
 			Name:         "hub with ref",
-			Source:       "aws?ref=policy_v3",
+			Source:       "aws?ref=v0.1.0",
 			Expected:     true,
 			ExpectedMeta: &Meta{Type: "hub", Version: "", subPolicy: "", Directory: "tests/output/github.com/cloudquery-policies/aws"},
 		},
 		{
 			Name:         "hub with @",
-			Source:       "aws@policy_v3",
+			Source:       "aws@v0.1.0",
 			Expected:     true,
 			ExpectedMeta: &Meta{Type: "hub", Version: "", subPolicy: "", Directory: "tests/output/github.com/cloudquery-policies/aws"},
 		},
@@ -97,9 +97,9 @@ func TestLoadSource(t *testing.T) {
 		},
 		{
 			Name:         "subpolicy path with specific rev using @",
-			Source:       "github.com/cloudquery-policies/aws//cis_v1.2.0@policy_v3",
+			Source:       "github.com/cloudquery-policies/aws//cis_v1.2.0@v0.1.0",
 			Expected:     true,
-			ExpectedMeta: &Meta{Type: "github", Version: "policy_v3", subPolicy: "cis_v1.2.0", Directory: "tests/output/github.com/cloudquery-policies/aws"},
+			ExpectedMeta: &Meta{Type: "github", Version: "v0.1.0", subPolicy: "cis_v1.2.0", Directory: "tests/output/github.com/cloudquery-policies/aws"},
 		},
 	}
 


### PR DESCRIPTION
Since the `policy_v3` branch is no more the tests were failing.