### PR TITLE
fix: Init command cleanup

### DIFF
--- a/cmd/init.go
+++ b/cmd/init.go
@@ -53,7 +53,7 @@ func Initialize(ctx context.Context, providers []string) error {
 	for i, p := range providers {
 		organization, providerName, err := registry.ParseProviderName(p)
 		if err != nil {
-			return fmt.Errorf("could not parse requested provider")
+			return fmt.Errorf("could not parse requested provider: %w", err)
 		}
 		rp := config.RequiredProvider{
 			Name:    providerName,

--- a/cmd/init.go
+++ b/cmd/init.go
@@ -51,19 +51,20 @@ func Initialize(ctx context.Context, providers []string) error {
 	rootBody := f.Body()
 	requiredProviders := make([]*config.RequiredProvider, len(providers))
 	for i, p := range providers {
-		organization, providerName, err := registry.ParseProviderName(p)
+		organization, providerName, provVersion, err := registry.ParseProviderNameWithVersion(p)
 		if err != nil {
 			return fmt.Errorf("could not parse requested provider: %w", err)
 		}
 		rp := config.RequiredProvider{
 			Name:    providerName,
-			Version: "latest",
+			Version: provVersion,
 		}
 		if organization != registry.DefaultOrganization {
 			source := fmt.Sprintf("%s/%s", organization, providerName)
 			rp.Source = &source
 		}
 		requiredProviders[i] = &rp
+		providers[i] = providerName // overwrite "provider@version" with just "provider"
 	}
 	// TODO: build this manually with block and add comments as well
 	cqBlock := gohcl.EncodeAsBlock(&config.CloudQuery{

--- a/cmd/init.go
+++ b/cmd/init.go
@@ -53,14 +53,17 @@ func Initialize(ctx context.Context, providers []string) error {
 	for i, p := range providers {
 		organization, providerName, err := registry.ParseProviderName(p)
 		if err != nil {
-			return fmt.Errorf("colud not parse requested provider")
+			return fmt.Errorf("could not parse requested provider")
 		}
-		source := fmt.Sprintf("%s/%s", organization, providerName)
-		requiredProviders[i] = &config.RequiredProvider{
+		rp := config.RequiredProvider{
 			Name:    providerName,
-			Source:  &source,
 			Version: "latest",
 		}
+		if organization != registry.DefaultOrganization {
+			source := fmt.Sprintf("%s/%s", organization, providerName)
+			rp.Source = &source
+		}
+		requiredProviders[i] = &rp
 	}
 	// TODO: build this manually with block and add comments as well
 	cqBlock := gohcl.EncodeAsBlock(&config.CloudQuery{
@@ -111,7 +114,7 @@ func Initialize(ctx context.Context, providers []string) error {
 		buffer.WriteString("\n")
 	}
 
-	if mex := c.Client().ModuleManager.ExampleConfigs(); len(mex) > 0 {
+	if mex := c.Client().ModuleManager.ExampleConfigs(providers); len(mex) > 0 {
 		buffer.WriteString("\n// Module Configurations\nmodules {\n")
 		for _, c := range mex {
 			buffer.WriteString(c)

--- a/go.mod
+++ b/go.mod
@@ -33,6 +33,7 @@ require (
 )
 
 require (
+	github.com/Masterminds/semver/v3 v3.1.1
 	github.com/ProtonMail/go-crypto v0.0.0-20211221144345-a4f6767435ab
 	github.com/aws/aws-sdk-go v1.42.1
 	github.com/creasty/defaults v1.5.2

--- a/go.sum
+++ b/go.sum
@@ -76,6 +76,7 @@ github.com/CloudyKit/jet/v3 v3.0.0/go.mod h1:HKQPgSJmdK8hdoAbKUUWajkHyHo4RaU5rMd
 github.com/DATA-DOG/go-sqlmock v1.5.0 h1:Shsta01QNfFxHCfpW6YH2STWB0MudeXXEWMr20OEh60=
 github.com/DATA-DOG/go-sqlmock v1.5.0/go.mod h1:f/Ixk793poVmq4qj/V1dPUg2JEAKC73Q5eFN3EC/SaM=
 github.com/Joker/hpp v1.0.0/go.mod h1:8x5n+M1Hp5hC0g8okX3sR3vFQwynaX/UgSOM9MeBKzY=
+github.com/Masterminds/semver/v3 v3.1.1 h1:hLg3sBzpNErnxhQtUy/mmLR2I9foDujNK030IGemrRc=
 github.com/Masterminds/semver/v3 v3.1.1/go.mod h1:VPu/7SZ7ePZ3QOrcuXROw5FAcLl4a0cBrbBpGY/8hQs=
 github.com/Masterminds/squirrel v1.5.0 h1:JukIZisrUXadA9pl3rMkjhiamxiB0cXiu+HGp/Y8cY8=
 github.com/Masterminds/squirrel v1.5.0/go.mod h1:NNaOrjSoIDfDA40n7sr2tPNZRfjzjA400rg+riTZj10=

--- a/pkg/config/parser.go
+++ b/pkg/config/parser.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"errors"
 	"fmt"
 	"io/fs"
 	"strings"
@@ -83,7 +84,11 @@ func (p *Parser) LoadHCLFile(path string) (hcl.Body, hcl.Diagnostics) {
 
 	if err != nil {
 		if e, ok := err.(*fs.PathError); ok {
-			err = fmt.Errorf(e.Err.Error())
+			if errors.Is(err, fs.ErrNotExist) {
+				err = fmt.Errorf("%s. Hint: Try `cloudquery init <provider>`.", e.Err.Error())
+			} else {
+				err = fmt.Errorf(e.Err.Error())
+			}
 		}
 		return nil, hcl.Diagnostics{
 			{

--- a/pkg/module/drift/drift.go
+++ b/pkg/module/drift/drift.go
@@ -94,7 +94,18 @@ func (d *Drift) Execute(ctx context.Context, req *module.ExecuteRequest) *module
 	return ret
 }
 
-func (d *Drift) ExampleConfig() string {
+func (d *Drift) ExampleConfig(providers []string) string {
+	hasAws := false
+	for i := range providers {
+		if providers[i] == "aws" {
+			hasAws = true
+			break
+		}
+	}
+	if !hasAws {
+		return ""
+	}
+
 	return `// drift configuration block
 drift "drift-example" {
   // state block defines from where to access the state

--- a/pkg/module/manager.go
+++ b/pkg/module/manager.go
@@ -36,7 +36,7 @@ type Manager interface {
 	ExecuteModule(ctx context.Context, execReq *ExecuteRequest) (*ExecutionResult, error)
 
 	// ExampleConfigs returns a list of example module configs from loaded modules
-	ExampleConfigs() []string
+	ExampleConfigs(providers []string) []string
 }
 
 type moduleInfoRequester interface {
@@ -89,10 +89,10 @@ func (m *ManagerImpl) ExecuteModule(ctx context.Context, execReq *ExecuteRequest
 }
 
 // ExampleConfigs returns a list of example module configs from loaded modules
-func (m *ManagerImpl) ExampleConfigs() []string {
+func (m *ManagerImpl) ExampleConfigs(providers []string) []string {
 	ret := make([]string, 0, len(m.modules))
 	for _, i := range m.modOrder {
-		cfg := m.modules[i].ExampleConfig()
+		cfg := m.modules[i].ExampleConfig(providers)
 		if cfg == "" {
 			continue
 		}

--- a/pkg/module/types.go
+++ b/pkg/module/types.go
@@ -19,7 +19,7 @@ type Module interface {
 	// Execute executes the module, using given args in ExecuteRequest
 	Execute(context.Context, *ExecuteRequest) *ExecutionResult
 	// ExampleConfig returns an example configuration to be put in config.hcl
-	ExampleConfig() string
+	ExampleConfig(providers []string) string
 }
 
 // Info about user supplied configs and provider supplied module info

--- a/pkg/plugin/registry/hub.go
+++ b/pkg/plugin/registry/hub.go
@@ -94,7 +94,7 @@ func (h Hub) GetProvider(providerName, providerVersion string) (ProviderDetails,
 
 func (h Hub) VerifyProvider(ctx context.Context, organization, providerName, version string) bool {
 
-	if organization != defaultOrganization {
+	if organization != DefaultOrganization {
 		if h.ProgressUpdater != nil {
 			h.ProgressUpdater.Update(providerName, ui.StatusWarn, "skipped community provider verification...", 2)
 		}

--- a/pkg/plugin/registry/organization.go
+++ b/pkg/plugin/registry/organization.go
@@ -3,6 +3,8 @@ package registry
 import (
 	"fmt"
 	"strings"
+
+	"github.com/Masterminds/semver/v3"
 )
 
 const (
@@ -26,4 +28,28 @@ func ParseProviderName(name string) (string, string, error) {
 // ProviderRepoName returns a repository name for a given provider name.
 func ProviderRepoName(name string) string {
 	return fmt.Sprintf("cq-provider-%s", name)
+}
+
+// ParseProviderNameWithVersion parses the given string as "repository/provider@version" or "provider@version" (or @version omitted, defaulting to "latest")
+func ParseProviderNameWithVersion(nameWithVersion string) (string, string, string, error) {
+	versionParts := strings.Split(nameWithVersion, "@")
+
+	if l := len(versionParts); l == 1 || (l == 2 && versionParts[1] == "latest") {
+		org, name, err := ParseProviderName(versionParts[0])
+		return org, name, "latest", err
+	} else if l != 2 {
+		return "", "", "", fmt.Errorf("invalid provider name@version %q", nameWithVersion)
+	}
+
+	org, name, err := ParseProviderName(versionParts[0])
+	if err != nil {
+		return "", "", "", err
+	}
+
+	ver, err := semver.NewVersion(versionParts[1])
+	if err != nil {
+		return "", "", "", fmt.Errorf("invalid version %q: %w", versionParts[1], err)
+	}
+
+	return org, name, "v" + ver.String(), err
 }

--- a/pkg/plugin/registry/organization.go
+++ b/pkg/plugin/registry/organization.go
@@ -6,7 +6,7 @@ import (
 )
 
 const (
-	defaultOrganization = "cloudquery"
+	DefaultOrganization = "cloudquery"
 )
 
 // ParseProviderName parses a name of a provider which can be just a name or a name + organization
@@ -18,7 +18,7 @@ func ParseProviderName(name string) (string, string, error) {
 		return strings.ToLower(names[0]), names[1], nil
 	}
 	if len(names) == 1 {
-		return defaultOrganization, name, nil
+		return DefaultOrganization, name, nil
 	}
 	return "", "", fmt.Errorf("invalid provider name %s", name)
 }

--- a/pkg/plugin/registry/organization.go
+++ b/pkg/plugin/registry/organization.go
@@ -20,7 +20,7 @@ func ParseProviderName(name string) (string, string, error) {
 	if len(names) == 1 {
 		return DefaultOrganization, name, nil
 	}
-	return "", "", fmt.Errorf("invalid provider name %s", name)
+	return "", "", fmt.Errorf("invalid provider name %q", name)
 }
 
 // ProviderRepoName returns a repository name for a given provider name.


### PR DESCRIPTION
- [x] Don't set `source` if default org
- [x] Include drift config only with AWS
- [x] Support `cloudquery init provider@version`
- [x] Add hint to use `cloudquery init <provider>` if `config.hcl` loading fails with `fs.ErrNotExist`
