### PR TITLE
chore(test): Ignore files generated during tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,8 @@ config.hcl
 config_old.hcl
 /pkg/policy/tests/output/
 /pkg/policy/cq/*
+/pkg/ui/console/.cq/*
 database-data/*
 dest/*
 outfile
+test_init_config.hcl


### PR DESCRIPTION
While running the tests I noticed some files that are generated by the tests are not `git` ignored.

This PR fixes it