### PR TITLE
fix: Classify subdir not found error

### DIFF
--- a/pkg/policy/source.go
+++ b/pkg/policy/source.go
@@ -40,7 +40,7 @@ func DetectPolicy(name string, subPolicy string) (*Policy, bool, error) {
 
 func classifyError(source string, err error) error {
 	matched, _ := regexp.MatchString("subdir .+? not found", err.Error())
-	formattedError := fmt.Errorf("failed to  %s: %w", source, err)
+	formattedError := fmt.Errorf("failed to get source %s: %w", source, err)
 	if matched {
 		return diag.FromError(formattedError, diag.USER)
 	}


### PR DESCRIPTION
Fixes https://github.com/cloudquery/cloudquery-issues/issues/334 (internal issue).

I could not reproduce this (probably needs a Windows machine). However the error is descriptive enough for the user to take action, so we should probably just filter it from our analytics.

The reported error is:
```
*errors.errorString: subdir "<redacted>" not found
*fmt.wrapError: failed to get source file://C://<redacted>: subdir "<redacted>" not found
```