### PR TITLE
feat: Use provider name/version as exception type when reporting diagnostics to Sentry

### DIFF
--- a/cmd/sentry.go
+++ b/cmd/sentry.go
@@ -79,13 +79,6 @@ func initSentry() {
 				event.Exception[i].Stacktrace = nil
 			}
 
-			//if len(event.Exception) > 0 && hint != nil && hint.OriginalException != nil {
-			//	if d, ok := hint.OriginalException.(diag.Diagnostic); ok {
-			//		if d.Description().Summary != "" {
-			//			event.Exception[0].Type = d.Description().Summary
-			//		}
-			//	}
-			//}
 			if len(event.Exception) > 0 {
 				if event.Tags["provider"] != "" {
 					event.Exception[0].Type = "Diag:" + event.Tags["provider"] + "@" + event.Tags["provider_version"]

--- a/cmd/sentry.go
+++ b/cmd/sentry.go
@@ -78,6 +78,20 @@ func initSentry() {
 			for i := range event.Exception {
 				event.Exception[i].Stacktrace = nil
 			}
+
+			//if len(event.Exception) > 0 && hint != nil && hint.OriginalException != nil {
+			//	if d, ok := hint.OriginalException.(diag.Diagnostic); ok {
+			//		if d.Description().Summary != "" {
+			//			event.Exception[0].Type = d.Description().Summary
+			//		}
+			//	}
+			//}
+			if len(event.Exception) > 0 {
+				if event.Tags["provider"] != "" {
+					event.Exception[0].Type = "Diag:" + event.Tags["provider"] + "@" + event.Tags["provider_version"]
+				}
+			}
+
 			return event
 		},
 	}); err != nil {

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -1090,9 +1090,9 @@ func reportFetchSummaryErrors(span trace.Span, fetchSummaries map[string]Provide
 				}
 			}
 
-			//if e.Severity() == diag.IGNORE {
-			//	continue
-			//}
+			if e.Severity() == diag.IGNORE {
+				continue
+			}
 
 			sentry.WithScope(func(scope *sentry.Scope) {
 				scope.SetTags(map[string]string{

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -1090,9 +1090,9 @@ func reportFetchSummaryErrors(span trace.Span, fetchSummaries map[string]Provide
 				}
 			}
 
-			if e.Severity() == diag.IGNORE {
-				continue
-			}
+			//if e.Severity() == diag.IGNORE {
+			//	continue
+			//}
 
 			sentry.WithScope(func(scope *sentry.Scope) {
 				scope.SetTags(map[string]string{
@@ -1103,6 +1103,8 @@ func reportFetchSummaryErrors(span trace.Span, fetchSummaries map[string]Provide
 				})
 				scope.SetExtra("detail", e.Description().Detail)
 				switch e.Severity() {
+				case diag.IGNORE:
+					scope.SetLevel(sentry.LevelDebug)
 				case diag.WARNING:
 					scope.SetLevel(sentry.LevelWarning)
 				case diag.PANIC:


### PR DESCRIPTION
The commented part will be removed once we finalize on a convention