### PR TITLE
feat: Small improvements

### DIFF
--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -232,7 +232,7 @@ type Client struct {
 	// Optional: Logger framework can use to log.
 	// default: global logger provided.
 	Logger hclog.Logger
-	// Optional: Hub client to use to download plugins, the Hub is used to download and pluginManager providers binaries
+	// Hub client to use to download plugins, the Hub is used to download and pluginManager providers binaries
 	// if not specified, default cloudquery registry is used.
 	Hub registry.Hub
 	// manager manages all plugins lifecycle
@@ -260,6 +260,7 @@ func New(ctx context.Context, options ...Option) (*Client, error) {
 		HistoryCfg:         nil,
 		RegistryURL:        registry.CloudQueryRegistryURl,
 		Logger:             logging.NewZHcLog(&zerolog.Logger, ""),
+		Hub:                *registry.NewRegistryHub(registry.CloudQueryRegistryURl),
 	}
 	for _, o := range options {
 		o(c)

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -315,14 +315,14 @@ func (c *Client) CheckForProviderUpdates(ctx context.Context) ([]ProviderUpdateS
 			c.Logger.Warn("Failed check provider update", "provider", p.Name, "error", err)
 			continue
 		}
-		if version == nil {
+		if version == "" {
 			c.Logger.Debug("already at latest version", "provider", p.Name, "version", p.Version)
 			continue
 		}
 
-		if p.Version != *version {
-			summary = append(summary, ProviderUpdateSummary{p.Name, p.Version, *version})
-			c.Logger.Info("Update available", "provider", p.Name, "version", p.Version, "latestVersion", *version)
+		if p.Version != version {
+			summary = append(summary, ProviderUpdateSummary{p.Name, p.Version, version})
+			c.Logger.Info("Update available", "provider", p.Name, "version", p.Version, "latestVersion", version)
 		}
 	}
 	return summary, nil

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -302,8 +302,8 @@ type ProviderUpdateSummary struct {
 }
 
 // CheckForProviderUpdates checks for provider updates
-func (c *Client) CheckForProviderUpdates(ctx context.Context) ([]ProviderUpdateSummary, error) {
-	var summary []ProviderUpdateSummary
+func (c *Client) CheckForProviderUpdates(ctx context.Context) []ProviderUpdateSummary {
+	summary := make([]ProviderUpdateSummary, 0, len(c.Providers))
 	for _, p := range c.Providers {
 		// if version is latest it means there is no update as DownloadProvider will download the latest version automatically
 		if strings.Compare(p.Version, "latest") == 0 {
@@ -325,7 +325,7 @@ func (c *Client) CheckForProviderUpdates(ctx context.Context) ([]ProviderUpdateS
 			c.Logger.Info("Update available", "provider", p.Name, "version", p.Version, "latestVersion", version)
 		}
 	}
-	return summary, nil
+	return summary
 }
 
 func (c *Client) TestProvider(ctx context.Context, providerCfg *config.Provider) error {

--- a/pkg/client/client_test.go
+++ b/pkg/client/client_test.go
@@ -16,10 +16,13 @@ import (
 
 	"github.com/cloudquery/cloudquery/internal/test/provider"
 	"github.com/cloudquery/cloudquery/pkg/config"
+	"github.com/cloudquery/cloudquery/pkg/plugin/registry"
 	"github.com/cloudquery/cq-provider-sdk/provider/schema"
 	"github.com/cloudquery/cq-provider-sdk/serve"
 	"github.com/fsnotify/fsnotify"
 	"github.com/golang-migrate/migrate/v4"
+	"github.com/google/go-github/v35/github"
+	"github.com/hashicorp/go-hclog"
 	"github.com/hashicorp/go-version"
 	"github.com/hashicorp/hcl/v2/hclparse"
 	"github.com/jackc/pgx/v4"
@@ -708,83 +711,99 @@ func Test_collectProviderVersions(t *testing.T) {
 	}
 }
 
-func Test_CheckForProviderUpdates(t *testing.T) {
-	source := fmt.Sprintf("%s/%s", "cloudquery", "test")
-	nonExsitingSource := fmt.Sprintf("%s/%s", "cloudquery", "test1")
+func TestCheckForProviderUpdates(t *testing.T) {
+	type githubResult struct {
+		release *github.RepositoryRelease
+		err     error
+	}
+	version1 := "1.0.0"
+	version2 := "2.0.0"
 	tests := []struct {
-		name      string
-		providers []*config.RequiredProvider
-		updates   int
+		name          string
+		providers     []*config.RequiredProvider
+		githubResults []githubResult
+		want          []ProviderUpdateSummary
 	}{
 		{
-			"use of prior version of provider",
-			[]*config.RequiredProvider{
-				{
-					Name:    "test",
-					Source:  &source,
-					Version: "0.0.7",
-				},
-			},
-			1,
+			"empty list of providers",
+			nil,
+			nil,
+			[]ProviderUpdateSummary{},
 		},
 		{
-			"use of non existing provider",
-			[]*config.RequiredProvider{
-				{
-					Name:    "test1",
-					Source:  &nonExsitingSource,
-					Version: "v0.0.7",
-				},
-			},
-			0,
+			"one provider, github error",
+			[]*config.RequiredProvider{{Name: "test", Version: version1}},
+			[]githubResult{{nil, errors.New("fake")}},
+			[]ProviderUpdateSummary{},
 		},
 		{
-			"use of prior version of provider",
-			[]*config.RequiredProvider{
-				{
-					Name:    "test",
-					Source:  &source,
-					Version: "v0.0.7",
-				},
-			},
-			1,
+			"one provider, no update",
+			[]*config.RequiredProvider{{Name: "test", Version: version1}},
+			[]githubResult{{&github.RepositoryRelease{TagName: &version1}, nil}},
+			[]ProviderUpdateSummary{},
 		},
 		{
-			"direct set of latest version",
-			[]*config.RequiredProvider{
-				{
-					Name:    "test",
-					Source:  &source,
-					Version: "v0.0.11",
-				},
-			},
-			0,
+			"latest provider, no update",
+			[]*config.RequiredProvider{{Name: "test", Version: "latest"}},
+			[]githubResult{{&github.RepositoryRelease{TagName: &version1}, nil}},
+			[]ProviderUpdateSummary{},
 		},
 		{
-			"latest version using word 'latest'",
+			"two providers, one update",
 			[]*config.RequiredProvider{
-				{
-					Name:    "test",
-					Source:  &source,
-					Version: "latest",
-				},
+				{Name: "test", Version: version1},
+				{Name: "other", Version: version1},
 			},
-			0,
+			[]githubResult{
+				{&github.RepositoryRelease{TagName: &version1}, nil},
+				{&github.RepositoryRelease{TagName: &version2}, nil},
+			},
+			[]ProviderUpdateSummary{
+				{Name: "other", Version: version1, LatestVersion: version2},
+			},
+		},
+		{
+			"three providers, github error, one update",
+			[]*config.RequiredProvider{{Name: "test", Version: version1}, {Name: "other", Version: version1}, {Name: "third", Version: version1}},
+			[]githubResult{
+				{&github.RepositoryRelease{TagName: &version1}, nil},
+				{nil, errors.New("fake")},
+				{&github.RepositoryRelease{TagName: &version2}, nil},
+			},
+			[]ProviderUpdateSummary{
+				{Name: "third", Version: version1, LatestVersion: version2},
+			},
+		},
+		{
+			"three providers, three updates",
+			[]*config.RequiredProvider{{Name: "test", Version: version1}, {Name: "other", Version: version1}, {Name: "third", Version: version1}},
+			[]githubResult{
+				{&github.RepositoryRelease{TagName: &version2}, nil},
+				{&github.RepositoryRelease{TagName: &version2}, nil},
+				{&github.RepositoryRelease{TagName: &version2}, nil},
+			},
+			[]ProviderUpdateSummary{
+				{Name: "test", Version: version1, LatestVersion: version2},
+				{Name: "other", Version: version1, LatestVersion: version2},
+				{Name: "third", Version: version1, LatestVersion: version2},
+			},
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			ctx := context.Background()
-
-			c, err := New(ctx, func(options *Client) {
-				options.DSN = setupDB(t)
-				options.Providers = tt.providers
-			})
-			assert.Nil(t, err)
-			t.Cleanup(c.Close)
-			providers, err := c.CheckForProviderUpdates(ctx)
-			assert.Nil(t, err)
-			assert.Len(t, providers, tt.updates)
+			getReleaseCall := 0
+			c := Client{
+				Providers: tt.providers,
+				Logger:    hclog.Default(),
+				Hub: *registry.NewRegistryHub("", registry.WithLatestReleaseGetter(func(ctx context.Context, owner, repo string) (*github.RepositoryRelease, error) {
+					r := tt.githubResults[getReleaseCall]
+					getReleaseCall++
+					return r.release, r.err
+				})),
+			}
+			got := c.CheckForProviderUpdates(ctx)
+			assert.Equal(t, tt.want, got)
 		})
 	}
 }

--- a/pkg/plugin/registry/hub.go
+++ b/pkg/plugin/registry/hub.go
@@ -8,6 +8,7 @@ import (
 	"path/filepath"
 	"runtime"
 	"strings"
+	"time"
 
 	"github.com/cloudquery/cloudquery/internal/file"
 	"github.com/cloudquery/cloudquery/internal/logging"
@@ -21,6 +22,9 @@ import (
 
 const (
 	CloudQueryRegistryURl = "https://firestore.googleapis.com/v1/projects/hub-cloudquery/databases/(default)/documents/orgs/%s/providers/%s"
+
+	// Timeout for http requests related to CloudQuery providers version check.
+	versionCheckHTTPTimeout = time.Second * 10
 )
 
 type ProviderDetails struct {
@@ -41,16 +45,26 @@ type Hub struct {
 	url string
 	// map of downloaded providers
 	providers map[string]ProviderDetails
+
+	// getLatestRelease is a function that will return latest release from Github repo given organization and repo name.
+	getLatestRelease LatestReleaseGetter
 }
 
 type Option func(h *Hub)
 
+func WithLatestReleaseGetter(g LatestReleaseGetter) Option {
+	return func(h *Hub) {
+		h.getLatestRelease = g
+	}
+}
+
 func NewRegistryHub(url string, opts ...Option) *Hub {
 	h := &Hub{
-		PluginDirectory: filepath.Join(".", ".cq", "providers"),
-		Logger:          logging.NewZHcLog(&zerolog.Logger, ""),
-		url:             url,
-		providers:       make(map[string]ProviderDetails),
+		PluginDirectory:  filepath.Join(".", ".cq", "providers"),
+		Logger:           logging.NewZHcLog(&zerolog.Logger, ""),
+		url:              url,
+		providers:        make(map[string]ProviderDetails),
+		getLatestRelease: getLatestRelease,
 	}
 	// apply the list of options to hub
 	for _, opt := range opts {
@@ -140,30 +154,35 @@ func (h Hub) VerifyProvider(ctx context.Context, organization, providerName, ver
 	return true
 }
 
-// CheckProviderUpdate - checks if there is an update for provider, returns nil if there is no update
-func (h Hub) CheckProviderUpdate(ctx context.Context, requestedProvider *config.RequiredProvider) (*string, error) {
+// CheckProviderUpdate checks if there is an update available for the requested provider.
+// Returns a new version if there is one, otherwise empty string.
+// Call will be cancelled either if ctx is cancelled or after a timeout set by versionCheckHTTPTimeout.
+// This function should not be called for a provider having Version set to "latest".
+func (h Hub) CheckProviderUpdate(ctx context.Context, requestedProvider *config.RequiredProvider) (string, error) {
 	organization, providerName, err := parseProviderSource(requestedProvider)
 	if err != nil {
-		return nil, err
+		return "", err
 	}
 	currentVersion, err := version.NewVersion(requestedProvider.Version)
 	if err != nil {
-		return nil, fmt.Errorf("bad version: provider %s, version %s", providerName, requestedProvider.Version)
+		return "", fmt.Errorf("bad version: provider %s, version %s", providerName, requestedProvider.Version)
 	}
 
-	release, err := h.getRelease(ctx, organization, providerName, "latest")
+	ctx, cancel := context.WithTimeout(ctx, versionCheckHTTPTimeout)
+	defer cancel()
+	release, err := h.getLatestRelease(ctx, organization, ProviderRepoName(providerName))
 	if err != nil {
-		return nil, err
+		return "", err
 	}
 	latestVersion := release.GetTagName()
 	v, err := version.NewVersion(latestVersion)
 	if err != nil {
-		return nil, fmt.Errorf("bad version received: provider %s, version %s", providerName, latestVersion)
+		return "", fmt.Errorf("bad version received: provider %s, version %s", providerName, latestVersion)
 	}
 	if currentVersion.LessThan(v) {
-		return &latestVersion, nil
+		return latestVersion, nil
 	}
-	return nil, nil
+	return "", nil
 }
 
 func (h Hub) DownloadProvider(ctx context.Context, requestedProvider *config.RequiredProvider, noVerify bool) (ProviderDetails, error) {
@@ -357,4 +376,12 @@ func parseProviderSource(requestedProvider *config.RequiredProvider) (string, st
 		requestedSource = *requestedProvider.Source
 	}
 	return ParseProviderName(requestedSource)
+}
+
+type LatestReleaseGetter func(ctx context.Context, owner, repo string) (*github.RepositoryRelease, error)
+
+func getLatestRelease(ctx context.Context, owner, repo string) (*github.RepositoryRelease, error) {
+	gh := github.NewClient(nil)
+	r, _, err := gh.Repositories.GetLatestRelease(ctx, owner, repo)
+	return r, err
 }

--- a/pkg/plugin/registry/hub_test.go
+++ b/pkg/plugin/registry/hub_test.go
@@ -1,0 +1,96 @@
+package registry
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/cloudquery/cloudquery/pkg/config"
+	"github.com/google/go-github/v35/github"
+)
+
+func TestCheckProviderUpdate(t *testing.T) {
+	type githubResult struct {
+		version string
+		err     error
+	}
+	tests := []struct {
+		name              string
+		requestedProvider *config.RequiredProvider
+		github            githubResult
+		want              string
+		wantErr           bool
+	}{
+		{
+			"bad provider name",
+			&config.RequiredProvider{Name: "very/strange/name"},
+			githubResult{},
+			"",
+			true,
+		},
+		{
+			"bad local provider version",
+			&config.RequiredProvider{Name: "test", Version: "bad"},
+			githubResult{},
+			"",
+			true,
+		},
+		{
+			"github returns an error",
+			&config.RequiredProvider{Name: "test", Version: "1.0.0"},
+			githubResult{"", errors.New("fake")},
+			"",
+			true,
+		},
+		{
+			"bad remote provider version",
+			&config.RequiredProvider{Name: "test", Version: "1.0.0"},
+			githubResult{"bad", nil},
+			"",
+			true,
+		},
+		{
+			"remote version is newer",
+			&config.RequiredProvider{Name: "test", Version: "1.0.0"},
+			githubResult{"1.0.1", nil},
+			"1.0.1",
+			false,
+		},
+		{
+			"versions are equal",
+			&config.RequiredProvider{Name: "test", Version: "1.0.0"},
+			githubResult{"1.0.0", nil},
+			"",
+			false,
+		},
+		{
+			"local version is newer",
+			&config.RequiredProvider{Name: "test", Version: "1.0.1"},
+			githubResult{"1.0.0", nil},
+			"",
+			false,
+		},
+		{
+			"latest version",
+			&config.RequiredProvider{Name: "test", Version: "latest"},
+			githubResult{"1.0.0", nil},
+			"",
+			true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			h := NewRegistryHub("", WithLatestReleaseGetter(func(ctx context.Context, owner, repo string) (*github.RepositoryRelease, error) {
+				return &github.RepositoryRelease{TagName: &tt.github.version}, tt.github.err
+			}))
+			got, err := h.CheckProviderUpdate(context.Background(), tt.requestedProvider)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("Hub.CheckProviderUpdate() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if got != tt.want {
+				t.Errorf("Hub.CheckProviderUpdate() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/pkg/plugin/registry/organization.go
+++ b/pkg/plugin/registry/organization.go
@@ -22,3 +22,8 @@ func ParseProviderName(name string) (string, string, error) {
 	}
 	return "", "", fmt.Errorf("invalid provider name %s", name)
 }
+
+// ProviderRepoName returns a repository name for a given provider name.
+func ProviderRepoName(name string) string {
+	return fmt.Sprintf("cq-provider-%s", name)
+}

--- a/pkg/ui/console/client.go
+++ b/pkg/ui/console/client.go
@@ -91,7 +91,7 @@ func (c Client) DownloadProviders(ctx context.Context) error {
 		c.updater.Wait()
 	}
 	ui.ColorizedOutput(ui.ColorProgress, "Finished provider initialization...\n\n")
-	updates, _ := c.c.CheckForProviderUpdates(ctx)
+	updates := c.c.CheckForProviderUpdates(ctx)
 	for _, u := range updates {
 		ui.ColorizedOutput(ui.ColorInfo, fmt.Sprintf("Update available for provider %s: %s ➡️ %s\n\n", u.Name, u.Version, u.LatestVersion))
 	}


### PR DESCRIPTION
* Remove double import of a package
* Rewrite Client.CheckForProviderUpdates test
    Rewrite the test so that it does not depend on database availability
    and network access to a git repo.
* Add a unit test for Hub.CheckProviderUpdate
* A few cleanups
    * introduce ProviderRepoName function
    * drop unused Hub.getLatestReleaseVersion
