### PR TITLE
feat: Remove auto-prefixing env variables in config

### DIFF
--- a/cmd/init.go
+++ b/cmd/init.go
@@ -74,7 +74,7 @@ func Initialize(ctx context.Context, providers []string) error {
 
 	rootBody.AppendBlock(cqBlock)
 	cfg, diags := config.NewParser(
-		config.WithEnvironmentVariables(config.EnvVarPrefix, os.Environ()),
+		config.WithEnvironmentVariables(os.Environ()),
 	).LoadConfigFromSource("init.hcl", f.Bytes())
 	if diags.HasErrors() {
 		return diags

--- a/deploy/lambda.go
+++ b/deploy/lambda.go
@@ -38,7 +38,7 @@ func TaskExecutor(ctx context.Context, req Request) (string, error) {
 	viper.Set("policy-dir", policyDir)
 
 	cfg, diags := config.NewParser(
-		config.WithEnvironmentVariables(config.EnvVarPrefix, os.Environ()),
+		config.WithEnvironmentVariables(os.Environ()),
 	).LoadConfigFromSource("config.hcl", []byte(req.HCL))
 	if diags != nil {
 		return "", fmt.Errorf("bad configuration: %s", diags)

--- a/pkg/config/parser.go
+++ b/pkg/config/parser.go
@@ -18,6 +18,10 @@ const (
 	SourceHCL = "hcl"
 )
 
+// EnvVarPrefix is a prefix for environment variable names to be exported for HCL substitution.
+// This is going to be deprecated
+const EnvVarPrefix = "CQ_VAR_"
+
 // Parser is the main interface to read configuration files and other related
 // files from disk.
 //
@@ -107,6 +111,10 @@ func (p *Parser) LoadFromSource(name string, data []byte) (hcl.Body, hcl.Diagnos
 func EnvToHCLContext(evalContext *hcl.EvalContext, vars []string) {
 	for _, e := range vars {
 		pair := strings.SplitN(e, "=", 2)
+		// this part is just for backward compatibility and will be removed in future versions
+		if strings.HasPrefix(pair[0], EnvVarPrefix) {
+			evalContext.Variables[strings.TrimPrefix(pair[0], EnvVarPrefix)] = cty.StringVal(pair[1])
+		}
 		evalContext.Variables[pair[0]] = cty.StringVal(pair[1])
 	}
 }

--- a/pkg/config/parser.go
+++ b/pkg/config/parser.go
@@ -18,9 +18,6 @@ const (
 	SourceHCL = "hcl"
 )
 
-// EnvVarPrefix is a prefix for environment variable names to be exported for HCL substitution.
-const EnvVarPrefix = "CQ_VAR_"
-
 // Parser is the main interface to read configuration files and other related
 // files from disk.
 //
@@ -43,9 +40,9 @@ func WithFS(fs afero.Fs) Option {
 // WithEnvironmentVariables fills hcl.Context with values of environment variables given in vars.
 // Only variables that start with given prefix are considered. Prefix is removed from the name and
 // the name is lower cased then.
-func WithEnvironmentVariables(prefix string, vars []string) Option {
+func WithEnvironmentVariables(vars []string) Option {
 	return func(p *Parser) {
-		EnvToHCLContext(&p.HCLContext, prefix, vars)
+		EnvToHCLContext(&p.HCLContext, vars)
 	}
 }
 
@@ -107,11 +104,9 @@ func (p *Parser) LoadFromSource(name string, data []byte) (hcl.Body, hcl.Diagnos
 	return file.Body, diags
 }
 
-func EnvToHCLContext(evalContext *hcl.EvalContext, prefix string, vars []string) {
+func EnvToHCLContext(evalContext *hcl.EvalContext, vars []string) {
 	for _, e := range vars {
 		pair := strings.SplitN(e, "=", 2)
-		if strings.HasPrefix(pair[0], prefix) {
-			evalContext.Variables[strings.TrimPrefix(pair[0], prefix)] = cty.StringVal(pair[1])
-		}
+		evalContext.Variables[pair[0]] = cty.StringVal(pair[1])
 	}
 }

--- a/pkg/config/parser_test.go
+++ b/pkg/config/parser_test.go
@@ -238,15 +238,14 @@ func TestProviderLoadConfiguration(t *testing.T) {
 }
 
 func TestWithEnvironmentVariables(t *testing.T) {
-	const prefix = "PREFIX_"
-	p := NewParser(WithEnvironmentVariables(prefix, []string{prefix + "VAR1=value1", prefix + "Var2=value 2"}))
-	assert.Equal(t, "value1", p.HCLContext.Variables["VAR1"].AsString())
-	assert.Equal(t, "value 2", p.HCLContext.Variables["Var2"].AsString())
+	p := NewParser(WithEnvironmentVariables([]string{"CQ_VAR1=value1", "CQ_Var2=value 2"}))
+	assert.Equal(t, "value1", p.HCLContext.Variables["CQ_VAR1"].AsString())
+	assert.Equal(t, "value 2", p.HCLContext.Variables["CQ_Var2"].AsString())
 }
 
 const testEnvVarConfig = `cloudquery {
   connection {
-    dsn =  "${DSN}"
+    dsn =  "${CQ_DSN}"
   }
   provider "test" {
     source = "cloudquery"
@@ -257,7 +256,7 @@ const testEnvVarConfig = `cloudquery {
 provider "aws" {
   configuration {
 	account "dev" {
-		role_arn ="${ROLE_ARN}"
+		role_arn ="${CQ_ROLE_ARN}"
 	}
 	account "ron" {}
   }
@@ -265,9 +264,9 @@ provider "aws" {
 }`
 
 func TestConfigEnvVariableSubstitution(t *testing.T) {
-	p := NewParser(WithEnvironmentVariables(EnvVarPrefix, []string{
-		"CQ_VAR_DSN=postgres://postgres:pass@localhost:5432/postgres",
-		"CQ_VAR_ROLE_ARN=12312312",
+	p := NewParser(WithEnvironmentVariables([]string{
+		"CQ_DSN=postgres://postgres:pass@localhost:5432/postgres",
+		"CQ_ROLE_ARN=12312312",
 	}))
 	cfg, diags := p.LoadConfigFromSource("test.hcl", []byte(testEnvVarConfig))
 	if diags != nil {

--- a/pkg/module/drift/config_parser.go
+++ b/pkg/module/drift/config_parser.go
@@ -40,7 +40,7 @@ func NewParser(basePath string) *Parser {
 		},
 	})
 
-	config.EnvToHCLContext(ctx, config.EnvVarPrefix, os.Environ())
+	config.EnvToHCLContext(ctx, os.Environ())
 
 	return &Parser{
 		p:          hclparse.NewParser(),

--- a/pkg/module/drift/config_parser_test.go
+++ b/pkg/module/drift/config_parser_test.go
@@ -4,7 +4,6 @@ import (
 	"os"
 	"testing"
 
-	"github.com/cloudquery/cloudquery/pkg/config"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -13,7 +12,7 @@ func TestEnvVars(t *testing.T) {
 		varName = "TEST_VARIABLE"
 		val     = "VALUE"
 	)
-	_ = os.Setenv(config.EnvVarPrefix+varName, val)
+	_ = os.Setenv(varName, val)
 
 	p := NewParser("")
 

--- a/pkg/ui/console/client.go
+++ b/pkg/ui/console/client.go
@@ -652,7 +652,7 @@ func buildPolicyRunProgress(ctx context.Context, policies policy.Policies) (*Pro
 
 func loadConfig(path string) (*config.Config, bool) {
 	parser := config.NewParser(
-		config.WithEnvironmentVariables(config.EnvVarPrefix, os.Environ()),
+		config.WithEnvironmentVariables(os.Environ()),
 	)
 	cfg, diags := parser.LoadConfigFile(path)
 	if diags != nil {


### PR DESCRIPTION
We will have also to update docs and lambda but I think there is no need for this auto-prefixing of environment variables as it's just confusing (hit that in our k8s deployment). This way what you see in the config is what you get in the env variable. 