### PR TITLE
fix: Use URI DSNs

### DIFF
--- a/cmd/init.go
+++ b/cmd/init.go
@@ -68,7 +68,7 @@ func Initialize(ctx context.Context, providers []string) error {
 		PolicyDirectory: "./cq/policies",
 		Providers:       requiredProviders,
 		Connection: &config.Connection{
-			DSN: "host=localhost user=postgres password=pass database=postgres port=5432 sslmode=disable",
+			DSN: "postgres://postgres:pass@localhost:5432/postgres?sslmode=disable",
 		},
 	}, "cloudquery")
 

--- a/pkg/ui/console/fixtures/config.yaml
+++ b/pkg/ui/console/fixtures/config.yaml
@@ -1,5 +1,5 @@
 cloudquery {
   connection {
-    dsn = "host=localhost user=postgres password=pass database=postgres port=5432 sslmode=disable"
+    dsn = "postgres://postgres:pass@localhost:5432/postgres?sslmode=disable"
   }
 }


### PR DESCRIPTION
easier to switch to `tsdb://` etc.

Also https://github.com/cloudquery/docs/pull/92