### PR TITLE
feat: DSN credentials

### DIFF
--- a/cmd/init.go
+++ b/cmd/init.go
@@ -73,18 +73,17 @@ func Initialize(ctx context.Context, providers []string) error {
 		providers[i] = providerName // overwrite "provider@version" with just "provider"
 	}
 	// TODO: build this manually with block and add comments as well
-	defaultPort := 5432
 	cqBlock := gohcl.EncodeAsBlock(&config.CloudQuery{
 		PluginDirectory: "./cq/providers",
 		PolicyDirectory: "./cq/policies",
 		Providers:       requiredProviders,
 		Connection: &config.Connection{
-			Username: ptr("postgres"),
-			Password: ptr("pass"),
-			Host:     ptr("localhost"),
-			Port:     &defaultPort,
-			Database: ptr("postgres"),
-			SSLMode:  ptr("disable"),
+			Username: "postgres",
+			Password: "pass",
+			Host:     "localhost",
+			Port:     5432,
+			Database: "postgres",
+			SSLMode:  "disable",
 		},
 	}, "cloudquery")
 
@@ -96,7 +95,7 @@ func Initialize(ctx context.Context, providers []string) error {
 		return diags
 	}
 
-	cfg.CloudQuery.Connection.DSN = nil // Don't connect
+	cfg.CloudQuery.Connection.DSN = "" // Don't connect
 	c, err := console.CreateClientFromConfig(ctx, cfg)
 	if err != nil {
 		return err
@@ -149,8 +148,4 @@ func Initialize(ctx context.Context, providers []string) error {
 func init() {
 	initCmd.SetUsageTemplate(usageTemplateWithFlags)
 	rootCmd.AddCommand(initCmd)
-}
-
-func ptr(s string) *string {
-	return &s
 }

--- a/cmd/init.go
+++ b/cmd/init.go
@@ -73,12 +73,13 @@ func Initialize(ctx context.Context, providers []string) error {
 		providers[i] = providerName // overwrite "provider@version" with just "provider"
 	}
 	// TODO: build this manually with block and add comments as well
+	defaultDSN := "postgres://postgres:pass@localhost:5432/postgres?sslmode=disable"
 	cqBlock := gohcl.EncodeAsBlock(&config.CloudQuery{
 		PluginDirectory: "./cq/providers",
 		PolicyDirectory: "./cq/policies",
 		Providers:       requiredProviders,
 		Connection: &config.Connection{
-			DSN: "postgres://postgres:pass@localhost:5432/postgres?sslmode=disable",
+			DSN: &defaultDSN,
 		},
 	}, "cloudquery")
 
@@ -90,7 +91,7 @@ func Initialize(ctx context.Context, providers []string) error {
 		return diags
 	}
 
-	cfg.CloudQuery.Connection.DSN = "" // Don't connect
+	cfg.CloudQuery.Connection.DSN = nil // Don't connect
 	c, err := console.CreateClientFromConfig(ctx, cfg)
 	if err != nil {
 		return err

--- a/cmd/init.go
+++ b/cmd/init.go
@@ -73,13 +73,18 @@ func Initialize(ctx context.Context, providers []string) error {
 		providers[i] = providerName // overwrite "provider@version" with just "provider"
 	}
 	// TODO: build this manually with block and add comments as well
-	defaultDSN := "postgres://postgres:pass@localhost:5432/postgres?sslmode=disable"
+	defaultPort := 5432
 	cqBlock := gohcl.EncodeAsBlock(&config.CloudQuery{
 		PluginDirectory: "./cq/providers",
 		PolicyDirectory: "./cq/policies",
 		Providers:       requiredProviders,
 		Connection: &config.Connection{
-			DSN: &defaultDSN,
+			Username: ptr("postgres"),
+			Password: ptr("pass"),
+			Host:     ptr("localhost"),
+			Port:     &defaultPort,
+			Database: ptr("postgres"),
+			SSLMode:  ptr("disable"),
 		},
 	}, "cloudquery")
 
@@ -144,4 +149,8 @@ func Initialize(ctx context.Context, providers []string) error {
 func init() {
 	initCmd.SetUsageTemplate(usageTemplateWithFlags)
 	rootCmd.AddCommand(initCmd)
+}
+
+func ptr(s string) *string {
+	return &s
 }

--- a/deploy/lambda.go
+++ b/deploy/lambda.go
@@ -74,15 +74,11 @@ func Fetch(ctx context.Context, cfg *config.Config) error {
 	}
 	defer pm.Shutdown()
 
-	var ds string
-	if cfg.CloudQuery.Connection.DSN != nil {
-		ds = *cfg.CloudQuery.Connection.DSN
-	}
-	_, dialect, err := database.GetExecutor(ds, cfg.CloudQuery.History)
+	_, dialect, err := database.GetExecutor(cfg.CloudQuery.Connection.DSN, cfg.CloudQuery.History)
 	if err != nil {
 		return err
 	}
-	storage := database.NewStorage(*cfg.CloudQuery.Connection.DSN, dialect)
+	storage := database.NewStorage(cfg.CloudQuery.Connection.DSN, dialect)
 
 	providers := make([]core.ProviderInfo, len(cfg.Providers))
 	for i, p := range cfg.Providers {
@@ -115,7 +111,7 @@ func Fetch(ctx context.Context, cfg *config.Config) error {
 // Policy Runs a policy SQL statement and returns results
 func Policy(ctx context.Context, cfg *config.Config) error {
 	outputPath := "/tmp/"
-	storage := database.NewStorage(*cfg.CloudQuery.Connection.DSN, nil)
+	storage := database.NewStorage(cfg.CloudQuery.Connection.DSN, nil)
 	_, err := policy.Run(ctx, storage, &policy.RunRequest{
 		Policies:  cfg.Policies,
 		Directory: cfg.CloudQuery.PolicyDirectory,

--- a/deploy/lambda.go
+++ b/deploy/lambda.go
@@ -26,7 +26,11 @@ func LambdaHandler(ctx context.Context, req Request) (string, error) {
 }
 
 func TaskExecutor(ctx context.Context, req Request) (string, error) {
-	dsn := os.Getenv("CQ_DSN")
+	// Override dsn env if set
+	if envDsn, present := os.LookupEnv("CQ_DSN"); present {
+		viper.Set("dsn", envDsn)
+	}
+
 	dataDir, present := os.LookupEnv("CQ_DATA_DIR")
 	if !present {
 		dataDir = ".cq"
@@ -49,10 +53,6 @@ func TaskExecutor(ctx context.Context, req Request) (string, error) {
 	if diags != nil {
 		return "", fmt.Errorf("bad configuration: %s", diags)
 	}
-	// Override dsn env if set
-	if dsn != "" {
-		cfg.CloudQuery.Connection.DSN = dsn
-	}
 
 	completedMsg := fmt.Sprintf("Completed task %s", req.TaskName)
 	switch req.TaskName {
@@ -74,11 +74,15 @@ func Fetch(ctx context.Context, cfg *config.Config) error {
 	}
 	defer pm.Shutdown()
 
-	_, dialect, err := database.GetExecutor(cfg.CloudQuery.Connection.DSN, cfg.CloudQuery.History)
+	var ds string
+	if cfg.CloudQuery.Connection.DSN != nil {
+		ds = *cfg.CloudQuery.Connection.DSN
+	}
+	_, dialect, err := database.GetExecutor(ds, cfg.CloudQuery.History)
 	if err != nil {
 		return err
 	}
-	storage := database.NewStorage(cfg.CloudQuery.Connection.DSN, dialect)
+	storage := database.NewStorage(*cfg.CloudQuery.Connection.DSN, dialect)
 
 	providers := make([]core.ProviderInfo, len(cfg.Providers))
 	for i, p := range cfg.Providers {
@@ -111,7 +115,7 @@ func Fetch(ctx context.Context, cfg *config.Config) error {
 // Policy Runs a policy SQL statement and returns results
 func Policy(ctx context.Context, cfg *config.Config) error {
 	outputPath := "/tmp/"
-	storage := database.NewStorage(cfg.CloudQuery.Connection.DSN, nil)
+	storage := database.NewStorage(*cfg.CloudQuery.Connection.DSN, nil)
 	_, err := policy.Run(ctx, storage, &policy.RunRequest{
 		Policies:  cfg.Policies,
 		Directory: cfg.CloudQuery.PolicyDirectory,

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -56,7 +56,10 @@ func (c CloudQuery) GetRequiredProvider(name string) (*RequiredProvider, error) 
 }
 
 type Connection struct {
-	DSN string `hcl:"dsn,attr"`
+	DSN      string  `hcl:"dsn,attr"`
+	Username *string `hcl:"username,attr"`
+	Password *string `hcl:"password,attr"`
+	Type     *string `hcl:"type,attr"`
 }
 
 type RequiredProvider struct {

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -7,12 +7,12 @@ import (
 	"sort"
 	"strings"
 
-	"github.com/cloudquery/cloudquery/pkg/policy"
+	"github.com/hashicorp/hcl/v2"
 	"github.com/xo/dburl"
 
 	"github.com/cloudquery/cloudquery/internal/logging"
 	"github.com/cloudquery/cloudquery/pkg/core/history"
-	"github.com/hashicorp/hcl/v2"
+	"github.com/cloudquery/cloudquery/pkg/policy"
 )
 
 type Providers []*Provider

--- a/pkg/config/config_parser.go
+++ b/pkg/config/config_parser.go
@@ -7,13 +7,13 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/cloudquery/cloudquery/internal/logging"
-	"github.com/cloudquery/cloudquery/pkg/policy"
 	"github.com/creasty/defaults"
+	"github.com/hashicorp/hcl/v2"
 	"github.com/hashicorp/hcl/v2/gohcl"
 	"github.com/spf13/viper"
 
-	"github.com/hashicorp/hcl/v2"
+	"github.com/cloudquery/cloudquery/internal/logging"
+	"github.com/cloudquery/cloudquery/pkg/policy"
 )
 
 func (p *Parser) LoadConfigFromSource(name string, data []byte) (*Config, hcl.Diagnostics) {

--- a/pkg/config/config_parser.go
+++ b/pkg/config/config_parser.go
@@ -183,10 +183,10 @@ func decodeCloudQueryBlock(block *hcl.Block, ctx *hcl.EvalContext) (CloudQuery, 
 
 func handleConnectionBlock(c *Connection) error {
 	if ds := viper.GetString("dsn"); ds != "" {
-		c.DSN = &ds
+		c.DSN = ds
 		return nil
 	}
-	if isSet(c.DSN) {
+	if c.DSN != "" {
 		if c.IsAnyConnParamsSet() {
 			return errors.New("DSN specified along with explicit attributes, only one type is supported")
 		}
@@ -197,6 +197,6 @@ func handleConnectionBlock(c *Connection) error {
 	if err != nil {
 		return err
 	}
-	c.DSN = ptr(s.String())
+	c.DSN = s.String()
 	return nil
 }

--- a/pkg/config/config_parser.go
+++ b/pkg/config/config_parser.go
@@ -207,11 +207,12 @@ func handleConnectionBlock(c *Connection) error {
 
 	usingURLs := strings.HasPrefix(c.DSN, ds.OriginalScheme+"://")
 	if c.Username != nil {
-		if !usingURLs {
+		switch {
+		case !usingURLs:
 			return errors.New("`username` param specified but given DSN is of non-URL type")
-		} else if ds.User != nil && ds.User.Username() != "" {
+		case ds.User != nil && ds.User.Username() != "":
 			return errors.New("`username` param specified but given DSN already specifies username")
-		} else {
+		default:
 			setUser = c.Username
 		}
 	}

--- a/pkg/config/config_parser_test.go
+++ b/pkg/config/config_parser_test.go
@@ -40,6 +40,19 @@ func TestHandleConnectionBlock(t *testing.T) {
 			&Connection{
 				connParams: connParams{
 					Username: `user`,
+					Type:     `tsdb`,
+					Host:     `localhost`,
+					Port:     15432,
+					Database: `postgres`,
+				},
+			},
+			"tsdb://user@localhost:15432/postgres",
+			false,
+		},
+		{
+			&Connection{
+				connParams: connParams{
+					Username: `user`,
 					Password: `pass`,
 					Host:     `localhost`,
 					Database: `postdb`,

--- a/pkg/config/config_parser_test.go
+++ b/pkg/config/config_parser_test.go
@@ -8,10 +8,6 @@ import (
 )
 
 func TestHandleConnectionBlock(t *testing.T) {
-	s := func(s string) *string {
-		return &s
-	}
-
 	cases := []struct {
 		input          *Connection
 		expectedResult string
@@ -19,62 +15,39 @@ func TestHandleConnectionBlock(t *testing.T) {
 	}{
 		{
 			&Connection{
-				DSN:  `host=localhost database=somedb port=5432 sslmode=disable`,
-				Type: s(`tsdb`),
+				DSN: `host=localhost database=somedb port=5432 sslmode=disable`,
+				connParams: connParams{
+					Type: "tsdb",
+				},
 			},
-			"tsdb://localhost:5432/somedb?sslmode=disable",
+			"",
+			true,
+		},
+		{
+			&Connection{
+				connParams: connParams{
+					Username: `user`,
+					Password: `pass`,
+					Type:     `tsdb`,
+					Host:     `localhost`,
+					Database: `postgres`,
+				},
+			},
+			"tsdb://user:pass@localhost:5432/postgres",
 			false,
 		},
 		{
 			&Connection{
-				DSN:      `host=localhost database=somedb port=5432 sslmode=disable`,
-				Username: s(`user`),
+				connParams: connParams{
+					Username: `user`,
+					Password: `pass`,
+					Host:     `localhost`,
+					Database: `postdb`,
+					SSLMode:  `disable`,
+					Extras:   []string{"a=b", "c=d", "e", "sslmode=enable"},
+				},
 			},
-			"",
-			true,
-		},
-		{
-			&Connection{
-				DSN:      `host=localhost database=somedb port=5432 sslmode=disable`,
-				Password: s(`pass`),
-			},
-			"",
-			true,
-		},
-		{
-			&Connection{
-				DSN:      `host=localhost database=somedb port=5432 sslmode=disable`,
-				Username: s(`user`),
-				Password: s(`pass`),
-				Type:     s(`tsdb`),
-			},
-			"",
-			true,
-		},
-		{
-			&Connection{
-				DSN:  `host=localhost user=postgres password=pass database=somedb port=5432 sslmode=disable`,
-				Type: s(`tsdb`),
-			},
-			"tsdb://postgres:pass@localhost:5432/somedb?sslmode=disable",
-			false,
-		},
-		{
-			&Connection{
-				DSN:      `postgres://user:pass@localhost:5432/somedb?sslmode=disable`,
-				Username: s(`us3r`),
-				Password: s(`p4ss`),
-			},
-			"",
-			true,
-		},
-		{
-			&Connection{
-				DSN:      `postgres://localhost:5432/somedb?sslmode=disable`,
-				Username: s(`us3r`),
-				Password: s(`p4ss`),
-			},
-			"postgres://us3r:p4ss@localhost:5432/somedb?sslmode=disable",
+			"postgres://user:pass@localhost:5432/postdb?a=b&c=d&e=&sslmode=disable",
 			false,
 		},
 	}

--- a/pkg/config/config_parser_test.go
+++ b/pkg/config/config_parser_test.go
@@ -15,42 +15,42 @@ func TestHandleConnectionBlock(t *testing.T) {
 	}{
 		{
 			&Connection{
-				DSN:  ptr(`host=localhost database=somedb port=5432 sslmode=disable`),
-				Type: ptr("tsdb"),
+				DSN:  `host=localhost database=somedb port=5432 sslmode=disable`,
+				Type: "tsdb",
 			},
 			"",
 			true,
 		},
 		{
 			&Connection{
-				Username: ptr(`user`),
-				Password: ptr(`pass`),
-				Type:     ptr(`tsdb`),
-				Host:     ptr(`localhost`),
-				Database: ptr(`postgres`),
+				Username: `user`,
+				Password: `pass`,
+				Type:     `tsdb`,
+				Host:     `localhost`,
+				Database: `postgres`,
 			},
 			"tsdb://user:pass@localhost:5432/postgres",
 			false,
 		},
 		{
 			&Connection{
-				Username: ptr(`user`),
-				Type:     ptr(`tsdb`),
-				Host:     ptr(`localhost`),
-				Port:     func(i int) *int { return &i }(15432),
-				Database: ptr(`postgres`),
+				Username: `user`,
+				Type:     `tsdb`,
+				Host:     `localhost`,
+				Port:     15432,
+				Database: `postgres`,
 			},
 			"tsdb://user@localhost:15432/postgres",
 			false,
 		},
 		{
 			&Connection{
-				Username: ptr(`user`),
-				Password: ptr(`pass`),
-				Host:     ptr(`localhost`),
-				Database: ptr(`postdb`),
-				SSLMode:  ptr(`disable`),
-				Extras:   func(s []string) *[]string { return &s }([]string{"a=b", "c=d", "e", "sslmode=enable"}),
+				Username: `user`,
+				Password: `pass`,
+				Host:     `localhost`,
+				Database: `postdb`,
+				SSLMode:  `disable`,
+				Extras:   []string{"a=b", "c=d", "e", "sslmode=enable"},
 			},
 			"postgres://user:pass@localhost:5432/postdb?a=b&c=d&e=&sslmode=disable",
 			false,
@@ -64,8 +64,7 @@ func TestHandleConnectionBlock(t *testing.T) {
 				assert.Error(t, err)
 			} else {
 				assert.NoError(t, err)
-				assert.NotNil(t, tc.input.DSN)
-				assert.Equal(t, tc.expectedResult, *tc.input.DSN)
+				assert.Equal(t, tc.expectedResult, tc.input.DSN)
 			}
 		})
 	}

--- a/pkg/config/config_parser_test.go
+++ b/pkg/config/config_parser_test.go
@@ -1,0 +1,93 @@
+package config
+
+import (
+	"strconv"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestHandleConnectionBlock(t *testing.T) {
+	s := func(s string) *string {
+		return &s
+	}
+
+	cases := []struct {
+		input          *Connection
+		expectedResult string
+		expectedError  bool
+	}{
+		{
+			&Connection{
+				DSN:  `host=localhost database=somedb port=5432 sslmode=disable`,
+				Type: s(`tsdb`),
+			},
+			"tsdb://localhost:5432/somedb?sslmode=disable",
+			false,
+		},
+		{
+			&Connection{
+				DSN:      `host=localhost database=somedb port=5432 sslmode=disable`,
+				Username: s(`user`),
+			},
+			"",
+			true,
+		},
+		{
+			&Connection{
+				DSN:      `host=localhost database=somedb port=5432 sslmode=disable`,
+				Password: s(`pass`),
+			},
+			"",
+			true,
+		},
+		{
+			&Connection{
+				DSN:      `host=localhost database=somedb port=5432 sslmode=disable`,
+				Username: s(`user`),
+				Password: s(`pass`),
+				Type:     s(`tsdb`),
+			},
+			"",
+			true,
+		},
+		{
+			&Connection{
+				DSN:  `host=localhost user=postgres password=pass database=somedb port=5432 sslmode=disable`,
+				Type: s(`tsdb`),
+			},
+			"tsdb://postgres:pass@localhost:5432/somedb?sslmode=disable",
+			false,
+		},
+		{
+			&Connection{
+				DSN:      `postgres://user:pass@localhost:5432/somedb?sslmode=disable`,
+				Username: s(`us3r`),
+				Password: s(`p4ss`),
+			},
+			"",
+			true,
+		},
+		{
+			&Connection{
+				DSN:      `postgres://localhost:5432/somedb?sslmode=disable`,
+				Username: s(`us3r`),
+				Password: s(`p4ss`),
+			},
+			"postgres://us3r:p4ss@localhost:5432/somedb?sslmode=disable",
+			false,
+		},
+	}
+	for i := range cases {
+		tc := cases[i]
+		t.Run("case #"+strconv.Itoa(i+1), func(t *testing.T) {
+			err := handleConnectionBlock(tc.input)
+			if tc.expectedError {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+				assert.Equal(t, tc.expectedResult, tc.input.DSN)
+			}
+		})
+	}
+}

--- a/pkg/config/config_parser_test.go
+++ b/pkg/config/config_parser_test.go
@@ -15,50 +15,42 @@ func TestHandleConnectionBlock(t *testing.T) {
 	}{
 		{
 			&Connection{
-				DSN: `host=localhost database=somedb port=5432 sslmode=disable`,
-				connParams: connParams{
-					Type: "tsdb",
-				},
+				DSN:  ptr(`host=localhost database=somedb port=5432 sslmode=disable`),
+				Type: ptr("tsdb"),
 			},
 			"",
 			true,
 		},
 		{
 			&Connection{
-				connParams: connParams{
-					Username: `user`,
-					Password: `pass`,
-					Type:     `tsdb`,
-					Host:     `localhost`,
-					Database: `postgres`,
-				},
+				Username: ptr(`user`),
+				Password: ptr(`pass`),
+				Type:     ptr(`tsdb`),
+				Host:     ptr(`localhost`),
+				Database: ptr(`postgres`),
 			},
 			"tsdb://user:pass@localhost:5432/postgres",
 			false,
 		},
 		{
 			&Connection{
-				connParams: connParams{
-					Username: `user`,
-					Type:     `tsdb`,
-					Host:     `localhost`,
-					Port:     15432,
-					Database: `postgres`,
-				},
+				Username: ptr(`user`),
+				Type:     ptr(`tsdb`),
+				Host:     ptr(`localhost`),
+				Port:     func(i int) *int { return &i }(15432),
+				Database: ptr(`postgres`),
 			},
 			"tsdb://user@localhost:15432/postgres",
 			false,
 		},
 		{
 			&Connection{
-				connParams: connParams{
-					Username: `user`,
-					Password: `pass`,
-					Host:     `localhost`,
-					Database: `postdb`,
-					SSLMode:  `disable`,
-					Extras:   []string{"a=b", "c=d", "e", "sslmode=enable"},
-				},
+				Username: ptr(`user`),
+				Password: ptr(`pass`),
+				Host:     ptr(`localhost`),
+				Database: ptr(`postdb`),
+				SSLMode:  ptr(`disable`),
+				Extras:   func(s []string) *[]string { return &s }([]string{"a=b", "c=d", "e", "sslmode=enable"}),
 			},
 			"postgres://user:pass@localhost:5432/postdb?a=b&c=d&e=&sslmode=disable",
 			false,
@@ -72,7 +64,8 @@ func TestHandleConnectionBlock(t *testing.T) {
 				assert.Error(t, err)
 			} else {
 				assert.NoError(t, err)
-				assert.Equal(t, tc.expectedResult, tc.input.DSN)
+				assert.NotNil(t, tc.input.DSN)
+				assert.Equal(t, tc.expectedResult, *tc.input.DSN)
 			}
 		})
 	}

--- a/pkg/config/parser_test.go
+++ b/pkg/config/parser_test.go
@@ -278,7 +278,7 @@ func TestConfigEnvVariableSubstitution(t *testing.T) {
 		}
 		return
 	}
-	assert.Equal(t, "postgres://postgres:pass@localhost:5432/postgres", cfg.CloudQuery.Connection.DSN)
+	assert.Equal(t, "postgres://postgres:pass@localhost:5432/postgres", *cfg.CloudQuery.Connection.DSN)
 
 	c := AwsConfig{}
 	errs := hclsimple.Decode("res.hcl", cfg.Providers[0].Configuration, nil, &c)

--- a/pkg/config/parser_test.go
+++ b/pkg/config/parser_test.go
@@ -177,7 +177,7 @@ func TestParser_LoadConfigFromSource(t *testing.T) {
 	source := "cloudquery"
 	assert.Equal(t, &Config{
 		CloudQuery: CloudQuery{
-			Connection: &Connection{DSN: "postgres://postgres:pass@localhost:5432/postgres"},
+			Connection: &Connection{DSN: ptr("postgres://postgres:pass@localhost:5432/postgres")},
 			Providers: []*RequiredProvider{{
 				Name:    "test",
 				Source:  &source,
@@ -296,7 +296,7 @@ func TestParser_LoadConfigNoSourceField(t *testing.T) {
 	cfg.Providers[0].Configuration = nil
 	assert.Equal(t, &Config{
 		CloudQuery: CloudQuery{
-			Connection: &Connection{DSN: "postgres://postgres:pass@localhost:5432/postgres"},
+			Connection: &Connection{DSN: ptr("postgres://postgres:pass@localhost:5432/postgres")},
 			Providers: []*RequiredProvider{{
 				Name:    "test",
 				Source:  nil,

--- a/pkg/config/parser_test.go
+++ b/pkg/config/parser_test.go
@@ -177,7 +177,7 @@ func TestParser_LoadConfigFromSource(t *testing.T) {
 	source := "cloudquery"
 	assert.Equal(t, &Config{
 		CloudQuery: CloudQuery{
-			Connection: &Connection{DSN: ptr("postgres://postgres:pass@localhost:5432/postgres")},
+			Connection: &Connection{DSN: "postgres://postgres:pass@localhost:5432/postgres"},
 			Providers: []*RequiredProvider{{
 				Name:    "test",
 				Source:  &source,
@@ -278,7 +278,7 @@ func TestConfigEnvVariableSubstitution(t *testing.T) {
 		}
 		return
 	}
-	assert.Equal(t, "postgres://postgres:pass@localhost:5432/postgres", *cfg.CloudQuery.Connection.DSN)
+	assert.Equal(t, "postgres://postgres:pass@localhost:5432/postgres", cfg.CloudQuery.Connection.DSN)
 
 	c := AwsConfig{}
 	errs := hclsimple.Decode("res.hcl", cfg.Providers[0].Configuration, nil, &c)
@@ -296,7 +296,7 @@ func TestParser_LoadConfigNoSourceField(t *testing.T) {
 	cfg.Providers[0].Configuration = nil
 	assert.Equal(t, &Config{
 		CloudQuery: CloudQuery{
-			Connection: &Connection{DSN: ptr("postgres://postgres:pass@localhost:5432/postgres")},
+			Connection: &Connection{DSN: "postgres://postgres:pass@localhost:5432/postgres"},
 			Providers: []*RequiredProvider{{
 				Name:    "test",
 				Source:  nil,

--- a/pkg/ui/console/client.go
+++ b/pkg/ui/console/client.go
@@ -70,7 +70,7 @@ func CreateClient(ctx context.Context, configPath string, allowDefaultConfig boo
 			CloudQuery: config.CloudQuery{
 				PluginDirectory: "./.cq/providers",
 				PolicyDirectory: "./.cq/policies",
-				Connection:      &config.Connection{DSN: ""},
+				Connection:      &config.Connection{},
 			},
 		}
 	}
@@ -105,8 +105,8 @@ func CreateClientFromConfig(ctx context.Context, cfg *config.Config) (*Client, e
 	}
 
 	var storage database.Storage
-	if cfg.CloudQuery.Connection.DSN != "" {
-		_, dialect, err = database.GetExecutor(cfg.CloudQuery.Connection.DSN, cfg.CloudQuery.History)
+	if cfg.CloudQuery.Connection.DSN != nil && *cfg.CloudQuery.Connection.DSN != "" {
+		_, dialect, err = database.GetExecutor(*cfg.CloudQuery.Connection.DSN, cfg.CloudQuery.History)
 		if err != nil {
 			return nil, err
 		}
@@ -123,7 +123,7 @@ func CreateClientFromConfig(ctx context.Context, cfg *config.Config) (*Client, e
 			setAnalyticsProperties(map[string]interface{}{"database_id": dbId})
 		}
 
-		storage = database.NewStorage(cfg.CloudQuery.Connection.DSN, dialect)
+		storage = database.NewStorage(*cfg.CloudQuery.Connection.DSN, dialect)
 	}
 	pp := make(registry.Providers, len(cfg.CloudQuery.Providers))
 	for i, rp := range cfg.CloudQuery.Providers {

--- a/pkg/ui/console/client.go
+++ b/pkg/ui/console/client.go
@@ -105,8 +105,8 @@ func CreateClientFromConfig(ctx context.Context, cfg *config.Config) (*Client, e
 	}
 
 	var storage database.Storage
-	if cfg.CloudQuery.Connection.DSN != nil && *cfg.CloudQuery.Connection.DSN != "" {
-		_, dialect, err = database.GetExecutor(*cfg.CloudQuery.Connection.DSN, cfg.CloudQuery.History)
+	if cfg.CloudQuery.Connection.DSN != "" {
+		_, dialect, err = database.GetExecutor(cfg.CloudQuery.Connection.DSN, cfg.CloudQuery.History)
 		if err != nil {
 			return nil, err
 		}
@@ -123,7 +123,7 @@ func CreateClientFromConfig(ctx context.Context, cfg *config.Config) (*Client, e
 			setAnalyticsProperties(map[string]interface{}{"database_id": dbId})
 		}
 
-		storage = database.NewStorage(*cfg.CloudQuery.Connection.DSN, dialect)
+		storage = database.NewStorage(cfg.CloudQuery.Connection.DSN, dialect)
 	}
 	pp := make(registry.Providers, len(cfg.CloudQuery.Providers))
 	for i, rp := range cfg.CloudQuery.Providers {


### PR DESCRIPTION
Introduce all DSN parts separately in connection block.
Old DSN syntax (URL or non-URL) can still be used, but the two types can't be combined.

Closes #600.
Fixes #612.