### PR TITLE
refactor: Use pointer for connection receiver

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -80,7 +80,7 @@ func (c Connection) IsAnyConnParamsSet() bool {
 	return c.Type != "" || c.Username != "" || c.Password != "" || c.Host != "" || c.Port != 0 || c.Database != "" || c.SSLMode != "" || len(c.Extras) > 0
 }
 
-func (c Connection) BuildFromConnParams() (*dburl.URL, error) {
+func (c *Connection) BuildFromConnParams() error {
 	if c.Port == 0 {
 		c.Port = 5432
 	}
@@ -88,10 +88,10 @@ func (c Connection) BuildFromConnParams() (*dburl.URL, error) {
 		c.Type = "postgres"
 	}
 	if c.Host == "" {
-		return nil, errors.New("missing host")
+		return errors.New("missing host")
 	}
 	if c.Database == "" {
-		return nil, errors.New("missing database")
+		return errors.New("missing database")
 	}
 
 	u := url.URL{
@@ -121,10 +121,14 @@ func (c Connection) BuildFromConnParams() (*dburl.URL, error) {
 	}
 	u.RawQuery = v.Encode()
 
-	return &dburl.URL{
+	dbUrl := &dburl.URL{
 		OriginalScheme: c.Type,
 		URL:            u,
-	}, nil
+	}
+
+	c.DSN = dbUrl.String()
+
+	return nil
 }
 
 type RequiredProvider struct {

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -121,12 +121,7 @@ func (c *Connection) BuildFromConnParams() error {
 	}
 	u.RawQuery = v.Encode()
 
-	dbUrl := &dburl.URL{
-		OriginalScheme: c.Type,
-		URL:            u,
-	}
-
-	c.DSN = dbUrl.String()
+	c.DSN = (&dburl.URL{OriginalScheme: c.Type, URL: u}).String()
 
 	return nil
 }

--- a/pkg/config/config_parser.go
+++ b/pkg/config/config_parser.go
@@ -180,6 +180,7 @@ func handleConnectionBlock(c *Connection) error {
 		c.DSN = ds
 		return nil
 	}
+
 	if c.DSN != "" {
 		if c.IsAnyConnParamsSet() {
 			return errors.New("DSN specified along with explicit attributes, only one type is supported")
@@ -187,10 +188,5 @@ func handleConnectionBlock(c *Connection) error {
 		return nil
 	}
 
-	s, err := c.BuildFromConnParams()
-	if err != nil {
-		return err
-	}
-	c.DSN = s.String()
-	return nil
+	return c.BuildFromConnParams()
 }


### PR DESCRIPTION
🎉 Thank you for making CloudQuery awesome by submitting a PR 🎉

#### Summary

Another lint related issue. I don't think it's a "real" issue as we update the DSN outside of `BuildFromConnParams`.
However it might be a bit confusing that the DNS is updated and the port and type aren't.

A smaller fix would be to only change `c Connection` to `c *Connection`

---

Use the following steps to ensure your PR is ready to be reviewed

- [x] Read the [contribution guidelines](../blob/main/.github/CONTRIBUTING.md) 🧑‍🎓
- [x] Run `go fmt` to format your code 🖊
- [x] Lint your changes via `golangci-lint run --new-from-rev main` 🚨 (install golangci-lint [here](https://golangci-lint.run/usage/install/#local-installation))
- [x] Update or add tests 🧪
- [x] Ensure the status checks below are successful ✅
