### PR TITLE
fix: Handle empty policy directory

### DIFF
--- a/pkg/policy/source.go
+++ b/pkg/policy/source.go
@@ -2,12 +2,15 @@ package policy
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net/url"
+	"os"
 	"path/filepath"
 	"strings"
 
 	"github.com/cloudquery/cloudquery/internal/getter"
+	"github.com/cloudquery/cq-provider-sdk/provider/diag"
 	"github.com/spf13/afero"
 )
 
@@ -59,6 +62,9 @@ func LoadSource(ctx context.Context, installDir, source string) ([]byte, *Meta, 
 
 	data, err := afero.ReadFile(afero.NewOsFs(), filepath.Join(policyDir, defaultPolicyFileName))
 	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return nil, nil, diag.FromError(fmt.Errorf("could not find %q in %q. Please verify it exists", defaultPolicyFileName, source), diag.USER)
+		}
 		// TODO: make more descriptive error
 		return nil, nil, fmt.Errorf("failed to open source: %w", err)
 	}


### PR DESCRIPTION
Fixes https://github.com/cloudquery/cloudquery-issues/issues/333 (internal issue).

To reproduce:
`cloudquery policy run empty-dir` when `empty-dir` is an empty directory.

https://github.com/cloudquery/cloudquery/pull/697 actually fixed a related issue when running `cloudquery policy run non-existing-dir`