### PR TITLE
fix: Don't generate telemetry-random-id in current dir

### DIFF
--- a/internal/analytics/client.go
+++ b/internal/analytics/client.go
@@ -29,7 +29,7 @@ type VersionInfo struct {
 }
 
 // Consumers must call analytics.Init before using this package
-var currentHub *Client = nil
+var currentHub *Client
 
 type Client struct {
 	version    VersionInfo

--- a/internal/analytics/client.go
+++ b/internal/analytics/client.go
@@ -28,8 +28,8 @@ type VersionInfo struct {
 	CommitId  string `json:"commit_id,omitempty"`
 }
 
-// currentHub is the initial Hub with no Client bound and an empty Scope.
-var currentHub = New()
+// Consumers must call analytics.Init before using this package
+var currentHub *Client = nil
 
 type Client struct {
 	version    VersionInfo

--- a/pkg/ui/console/client_test.go
+++ b/pkg/ui/console/client_test.go
@@ -12,7 +12,7 @@ import (
 )
 
 func TestCreateClient(t *testing.T) {
-	analytics.Init()
+	_ = analytics.Init()
 
 	_, filename, _, _ := runtime.Caller(0)
 	fixtures := filepath.Join(filepath.Dir(filename), "fixtures")

--- a/pkg/ui/console/client_test.go
+++ b/pkg/ui/console/client_test.go
@@ -7,10 +7,13 @@ import (
 	"runtime"
 	"testing"
 
+	"github.com/cloudquery/cloudquery/internal/analytics"
 	"github.com/google/uuid"
 )
 
 func TestCreateClient(t *testing.T) {
+	analytics.Init()
+
 	_, filename, _, _ := runtime.Caller(0)
 	fixtures := filepath.Join(filepath.Dir(filename), "fixtures")
 


### PR DESCRIPTION
🎉 Thank you for making CloudQuery awesome by submitting a PR 🎉

#### Summary

Fixes an issue that on each run of `cloudquery` a telemetry id file is created in the current dir

---

Use the following steps to ensure your PR is ready to be reviewed

- [x] Read the [contribution guidelines](../blob/main/.github/CONTRIBUTING.md) 🧑‍🎓
- [x] Run `go fmt` to format your code 🖊
- [x] Lint your changes via `golangci-lint run --new-from-rev main` 🚨 (install golangci-lint [here](https://golangci-lint.run/usage/install/#local-installation))
- [x] Update or add tests 🧪
- [x] Ensure the status checks below are successful ✅
