### PR TITLE
fix: Upgrade schema in history mode

### DIFF
--- a/.github/workflows/history_test.yml
+++ b/.github/workflows/history_test.yml
@@ -47,6 +47,11 @@ jobs:
       - name: Build
         run: go build -v .
 
+      - name: Sanity Fetch with old version
+        run: go run ./main.go fetch --config=internal/test/test_history_config_oldversion.hcl --enable-console-log
+        env:
+          CQ_NO_TELEMETRY: 1
+
       - name: Sanity Fetch
         run: go run ./main.go fetch --config=internal/test/test_history_config.hcl --enable-console-log
         env:

--- a/internal/test/test_history_config_oldversion.hcl
+++ b/internal/test/test_history_config_oldversion.hcl
@@ -1,0 +1,25 @@
+cloudquery {
+
+  connection {
+    dsn = "tsdb://postgres:pass@localhost:5432/postgres?sslmode=disable"
+  }
+  provider "test" {
+    version = "v0.0.10"
+  }
+  history {
+    // Save data retention for 7 days
+    retention = 7
+    // Truncate our fetch by 6 hours per fetch
+    truncation = 6
+  }
+
+}
+
+// All Provider Configurations
+provider "test" {
+  configuration {}
+
+  resources = [
+    "slow_resource"
+  ]
+}

--- a/pkg/client/database/timescale/timescale.go
+++ b/pkg/client/database/timescale/timescale.go
@@ -46,8 +46,12 @@ func (e Executor) Setup(ctx context.Context) (string, error) {
 	}
 	defer conn.Release()
 
-	if err := AddHistoryFunctions(ctx, conn); err != nil {
-		return e.dsn, fmt.Errorf("failed to create history functions: %w", err)
+	ddl, err := NewDDLManager(e.logger, conn, e.cfg, schema.TSDB)
+	if err != nil {
+		return e.dsn, err
+	}
+	if err := ddl.PrepareHistory(ctx, conn); err != nil {
+		return e.dsn, fmt.Errorf("failed to prepare history: %w", err)
 	}
 
 	return history.TransformDSN(e.dsn)

--- a/pkg/module/manager.go
+++ b/pkg/module/manager.go
@@ -3,6 +3,7 @@ package module
 import (
 	"context"
 	"fmt"
+	"sort"
 	"strings"
 
 	"github.com/cloudquery/cq-provider-sdk/cqproto"
@@ -167,6 +168,10 @@ func versionError(modName string, modVersions []uint32, provVersions map[string]
 			newerProviders = append(newerProviders, p)
 		}
 	}
+
+	sort.Strings(unsupportingProviders)
+	sort.Strings(olderProviders)
+	sort.Strings(newerProviders)
 
 	if l := len(unsupportingProviders); l == 1 {
 		return fmt.Errorf("provider %s doesn't support %s yet", unsupportingProviders[0], modName)


### PR DESCRIPTION
Views need to be dropped before any migrations can be applied (except creating new tables)