### PR TITLE
feat: Increase ulimit in unix environment

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -138,7 +138,13 @@ func init() {
 
 	rootCmd.SetHelpCommand(&cobra.Command{Hidden: true})
 	rootCmd.SetUsageTemplate(usageTemplate)
-	cobra.OnInitialize(initConfig, initLogging, initSentry)
+	cobra.OnInitialize(initConfig, initLogging, initUlimit, initSentry)
+}
+
+func initUlimit() {
+	if fileDescriptorF != nil {
+		fileDescriptorF()
+	}
 }
 
 func initConfig() {

--- a/cmd/ulimit_unix.go
+++ b/cmd/ulimit_unix.go
@@ -1,0 +1,45 @@
+//go:build darwin || linux
+// +build darwin linux
+
+package cmd
+
+import (
+	"fmt"
+	"syscall"
+
+	zerolog "github.com/rs/zerolog/log"
+)
+
+const ulimitUnix uint64 = 16384
+
+func init() {
+	fileDescriptorF = checkAndSetUlimitUnix
+}
+
+func checkAndSetUlimitUnix() {
+	logger := zerolog.Logger
+	if err := setUlimit(ulimitUnix); err != nil {
+		logger.Err(fmt.Errorf("error setting ulimit: %w", err))
+	}
+}
+
+func setUlimit(ulimit uint64) error {
+	logger := zerolog.Logger
+	rLimit, err := getUlimit()
+	if err != nil {
+		logger.Err(fmt.Errorf("error getting ulimit: %w", err))
+	}
+	if rLimit.Max < ulimit {
+		logger.Debug().Uint64("previous_ulimit", rLimit.Max).Uint64("new_ulimit", ulimit).Msg("adjusting max ulimit")
+		rLimit.Max = ulimit
+	}
+	logger.Debug().Uint64("previous_ulimit", rLimit.Cur).Uint64("new_ulimit", ulimit).Msg("adjusting current ulimit")
+	rLimit.Cur = ulimit
+	return syscall.Setrlimit(syscall.RLIMIT_NOFILE, &rLimit)
+}
+
+func getUlimit() (syscall.Rlimit, error) {
+	var rLimit syscall.Rlimit
+	err := syscall.Getrlimit(syscall.RLIMIT_NOFILE, &rLimit)
+	return rLimit, err
+}

--- a/cmd/util.go
+++ b/cmd/util.go
@@ -5,18 +5,22 @@ import (
 	"os"
 	"time"
 
-	"github.com/cloudquery/cloudquery/internal/logging"
-	"github.com/cloudquery/cloudquery/internal/signalcontext"
-	"github.com/cloudquery/cloudquery/internal/telemetry"
-	"github.com/cloudquery/cloudquery/pkg/ui"
-	"github.com/cloudquery/cloudquery/pkg/ui/console"
 	"github.com/getsentry/sentry-go"
 	"github.com/rs/zerolog/log"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/trace"
+
+	"github.com/cloudquery/cloudquery/internal/logging"
+	"github.com/cloudquery/cloudquery/internal/signalcontext"
+	"github.com/cloudquery/cloudquery/internal/telemetry"
+	"github.com/cloudquery/cloudquery/pkg/ui"
+	"github.com/cloudquery/cloudquery/pkg/ui/console"
 )
+
+// fileDescriptorF gets set trough system relevant files like ulimit_unix.go
+var fileDescriptorF func()
 
 func handleCommand(f func(context.Context, *console.Client, *cobra.Command, []string) error) func(cmd *cobra.Command, args []string) {
 	return func(cmd *cobra.Command, args []string) {


### PR DESCRIPTION
The ulimit in Unix environment will be increased automatically.
Currently, we fail a lot of runs due to low limits.
In case of an error, we just log and continue.