### PR TITLE
fix: Validate DB connection with an explicit timeout, rather than the…

### DIFF
--- a/pkg/client/database/postgres/executor.go
+++ b/pkg/client/database/postgres/executor.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"strings"
+	"time"
 
 	sdkpg "github.com/cloudquery/cq-provider-sdk/database/postgres"
 	"github.com/hashicorp/go-hclog"
@@ -36,6 +37,10 @@ func (e Executor) Validate(ctx context.Context) (bool, error) {
 		return false, err
 	}
 
+	if err := ValidatePostgresConnection(ctx, pool); err != nil {
+		return false, err
+	}
+
 	if err := ValidatePostgresVersion(ctx, pool, MinPostgresVersion); err != nil {
 		return true, err
 	}
@@ -49,6 +54,14 @@ func (e Executor) Prepare(_ context.Context) error {
 
 func (e Executor) Finalize(_ context.Context, err error) error {
 	return err
+}
+
+// ValidatePostgresConnection validates that we can actually connect to the postgres database.
+func ValidatePostgresConnection(ctx context.Context, pool *pgxpool.Pool) error {
+	ctx, cancel := context.WithTimeout(ctx, time.Second*10)
+	defer cancel()
+
+	return pool.Ping(ctx)
 }
 
 // queryRower helps with unit tests

--- a/pkg/client/database/timescale/timescale.go
+++ b/pkg/client/database/timescale/timescale.go
@@ -61,6 +61,10 @@ func (e Executor) Validate(ctx context.Context) (bool, error) {
 	}
 	defer pool.Close()
 
+	if err := postgres.ValidatePostgresConnection(ctx, pool); err != nil {
+		return false, err
+	}
+
 	if err := postgres.ValidatePostgresVersion(ctx, pool, postgres.MinPostgresVersion); err != nil {
 		return false, err
 	}


### PR DESCRIPTION
… default timeout

- The default timeout is many minutes, way too long to give the user feedback about failed db connection.
- Note that cq-provider-sdk/database/postgres uses lazy-connect, so it won't return an error in case of failed DB connection.