### PR TITLE
fix: DB version validation shouldn't block on vanilla PG

### DIFF
--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -1140,10 +1140,13 @@ func (c *Client) initDatabase(ctx context.Context) error {
 		return fmt.Errorf("history is only supported on timescaledb")
 	}
 
-	if ok, err := c.dialectExecutor.Validate(ctx); !ok && err != nil {
-		return fmt.Errorf("validate: %w", err)
+	if ok, err := c.dialectExecutor.Validate(ctx); err != nil {
+		if !ok {
+			return fmt.Errorf("validate: %w", err)
+		}
+		c.Logger.Warn("database validation warning", "message", err.Error())
 	} else if !ok {
-		c.Logger.Warn("postgres validation warning: %s", err.Error())
+		c.Logger.Warn("database validation warning")
 	}
 
 	// migrate cloudquery core tables to latest version

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -1140,10 +1140,10 @@ func (c *Client) initDatabase(ctx context.Context) error {
 		return fmt.Errorf("history is only supported on timescaledb")
 	}
 
-	if ok, err := c.dialectExecutor.Validate(ctx); err != nil {
+	if ok, err := c.dialectExecutor.Validate(ctx); !ok && err != nil {
 		return fmt.Errorf("validate: %w", err)
 	} else if !ok {
-		c.Logger.Warn("postgres validation warning")
+		c.Logger.Warn("postgres validation warning: %s", err.Error())
 	}
 
 	// migrate cloudquery core tables to latest version

--- a/pkg/client/database/database.go
+++ b/pkg/client/database/database.go
@@ -16,7 +16,7 @@ type DialectExecutor interface {
 	// Setup is called on the dialect on initialization, returns the DSN (modified if necessary) to use for migrations
 	Setup(context.Context) (string, error)
 
-	// Validate is called before startup to check that the dialect can execute properly
+	// Validate is called before startup to check that the dialect can execute properly. If returns true and error is set, the error is merely logged.
 	Validate(context.Context) (bool, error)
 
 	// Finalize is called after migrations and upgrades are run

--- a/pkg/client/database/postgres/executor.go
+++ b/pkg/client/database/postgres/executor.go
@@ -37,7 +37,7 @@ func (e Executor) Validate(ctx context.Context) (bool, error) {
 	}
 
 	if err := ValidatePostgresVersion(ctx, pool, MinPostgresVersion); err != nil {
-		return false, err
+		return true, err
 	}
 
 	return true, nil


### PR DESCRIPTION
related to #431