### PR TITLE
feat: Configurable data folder

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -108,6 +108,7 @@ func init() {
 	rootCmd.PersistentFlags().IntVar(&loggerConfig.MaxSize, "max-size", 30, "MaxSize the max size in MB of the logfile before it's rolled")
 	rootCmd.PersistentFlags().IntVar(&loggerConfig.MaxBackups, "max-backups", 3, "MaxBackups the max number of rolled files to keep")
 	rootCmd.PersistentFlags().IntVar(&loggerConfig.MaxAge, "max-age", 3, "MaxAge the max age in days to keep a logfile")
+	rootCmd.PersistentFlags().String("data-dir", "./.cq", "Directory to save and load CloudQuery persistent data to (env: CQ_DATA_DIR)")
 	rootCmd.PersistentFlags().String("plugin-dir", "./.cq/providers", "Directory to save and load CloudQuery plugins from (env: CQ_PLUGIN_DIR)")
 	rootCmd.PersistentFlags().String("policy-dir", "./.cq/policies", "Directory to save and load CloudQuery policies from (env: CQ_POLICY_DIR)")
 	rootCmd.PersistentFlags().String("reattach-providers", "", "Path to reattach unmanaged plugins, mostly used for testing purposes (env: CQ_REATTACH_PROVIDERS)")
@@ -121,6 +122,7 @@ func init() {
 	_ = rootCmd.PersistentFlags().MarkHidden("telemetry-endpoint")
 	_ = rootCmd.PersistentFlags().MarkHidden("insecure-telemetry-endpoint")
 
+	_ = viper.BindPFlag("data-dir", rootCmd.PersistentFlags().Lookup("data-dir"))
 	_ = viper.BindPFlag("plugin-dir", rootCmd.PersistentFlags().Lookup("plugin-dir"))
 	_ = viper.BindPFlag("policy-dir", rootCmd.PersistentFlags().Lookup("policy-dir"))
 	_ = viper.BindPFlag("reattach-providers", rootCmd.PersistentFlags().Lookup("reattach-providers"))

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -109,8 +109,8 @@ func init() {
 	rootCmd.PersistentFlags().IntVar(&loggerConfig.MaxBackups, "max-backups", 3, "MaxBackups the max number of rolled files to keep")
 	rootCmd.PersistentFlags().IntVar(&loggerConfig.MaxAge, "max-age", 3, "MaxAge the max age in days to keep a logfile")
 	rootCmd.PersistentFlags().String("data-dir", "./.cq", "Directory to save and load CloudQuery persistent data to (env: CQ_DATA_DIR)")
-	rootCmd.PersistentFlags().String("plugin-dir", "./.cq/providers", "Directory to save and load CloudQuery plugins from (env: CQ_PLUGIN_DIR)")
-	rootCmd.PersistentFlags().String("policy-dir", "./.cq/policies", "Directory to save and load CloudQuery policies from (env: CQ_POLICY_DIR)")
+	rootCmd.PersistentFlags().String("plugin-dir", "", "Directory to save and load CloudQuery plugins from (env: CQ_PLUGIN_DIR)")
+	rootCmd.PersistentFlags().String("policy-dir", "", "Directory to save and load CloudQuery policies from (env: CQ_POLICY_DIR)")
 	rootCmd.PersistentFlags().String("reattach-providers", "", "Path to reattach unmanaged plugins, mostly used for testing purposes (env: CQ_REATTACH_PROVIDERS)")
 	rootCmd.PersistentFlags().Bool("skip-build-tables", false, "Skip building tables on run, this should only be true if tables already exist.")
 	rootCmd.PersistentFlags().Bool("no-telemetry", false, "NoTelemetry is true telemetry collection will be disabled")
@@ -118,6 +118,10 @@ func init() {
 	rootCmd.PersistentFlags().Bool("debug-telemetry", false, "DebugTelemetry is true to debug telemetry logging")
 	rootCmd.PersistentFlags().String("telemetry-endpoint", "telemetry.cloudquery.io:443", "Telemetry endpoint")
 	rootCmd.PersistentFlags().Bool("insecure-telemetry-endpoint", false, "Allow insecure connection to telemetry endpoint")
+
+	// Derived from data-dir if empty
+	_ = rootCmd.PersistentFlags().MarkHidden("plugin-dir")
+	_ = rootCmd.PersistentFlags().MarkHidden("policy-dir")
 
 	_ = rootCmd.PersistentFlags().MarkHidden("telemetry-endpoint")
 	_ = rootCmd.PersistentFlags().MarkHidden("insecure-telemetry-endpoint")

--- a/deploy/lambda.go
+++ b/deploy/lambda.go
@@ -32,6 +32,12 @@ func TaskExecutor(ctx context.Context, req Request) (string, error) {
 	}
 	viper.Set("policy-dir", policyDir)
 
+	dataDir, present := os.LookupEnv("CQ_DATA_DIR")
+	if !present {
+		dataDir = ".cq"
+	}
+	viper.Set("data-dir", dataDir)
+
 	cfg, diags := config.NewParser(
 		config.WithEnvironmentVariables(config.EnvVarPrefix, os.Environ()),
 	).LoadConfigFromSource("config.hcl", []byte(req.HCL))

--- a/deploy/lambda.go
+++ b/deploy/lambda.go
@@ -21,6 +21,11 @@ func LambdaHandler(ctx context.Context, req Request) (string, error) {
 
 func TaskExecutor(ctx context.Context, req Request) (string, error) {
 	dsn := os.Getenv("CQ_DSN")
+	dataDir, present := os.LookupEnv("CQ_DATA_DIR")
+	if !present {
+		dataDir = ".cq"
+	}
+	viper.Set("data-dir", dataDir)
 	pluginDir, present := os.LookupEnv("CQ_PLUGIN_DIR")
 	if !present {
 		pluginDir = "."
@@ -31,12 +36,6 @@ func TaskExecutor(ctx context.Context, req Request) (string, error) {
 		policyDir = "."
 	}
 	viper.Set("policy-dir", policyDir)
-
-	dataDir, present := os.LookupEnv("CQ_DATA_DIR")
-	if !present {
-		dataDir = ".cq"
-	}
-	viper.Set("data-dir", dataDir)
 
 	cfg, diags := config.NewParser(
 		config.WithEnvironmentVariables(config.EnvVarPrefix, os.Environ()),

--- a/internal/persistentdata/persistentdata_test.go
+++ b/internal/persistentdata/persistentdata_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/spf13/afero"
+	"github.com/spf13/viper"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -22,6 +23,8 @@ func TestReadOrder(t *testing.T) {
 	// write file in home dir last because "." and $HOME could be the same path
 	err = af.WriteFile(filepath.Join(home, ".cq", fn), []byte("foo"), 0644)
 	assert.NoError(t, err)
+
+	viper.Set("data-dir", "./.cq")
 
 	for i := 0; i < 2; i++ { // run it multiple times so we're sure it's not overwriting current files
 		v, err := New(af, fn, func() string { return "boo" }).Get()
@@ -42,6 +45,8 @@ func TestReadDir(t *testing.T) {
 	err = af.WriteFile(filepath.Join(home, ".cq", fn, "inner-file"), []byte("we're in a directory!"), 0644)
 	assert.NoError(t, err)
 
+	viper.Set("data-dir", "./.cq")
+
 	for i := 0; i < 2; i++ { // run it multiple times so we're sure it's not overwriting current files
 		v, err := New(af, fn, func() string { return "boo" }).Get()
 		assert.False(t, v.Created)
@@ -57,6 +62,8 @@ func TestRegularRead(t *testing.T) {
 	err := af.WriteFile(filepath.Join(".", ".cq", fn), []byte("bar"), 0644)
 	assert.NoError(t, err)
 
+	viper.Set("data-dir", "./.cq")
+
 	for i := 0; i < 2; i++ { // run it multiple times so we're sure it's not overwriting current files
 		v, err := New(af, fn, func() string { return "boo" }).Get()
 		assert.NoError(t, err)
@@ -68,6 +75,8 @@ func TestRegularRead(t *testing.T) {
 func TestGen(t *testing.T) {
 	const fn = "the-file"
 	af := afero.Afero{Fs: afero.NewMemMapFs()}
+
+	viper.Set("data-dir", "./.cq")
 
 	p := New(af, fn, func() string { return "hello" })
 	v, err := p.Get()

--- a/pkg/client/version_test.go
+++ b/pkg/client/version_test.go
@@ -9,12 +9,15 @@ import (
 	"github.com/google/go-github/v35/github"
 	"github.com/hashicorp/go-version"
 	"github.com/spf13/afero"
+	"github.com/spf13/viper"
 	"github.com/stretchr/testify/require"
 )
 
 func TestMaybeCheckForUpdate(t *testing.T) {
 	ctx := context.Background()
 	const lastUpdateCheckPath = ".cq/last-update-check"
+	viper.Set("data-dir", "./.cq")
+
 	tests := []struct {
 		name           string
 		init           func(t *testing.T, fs afero.Afero)

--- a/pkg/config/config_parser.go
+++ b/pkg/config/config_parser.go
@@ -142,7 +142,7 @@ func decodeCloudQueryBlock(block *hcl.Block, ctx *hcl.EvalContext) (CloudQuery, 
 		} else {
 			cq.PluginDirectory = dir
 		}
-	} else {
+	} else if datadir != "" {
 		cq.PluginDirectory = filepath.Join(datadir, "providers")
 	}
 
@@ -154,7 +154,7 @@ func decodeCloudQueryBlock(block *hcl.Block, ctx *hcl.EvalContext) (CloudQuery, 
 		} else {
 			cq.PolicyDirectory = dir
 		}
-	} else {
+	} else if datadir != "" {
 		cq.PolicyDirectory = filepath.Join(datadir, "policies")
 	}
 

--- a/pkg/config/config_parser.go
+++ b/pkg/config/config_parser.go
@@ -3,6 +3,7 @@ package config
 import (
 	"fmt"
 	"os"
+	"path/filepath"
 	"strings"
 
 	"github.com/creasty/defaults"
@@ -130,7 +131,10 @@ func decodeCloudQueryBlock(block *hcl.Block, ctx *hcl.EvalContext) (CloudQuery, 
 	if dsn := viper.GetString("dsn"); dsn != "" {
 		cq.Connection.DSN = dsn
 	}
-	if dir := viper.GetString("plugin-dir"); dir != "." {
+
+	datadir := viper.GetString("data-dir")
+
+	if dir := viper.GetString("plugin-dir"); dir != "" {
 		if dir == "." {
 			if dir, err := os.Getwd(); err == nil {
 				cq.PluginDirectory = dir
@@ -138,7 +142,10 @@ func decodeCloudQueryBlock(block *hcl.Block, ctx *hcl.EvalContext) (CloudQuery, 
 		} else {
 			cq.PluginDirectory = dir
 		}
+	} else {
+		cq.PluginDirectory = filepath.Join(datadir, "providers")
 	}
+
 	if dir := viper.GetString("policy-dir"); dir != "" {
 		if dir == "." {
 			if dir, err := os.Getwd(); err == nil {
@@ -147,7 +154,10 @@ func decodeCloudQueryBlock(block *hcl.Block, ctx *hcl.EvalContext) (CloudQuery, 
 		} else {
 			cq.PolicyDirectory = dir
 		}
+	} else {
+		cq.PolicyDirectory = filepath.Join(datadir, "policies")
 	}
+
 	// validate provider versions
 	for _, cp := range cq.Providers {
 		if cp.Version != "latest" && !strings.HasPrefix(cp.Version, "v") {

--- a/pkg/config/parser_test.go
+++ b/pkg/config/parser_test.go
@@ -4,7 +4,6 @@ import (
 	"testing"
 
 	"github.com/hashicorp/hcl/v2/hclsimple"
-
 	"github.com/stretchr/testify/assert"
 )
 


### PR DESCRIPTION
Implements #446.

```
	rootCmd.PersistentFlags().String("data-dir", "./.cq", "Directory to save and load CloudQuery persistent data to (env: CQ_DATA_DIR)")
	rootCmd.PersistentFlags().String("plugin-dir", "./.cq/providers", "Directory to save and load CloudQuery plugins from (env: CQ_PLUGIN_DIR)")
	rootCmd.PersistentFlags().String("policy-dir", "./.cq/policies", "Directory to save and load CloudQuery policies from (env: CQ_POLICY_DIR)")
```

Little bit too much. Maybe migrate away from plugin-dir and policy-dir in the future
