### PR TITLE
fix: Fetch summary SQL state 54000

### DIFF
--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -549,13 +549,11 @@ func (c *Client) Fetch(ctx context.Context, request FetchRequest) (res *FetchRes
 				}
 
 				fetchSummary.Resources = append(fetchSummary.Resources, ResourceFetchSummary{
-					ResourceName:                resp.ResourceName,
-					FinishedResources:           resp.FinishedResources,
-					Status:                      strconv.Itoa(int(resp.Summary.Status)), // todo use human readable representation of status
-					Error:                       resp.Error,
-					PartialFetchFailedResources: resp.PartialFetchFailedResources,
-					ResourceCount:               resp.ResourceCount,
-					Diagnostics:                 resp.Summary.Diagnostics,
+					ResourceName:      resp.ResourceName,
+					FinishedResources: resp.FinishedResources,
+					Status:            resp.Summary.Status.String(),
+					Error:             resp.Error,
+					ResourceCount:     resp.ResourceCount,
 				})
 			}
 		})

--- a/pkg/client/fetch.go
+++ b/pkg/client/fetch.go
@@ -6,8 +6,6 @@ import (
 	"encoding/json"
 	"time"
 
-	"github.com/cloudquery/cq-provider-sdk/cqproto"
-	"github.com/cloudquery/cq-provider-sdk/provider/diag"
 	"github.com/doug-martin/goqu/v9"
 	"github.com/google/uuid"
 )
@@ -46,18 +44,12 @@ type ResourceFetchSummary struct {
 	ResourceName string `json:"resource_name"`
 	// map of resources that have finished fetching
 	FinishedResources map[string]bool `json:"finished_resources"`
-	// Amount of resources collected so far
 	// Error value if any, if returned the stream will be canceled
 	Error string `json:"error"`
-	// list of resources where the fetching failed
-	PartialFetchFailedResources []*cqproto.FailedResourceFetch `json:"partial_fetch_failed_resources"`
 	// Execution status of resource
 	Status string `json:"status"`
 	// Total Amount of resources collected by this resource
 	ResourceCount uint64 `json:"resource_count"`
-	// Diagnostics of failed resource fetch, the diagnostic provides insights such as severity, summary and
-	// details on how to solve this issue
-	Diagnostics diag.Diagnostics `json:"diagnostics"`
 }
 
 // SaveFetchSummary saves fetch summary into fetches database


### PR DESCRIPTION
if we have many diagnostics in the fetch summary it will cause an OOM memory insert failure, we remove the diagnostics from the summary, as they are logged regardless.