### PR TITLE
fix: Exit with 1 on policy error

### DIFF
--- a/cmd/policy_run.go
+++ b/cmd/policy_run.go
@@ -25,23 +25,19 @@ var (
   # See https://hub.cloudquery.io for additional policies.`,
 		Run: handleCommand(func(ctx context.Context, c *console.Client, cmd *cobra.Command, args []string) error {
 			if len(args) == 1 {
-				return c.RunPolicies(ctx, args[0], outputDir, stopOnFailure, failOnViolation, noResults)
+				return c.RunPolicies(ctx, args[0], outputDir, noResults)
 			}
-			return c.RunPolicies(ctx, "", outputDir, stopOnFailure, failOnViolation, noResults)
+			return c.RunPolicies(ctx, "", outputDir, noResults)
 		}),
 		Args: cobra.MaximumNArgs(1),
 	}
-	outputDir       string
-	stopOnFailure   bool
-	failOnViolation bool
-	noResults       bool
+	outputDir string
+	noResults bool
 )
 
 func init() {
 	flags := policyRunCmd.Flags()
 	flags.StringVar(&outputDir, "output-dir", "", "Generates a new file for each policy at the given dir with the output")
-	flags.BoolVar(&stopOnFailure, "stop-on-failure", false, "Stops the policy execution on the first failure")
-	flags.BoolVar(&failOnViolation, "fail-on-violation", false, "Return non zero exit code if one of the policy is violated")
 	flags.BoolVar(&noResults, "no-results", false, "Do not show policies results")
 	policyRunCmd.SetUsageTemplate(usageTemplateWithFlags)
 	policyCmd.AddCommand(policyRunCmd)

--- a/deploy/lambda.go
+++ b/deploy/lambda.go
@@ -93,10 +93,8 @@ func Policy(ctx context.Context, cfg *config.Config) error {
 		return fmt.Errorf("unable to create client: %w", err)
 	}
 	_, err = c.RunPolicies(ctx, &client.PoliciesRunRequest{
-		Policies:        cfg.Policies,
-		OutputDir:       outputPath,
-		StopOnFailure:   false,
-		FailOnViolation: false,
+		Policies:  cfg.Policies,
+		OutputDir: outputPath,
 	})
 	if err != nil {
 		return fmt.Errorf("error running query: %s", err)

--- a/pkg/ui/console/client.go
+++ b/pkg/ui/console/client.go
@@ -179,8 +179,8 @@ policy "%s" {
 	return nil
 }
 
-func (c Client) RunPolicies(ctx context.Context, policySource, outputDir string, stopOnFailure, failOnViolation, noResults bool) error {
-	c.c.Logger.Debug("run policy received params:", "policy", policySource, "outputDir", outputDir, "stopOnFailure", stopOnFailure, "failOnViolation", failOnViolation, "noResults", noResults)
+func (c Client) RunPolicies(ctx context.Context, policySource, outputDir string, noResults bool) error {
+	c.c.Logger.Debug("run policy received params:", "policy", policySource, "outputDir", outputDir, "noResults", noResults)
 	if err := c.DownloadProviders(ctx); err != nil {
 		return err
 	}
@@ -198,15 +198,13 @@ func (c Client) RunPolicies(ctx context.Context, policySource, outputDir string,
 
 	// if we are running in a terminal, build the progress bar
 	if ui.IsTerminal() {
-		policyRunProgress, policyRunCallback = buildPolicyRunProgress(ctx, policiesToRun, failOnViolation)
+		policyRunProgress, policyRunCallback = buildPolicyRunProgress(ctx, policiesToRun)
 	}
 	// Policies run request
 	req := &client.PoliciesRunRequest{
-		Policies:        policiesToRun,
-		OutputDir:       outputDir,
-		StopOnFailure:   stopOnFailure,
-		FailOnViolation: failOnViolation,
-		RunCallback:     policyRunCallback,
+		Policies:    policiesToRun,
+		OutputDir:   outputDir,
+		RunCallback: policyRunCallback,
 	}
 	results, err := c.c.RunPolicies(ctx, req)
 
@@ -564,7 +562,7 @@ func buildFetchProgress(ctx context.Context, providers []*config.Provider) (*Pro
 	return fetchProgress, fetchCallback
 }
 
-func buildPolicyRunProgress(ctx context.Context, policies policy.Policies, failOnViolation bool) (*Progress, policy.UpdateCallback) {
+func buildPolicyRunProgress(ctx context.Context, policies policy.Policies) (*Progress, policy.UpdateCallback) {
 	policyRunProgress := NewProgress(ctx, func(o *ProgressOptions) {
 		o.AppendDecorators = []decor.Decorator{decor.CountersNoUnit(" Finished Checks: %d/%d")}
 	})
@@ -586,15 +584,6 @@ func buildPolicyRunProgress(ctx context.Context, policies policy.Policies, failO
 		}
 		if update.Error != "" {
 			policyRunProgress.Update(update.PolicyName, ui.StatusError, fmt.Sprintf("error: %s", update.Error), 0)
-
-			if failOnViolation {
-				// update running progress as the process has terminated
-				for _, bar := range policyRunProgress.bars {
-					if bar.Status == ui.StatusInProgress {
-						policyRunProgress.Update(bar.Name, ui.StatusError, "execution stops", 0)
-					}
-				}
-			}
 			return
 		}
 

--- a/pkg/ui/console/model.go
+++ b/pkg/ui/console/model.go
@@ -1,6 +1,9 @@
 package console
 
-import "strconv"
+import (
+	"fmt"
+	"strconv"
+)
 
 // ModuleCallRequest is the request used to call a module.
 type ModuleCallRequest struct {
@@ -18,9 +21,10 @@ type ModuleCallRequest struct {
 }
 
 type ExitCodeError struct {
-	ExitCode int
+	OriginalError error
+	ExitCode      int
 }
 
 func (e *ExitCodeError) Error() string {
-	return "exit code " + strconv.Itoa(e.ExitCode)
+	return fmt.Sprintf("exit code %s. err: %s", strconv.Itoa(e.ExitCode), e.OriginalError.Error())
 }


### PR DESCRIPTION
Remove confusing and unused flags:
stop-on-failure
fail-on-violations

Reasoning:

If there is an internal error such as incorrect version, missing tables, there is no reason really to not stop, so this just creates additional documentation and not-intuitive default behaviour (such as not returning 1 on internal error)

 `stop-on-failure` - policies run very fast so I would eliminate that flag as well, just have a default behaviour that shows all the results.

Why I started it:

In the CI we always had to add special flags to detect errors and sometimes we missed errors because the CI didn't fail on internal errors.

