### PR TITLE
Use of sha1 is insecure

### DIFF
--- a/internal/telemetry/telemetry.go
+++ b/internal/telemetry/telemetry.go
@@ -2,7 +2,7 @@ package telemetry
 
 import (
 	"context"
-	"crypto/sha1"
+	"crypto/sha512"
 	"fmt"
 	"io"
 	"net"
@@ -344,7 +344,7 @@ func IsFaaS() bool {
 
 // HashAttribute creates a one-way hash from an attribute
 func HashAttribute(value string) string {
-	s := sha1.New()
+	s := sha512.New()
 	_, _ = s.Write([]byte(value))
 	return fmt.Sprintf("%0x", s.Sum(nil))
 }

--- a/pkg/ui/console/client.go
+++ b/pkg/ui/console/client.go
@@ -2,7 +2,7 @@ package console
 
 import (
 	"context"
-	"crypto/sha1"
+	"crypto/sha512"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -575,7 +575,7 @@ func (c Client) checkForUpdate(ctx context.Context) {
 
 func (c Client) setTelemetryAttributes(span trace.Span) {
 	cfgJSON, _ := json.Marshal(c.cfg)
-	s := sha1.New()
+	s := sha512.New()
 	_, _ = s.Write(cfgJSON)
 	cfgHash := fmt.Sprintf("%0x", s.Sum(nil))
 	attrs := []attribute.KeyValue{


### PR DESCRIPTION
Hello,

I found the use of sha1 within the project, and I would suggest updating the crypto package to something with greater integrity.

The use of sha1 is not recommended (https://pkg.go.dev/crypto/sha1), so I have updated it to the sha512 package in the files I found sha1 in.

Thanks

PS I am not sure of the testing edict or process on this repo do forgive me if I have missed a step :)