### PR TITLE
fix: Foreign Keys in Snapshots

### DIFF
--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -666,7 +666,7 @@ func (c *Client) BuildProviderTables(ctx context.Context, providerName string) (
 		}
 
 		c.Logger.Error("BuildProviderTables failed", "error", retErr)
-		retErr = fmt.Errorf("incompatible provider schema: Please drop provider tables and recreate, alternatively execute `cloudquery provider drop %s`", providerName)
+		retErr = fmt.Errorf("Incompatible provider schema: Please drop provider tables and recreate, alternatively execute `cloudquery provider drop %s`", providerName)
 	}()
 
 	// create migration table and set it to version based on latest create table

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -666,7 +666,7 @@ func (c *Client) BuildProviderTables(ctx context.Context, providerName string) (
 		}
 
 		c.Logger.Error("BuildProviderTables failed", "error", retErr)
-		retErr = fmt.Errorf("Incompatible provider schema: Please drop provider tables and recreate, alternatively execute `cloudquery provider drop %s`", providerName)
+		retErr = fmt.Errorf("incompatible provider schema: Please drop provider tables and recreate, alternatively execute `cloudquery provider drop %s`", providerName)
 	}()
 
 	// create migration table and set it to version based on latest create table


### PR DESCRIPTION
When restoring a snapshot prior to copying the data drop all FK requirements