### PR TITLE
fix: Don't return an error if encountering an empty subpolicy

### DIFF
--- a/pkg/policy/execute_test.go
+++ b/pkg/policy/execute_test.go
@@ -230,6 +230,19 @@ var (
 			ExpectOutput: true,
 		}},
 	}
+	multiLayerWithEmptySubPolicy = &Policy{
+		Name: "test",
+		Policies: Policies{
+			{
+				Name:   "subpolicy",
+				Checks: []*Check{},
+			},
+		},
+		Checks: []*Check{{
+			Query:        "SELECT 1 as result;",
+			ExpectOutput: true,
+		}},
+	}
 )
 
 func TestExecutor_Execute(t *testing.T) {
@@ -270,15 +283,6 @@ func TestExecutor_Execute(t *testing.T) {
 			TotalExpectedResults: 2,
 		},
 		{
-			Name:                 "multilayer policies \\w invalid selector",
-			Policy:               multiLayerPolicy,
-			Selector:             "invalidselector",
-			Pass:                 true,
-			ShouldBeEmpty:        true,
-			TotalExpectedResults: 0,
-			ErrorOutput:          "no checks or policies to execute",
-		},
-		{
 			Name:                 "multilayer policies \\w selector on query",
 			Policy:               multiLayerPolicy,
 			Selector:             "subpolicy/sub-query",
@@ -305,6 +309,12 @@ func TestExecutor_Execute(t *testing.T) {
 			Pass:                 true,
 			TotalExpectedResults: 1,
 			StopOnFailure:        true,
+		},
+		{
+			Name:                 "multilayer policy w/ empty subpolicy",
+			Policy:               multiLayerWithEmptySubPolicy,
+			Pass:                 true,
+			TotalExpectedResults: 1,
 		},
 	}
 


### PR DESCRIPTION
Also removed the "multilayer policies with invalid selector" test (since now,
the "executor" won't actually return an error in the "invalid selector" case - it
will be up to the "manager").