### PR TITLE
fix: Replace non-supported satori/go.uuid with google/uuid

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -18,7 +18,6 @@ require (
 	github.com/mattn/go-isatty v0.0.14
 	github.com/mitchellh/mapstructure v1.4.1 // indirect
 	github.com/rs/zerolog v1.20.0
-	github.com/satori/go.uuid v1.2.0
 	github.com/spf13/afero v1.7.0
 	github.com/spf13/cobra v1.1.3
 	github.com/spf13/viper v1.7.1

--- a/internal/telemetry/telemetry.go
+++ b/internal/telemetry/telemetry.go
@@ -9,8 +9,8 @@ import (
 	"os"
 	"time"
 
+	"github.com/google/uuid"
 	"github.com/hashicorp/go-hclog"
-	uuid "github.com/satori/go.uuid"
 	"github.com/spf13/afero"
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
@@ -373,5 +373,5 @@ func (e *errorHandler) Handle(err error) {
 }
 
 func genRandomId() string {
-	return uuid.NewV4().String()
+	return uuid.NewString()
 }

--- a/pkg/policy/manager.go
+++ b/pkg/policy/manager.go
@@ -8,9 +8,9 @@ import (
 	"strings"
 
 	"github.com/cloudquery/cq-provider-sdk/provider/execution"
+	"github.com/google/uuid"
 	"github.com/hashicorp/hcl/v2"
 	"github.com/hashicorp/hcl/v2/hclsyntax"
-	uuid "github.com/satori/go.uuid"
 
 	"github.com/hashicorp/go-hclog"
 )
@@ -61,7 +61,7 @@ func NewManager(policyDir string, pool LowLevelQueryExecer, logger hclog.Logger)
 //
 func createSnapshotPath(directory, queryName string) (string, error) {
 	path := strings.TrimSuffix(directory, "/")
-	cleanedPath := filepath.Join(path, queryName, "tests", uuid.NewV4().String())
+	cleanedPath := filepath.Join(path, queryName, "tests", uuid.NewString())
 
 	err := os.MkdirAll(cleanedPath, os.ModePerm)
 	if err != nil {

--- a/pkg/ui/progress.go
+++ b/pkg/ui/progress.go
@@ -3,7 +3,7 @@ package ui
 import (
 	"io"
 
-	uuid "github.com/satori/go.uuid"
+	"github.com/google/uuid"
 )
 
 const (
@@ -41,7 +41,7 @@ type ProgressUpdateFunc func(io.Reader, int64) io.Reader
 // CreateProgressUpdater creates a progress update callback method for periodic updates.
 func CreateProgressUpdater(progress Progress, displayName string) ProgressUpdateFunc {
 	return func(reader io.Reader, total int64) io.Reader {
-		id := uuid.NewV4()
+		id := uuid.New()
 		progress.Add(id.String(), displayName, "downloading...", total+2)
 		return progress.AttachReader(id.String(), reader)
 	}


### PR DESCRIPTION
Hi!

The satori/go.uuid library isn't longer supported, and contains security [issues](https://github.com/satori/go.uuid/issues/115). So I've replaced this with google/uuid. 