### PR TITLE
fix(policy): Use firebase instead of GitHub to get latest version

### DIFF
--- a/internal/firebase/client.go
+++ b/internal/firebase/client.go
@@ -24,7 +24,7 @@ type FirebaseClient struct {
 	url string
 }
 
-func NewFirebaseClient(registryUrl string) *FirebaseClient {
+func New(registryUrl string) *FirebaseClient {
 	f := &FirebaseClient{
 		url: registryUrl,
 	}

--- a/internal/firebase/client.go
+++ b/internal/firebase/client.go
@@ -14,9 +14,10 @@ import (
 )
 
 const (
-	CloudQueryRegistryURL = "https://firestore.googleapis.com/v1/projects/hub-cloudquery/databases/(default)/documents/orgs/"
-	providersPath         = "%s/providers/%s/versions"
-	policiesPath          = "%s/policies/%s/versions"
+	CloudQueryRegistryURL              = "https://firestore.googleapis.com/v1/projects/hub-cloudquery/databases/(default)/documents/orgs/"
+	CloudQueryRegistryURLWithProviders = CloudQueryRegistryURL + "%s/providers/%s"
+	providersVersionsPath              = "%s/providers/%s/versions"
+	policiesVersionPath                = "%s/policies/%s/versions"
 )
 
 type FirebaseClient struct {
@@ -32,7 +33,7 @@ func NewFirebaseClient(registryUrl string) *FirebaseClient {
 }
 
 func (f *FirebaseClient) GetLatestProviderRelease(ctx context.Context, organization, providerName string) (string, error) {
-	versions, err := url.Parse(fmt.Sprintf(f.url+providersPath, organization, providerName))
+	versions, err := url.Parse(fmt.Sprintf(f.url+providersVersionsPath, organization, providerName))
 	if err != nil {
 		return "", err
 	}
@@ -74,7 +75,7 @@ func (f *FirebaseClient) GetLatestProviderRelease(ctx context.Context, organizat
 }
 
 func (f *FirebaseClient) GetLatestPolicyRelease(ctx context.Context, organization, policyName string) (string, error) {
-	versions, err := url.Parse(fmt.Sprintf(f.url+policiesPath, organization, policyName))
+	versions, err := url.Parse(fmt.Sprintf(f.url+policiesVersionPath, organization, policyName))
 	if err != nil {
 		return "", err
 	}

--- a/internal/firebase/client.go
+++ b/internal/firebase/client.go
@@ -1,0 +1,122 @@
+package firebase
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/url"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/hashicorp/go-version"
+)
+
+const (
+	CloudQueryRegistryURL = "https://firestore.googleapis.com/v1/projects/hub-cloudquery/databases/(default)/documents/orgs/"
+	providersPath         = "%s/providers/%s/versions"
+	policiesPath          = "%s/policies/%s/versions"
+)
+
+type FirebaseClient struct {
+	url string
+}
+
+func NewFirebaseClient(registryUrl string) *FirebaseClient {
+	f := &FirebaseClient{
+		url: registryUrl,
+	}
+
+	return f
+}
+
+func (f *FirebaseClient) GetLatestProviderRelease(ctx context.Context, organization, providerName string) (string, error) {
+	versions, err := url.Parse(fmt.Sprintf(f.url+providersPath, organization, providerName))
+	if err != nil {
+		return "", err
+	}
+	qv := versions.Query()
+	qv.Set("pageSize", "1")
+	qv.Set("orderBy", "v_major desc, v_minor desc, v_patch desc, published_at desc")
+	qv.Set("mask.fieldPaths", "tag")
+	versions.RawQuery = qv.Encode()
+
+	hc := &http.Client{Timeout: 15 * time.Second}
+	req, _ := http.NewRequestWithContext(ctx, http.MethodGet, versions.String(), nil)
+	res, err := hc.Do(req)
+	if err != nil {
+		return "", err
+	}
+	defer res.Body.Close()
+	if res.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("unexpected status code %d", res.StatusCode)
+	}
+
+	var doc struct {
+		Documents []struct {
+			Name   string `json:"name"`
+			Fields struct {
+				Tag struct {
+					Val string `json:"stringValue"`
+				} `json:"tag"`
+			} `json:"fields"`
+		} `json:"documents"`
+	}
+	if err := json.NewDecoder(res.Body).Decode(&doc); err != nil {
+		return "", err
+	}
+
+	if len(doc.Documents) == 0 || doc.Documents[0].Fields.Tag.Val == "" {
+		return "", fmt.Errorf("failed to find provider %s latest version", providerName)
+	}
+	return doc.Documents[0].Fields.Tag.Val, nil
+}
+
+func (f *FirebaseClient) GetLatestPolicyRelease(ctx context.Context, organization, policyName string) (string, error) {
+	versions, err := url.Parse(fmt.Sprintf(f.url+policiesPath, organization, policyName))
+	if err != nil {
+		return "", err
+	}
+	qv := versions.Query()
+	qv.Set("mask.fieldPaths", "policy.Name")
+	versions.RawQuery = qv.Encode()
+
+	hc := &http.Client{Timeout: 15 * time.Second}
+	req, _ := http.NewRequestWithContext(ctx, http.MethodGet, versions.String(), nil)
+	res, err := hc.Do(req)
+	if err != nil {
+		return "", err
+	}
+	defer res.Body.Close()
+	if res.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("unexpected status code %d", res.StatusCode)
+	}
+
+	var doc struct {
+		Documents []struct {
+			Name string `json:"name"`
+		} `json:"documents"`
+	}
+
+	if err := json.NewDecoder(res.Body).Decode(&doc); err != nil {
+		return "", err
+	}
+
+	valid := make([]*version.Version, 0)
+	for _, d := range doc.Documents {
+		nameParts := strings.Split(d.Name, "/")
+		if v, err := version.NewSemver(nameParts[len(nameParts)-1]); err == nil {
+			valid = append(valid, v)
+		}
+	}
+
+	sort.SliceStable(valid, func(i, j int) bool {
+		return valid[i].GreaterThan((valid[j]))
+	})
+
+	if len(valid) == 0 || valid[0].Original() == "" {
+		return "", fmt.Errorf("failed to find policy %s latest version", policyName)
+	}
+	return valid[0].Original(), nil
+}

--- a/internal/getter/github.go
+++ b/internal/getter/github.go
@@ -62,7 +62,7 @@ func (d *GitHubDetector) detectHTTP(src string) (string, bool, error) {
 }
 
 func addLatestTag(_url *url.URL, owner, repo string) error {
-	client := firebase.NewFirebaseClient(firebase.CloudQueryRegistryURL)
+	client := firebase.New(firebase.CloudQueryRegistryURL)
 	org, ok := repoToFirebasePath[owner]
 	if !ok {
 		org = owner

--- a/internal/getter/github_test.go
+++ b/internal/getter/github_test.go
@@ -16,13 +16,6 @@ func TestGitHubDetector_Detect(t *testing.T) {
 	}{
 		{
 			Name:           "base",
-			Source:         "github.com/cloudquery-policies/test_policy",
-			ExpectedSource: "git::https://github.com/cloudquery-policies/test_policy.git?ref=v0.0.1",
-			ExpectedFound:  true,
-			ExpectedError:  nil,
-		},
-		{
-			Name:           "base",
 			Source:         "github.com/cloudquery-policies/aws?ref=v0.0.1",
 			ExpectedSource: "git::https://github.com/cloudquery-policies/aws.git?ref=v0.0.1",
 			ExpectedFound:  true,

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -250,9 +250,9 @@ func New(ctx context.Context, options ...Option) (*Client, error) {
 		SkipBuildTables:    false,
 		HubProgressUpdater: nil,
 		HistoryCfg:         nil,
-		RegistryURL:        firebase.CloudQueryRegistryURL,
+		RegistryURL:        firebase.CloudQueryRegistryURLWithProviders,
 		Logger:             logging.NewZHcLog(&zerolog.Logger, ""),
-		Hub:                *registry.NewRegistryHub(firebase.CloudQueryRegistryURL),
+		Hub:                *registry.NewRegistryHub(firebase.CloudQueryRegistryURLWithProviders),
 	}
 	for _, o := range options {
 		o(c)

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -12,6 +12,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/cloudquery/cloudquery/internal/firebase"
 	"github.com/cloudquery/cloudquery/internal/logging"
 	"github.com/cloudquery/cloudquery/internal/telemetry"
 	"github.com/cloudquery/cloudquery/pkg/client/database"
@@ -249,9 +250,9 @@ func New(ctx context.Context, options ...Option) (*Client, error) {
 		SkipBuildTables:    false,
 		HubProgressUpdater: nil,
 		HistoryCfg:         nil,
-		RegistryURL:        registry.CloudQueryRegistryURL,
+		RegistryURL:        firebase.CloudQueryRegistryURL,
 		Logger:             logging.NewZHcLog(&zerolog.Logger, ""),
-		Hub:                *registry.NewRegistryHub(registry.CloudQueryRegistryURL),
+		Hub:                *registry.NewRegistryHub(firebase.CloudQueryRegistryURL),
 	}
 	for _, o := range options {
 		o(c)

--- a/pkg/client/purge_test.go
+++ b/pkg/client/purge_test.go
@@ -9,13 +9,13 @@ import (
 
 	"github.com/google/uuid"
 
+	"github.com/cloudquery/cloudquery/internal/firebase"
 	"github.com/cloudquery/cloudquery/internal/test/providertest"
 
 	"github.com/cloudquery/cq-provider-sdk/database"
 	"github.com/cloudquery/cq-provider-sdk/provider/schema"
 
 	"github.com/cloudquery/cloudquery/pkg/plugin"
-	"github.com/cloudquery/cloudquery/pkg/plugin/registry"
 	"github.com/cloudquery/cq-provider-sdk/provider/diag"
 	"github.com/hashicorp/go-hclog"
 
@@ -268,7 +268,7 @@ func TestPurgeProviderData(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.Name, func(t *testing.T) {
-			pm, err := plugin.NewManager(hclog.Default(), defaultProviderPath, registry.CloudQueryRegistryURL, nil)
+			pm, err := plugin.NewManager(hclog.Default(), defaultProviderPath, firebase.CloudQueryRegistryURL, nil)
 			if !assert.Nil(t, err) {
 				t.FailNow()
 			}

--- a/pkg/client/purge_test.go
+++ b/pkg/client/purge_test.go
@@ -268,7 +268,7 @@ func TestPurgeProviderData(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.Name, func(t *testing.T) {
-			pm, err := plugin.NewManager(hclog.Default(), defaultProviderPath, firebase.CloudQueryRegistryURL, nil)
+			pm, err := plugin.NewManager(hclog.Default(), defaultProviderPath, firebase.CloudQueryRegistryURLWithProviders, nil)
 			if !assert.Nil(t, err) {
 				t.FailNow()
 			}

--- a/pkg/client/schema_test.go
+++ b/pkg/client/schema_test.go
@@ -15,7 +15,7 @@ func Test_GetProviderSchema(t *testing.T) {
 	cancelServe := setupTestPlugin(t)
 	defer cancelServe()
 
-	pManager, err := plugin.NewManager(hclog.Default(), filepath.Join(".", ".cq", "providers"), firebase.CloudQueryRegistryURL, nil)
+	pManager, err := plugin.NewManager(hclog.Default(), filepath.Join(".", ".cq", "providers"), firebase.CloudQueryRegistryURLWithProviders, nil)
 	if !assert.NoError(t, err) {
 		t.FailNow()
 	}

--- a/pkg/client/schema_test.go
+++ b/pkg/client/schema_test.go
@@ -5,8 +5,8 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/cloudquery/cloudquery/internal/firebase"
 	"github.com/cloudquery/cloudquery/pkg/plugin"
-	"github.com/cloudquery/cloudquery/pkg/plugin/registry"
 	"github.com/hashicorp/go-hclog"
 	"github.com/stretchr/testify/assert"
 )
@@ -15,7 +15,7 @@ func Test_GetProviderSchema(t *testing.T) {
 	cancelServe := setupTestPlugin(t)
 	defer cancelServe()
 
-	pManager, err := plugin.NewManager(hclog.Default(), filepath.Join(".", ".cq", "providers"), registry.CloudQueryRegistryURL, nil)
+	pManager, err := plugin.NewManager(hclog.Default(), filepath.Join(".", ".cq", "providers"), firebase.CloudQueryRegistryURL, nil)
 	if !assert.NoError(t, err) {
 		t.FailNow()
 	}

--- a/pkg/plugin/registry/hub.go
+++ b/pkg/plugin/registry/hub.go
@@ -256,7 +256,7 @@ func (h Hub) downloadProvider(ctx context.Context, organization, providerName, p
 }
 
 func (h Hub) getLatestRelease(ctx context.Context, organization, providerName string) (string, error) {
-	client := firebase.NewFirebaseClient(firebase.CloudQueryRegistryURL)
+	client := firebase.New(firebase.CloudQueryRegistryURL)
 	latest, err := client.GetLatestProviderRelease(ctx, organization, providerName)
 	return latest, err
 }

--- a/pkg/plugin/registry/hub.go
+++ b/pkg/plugin/registry/hub.go
@@ -2,10 +2,8 @@ package registry
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"net/http"
-	"net/url"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -13,6 +11,7 @@ import (
 	"time"
 
 	"github.com/cloudquery/cloudquery/internal/file"
+	"github.com/cloudquery/cloudquery/internal/firebase"
 	"github.com/cloudquery/cloudquery/internal/logging"
 	"github.com/cloudquery/cloudquery/pkg/config"
 	"github.com/cloudquery/cloudquery/pkg/ui"
@@ -22,8 +21,6 @@ import (
 )
 
 const (
-	CloudQueryRegistryURL = "https://firestore.googleapis.com/v1/projects/hub-cloudquery/databases/(default)/documents/orgs/%s/providers/%s"
-
 	// Timeout for http requests related to CloudQuery providers version check.
 	versionCheckHTTPTimeout = time.Second * 10
 )
@@ -259,45 +256,9 @@ func (h Hub) downloadProvider(ctx context.Context, organization, providerName, p
 }
 
 func (h Hub) getLatestRelease(ctx context.Context, organization, providerName string) (string, error) {
-	versions, err := url.Parse(fmt.Sprintf(h.url+"/versions", organization, providerName))
-	if err != nil {
-		return "", err
-	}
-	qv := versions.Query()
-	qv.Set("pageSize", "1")
-	qv.Set("orderBy", "v_major desc, v_minor desc, v_patch desc, published_at desc")
-	qv.Set("mask.fieldPaths", "tag")
-	versions.RawQuery = qv.Encode()
-
-	hc := &http.Client{Timeout: 15 * time.Second}
-	req, _ := http.NewRequestWithContext(ctx, http.MethodGet, versions.String(), nil)
-	res, err := hc.Do(req)
-	if err != nil {
-		return "", err
-	}
-	defer res.Body.Close()
-	if res.StatusCode != http.StatusOK {
-		return "", fmt.Errorf("unexpected status code %d", res.StatusCode)
-	}
-
-	var doc struct {
-		Documents []struct {
-			Name   string `json:"name"`
-			Fields struct {
-				Tag struct {
-					Val string `json:"stringValue"`
-				} `json:"tag"`
-			} `json:"fields"`
-		} `json:"documents"`
-	}
-	if err := json.NewDecoder(res.Body).Decode(&doc); err != nil {
-		return "", err
-	}
-
-	if len(doc.Documents) == 0 || doc.Documents[0].Fields.Tag.Val == "" {
-		return "", fmt.Errorf("failed to find provider %s latest version", providerName)
-	}
-	return doc.Documents[0].Fields.Tag.Val, nil
+	client := firebase.NewFirebaseClient(firebase.CloudQueryRegistryURL)
+	latest, err := client.GetLatestProviderRelease(ctx, organization, providerName)
+	return latest, err
 }
 
 func (h Hub) verifyRegistered(organization, providerName, version string, noVerify bool) bool {


### PR DESCRIPTION
Fixes https://github.com/cloudquery/cloudquery-issues/issues/324 (internal issue).

This PR gets the policy latest version from Firebase instead of GitHub to avoid hitting rate limits.
To reproduce run `cloudquery policy run github::github.com/cloudquery-policies/aws` multiple times.

This is the smallest change I could think of to fix the issue.

Example data  https://firestore.googleapis.com/v1/projects/hub-cloudquery/databases/(default)/documents/orgs/cloudquery/policies/aws/versions?mask.fieldPaths=policy.Name

