### PR TITLE
fix: Diag import clean up

### DIFF
--- a/pkg/core/diagnostics.go
+++ b/pkg/core/diagnostics.go
@@ -1,23 +1,20 @@
 package core
 
-import "github.com/cloudquery/cq-provider-sdk/provider/diag"
+import (
+	"github.com/cloudquery/cloudquery/pkg/plugin"
+	"github.com/cloudquery/cq-provider-sdk/provider/diag"
+	"github.com/spf13/viper"
+)
 
-type ConfigureDiagnostic struct {
+type SentryDiagnostic struct {
 	diag.Diagnostic
+
+	Tags   map[string]string
+	Ignore bool
 }
 
-func (d *ConfigureDiagnostic) IsConfigureDiagnostic() bool {
-	return true
-}
-
-type FetchDiagnostic struct {
-	diag.Diagnostic
-	Provider string
-	Version  string
-}
-
-func (d *FetchDiagnostic) IsFetchDiagnostic() (bool, string, string) {
-	return true, d.Provider, d.Version
+func (d *SentryDiagnostic) IsSentryDiagnostic() (bool, map[string]string, bool) {
+	return true, d.Tags, d.Ignore
 }
 
 type DiagnosticsSummary struct {
@@ -49,24 +46,41 @@ func SummarizeDiagnostics(diags diag.Diagnostics) DiagnosticsSummary {
 	return summary
 }
 
-func convertToConfigureDiags(dd diag.Diagnostics) diag.Diagnostics {
-	ret := make(diag.Diagnostics, len(dd))
-	for i := range dd {
-		ret[i] = &ConfigureDiagnostic{
-			Diagnostic: dd[i],
+func convertToConfigureDiags(diags diag.Diagnostics) diag.Diagnostics {
+	return convertToSentryDiags(diags, func(d diag.Diagnostic) *SentryDiagnostic {
+		return &SentryDiagnostic{
+			Diagnostic: d,
+			Tags:       map[string]string{"source": "configure"},
+			Ignore:     d.Type() == diag.ACCESS,
 		}
-	}
-	return ret
+	})
 }
 
-func convertToFetchDiags(diags diag.Diagnostics, provider, version string) diag.Diagnostics {
-	fd := make(diag.Diagnostics, len(diags))
-	for i, d := range diags {
-		fd[i] = FetchDiagnostic{
+func convertToFetchDiags(diags diag.Diagnostics, providerName, providerVersion string) diag.Diagnostics {
+	allowUnmanaged := viper.GetBool("debug-sentry")
+
+	return convertToSentryDiags(diags, func(d diag.Diagnostic) *SentryDiagnostic {
+		return &SentryDiagnostic{
 			Diagnostic: d,
-			Provider:   provider,
-			Version:    version,
+			Tags: map[string]string{
+				"provider":         providerName,
+				"provider_version": providerVersion,
+				"resource":         d.Description().Resource,
+			},
+			Ignore: !allowUnmanaged && providerVersion == plugin.Unmanaged,
 		}
+	})
+}
+
+// convertToSentryDiags gets the diags and applies the given handleFunc to each diag which converts them to a Sentry Diagnostic.
+func convertToSentryDiags(diags diag.Diagnostics, handleFunc func(diag.Diagnostic) *SentryDiagnostic) diag.Diagnostics {
+	fd := make(diag.Diagnostics, 0, len(diags))
+	for i := range diags {
+		sd := handleFunc(diags[i])
+		if sd == nil {
+			continue
+		}
+		fd = append(fd, sd)
 	}
 	return fd
 }

--- a/pkg/core/diagnostics.go
+++ b/pkg/core/diagnostics.go
@@ -10,32 +10,14 @@ func (d *ConfigureDiagnostic) IsConfigureDiagnostic() bool {
 	return true
 }
 
-func convertToConfigureDiagnostics(dd diag.Diagnostics) diag.Diagnostics {
-	ret := make(diag.Diagnostics, len(dd))
-	for i := range dd {
-		ret[i] = &ConfigureDiagnostic{
-			Diagnostic: dd[i],
-		}
-	}
-	return ret
-}
-
 type FetchDiagnostic struct {
 	diag.Diagnostic
 	Provider string
 	Version  string
 }
 
-func convertToFetchDiags(diags diag.Diagnostics, provider, version string) diag.Diagnostics {
-	fd := make(diag.Diagnostics, len(diags))
-	for i, d := range diags {
-		fd[i] = FetchDiagnostic{
-			Diagnostic: d,
-			Provider:   provider,
-			Version:    version,
-		}
-	}
-	return fd
+func (d *FetchDiagnostic) IsFetchDiagnostic() (bool, string, string) {
+	return true, d.Provider, d.Version
 }
 
 type DiagnosticsSummary struct {
@@ -65,4 +47,26 @@ func SummarizeDiagnostics(diags diag.Diagnostics) DiagnosticsSummary {
 		}
 	}
 	return summary
+}
+
+func convertToConfigureDiags(dd diag.Diagnostics) diag.Diagnostics {
+	ret := make(diag.Diagnostics, len(dd))
+	for i := range dd {
+		ret[i] = &ConfigureDiagnostic{
+			Diagnostic: dd[i],
+		}
+	}
+	return ret
+}
+
+func convertToFetchDiags(diags diag.Diagnostics, provider, version string) diag.Diagnostics {
+	fd := make(diag.Diagnostics, len(diags))
+	for i, d := range diags {
+		fd[i] = FetchDiagnostic{
+			Diagnostic: d,
+			Provider:   provider,
+			Version:    version,
+		}
+	}
+	return fd
 }

--- a/pkg/core/fetch.go
+++ b/pkg/core/fetch.go
@@ -2,7 +2,7 @@ package core
 
 import (
 	"context"
-	stderrors "errors"
+	"errors"
 	"fmt"
 	"io"
 	"math"
@@ -16,7 +16,7 @@ import (
 	"github.com/cloudquery/cloudquery/pkg/core/database"
 	"github.com/cloudquery/cloudquery/pkg/core/history"
 	"github.com/cloudquery/cloudquery/pkg/core/state"
-	"github.com/cloudquery/cloudquery/pkg/errors"
+	cqerrors "github.com/cloudquery/cloudquery/pkg/errors"
 	"github.com/cloudquery/cloudquery/pkg/plugin"
 	"github.com/cloudquery/cloudquery/pkg/plugin/registry"
 	"github.com/cloudquery/cq-provider-sdk/cqproto"
@@ -226,7 +226,7 @@ func Fetch(ctx context.Context, storage database.Storage, pm *plugin.Manager, op
 	stateClient := state.NewClient(db, logging.NewZHcLog(&log.Logger, "fetch"))
 	// migrate CloudQuery core tables to latest version
 	// context.DeadlineExceeded is handled inside runProviderFetch that returns a response and summary
-	if err := stateClient.MigrateCore(ctx, storage.DialectExecutor()); err != nil && !errors.IsCancelation(err) {
+	if err := stateClient.MigrateCore(ctx, storage.DialectExecutor()); err != nil && !errors.Is(err, context.DeadlineExceeded) {
 		return nil, diag.FromError(err, diag.DATABASE, diag.WithSummary("failed to migrate cloudquery_core tables"))
 	}
 
@@ -308,8 +308,8 @@ func runProviderFetch(ctx context.Context, pm *plugin.Manager, info ProviderInfo
 			sts FetchStatus
 		)
 
-		if errors.IsCancelation(err) {
-			d = errors.CancelationDiag(err)
+		if cqerrors.IsCancelation(err) {
+			d = cqerrors.CancelationDiag(err)
 			sts = FetchCanceled
 		} else {
 			d = diag.FromError(err, diag.INTERNAL)
@@ -400,7 +400,7 @@ func executeFetch(ctx context.Context, pLog zerolog.Logger, plugin plugin.Plugin
 			summary.FetchedResources[resp.ResourceName] = ResourceFetchSummary{resp.Summary.Status.String(), resp.Summary.ResourceCount, resp.Summary.Diagnostics, time.Since(start)}
 			if resp.Error != "" {
 				pLog.Warn().Err(err).Str("resource", resp.ResourceName).Msg("received resource fetch error")
-				diags = diags.Add(diag.FromError(stderrors.New(resp.Error), diag.RESOLVING, diag.WithResourceName(resp.ResourceName)))
+				diags = diags.Add(diag.FromError(errors.New(resp.Error), diag.RESOLVING, diag.WithResourceName(resp.ResourceName)))
 			}
 			// TODO: print diags, specific to resource into log?
 			if resp.Summary.Diagnostics.HasDiags() {
@@ -422,10 +422,10 @@ func executeFetch(ctx context.Context, pLog zerolog.Logger, plugin plugin.Plugin
 				})
 			}
 			// We received an error, first lets check if we got canceled, if not we log the error and add to diags
-			if errors.IsCancelation(err) {
+			if cqerrors.IsCancelation(err) {
 				pLog.Warn().TimeDiff("execution", time.Now(), start).Msg("provider fetch was canceled")
 				summary.Status = FetchCanceled
-				return summary, diags.Add(errors.CancelationDiag(err))
+				return summary, diags.Add(cqerrors.CancelationDiag(err))
 			}
 			pLog.Error().Err(err).Msg("received unexpected provider fetch error")
 			summary.Status = FetchFailed
@@ -479,7 +479,7 @@ func doGlobResources(requested []string, allowWild bool, all map[string]*schema.
 	seen := make(map[string]struct{})
 	for _, r := range requested {
 		if r == "" {
-			return nil, diag.FromError(fmt.Errorf("invalid resource"), diag.USER, diag.WithDetails("empty resource names are not allowed"))
+			return nil, diag.FromError(errors.New("invalid resource"), diag.USER, diag.WithDetails("empty resource names are not allowed"))
 		}
 
 		if _, ok := seen[r]; ok {
@@ -517,7 +517,7 @@ func matchResourceGlob(pattern string, all map[string]*schema.Table) ([]string, 
 
 	if wildPos > 0 {
 		if wildPos != len(pattern)-2 { // make sure it ends with .*
-			return nil, diag.FromError(stderrors.New("invalid wildcard syntax"), diag.USER, diag.WithDetails("resource match should end with `.*`"))
+			return nil, diag.FromError(errors.New("invalid wildcard syntax"), diag.USER, diag.WithDetails("resource match should end with `.*`"))
 		}
 		for k := range all {
 			if strings.HasPrefix(k, pattern[:wildPos+1]) { // include the "." in the match
@@ -525,7 +525,7 @@ func matchResourceGlob(pattern string, all map[string]*schema.Table) ([]string, 
 			}
 		}
 	} else if wildPos == 0 || strings.Contains(pattern, "*") {
-		return nil, diag.FromError(stderrors.New("invalid wildcard syntax"), diag.USER, diag.WithDetails("you can only use `*` or `resource.*` or full resource name"))
+		return nil, diag.FromError(errors.New("invalid wildcard syntax"), diag.USER, diag.WithDetails("you can only use `*` or `resource.*` or full resource name"))
 	}
 
 	return result, nil

--- a/pkg/core/fetch.go
+++ b/pkg/core/fetch.go
@@ -226,7 +226,7 @@ func Fetch(ctx context.Context, storage database.Storage, pm *plugin.Manager, op
 	stateClient := state.NewClient(db, logging.NewZHcLog(&log.Logger, "fetch"))
 	// migrate CloudQuery core tables to latest version
 	// context.DeadlineExceeded is handled inside runProviderFetch that returns a response and summary
-	if err := stateClient.MigrateCore(ctx, storage.DialectExecutor()); err != nil && !errors.Is(err, context.DeadlineExceeded) {
+	if err := stateClient.MigrateCore(ctx, storage.DialectExecutor()); err != nil && !cqerrors.IsCancelation(err) {
 		return nil, diag.FromError(err, diag.DATABASE, diag.WithSummary("failed to migrate cloudquery_core tables"))
 	}
 

--- a/pkg/core/fetch.go
+++ b/pkg/core/fetch.go
@@ -332,7 +332,7 @@ func runProviderFetch(ctx context.Context, pm *plugin.Manager, info ProviderInfo
 			Version:          providerPlugin.Version(),
 			FetchedResources: make(map[string]ResourceFetchSummary),
 			Status:           FetchConfigureFailed,
-		}, convertToConfigureDiagnostics(resp.Diagnostics)
+		}, convertToConfigureDiags(resp.Diagnostics)
 	}
 
 	pLog.Info().Msg("provider configured successfully")

--- a/pkg/core/fetch_test.go
+++ b/pkg/core/fetch_test.go
@@ -153,8 +153,8 @@ func Test_Fetch(t *testing.T) {
 					Err:         "context deadline exceeded",
 					Type:        diag.USER,
 					Severity:    diag.ERROR,
-					Summary:     "provider fetch was canceled by user / fetch deadline exceeded",
-					Description: diag.Description{Resource: "", ResourceID: []string(nil), Summary: "provider fetch was canceled by user / fetch deadline exceeded", Detail: ""}},
+					Summary:     "operation was canceled by user",
+					Description: diag.Description{Resource: "", ResourceID: []string(nil), Summary: "operation was canceled by user", Detail: ""}},
 			},
 			ExpectedResponse: &FetchResponse{ProviderFetchSummary: map[string]*ProviderFetchSummary{"test": {
 				Name:                  "test",

--- a/pkg/errors/cancel.go
+++ b/pkg/errors/cancel.go
@@ -1,0 +1,27 @@
+package errors
+
+import (
+	"context"
+	stderrors "errors"
+
+	"github.com/cloudquery/cq-provider-sdk/provider/diag"
+
+	gcodes "google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+func IsCancelation(err error) bool {
+	if stderrors.Is(err, context.Canceled) || stderrors.Is(err, context.DeadlineExceeded) {
+		return true
+	}
+
+	if st, ok := status.FromError(err); ok && (st.Code() == gcodes.Canceled || st.Code() == gcodes.DeadlineExceeded) {
+		return true
+	}
+
+	return false
+}
+
+func CancelationDiag(err error) diag.Diagnostics {
+	return diag.Diagnostics{diag.NewBaseError(err, diag.USER, diag.WithSummary("operation was canceled by user"))}
+}

--- a/pkg/errors/error.go
+++ b/pkg/errors/error.go
@@ -121,14 +121,14 @@ func isConfigureDiagnostic(d diag.Diagnostic) bool {
 	return ok && cd.IsConfigureDiagnostic()
 }
 
-type fetchDiag interface {
-	IsFetchDiagnostic() (bool, string, string)
+type sentryDiag interface {
+	IsSentryDiagnostic() (bool, map[string]string, bool)
 }
 
-func isFetchDiagnostic(d diag.Diagnostic) (bool, string, string) {
-	cd, ok := diag.UnsquashDiag(d).(fetchDiag)
+func isSentryDiagnostic(d diag.Diagnostic) (bool, map[string]string, bool) {
+	cd, ok := diag.UnsquashDiag(d).(sentryDiag)
 	if !ok {
-		return false, "", ""
+		return false, nil, false
 	}
-	return cd.IsFetchDiagnostic()
+	return cd.IsSentryDiagnostic()
 }

--- a/pkg/errors/error.go
+++ b/pkg/errors/error.go
@@ -25,10 +25,6 @@ func ShouldIgnoreDiag(d diag.Diagnostic) bool {
 		return true
 	}
 
-	if d.Type() == diag.ACCESS && isConfigureDiagnostic(d) {
-		return true
-	}
-
 	if d.Type() == diag.DATABASE {
 		ret := sqlStateRegex.FindStringSubmatch(d.Error())
 		if len(ret) > 1 && shouldIgnorePgCode(ret[1]) {
@@ -110,15 +106,6 @@ func shouldIgnorePgCode(code string) bool {
 		}
 	}
 	return false
-}
-
-type configureDiag interface {
-	IsConfigureDiagnostic() bool
-}
-
-func isConfigureDiagnostic(d diag.Diagnostic) bool {
-	cd, ok := diag.UnsquashDiag(d).(configureDiag)
-	return ok && cd.IsConfigureDiagnostic()
 }
 
 type sentryDiag interface {

--- a/pkg/errors/error.go
+++ b/pkg/errors/error.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 
 	"github.com/cloudquery/cq-provider-sdk/provider/diag"
+
 	"github.com/jackc/pgconn"
 	"github.com/lib/pq"
 	gcodes "google.golang.org/grpc/codes"
@@ -116,7 +117,18 @@ type configureDiag interface {
 }
 
 func isConfigureDiagnostic(d diag.Diagnostic) bool {
-	d = diag.UnsquashDiag(d)
-	cd, ok := d.(configureDiag)
+	cd, ok := diag.UnsquashDiag(d).(configureDiag)
 	return ok && cd.IsConfigureDiagnostic()
+}
+
+type fetchDiag interface {
+	IsFetchDiagnostic() (bool, string, string)
+}
+
+func isFetchDiagnostic(d diag.Diagnostic) (bool, string, string) {
+	cd, ok := diag.UnsquashDiag(d).(fetchDiag)
+	if !ok {
+		return false, "", ""
+	}
+	return cd.IsFetchDiagnostic()
 }

--- a/pkg/errors/sentry.go
+++ b/pkg/errors/sentry.go
@@ -1,11 +1,9 @@
 package errors
 
 import (
-	"github.com/cloudquery/cloudquery/pkg/plugin"
 	"github.com/cloudquery/cq-provider-sdk/provider/diag"
 
 	"github.com/getsentry/sentry-go"
-	"github.com/spf13/viper"
 )
 
 func CaptureError(err error, tags map[string]string) {
@@ -22,7 +20,6 @@ func CaptureError(err error, tags map[string]string) {
 }
 
 func CaptureDiagnostics(dd diag.Diagnostics, tags map[string]string) {
-	allowUnmanaged := viper.GetBool("debug-sentry")
 	for _, d := range dd.Squash().Redacted() {
 		if ShouldIgnoreDiag(d) {
 			continue
@@ -32,14 +29,11 @@ func CaptureDiagnostics(dd diag.Diagnostics, tags map[string]string) {
 			continue
 		}
 		sentry.WithScope(func(scope *sentry.Scope) {
-			if ok, p, v := isFetchDiagnostic(d); ok {
-				if !allowUnmanaged && v == plugin.Unmanaged {
+			if ok, tags, ignore := isSentryDiagnostic(d); ok {
+				if ignore {
 					return
 				}
-				scope.SetTags(map[string]string{"provider": p, "provider_version": v, "resource": d.Description().Resource})
-			}
-			if isConfigureDiagnostic(d) {
-				scope.SetTag("source", "configure")
+				scope.SetTags(tags)
 			}
 			// set any extra tags to this scope
 			scope.SetTags(tags)


### PR DESCRIPTION
- pkg/errors can be imported from anywhere now (doesn't import core)
- new methods from https://github.com/cloudquery/cloudquery/pull/741 moved to errors pkg
- ~~tried importing pkg/errors as `cqerrors` (to leave stdlib errors as `errors`) which didn't work in the workflow, had to switch around (`errors` and `stderrors` respectively)~~ my bad