### PR TITLE
fix(policy): Improve file detector to detect non existing files

### DIFF
--- a/internal/getter/file.go
+++ b/internal/getter/file.go
@@ -39,7 +39,7 @@ func fmtFileURL(path string) string {
 	}
 
 	// Make sure that we don't start with "/" since we add that below.
-	if path[0] == '/' {
+	if len(path) > 0 && path[0] == '/' {
 		path = path[1:]
 	}
 	return fmt.Sprintf("file:///%s", path)

--- a/internal/getter/file.go
+++ b/internal/getter/file.go
@@ -1,7 +1,9 @@
 package getter
 
 import (
+	"fmt"
 	"path/filepath"
+	"runtime"
 
 	"github.com/hashicorp/go-getter"
 	"github.com/spf13/afero"
@@ -9,7 +11,38 @@ import (
 
 // fileDetector is a replacement for go-getter's own file detector which also verifies the source file exists
 type fileDetector struct {
-	fd getter.FileDetector
+	fd               getter.FileDetector
+	allowNonExisting bool
+}
+
+func isValidPath(fs afero.Fs, path string) bool {
+	err := fs.MkdirAll(path, 0700)
+	if err == nil {
+		_ = fs.Remove(path)
+	}
+
+	return err == nil
+}
+
+func NewFileDetector(allowNonExisting bool) *fileDetector {
+	p := new(fileDetector)
+	p.allowNonExisting = allowNonExisting
+	return p
+}
+
+// Extracted from getter.FileDetector
+func fmtFileURL(path string) string {
+	if runtime.GOOS == "windows" {
+		// Make sure we're using "/" on Windows. URLs are "/"-based.
+		path = filepath.ToSlash(path)
+		return fmt.Sprintf("file://%s", path)
+	}
+
+	// Make sure that we don't start with "/" since we add that below.
+	if path[0] == '/' {
+		path = path[1:]
+	}
+	return fmt.Sprintf("file:///%s", path)
 }
 
 func (d *fileDetector) Detect(src, pwd string) (string, bool, error) {
@@ -20,7 +53,11 @@ func (d *fileDetector) Detect(src, pwd string) (string, bool, error) {
 	if pwd != "" && !filepath.IsAbs(src) {
 		checkPath = filepath.Join(pwd, src)
 	}
-	if ok, _ := afero.Exists(afero.NewOsFs(), checkPath); !ok {
+	fs := afero.NewOsFs()
+	if ok, _ := afero.Exists(fs, checkPath); !ok {
+		if d.allowNonExisting && isValidPath(fs, checkPath) {
+			return fmtFileURL(checkPath), true, nil
+		}
 		return "", false, nil
 	}
 	return d.fd.Detect(src, pwd)

--- a/internal/getter/file.go
+++ b/internal/getter/file.go
@@ -15,15 +15,6 @@ type fileDetector struct {
 	allowNonExisting bool
 }
 
-func isValidPath(fs afero.Fs, path string) bool {
-	err := fs.MkdirAll(path, 0700)
-	if err == nil {
-		_ = fs.Remove(path)
-	}
-
-	return err == nil
-}
-
 func NewFileDetector(allowNonExisting bool) *fileDetector {
 	p := new(fileDetector)
 	p.allowNonExisting = allowNonExisting
@@ -55,7 +46,8 @@ func (d *fileDetector) Detect(src, pwd string) (string, bool, error) {
 	}
 	fs := afero.NewOsFs()
 	if ok, _ := afero.Exists(fs, checkPath); !ok {
-		if d.allowNonExisting && isValidPath(fs, checkPath) {
+		if d.allowNonExisting {
+			// This assumes the file detector runs last to give a chance to other detectors to detect the source
 			return fmtFileURL(checkPath), true, nil
 		}
 		return "", false, nil

--- a/internal/getter/getter.go
+++ b/internal/getter/getter.go
@@ -22,7 +22,7 @@ var (
 		new(getter.S3Detector),
 		new(getter.GCSDetector),
 		new(HubDetector),
-		new(fileDetector),
+		NewFileDetector(true),
 	}
 
 	detectorsWithNames = []Detector{
@@ -31,7 +31,7 @@ var (
 		{Name: "s3", Detector: new(getter.S3Detector)},
 		{Name: "gcs", Detector: new(getter.GCSDetector)},
 		{Name: "hub", Detector: new(HubDetector)},
-		{Name: "file", Detector: new(fileDetector)},
+		{Name: "file", Detector: NewFileDetector(true)},
 	}
 
 	detectorsMap = map[string]getter.Detector{
@@ -40,7 +40,7 @@ var (
 		"s3":     new(getter.S3Detector),
 		"gcs":    new(getter.GCSDetector),
 		"hub":    new(HubDetector),
-		"file":   new(fileDetector),
+		"file":   NewFileDetector(true),
 	}
 
 	decompressors = map[string]getter.Decompressor{

--- a/internal/getter/hub.go
+++ b/internal/getter/hub.go
@@ -14,7 +14,7 @@ func (h HubDetector) Detect(src, pwd string) (string, bool, error) {
 	if len(src) == 0 {
 		return "", false, nil
 	}
-	fileDetector := fileDetector{}
+	fileDetector := NewFileDetector(false)
 	if _, ok, _ := fileDetector.Detect(src, pwd); ok {
 		return "", false, nil
 	}

--- a/pkg/policy/source_test.go
+++ b/pkg/policy/source_test.go
@@ -124,7 +124,9 @@ func TestDetectPolicy(t *testing.T) {
 	require.Nil(t, err)
 	assert.Equal(t, "aws", p.Source)
 	assert.True(t, found)
-	_, found, err = DetectPolicy("not-exist", "")
+	// Detected as a file getter
+	p, found, err = DetectPolicy("not:exist", "")
 	require.Nil(t, err)
-	assert.False(t, found)
+	assert.Equal(t, "not:exist", p.Source)
+	assert.True(t, found)
 }


### PR DESCRIPTION
Fixes https://github.com/cloudquery/cloudquery-issues/issues/333 (internal issue).

Underlying issue - our file detector only detects existing files:
https://github.com/cloudquery/cloudquery/blob/38004809f7a0e4ae8a7ef86403524f0af3037eff/internal/getter/file.go#L24

This causes the code to return `found=false` here https://github.com/cloudquery/cloudquery/blob/38004809f7a0e4ae8a7ef86403524f0af3037eff/pkg/ui/console/policy.go#L43

And throw the error. The error itself is not that good either as it reports that no policies were found in the configuration.

This PR fixes the issue by improving the file detector to detect non existing files.
We need the `allowNonExisting` configuration in order not to break the `hub` detector logic.

### Todo
- [ ] Add a test