### PR TITLE
fix: Drift: Remove version constraints, always include all parents

### DIFF
--- a/pkg/module/drift/config_test.go
+++ b/pkg/module/drift/config_test.go
@@ -10,7 +10,6 @@ import (
 	"github.com/cloudquery/cq-provider-sdk/cqproto"
 	"github.com/cloudquery/cq-provider-sdk/provider/schema"
 	"github.com/hashicorp/go-hclog"
-	"github.com/hashicorp/go-version"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -357,8 +356,7 @@ func copyMap(in, out interface{}) {
 
 func TestApplyProvider(t *testing.T) {
 	prov := ProviderConfig{
-		Name:    "aws",
-		Version: ">=1.5.0",
+		Name: "aws",
 		Resources: map[string]*ResourceConfig{
 			"test1": {
 				IAC: map[iacProvider]*IACConfig{
@@ -376,9 +374,6 @@ func TestApplyProvider(t *testing.T) {
 			},
 		},
 	}
-	var err error
-	prov.versionConstraints, err = version.NewConstraint(prov.Version)
-	assert.NoError(t, err)
 
 	modify := func(p ProviderConfig, fn func(*ProviderConfig)) ProviderConfig {
 		var resCopy map[string]*ResourceConfig
@@ -414,17 +409,7 @@ func TestApplyProvider(t *testing.T) {
 			expectedError:  false,
 		},
 		{
-			name: "Old version",
-			cfg:  prov,
-			schema: &cqproto.GetProviderSchemaResponse{
-				Name:    "aws",
-				Version: "1.0.0",
-			},
-			expectedResult: false,
-			expectedError:  false,
-		},
-		{
-			name: "New version",
+			name: "Matching name",
 			cfg:  prov,
 			schema: &cqproto.GetProviderSchemaResponse{
 				Name:    "aws",
@@ -585,8 +570,7 @@ func TestApplyProvider(t *testing.T) {
 
 func TestSubResourceLookup(t *testing.T) {
 	prov := ProviderConfig{
-		Name:    "aws",
-		Version: ">=1.5.0",
+		Name: "aws",
 		Resources: map[string]*ResourceConfig{
 			"test1": {
 				IAC: map[iacProvider]*IACConfig{
@@ -621,9 +605,6 @@ func TestSubResourceLookup(t *testing.T) {
 			},
 		},
 	}
-	var err error
-	prov.versionConstraints, err = version.NewConstraint(prov.Version)
-	assert.NoError(t, err)
 
 	d := &Drift{
 		logger: hclog.NewNullLogger(),

--- a/pkg/module/drift/drift.go
+++ b/pkg/module/drift/drift.go
@@ -401,14 +401,7 @@ func handleSubresource(logger hclog.Logger, sel *goqu.SelectDataset, pr *travers
 	parentCounter := 0
 	parentTableName := "parent"
 	childTableName := "c"
-	var res *ResourceConfig
 	for pr.Parent != nil {
-		res = resources[pr.Name]
-		if res == nil {
-			logger.Warn("Found parent but no resourceConfig", "table", pr.Table.Name)
-			return sel // FIXME we're skipping the account_id filter here by returning
-		}
-
 		if parentCounter > 0 {
 			parentTableName = fmt.Sprintf("parent%d", parentCounter)
 		}


### PR DESCRIPTION
- Version constraints are not needed since HCL is bundled with the provider now
- Second commit fixes the issue about not being able to filter two resources down, using check_resources:

This would fail:
```hcl
      check_resources = [
        // "codepipeline.pipelines:*",
        // "aws_codepipeline_pipeline_stages:*",
        "aws_codepipeline_pipeline_stage_actions:*"
	]
```

but this would work:
```hcl
      check_resources = [
        // "codepipeline.pipelines:*",
        "aws_codepipeline_pipeline_stages:*",
        "aws_codepipeline_pipeline_stage_actions:*"
	]
```
(now the former also works)