### PR TITLE
fix: New release not found while building

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -33,6 +33,7 @@ require (
 )
 
 require (
+	cloud.google.com/go/firestore v1.1.0
 	github.com/ProtonMail/go-crypto v0.0.0-20211221144345-a4f6767435ab
 	github.com/aws/aws-sdk-go v1.42.1
 	github.com/creasty/defaults v1.5.2
@@ -55,6 +56,7 @@ require (
 	go.opentelemetry.io/otel/exporters/stdout/stdouttrace v1.2.0
 	go.opentelemetry.io/otel/sdk v1.2.0
 	go.opentelemetry.io/otel/trace v1.2.0
+	google.golang.org/api v0.51.0
 	google.golang.org/grpc v1.42.0
 )
 
@@ -132,7 +134,6 @@ require (
 	golang.org/x/text v0.3.7 // indirect
 	golang.org/x/tools v0.1.5 // indirect
 	golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1 // indirect
-	google.golang.org/api v0.51.0 // indirect
 	google.golang.org/appengine v1.6.7 // indirect
 	google.golang.org/genproto v0.0.0-20211129164237-f09f9a12af12 // indirect
 	google.golang.org/protobuf v1.27.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -34,6 +34,7 @@ cloud.google.com/go/bigquery v1.7.0/go.mod h1://okPTzCYNXSlb24MZs83e2Do+h+VXtc4g
 cloud.google.com/go/bigquery v1.8.0/go.mod h1:J5hqkt3O0uAFnINi6JXValWIb1v0goeZM77hZzJN/fQ=
 cloud.google.com/go/datastore v1.0.0/go.mod h1:LXYbyblFSglQ5pkeyhO+Qmw7ukd3C+pD7TKLgZqpHYE=
 cloud.google.com/go/datastore v1.1.0/go.mod h1:umbIZjpQpHh4hmRpGhH4tLFup+FVzqBi1b3c64qFpCk=
+cloud.google.com/go/firestore v1.1.0 h1:9x7Bx0A9R5/M9jibeJeZWqjeVEIxYW9fZYqB9a70/bY=
 cloud.google.com/go/firestore v1.1.0/go.mod h1:ulACoGHTpvq5r8rxGJ4ddJZBZqakUQqClKRT5SZwBmk=
 cloud.google.com/go/pubsub v1.0.1/go.mod h1:R0Gpsv3s54REJCy4fxDixWD93lHJMoZTyQ2kNxGRt3I=
 cloud.google.com/go/pubsub v1.1.0/go.mod h1:EwwdRX2sKPjnvnqCa270oGRyludottCI76h+R3AArQw=

--- a/pkg/plugin/registry/hub.go
+++ b/pkg/plugin/registry/hub.go
@@ -275,8 +275,20 @@ func (h Hub) getRelease(ctx context.Context, organization, providerName, version
 		release, _, err := client.Repositories.GetReleaseByTag(ctx, organization, ProviderRepoName(providerName), version)
 		return release, err
 	}
-	release, _, err := client.Repositories.GetLatestRelease(ctx, organization, ProviderRepoName(providerName))
-	return release, err
+	releases, _, err := client.Repositories.ListReleases(ctx, organization, ProviderRepoName(providerName), &github.ListOptions{
+		Page:    0,
+		PerPage: 2,
+	})
+	if err != nil {
+		return nil, err
+	}
+	if len(releases) == 1 {
+		return releases[0], nil
+	}
+	if len(releases[0].Assets) < len(releases[1].Assets) {
+		return releases[1], nil
+	}
+	return releases[0], nil
 }
 
 func (h Hub) verifyRegistered(organization, providerName, version string, noVerify bool) bool {


### PR DESCRIPTION
while creating a new release, the tag is created but the binary hasn't compiled yet, we want to avoid this by fetching the prior release until all assets are added.