### PR TITLE
fix: Added root policy config inheritance to selected subpolicy

### DIFF
--- a/pkg/policy/policy.go
+++ b/pkg/policy/policy.go
@@ -115,7 +115,7 @@ func (p Policy) Filter(path string) Policy {
 		if policy.Name == selectorPath[0] {
 			filtered := policy.Filter(nextPolicy)
 			if filtered.Config == nil {
-				filtered.Config = policy.Config
+				filtered.Config = p.Config
 			}
 			return filtered
 		}

--- a/pkg/policy/policy.go
+++ b/pkg/policy/policy.go
@@ -113,7 +113,11 @@ func (p Policy) Filter(path string) Policy {
 	}
 	for _, policy := range p.Policies {
 		if policy.Name == selectorPath[0] {
-			return policy.Filter(nextPolicy)
+			filtered := policy.Filter(nextPolicy)
+			if filtered.Config == nil {
+				filtered.Config = policy.Config
+			}
+			return filtered
 		}
 	}
 

--- a/pkg/policy/policy_test.go
+++ b/pkg/policy/policy_test.go
@@ -569,10 +569,10 @@ func TestFilterPolicies(t *testing.T) {
 			},
 			path: "test/test1",
 			expectedPolicy: Policy{
-				Name: "test",
+				Name: "test1",
 				Config: &Configuration{
 					[]*Provider{
-						{"test1", "v0.1.2"},
+						{"test", "v0.1.2"},
 					},
 				},
 			},

--- a/pkg/policy/policy_test.go
+++ b/pkg/policy/policy_test.go
@@ -268,7 +268,8 @@ func TestFilterPolicies(t *testing.T) {
 			},
 			path:           "test1",
 			expectedPolicy: Policy{},
-		}, {
+		},
+		{
 			expectError: true,
 			p: Policy{
 				Name: "aws",
@@ -514,6 +515,59 @@ func TestFilterPolicies(t *testing.T) {
 								Name: "Control-5",
 							},
 						},
+					},
+				},
+			},
+		},
+		{
+			p: Policy{
+				Name: "aws",
+				Config: &Configuration{
+					[]*Provider{
+						{"aws", "v0.1.1"},
+					},
+				},
+				Policies: Policies{
+					&Policy{
+						Name: "test",
+					},
+				},
+			},
+			path: "aws/test/",
+			expectedPolicy: Policy{
+				Name: "test",
+				Config: &Configuration{
+					[]*Provider{
+						{"aws", "v0.1.1"},
+					},
+				},
+			},
+		},
+		{
+			p: Policy{
+				Name: "aws",
+				Config: &Configuration{
+					[]*Provider{
+						{"aws", "v0.1.1"},
+					},
+				},
+				Policies: Policies{
+					&Policy{
+						Name: "test",
+						Config: &Configuration{
+							[]*Provider{
+								{"test", "v0.1.2"},
+							},
+						},
+					},
+				},
+			},
+			path: "aws/test/",
+			expectedPolicy: Policy{
+				Name: "test",
+				Config: &Configuration{
+					[]*Provider{
+						{"test", "v0.1.2"},
 					},
 				},
 			},

--- a/pkg/policy/policy_test.go
+++ b/pkg/policy/policy_test.go
@@ -533,7 +533,7 @@ func TestFilterPolicies(t *testing.T) {
 					},
 				},
 			},
-			path: "aws/test/",
+			path: "test",
 			expectedPolicy: Policy{
 				Name: "test",
 				Config: &Configuration{
@@ -554,20 +554,25 @@ func TestFilterPolicies(t *testing.T) {
 				Policies: Policies{
 					&Policy{
 						Name: "test",
-						Config: &Configuration{
-							[]*Provider{
-								{"test", "v0.1.2"},
+						Policies: Policies{
+							&Policy{
+								Name: "test1",
+								Config: &Configuration{
+									[]*Provider{
+										{"test", "v0.1.2"},
+									},
+								},
 							},
 						},
 					},
 				},
 			},
-			path: "aws/test/",
+			path: "test/test1",
 			expectedPolicy: Policy{
 				Name: "test",
 				Config: &Configuration{
 					[]*Provider{
-						{"test", "v0.1.2"},
+						{"test1", "v0.1.2"},
 					},
 				},
 			},

--- a/pkg/policy/run.go
+++ b/pkg/policy/run.go
@@ -143,6 +143,9 @@ func run(ctx context.Context, storage database.Storage, request *ExecuteRequest)
 		finishedQueries   = 0
 	)
 	filteredPolicy := request.Policy.Filter(request.Policy.meta.SubPolicy)
+	if filteredPolicy.Config == nil {
+		filteredPolicy.Config = request.Policy.Config
+	}
 	if !filteredPolicy.HasChecks() {
 		log.Error().Str("selector", request.Policy.meta.SubPolicy).Strs("available_policies", filteredPolicy.Policies.All()).Msg("policy/query not found with provided sub-policy selector")
 		return nil, diag.FromError(fmt.Errorf("%s//%s: %w", request.Policy.Name, request.Policy.meta.SubPolicy, ErrPolicyOrQueryNotFound),

--- a/pkg/policy/run.go
+++ b/pkg/policy/run.go
@@ -143,9 +143,6 @@ func run(ctx context.Context, storage database.Storage, request *ExecuteRequest)
 		finishedQueries   = 0
 	)
 	filteredPolicy := request.Policy.Filter(request.Policy.meta.SubPolicy)
-	if filteredPolicy.Config == nil {
-		filteredPolicy.Config = request.Policy.Config
-	}
 	if !filteredPolicy.HasChecks() {
 		log.Error().Str("selector", request.Policy.meta.SubPolicy).Strs("available_policies", filteredPolicy.Policies.All()).Msg("policy/query not found with provided sub-policy selector")
 		return nil, diag.FromError(fmt.Errorf("%s//%s: %w", request.Policy.Name, request.Policy.meta.SubPolicy, ErrPolicyOrQueryNotFound),


### PR DESCRIPTION
Added an inheritance of root policy to selected subpolicy to make fetch checks work if policy run targets subpolicy or section.
closes #626 
