### PR TITLE
feat: Drift: Improvements

### DIFF
--- a/.github/workflows/lint_golang.yml
+++ b/.github/workflows/lint_golang.yml
@@ -21,5 +21,5 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v2
         with:
-          version: v1.42.1
+          version: v1.45.2
           args: --timeout 5m

--- a/cmd/drift.go
+++ b/cmd/drift.go
@@ -46,7 +46,6 @@ func init() {
 
 	// flags handled by the drift package
 	flags.BoolVar(&driftParams.Debug, "debug", false, "Show debug output")
-	flags.StringVar(&driftParams.TfMode, "tf-mode", "managed", "Set Terraform mode")
 	flags.BoolVar(&driftParams.ForceDeep, "deep", false, "Force deep mode")
 	flags.BoolVar(&driftParams.ListManaged, "list-managed", false, "List managed resources in output")
 

--- a/internal/sort/sort.go
+++ b/internal/sort/sort.go
@@ -1,0 +1,27 @@
+package sort
+
+import stdsort "sort"
+
+// Unique sorts input alphabetically and returns only non-duplicate entries
+func Unique(input []string) []string {
+	if input == nil {
+		return nil
+	}
+
+	stdsort.Strings(input)
+	ret := make([]string, 0, len(input))
+	for i := range input {
+		if i == len(input)-1 { // always append last element
+			ret = append(ret, input[i])
+			continue
+		}
+
+		if input[i] == input[i+1] { // skip if it's the same as the next one
+			continue
+		}
+
+		ret = append(ret, input[i])
+	}
+
+	return ret
+}

--- a/internal/sort/sort_test.go
+++ b/internal/sort/sort_test.go
@@ -1,4 +1,4 @@
-package drift
+package sort
 
 import (
 	"testing"
@@ -6,7 +6,7 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestUniqueSort(t *testing.T) {
+func TestUnique(t *testing.T) {
 	for _, tc := range []struct {
 		Input    []string
 		Expected []string
@@ -44,7 +44,7 @@ func TestUniqueSort(t *testing.T) {
 			Expected: []string{"a", "b", "c", "d", "e"},
 		},
 	} {
-		ret := UniqueSort(tc.Input)
+		ret := Unique(tc.Input)
 		assert.EqualValues(t, tc.Expected, ret)
 	}
 }

--- a/pkg/module/drift/combination.go
+++ b/pkg/module/drift/combination.go
@@ -1,0 +1,30 @@
+package drift
+
+// MatrixProduct combines each item in `multiplier` with each element in `base`
+//
+// [(A),(B),(C)] x (1,2) = [(A,1)], [(B,1)], [(C,1)], [(A,2)], [(B,2)], [(C,2)]
+func MatrixProduct(base [][]string, multiplier []string) [][]string {
+	if len(multiplier) == 0 {
+		return base
+	}
+
+	if len(base) == 0 {
+		ret := make([][]string, len(multiplier))
+		for i, v := range multiplier {
+			ret[i] = []string{v}
+		}
+		return ret
+	}
+
+	ret := make([][]string, 0, len(base)*len(multiplier))
+	for _, v := range multiplier {
+		for _, l := range base {
+			ll := make([]string, len(l))
+			copy(ll, l)
+
+			ret = append(ret, append(ll, v))
+		}
+	}
+
+	return ret
+}

--- a/pkg/module/drift/combination_test.go
+++ b/pkg/module/drift/combination_test.go
@@ -1,0 +1,50 @@
+package drift
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestCombination(t *testing.T) {
+	cases := []struct {
+		InputBase      [][]string
+		InputMul       []string
+		ExpectedResult [][]string
+	}{
+		{ // 0 x 2
+			nil,
+			[]string{"a", "b"},
+			[][]string{{"a"}, {"b"}},
+		},
+		{ // 2 x 0
+			[][]string{{"a"}, {"b"}},
+			nil,
+			[][]string{{"a"}, {"b"}},
+		},
+		{ // 2 x 2
+			[][]string{{"a"}, {"b"}},
+			[]string{"A", "B"},
+			[][]string{{"a", "A"}, {"b", "A"}, {"a", "B"}, {"b", "B"}},
+		},
+		{ // 3 x 2
+			[][]string{{"a"}, {"b"}, {"c"}},
+			[]string{"A", "B"},
+			[][]string{{"a", "A"}, {"b", "A"}, {"c", "A"}, {"a", "B"}, {"b", "B"}, {"c", "B"}},
+		},
+		{ // 2 x 3
+			[][]string{{"a"}, {"b"}},
+			[]string{"A", "B", "C"},
+			[][]string{{"a", "A"}, {"b", "A"}, {"a", "B"}, {"b", "B"}, {"a", "C"}, {"b", "C"}},
+		},
+		{ // 3 x 3
+			[][]string{{"a"}, {"b"}, {"c"}},
+			[]string{"A", "B", "C"},
+			[][]string{{"a", "A"}, {"b", "A"}, {"c", "A"}, {"a", "B"}, {"b", "B"}, {"c", "B"}, {"a", "C"}, {"b", "C"}, {"c", "C"}},
+		},
+	}
+	for _, tc := range cases {
+		res := MatrixProduct(tc.InputBase, tc.InputMul)
+		assert.Equal(t, tc.ExpectedResult, res)
+	}
+}

--- a/pkg/module/drift/config.go
+++ b/pkg/module/drift/config.go
@@ -515,5 +515,8 @@ func (d *Drift) lookupResource(resName string, prov *cqproto.GetProviderSchemaRe
 // SplitHashedResource splits a given resource name and returns the resource and hash elements separately.
 func SplitHashedResource(configResName string) (string, string) {
 	resParts := strings.SplitN(configResName, "#", 2)
+	if len(resParts) == 1 {
+		return resParts[0], ""
+	}
 	return resParts[0], resParts[1]
 }

--- a/pkg/module/drift/drift.go
+++ b/pkg/module/drift/drift.go
@@ -41,7 +41,8 @@ const (
 	iacTerraform      iacProvider = "terraform"
 	iacCloudformation iacProvider = "cloudformation"
 
-	protoVersion = 1
+	compatibleProtoVersion = 1
+	protoVersion           = 2
 )
 
 func (i iacProvider) String() string {
@@ -66,7 +67,7 @@ func (d *Drift) ID() string {
 }
 
 func (d *Drift) ProtocolVersions() []uint32 {
-	return []uint32{protoVersion}
+	return []uint32{protoVersion, compatibleProtoVersion}
 }
 
 func (d *Drift) Configure(ctx context.Context, info module.Info, runParams module.ModuleRunParams) error {
@@ -134,7 +135,7 @@ drift "drift-example" {
 }
 
 func (d *Drift) readBaseConfig(version uint32, providerData map[string]cqproto.ModuleInfo) (*BaseConfig, error) {
-	if version != protoVersion {
+	if version != protoVersion && version != compatibleProtoVersion {
 		return nil, fmt.Errorf("unsupported module protocol version %d", version)
 	}
 

--- a/pkg/module/drift/model_test.go
+++ b/pkg/module/drift/model_test.go
@@ -1,0 +1,50 @@
+package drift
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestUniqueSort(t *testing.T) {
+	for _, tc := range []struct {
+		Input    []string
+		Expected []string
+	}{
+		{
+			Input:    nil,
+			Expected: nil,
+		},
+		{
+			Input:    []string{},
+			Expected: []string{},
+		},
+		{
+			Input:    []string{"a"},
+			Expected: []string{"a"},
+		},
+		{
+			Input:    []string{"b", "a"},
+			Expected: []string{"a", "b"},
+		},
+		{
+			Input:    []string{"a", "b"},
+			Expected: []string{"a", "b"},
+		},
+		{
+			Input:    []string{"a", "c", "b", "d"},
+			Expected: []string{"a", "b", "c", "d"},
+		},
+		{
+			Input:    []string{"a", "c", "b", "d", "b", "c"},
+			Expected: []string{"a", "b", "c", "d"},
+		},
+		{
+			Input:    []string{"a", "c", "b", "d", "b", "c", "e"},
+			Expected: []string{"a", "b", "c", "d", "e"},
+		},
+	} {
+		ret := UniqueSort(tc.Input)
+		assert.EqualValues(t, tc.Expected, ret)
+	}
+}

--- a/pkg/module/drift/terraform.go
+++ b/pkg/module/drift/terraform.go
@@ -334,6 +334,7 @@ func RenderDriftTable(resName string, resources map[string]*ResourceConfig, clou
 		return table
 	}
 
+	// If there are any cloud modifiers in the columns, process them before comparing/printing
 	for i := range differentIDs {
 		for j := range differentIDs[i].Attributes {
 			if alist[j].CloudMod != nil {

--- a/pkg/module/drift/terraform.go
+++ b/pkg/module/drift/terraform.go
@@ -244,12 +244,7 @@ func driftTerraform(ctx context.Context, logger hclog.Logger, conn execution.Que
 		}
 	}
 
-	tfMode := terraform.Mode(runParams.TfMode)
-	if !tfMode.Valid() {
-		return nil, fmt.Errorf("invalid tf mode %q", runParams.TfMode)
-	}
-
-	tfResources := states.FindType(iacData.Type, tfMode).AsResourceList(iacData.Identifiers, alist, iacData.Path)
+	tfResources := states.FindType(iacData.Type, terraform.ModeManaged).AsResourceList(iacData.Identifiers, alist, iacData.Path)
 
 	var cloudAttrQuery exp.LiteralExpression
 

--- a/pkg/module/drift/terraform.go
+++ b/pkg/module/drift/terraform.go
@@ -506,4 +506,14 @@ func registerGJsonHelpers() {
 			return strconv.FormatBool(bb)
 		})
 	}
+	if !gjson.ModifierExists("if", nil) {
+		// if given statement equals something, return the arg. otherwise return the statement.
+		gjson.AddModifier("if", func(body, arg string) string {
+			argParts := strings.SplitN(arg, ",", 2)
+			if body != strconv.Quote(argParts[0]) {
+				return body
+			}
+			return strconv.Quote(argParts[1])
+		})
+	}
 }

--- a/pkg/module/drift/terraform/state.go
+++ b/pkg/module/drift/terraform/state.go
@@ -57,9 +57,4 @@ type Mode string
 
 const (
 	ModeManaged Mode = "managed"
-	ModeData    Mode = "data"
 )
-
-func (m Mode) Valid() bool {
-	return m == ModeManaged || m == ModeData
-}

--- a/pkg/module/drift/terraform_test.go
+++ b/pkg/module/drift/terraform_test.go
@@ -1,0 +1,91 @@
+package drift
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/cloudquery/cloudquery/pkg/module/drift/terraform"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestParseTerraformInstance(t *testing.T) {
+	cases := []struct {
+		TFAttrs     map[string]interface{}
+		Identifiers []string
+		CloudAttrs  AttrList
+		Path        string
+		ExpectedIDs []string
+	}{
+		{
+			TFAttrs: map[string]interface{}{
+				"id":    "the-id",
+				"value": "the-value",
+			},
+			Identifiers: []string{"id"},
+			ExpectedIDs: []string{"the-id"},
+		},
+		{
+			TFAttrs: map[string]interface{}{
+				"arn": "the-arn",
+				"params": []map[string]interface{}{
+					{"val": "a", "other-key": "xx"},
+					{"val": "b", "other-key": "yy"},
+				},
+				"value": "the-value",
+			},
+			Identifiers: []string{"arn", "params.0.val"},
+			ExpectedIDs: []string{"the-arn|a"},
+		},
+		{
+			TFAttrs: map[string]interface{}{
+				"arn": "the-arn",
+				"params": []map[string]interface{}{
+					{"val": "a", "other-key": "xx"},
+					{"val": "b", "other-key": "yy"},
+				},
+				"value": "the-value",
+			},
+			Identifiers: []string{"arn", "params.#.val"},
+			ExpectedIDs: []string{"the-arn|a", "the-arn|b"},
+		},
+		{
+			TFAttrs: map[string]interface{}{
+				"arn": "the-arn",
+				"params": []map[string]interface{}{
+					{"val": "a", "other-key": "xx"},
+					{"val": "b", "other-key": "yy"},
+				},
+				"value": "the-value",
+			},
+			Path:        "params",
+			Identifiers: []string{"root.arn", "val"},
+			ExpectedIDs: []string{"the-arn|a", "the-arn|b"},
+		},
+		{
+			TFAttrs: map[string]interface{}{
+				"arn": "the-arn",
+				"data": []map[string]interface{}{
+					{"sub-key": "the-sub-val1"},
+					{"sub-key": "the-sub-val2"},
+				},
+				"value": "the-value",
+			},
+			Path:        "data",
+			Identifiers: []string{"root.arn", "sub-key"},
+			ExpectedIDs: []string{"the-arn|the-sub-val1", "the-arn|the-sub-val2"},
+		},
+	}
+	for _, tc := range cases {
+		raw, _ := json.Marshal(tc.TFAttrs)
+
+		resList := parseTerraformInstance(
+			terraform.Instance{
+				AttributesRaw: raw,
+			},
+			tc.Identifiers,
+			tc.CloudAttrs,
+			tc.Path,
+		)
+		assert.EqualValues(t, tc.ExpectedIDs, resList.IDs())
+	}
+}


### PR DESCRIPTION
- Turns out the "combination feature" was kind of doable with the `path` statement but I still wanted to leave it in for now.
- Added @if to GJSON `value|@if:this,that` (if value is `this` it will be replaced with `that`. if not, it will be left as-is)
- Added @split to GJSON to split a string into an array: `value1,value2|@split:,` => `[ value1, value2 ]`
- Added ability to run GJSON filters in the cloud provider attributes (in the attribute map) and updated drift protocol to v2
- Added ability to define a single cloud resource multiple times (explicitly, using a 'hash' syntax, so that it doesn't get confused/lost in the map accesses) to be able to cover a blanket resource (think `iam.accounts` or `ec2.regional_config`) using multiple TF resources.
- Removed `-tf-mode` cli param (which was pointless)