### PR TITLE
fix: Warn on providers with no resources requested

### DIFF
--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -407,6 +407,10 @@ func (c *Client) Fetch(ctx context.Context, request FetchRequest) (res *FetchRes
 	}
 
 	for _, providerConfig := range request.Providers {
+		if len(providerConfig.Resources) == 0 {
+			c.Logger.Warn("skipping provider which configured with 0 resources to fetch", "provider", providerConfig.Name, "alias", providerConfig.Alias)
+			continue
+		}
 		providerConfig := providerConfig
 		createdAt := time.Now().UTC()
 		fetchSummary := FetchSummary{


### PR DESCRIPTION
Fixes #514 

Run example:
![image](https://user-images.githubusercontent.com/38083777/158339565-e29d784d-9a42-4ef5-984a-e1f063d67e66.png)
