### PR TITLE
fix(policy): Don't crash when setting policy via config.hcl

### DIFF
--- a/pkg/policy/policy.go
+++ b/pkg/policy/policy.go
@@ -19,7 +19,7 @@ func (pp Policies) Properties() map[string]interface{} {
 	usedCustom := 0
 	policies := make([]*Meta, 0)
 	for _, p := range pp {
-		if p.meta.Type != "hub" {
+		if p.meta != nil && p.meta.Type != "hub" {
 			usedCustom++
 			// we don't add info about custom policies that were executed
 			continue


### PR DESCRIPTION
I encountered this while trying to reproduce https://github.com/cloudquery/cloudquery/issues/647

To reproduce:
1. Add the following in your `config.hcl` file (as a top level object)
```hcl
policy "aws" {
    source = "aws"
}
```
2. On the `main` branch run `go run main.go policy run`