### PR TITLE
fix(policy): Add missing GitHub policy getter

### DIFF
--- a/internal/getter/getter.go
+++ b/internal/getter/getter.go
@@ -46,11 +46,12 @@ var (
 	}
 
 	getters = map[string]getter.Getter{
-		"file": new(getter.FileGetter),
-		"gcs":  new(getter.GCSGetter),
-		"git":  new(getter.GitGetter),
-		"hg":   new(getter.HgGetter),
-		"s3":   new(getter.S3Getter),
+		"file":   new(getter.FileGetter),
+		"gcs":    new(getter.GCSGetter),
+		"github": new(getter.GitGetter),
+		"git":    new(getter.GitGetter),
+		"hg":     new(getter.HgGetter),
+		"s3":     new(getter.S3Getter),
 	}
 )
 


### PR DESCRIPTION
Related to https://github.com/cloudquery/cloudquery-issues/issues/324 (internal issue).

To reproduce the issue run: `cloudquery policy run github::github.com/cloudquery-policies/aws`, and see that it fails with `Failed to run policies: failed to get source github::github.com/cloudquery-policies/aws: download not supported for scheme 'github'.`