### PR TITLE
fix: Remove unused function return value

### DIFF
--- a/pkg/module/drift/config.go
+++ b/pkg/module/drift/config.go
@@ -425,7 +425,7 @@ func (d *Drift) applyProvider(cfg *ProviderConfig, p *core.ProviderSchema) (bool
 	checkEnabled := len(cfg.CheckResources) > 0
 
 	for resName, res := range cfg.Resources {
-		cleanRes, _ := SplitHashedResource(resName)
+		cleanRes := SplitHashedResource(resName)
 
 		// CheckResources / IgnoreResources broad strokes...
 		if checkEnabled {
@@ -482,15 +482,12 @@ func (d *Drift) lookupResource(resName string, prov *core.ProviderSchema) *trave
 		d.tableMap[prov.Name] = traverseResourceTable(prov.ResourceTables)
 	}
 
-	res, _ := SplitHashedResource(resName)
+	res := SplitHashedResource(resName)
 	return d.tableMap[prov.Name][res]
 }
 
 // SplitHashedResource splits a given resource name and returns the resource and hash elements separately.
-func SplitHashedResource(configResName string) (string, string) {
+func SplitHashedResource(configResName string) string {
 	resParts := strings.SplitN(configResName, "#", 2)
-	if len(resParts) == 1 {
-		return resParts[0], ""
-	}
-	return resParts[0], resParts[1]
+	return resParts[0]
 }

--- a/pkg/module/drift/model.go
+++ b/pkg/module/drift/model.go
@@ -170,7 +170,7 @@ func (rs *Results) process() {
 		if r == nil {
 			continue
 		}
-		cleanRes, _ := SplitHashedResource(r.ResourceType)
+		cleanRes := SplitHashedResource(r.ResourceType)
 		transform(r.Different.IDs(), r.Provider, cleanRes, &combo.Different)
 		transform(r.Extra.IDs(), r.Provider, cleanRes, &combo.Extra)
 		transform(r.Equal.IDs(), r.Provider, cleanRes, &combo.Equal)


### PR DESCRIPTION
🎉 Thank you for making CloudQuery awesome by submitting a PR 🎉

#### Summary

Noticed this while working on the lint errors. Doesn't look like the second return value is used anywhere.

---

Use the following steps to ensure your PR is ready to be reviewed

- [x] Read the [contribution guidelines](../blob/main/.github/CONTRIBUTING.md) 🧑‍🎓
- [x] Run `go fmt` to format your code 🖊
- [x] Lint your changes via `golangci-lint run --new-from-rev main` 🚨 (install golangci-lint [here](https://golangci-lint.run/usage/install/#local-installation))
- [x] Update or add tests 🧪
- [x] Ensure the status checks below are successful ✅
