### PR TITLE
test(policy): Don't prompt for GitHub user:pass when running the test

### DIFF
--- a/pkg/policy/source_test.go
+++ b/pkg/policy/source_test.go
@@ -68,7 +68,7 @@ func TestLoadSource(t *testing.T) {
 		},
 		{
 			Name:          "non-existing-github",
-			Source:        "github.com/cloudquery-policies/blabla",
+			Source:        "user:pass@github.com/cloudquery-policies/blabla",
 			ErrorExpected: true,
 		},
 		{


### PR DESCRIPTION
When I ran `go test -timeout 30s -run ^TestLoadSource$ github.com/cloudquery/cloudquery/pkg/policy` on my machine it prompted for a GitHub username and password.

The reason is that `git` tries to authenticate using `user/pass` when the scheme is `https` (I think `go-getter` tries it when it doesn't find a repo)

It doesn't prompt in CI/non interactive environment as `git` won't prompt in those, and will simply fail (see error [here](https://stackoverflow.com/questions/40274484/fatal-could-not-read-username-for-https-github-com-device-not-configured)).

This PR forces a `user:pass` (invalid, but that's ok as the test expects an error anyway).