### PR TITLE
feat: Expose max_parallel_resource_fetch_limit

### DIFF
--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -438,7 +438,12 @@ func (c *Client) Fetch(ctx context.Context, request FetchRequest) (res *FetchRes
 
 			pLog.Info("requesting provider fetch", "partial_fetch_enabled", providerConfig.EnablePartialFetch)
 			fetchStart := time.Now()
-			stream, err := providerPlugin.Provider().FetchResources(ctx, &cqproto.FetchResourcesRequest{Resources: providerConfig.Resources, PartialFetchingEnabled: providerConfig.EnablePartialFetch})
+			stream, err := providerPlugin.Provider().FetchResources(ctx,
+				&cqproto.FetchResourcesRequest{
+					Resources:              providerConfig.Resources,
+					PartialFetchingEnabled: providerConfig.EnablePartialFetch,
+					ParallelFetchingLimit:  providerConfig.MaxParallelResourceFetchLimit,
+				})
 			if err != nil {
 				return err
 			}

--- a/pkg/config/provider.go
+++ b/pkg/config/provider.go
@@ -11,12 +11,13 @@ import (
 )
 
 type Provider struct {
-	Name               string   `hcl:"name,label"`
-	Alias              string   `hcl:"alias,optional"`
-	EnablePartialFetch bool     `hcl:"enable_partial_fetch,optional"`
-	Resources          []string `hcl:"resources,optional"`
-	Env                []string `hcl:"env,optional"`
-	Configuration      []byte
+	Name                          string   `hcl:"name,label"`
+	Alias                         string   `hcl:"alias,optional"`
+	EnablePartialFetch            bool     `hcl:"enable_partial_fetch,optional"`
+	Resources                     []string `hcl:"resources,optional"`
+	Env                           []string `hcl:"env,optional"`
+	Configuration                 []byte
+	MaxParallelResourceFetchLimit uint64 `hcl:"max_parallel_resource_fetch_limit"`
 }
 
 func decodeProviderBlock(block *hcl.Block, ctx *hcl.EvalContext, existingProviders map[string]bool) (*Provider, hcl.Diagnostics) {


### PR DESCRIPTION
expose max_parallel_resource_fetch_limit to allow users to limit amount of concurrent resources fetched by provider, if 0 is provider or attribute is not defined it acts as if no limit is set