### PR TITLE
fix: Handle Outputting Policies With Selectors

### DIFF
--- a/pkg/policy/execute.go
+++ b/pkg/policy/execute.go
@@ -355,11 +355,16 @@ func (e *Executor) deleteViews(ctx context.Context, policy *Policy) {
 func GenerateExecutionResultFile(result *ExecutionResult, outputDir string) error {
 	fs := afero.NewOsFs()
 
-	if err := fs.MkdirAll(outputDir, 0755); err != nil {
+	fullPath := fmt.Sprintf("%s.json", filepath.Join(outputDir, result.PolicyName))
+
+	// Ensure entire directory structure is created
+	directory := fullPath[:strings.LastIndex(fullPath, "/")]
+
+	if err := fs.MkdirAll(directory, 0755); err != nil {
 		return err
 	}
 
-	f, err := fs.Create(fmt.Sprintf("%s.json", filepath.Join(outputDir, result.PolicyName)))
+	f, err := fs.Create(fullPath)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
🎉 Thank you for making CloudQuery awesome by submitting a PR 🎉

#### Summary

<!--
Explain what problem this PR addresses
-->
Currently you cannot output results of a policy to a file if you use a selector as we do not ensure the entire directory structure is created

This is a valid command and should be supported:
`cloudquery policy run gcp//cis_v1.2.0  --output-dir cloudquery-gcp/`

---



Use the following steps to ensure your PR is ready to be reviewed

- [x] Read the [contribution guidelines](../blob/main/.github/CONTRIBUTING.md) 🧑‍🎓
- [x] Run `go fmt` to format your code 🖊
- [x] Lint your changes via `golangci-lint run --new-from-rev main` 🚨 (install golangci-lint [here](https://golangci-lint.run/usage/install/#local-installation))
- [x] Update or add tests 🧪
- [x] Ensure the status checks below are successful ✅
