### PR TITLE
feat: Adjust log messages when .cq dir is absent

### DIFF
--- a/internal/persistentdata/persistentdata.go
+++ b/internal/persistentdata/persistentdata.go
@@ -3,7 +3,9 @@ package persistentdata
 
 import (
 	"fmt"
+	"io/fs"
 	"os"
+	"path"
 	"path/filepath"
 
 	"github.com/spf13/afero"
@@ -64,6 +66,9 @@ func (c *Client) Get() (v Value, err error) {
 
 	for _, prefix := range writeOrder() {
 		v.Path = filepath.Join(prefix, dirname, c.fn)
+		if err = os.MkdirAll(path.Dir(v.Path), fs.ModePerm); err != nil {
+			continue
+		}
 		if err = c.write(v.Path, v.Content); err != nil {
 			continue
 		}

--- a/pkg/plugin/registry/hub.go
+++ b/pkg/plugin/registry/hub.go
@@ -318,7 +318,7 @@ func (h Hub) loadExisting() {
 	osFs := file.NewOsFs()
 	_ = osFs.WalkPathTree(h.PluginDirectory, func(path string, info os.FileInfo, err error) error {
 		if err != nil {
-			h.Logger.Warn("failed to read plugin directory, no existing plugins loaded", "directory", h.PluginDirectory)
+			h.Logger.Debug("failed to read plugin directory, no existing plugins loaded", "directory", h.PluginDirectory)
 			return nil
 		}
 		if info.IsDir() {


### PR DESCRIPTION
Downgrade "failed to read plugin directory" message to debug level.

Create directories when saving persistent data files.

Closes #410 