### PR TITLE
fix: Panic in loadPolicyFromSource

### DIFF
--- a/pkg/policy/parser.go
+++ b/pkg/policy/parser.go
@@ -53,8 +53,9 @@ var policySchema = &hcl.BodySchema{
 	},
 }
 
-func DecodePolicy(body hcl.Body, diags hcl.Diagnostics, basePath string) (*Policy, hcl.Diagnostics) {
+func decodePolicy(body hcl.Body, diags hcl.Diagnostics, basePath string) (*Policy, hcl.Diagnostics) {
 	content, contentDiags := body.Content(policyWrapperSchema)
+	diags = append(diags, contentDiags...)
 	if contentDiags.HasErrors() {
 		return nil, diags
 	}

--- a/pkg/policy/parser.go
+++ b/pkg/policy/parser.go
@@ -53,10 +53,9 @@ var policySchema = &hcl.BodySchema{
 	},
 }
 
-func decodePolicy(body hcl.Body, diags hcl.Diagnostics, basePath string) (*Policy, hcl.Diagnostics) {
-	content, contentDiags := body.Content(policyWrapperSchema)
-	diags = append(diags, contentDiags...)
-	if contentDiags.HasErrors() {
+func decodePolicy(body hcl.Body, basePath string) (*Policy, hcl.Diagnostics) {
+	content, diags := body.Content(policyWrapperSchema)
+	if diags.HasErrors() {
 		return nil, diags
 	}
 	if len(content.Blocks) > 1 {

--- a/pkg/policy/parser_test.go
+++ b/pkg/policy/parser_test.go
@@ -29,6 +29,9 @@ policy "test_policy" {
    attr = "value"
  }
 }`
+
+	testPolicyUnexpectedBlockTopLevel = `myblock {}`
+
 	testPolicyMultipleConfigurationBlocks = `policy "test_policy" {
  configuration {
  }
@@ -128,7 +131,7 @@ policy "test_policy" {
 		}`
 )
 
-func TestPolicyParser_LoadConfigFromSource(t *testing.T) {
+func Test_decodePolicy(t *testing.T) {
 	tests := []struct {
 		name      string
 		policyHCL string
@@ -166,6 +169,12 @@ func TestPolicyParser_LoadConfigFromSource(t *testing.T) {
 		{
 			name:      "unexpected block within a policy",
 			policyHCL: testPolicyUnexpectedBlock,
+			wantErr:   true,
+			errString: "Unsupported block type",
+		},
+		{
+			name:      "unexpected block at the top level",
+			policyHCL: testPolicyUnexpectedBlockTopLevel,
 			wantErr:   true,
 			errString: "Unsupported block type",
 		},
@@ -333,7 +342,7 @@ func TestPolicyParser_LoadConfigFromSource(t *testing.T) {
 			if diags != nil && diags.HasErrors() {
 				t.Fatal(diags.Errs())
 			}
-			policiesWrapper, diags := DecodePolicy(f.Body, diags, "")
+			policiesWrapper, diags := decodePolicy(f.Body, diags, "")
 			if tt.wantErr != diags.HasErrors() {
 				t.Errorf("want errors is %v, but have %v, error details: %s", tt.wantErr, diags.HasErrors(), diags.Error())
 			}

--- a/pkg/policy/parser_test.go
+++ b/pkg/policy/parser_test.go
@@ -342,7 +342,7 @@ func Test_decodePolicy(t *testing.T) {
 			if diags != nil && diags.HasErrors() {
 				t.Fatal(diags.Errs())
 			}
-			policiesWrapper, diags := decodePolicy(f.Body, diags, "")
+			policiesWrapper, diags := decodePolicy(f.Body, "")
 			if tt.wantErr != diags.HasErrors() {
 				t.Errorf("want errors is %v, but have %v, error details: %s", tt.wantErr, diags.HasErrors(), diags.Error())
 			}

--- a/pkg/policy/run.go
+++ b/pkg/policy/run.go
@@ -194,7 +194,7 @@ func loadPolicyFromSource(ctx context.Context, directory, name, subPolicy, sourc
 	if dd.HasErrors() {
 		return nil, diag.FromError(dd, diag.USER)
 	}
-	policy, dd := decodePolicy(f.Body, nil, meta.Directory)
+	policy, dd := decodePolicy(f.Body, meta.Directory)
 	if dd.HasErrors() {
 		return nil, diag.FromError(dd, diag.USER)
 	}

--- a/pkg/policy/run.go
+++ b/pkg/policy/run.go
@@ -194,7 +194,7 @@ func loadPolicyFromSource(ctx context.Context, directory, name, subPolicy, sourc
 	if dd.HasErrors() {
 		return nil, diag.FromError(dd, diag.USER)
 	}
-	policy, dd := DecodePolicy(f.Body, nil, meta.Directory)
+	policy, dd := decodePolicy(f.Body, nil, meta.Directory)
 	if dd.HasErrors() {
 		return nil, diag.FromError(dd, diag.USER)
 	}


### PR DESCRIPTION
The reason is DecodePolicy does not actually return error diag when there
is parse error. But the returned policy is nil leading to panic.