### PR TITLE
breaking!: Disable policies in config file, Disallow running more tha…

### DIFF
--- a/cmd/policy.go
+++ b/cmd/policy.go
@@ -96,10 +96,7 @@ var (
 
   # See https://hub.cloudquery.io for additional policies.`,
 		Run: handleCommand(func(ctx context.Context, c *console.Client, cmd *cobra.Command, args []string) error {
-			source := ""
-			if len(args) == 1 {
-				source = args[0]
-			}
+			source := args[0]
 			diags := c.RunPolicies(ctx, source, outputDir, noResults, storeResults)
 			errors.CaptureDiagnostics(diags, map[string]string{"command": "policy_run"})
 			if diags.HasErrors() {
@@ -107,7 +104,7 @@ var (
 			}
 			return nil
 		}),
-		Args: cobra.MaximumNArgs(1),
+		Args: cobra.ExactArgs(1),
 	}
 
 	policyTestCmd = &cobra.Command{

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -8,7 +8,6 @@ import (
 	"strings"
 
 	"github.com/cloudquery/cloudquery/internal/logging"
-	"github.com/cloudquery/cloudquery/pkg/policy"
 	"github.com/hashicorp/hcl/v2"
 	"github.com/xo/dburl"
 )
@@ -16,10 +15,9 @@ import (
 type Providers []*Provider
 
 type Config struct {
-	CloudQuery CloudQuery      `hcl:"cloudquery,block"`
-	Providers  Providers       `hcl:"provider,block"`
-	Policies   policy.Policies `hcl:"policy,block"`
-	Modules    hcl.Body        `hcl:"modules,block"`
+	CloudQuery CloudQuery `hcl:"cloudquery,block"`
+	Providers  Providers  `hcl:"provider,block"`
+	Modules    hcl.Body   `hcl:"modules,block"`
 }
 
 // Deprecated

--- a/pkg/policy/policy.go
+++ b/pkg/policy/policy.go
@@ -47,8 +47,6 @@ type Check struct {
 type Analytic struct {
 	// Whether policy will persist in database
 	Persistence bool
-	// Where the policy was originated from (cli/config)
-	UsageOrigin string
 	// Name of the policy
 	Name string
 	// Type of the policy i.e S3/Hub/Git
@@ -95,35 +93,9 @@ func (pp Policies) All() []string {
 	return policyNames
 }
 
-func (pp Policies) Get(policyName, subPath string) *Policy {
-	if subPath == "" {
-		policyName, subPath = getter.ParseSourceSubPolicy(policyName)
-	}
-
-	for _, p := range pp {
-		if policyName != p.Name {
-			continue
-		}
-		if subPath != "" && p.SubPolicy() == "" {
-			return &Policy{
-				Name:   p.Name,
-				Source: p.Source + "//" + subPath,
-			}
-		}
-		return p
-	}
-	return nil
-}
-
-func (p Policy) Analytic(dbPersistence, usedConfig bool) Analytic {
-	origin := "cli"
-	if usedConfig {
-		origin = "config"
-	}
-
+func (p Policy) Analytic(dbPersistence bool) Analytic {
 	pa := Analytic{
 		Persistence: dbPersistence,
-		UsageOrigin: origin,
 		Name:        p.Name,
 		Type:        p.SourceType(),
 		Selector:    p.SubPolicy(),
@@ -245,6 +217,5 @@ func (a Analytic) Properties() map[string]interface{} {
 		"policy_type":        a.Type,
 		"policy_is_private":  a.Private,
 		"policy_selector":    a.Selector,
-		"policy_used_origin": a.UsageOrigin,
 	}
 }

--- a/pkg/policy/policy_test.go
+++ b/pkg/policy/policy_test.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
-	"github.com/stretchr/testify/assert"
 )
 
 func TestHasChecks(t *testing.T) {
@@ -584,64 +583,6 @@ func TestFilterPolicies(t *testing.T) {
 			diff := cmp.Diff(tt.expectedPolicy, tt.p.Filter(tt.path), cmpopts.IgnoreUnexported(Policy{}))
 			if diff != "" && !tt.expectError {
 				t.Fatalf("values are not the same %s", diff)
-			}
-		})
-	}
-}
-
-func TestPolicies_Get(t *testing.T) {
-	testCases := []struct {
-		Name           string
-		PolicyName     string
-		SubPolicy      string
-		Policies       Policies
-		ExpectedPolicy bool
-	}{
-		{
-			Name:       "simple",
-			PolicyName: "aws",
-			SubPolicy:  "",
-			Policies: Policies{
-				{
-					Name: "aws",
-				},
-			},
-			ExpectedPolicy: true,
-		},
-		{
-			Name:       "missing",
-			PolicyName: "not-existing",
-			SubPolicy:  "",
-			Policies: Policies{
-				{
-					Name: "aws",
-				},
-			},
-			ExpectedPolicy: false,
-		},
-		{
-			Name:       "sub-policy",
-			PolicyName: "aws//sub-policy",
-			SubPolicy:  "",
-			Policies: Policies{
-				{
-					Name: "aws",
-					meta: &Meta{
-						SubPolicy: "sub-policy",
-					},
-				},
-			},
-			ExpectedPolicy: true,
-		},
-	}
-
-	for _, tc := range testCases {
-		t.Run(tc.Name, func(t *testing.T) {
-			p := tc.Policies.Get(tc.PolicyName, tc.SubPolicy)
-			if tc.ExpectedPolicy {
-				assert.NotNil(t, p)
-			} else {
-				assert.Nil(t, p)
 			}
 		})
 	}

--- a/pkg/ui/console/client.go
+++ b/pkg/ui/console/client.go
@@ -376,7 +376,7 @@ func (c Client) RunPolicies(ctx context.Context, policySource, outputDir string,
 		dbPersistence = c.cfg.CloudQuery.Policy.DBPersistence
 	}
 
-	policiesToRun, err := FilterPolicies(policySource, c.cfg.Policies)
+	policiesToRun, err := ParseAndDetect(policySource)
 	if err != nil {
 		ui.ColorizedOutput(ui.ColorError, err.Error())
 		return diag.FromError(err, diag.RESOLVING)
@@ -403,7 +403,7 @@ func (c Client) RunPolicies(ctx context.Context, policySource, outputDir string,
 		policiesToRun = resp.Policies
 	}
 	for _, p := range policiesToRun {
-		analytics.Capture("policy run", c.Providers, p.Analytic(dbPersistence, c.cfg.Policies.Get(p.Name, p.SubPolicy()) != nil), diags)
+		analytics.Capture("policy run", c.Providers, p.Analytic(dbPersistence), diags)
 	}
 
 	if policyRunProgress != nil {
@@ -447,7 +447,7 @@ func (c Client) TestPolicies(ctx context.Context, policySource, snapshotDestinat
 }
 
 func (c Client) SnapshotPolicy(ctx context.Context, policySource, snapshotDestination string) error {
-	policiesToSnapshot, err := FilterPolicies(policySource, c.cfg.Policies)
+	policiesToSnapshot, err := ParseAndDetect(policySource)
 	if err != nil {
 		ui.ColorizedOutput(ui.ColorError, err.Error())
 		return err
@@ -462,7 +462,7 @@ func (c Client) SnapshotPolicy(ctx context.Context, policySource, snapshotDestin
 }
 
 func (c Client) DescribePolicies(ctx context.Context, policySource string) error {
-	policiesToDescribe, err := FilterPolicies(policySource, []*policy.Policy{})
+	policiesToDescribe, err := ParseAndDetect(policySource)
 	if err != nil {
 		ui.ColorizedOutput(ui.ColorError, err.Error())
 		return err
@@ -478,7 +478,7 @@ func (c Client) DescribePolicies(ctx context.Context, policySource string) error
 
 func (c Client) ValidatePolicy(ctx context.Context, policySource string) (diags diag.Diagnostics) {
 	defer printDiagnostics("", &diags, viper.GetBool("redact-diags"), viper.GetBool("verbose"))
-	policyToValidate, err := FilterPolicies(policySource, c.cfg.Policies)
+	policyToValidate, err := ParseAndDetect(policySource)
 	if err != nil {
 		ui.ColorizedOutput(ui.ColorError, err.Error())
 		return diag.FromError(err, diag.USER)

--- a/pkg/ui/console/policy.go
+++ b/pkg/ui/console/policy.go
@@ -1,7 +1,6 @@
 package console
 
 import (
-	"errors"
 	"fmt"
 	"os"
 	"path"
@@ -18,18 +17,15 @@ import (
 	"github.com/spf13/cast"
 )
 
-func FilterPolicies(policyPath string, policies policy.Policies) (policy.Policies, error) {
-	if policyPath == "" && len(policies) == 0 {
-		return nil, diag.NewBaseError(errors.New("no policies defined in configuration"), diag.USER)
+func ParseAndDetect(policyPath string) (policy.Policies, error) {
+	if policyPath == "" {
+		return nil, diag.FromError(fmt.Errorf("empty policy specified"), diag.USER)
 	}
+
 	policyName, subPath := getter.ParseSourceSubPolicy(policyPath)
-	// run them all
+
 	if policyName == "" {
-		return policies, nil
-	}
-	p := policies.Get(policyName, subPath)
-	if p != nil {
-		return policy.Policies{p}, nil
+		return nil, diag.FromError(fmt.Errorf("unable to parse policy path \"%s\"", policyPath), diag.USER)
 	}
 
 	// run hub detector. We got here if we couldn't find the policy specified by the command argument in the configuration
@@ -41,12 +37,7 @@ func FilterPolicies(policyPath string, policies policy.Policies) (policy.Policie
 		return policy.Policies{p}, nil
 	}
 
-	configPolicies := policies.All()
-	if len(configPolicies) == 0 {
-		return nil, diag.FromError(fmt.Errorf("no valid policy with name %q found. If using a local policy directory, ensure the path is correct and the directory exists", policyName), diag.USER)
-	}
-
-	return nil, diag.FromError(fmt.Errorf("no valid policy with name %q found in configuration or remote. Available in config: %s", policyName, configPolicies), diag.USER)
+	return nil, diag.FromError(fmt.Errorf("no valid policy with name %q found. If using a local policy directory, ensure the path is correct and the directory exists", policyName), diag.USER)
 }
 
 func buildDescribePolicyTable(t ui.Table, pp policy.Policies, policyRootPath string) {


### PR DESCRIPTION
…n one policy

- A config file is not the right place for a data file.
- This is a prerequisite to replacing "--output-dir" flag with "--output-file" flag (a "--output-file" flag
  can only work if every "policy run" command can only run a single policy.

Related to: https://github.com/cloudquery/cloudquery/issues/740

🎉 Thank you for making CloudQuery awesome by submitting a PR 🎉

#### Summary

<!--
Explain what problem this PR addresses
-->

---

Use the following steps to ensure your PR is ready to be reviewed

- [x] Read the [contribution guidelines](../blob/main/.github/CONTRIBUTING.md) 🧑‍🎓
- [x] Run `go fmt` to format your code 🖊
- [x] Lint your changes via `golangci-lint run` 🚨 (install golangci-lint [here](https://golangci-lint.run/usage/install/#local-installation))
- [ ] Update or add tests 🧪
- [x] Ensure the status checks below are successful ✅
