### PR TITLE
fix(console): Output to console when console log is enabled in non terminal envs

### DIFF
--- a/pkg/ui/output.go
+++ b/pkg/ui/output.go
@@ -53,13 +53,15 @@ func ColorizedOutput(c *color.Color, msg string, values ...interface{}) {
 				log.Info().Msg(logMsg)
 			}
 		}
-		return
+		if IsTerminal() {
+			return
+		}
 	}
 	_, _ = c.Printf(msg, values...)
 }
 
 func ColorizedNoLogOutput(c *color.Color, msg string, values ...interface{}) {
-	if viper.GetBool("enable-console-log") {
+	if viper.GetBool("enable-console-log") && IsTerminal() {
 		return
 	}
 	// TODO: make zerolog not print this


### PR DESCRIPTION
🎉 Thank you for making CloudQuery awesome by submitting a PR 🎉

#### Summary

Fixes https://github.com/cloudquery/cloudquery/issues/852

When console logging is enabled we dump all log messages to `stderr`:
https://github.com/cloudquery/cloudquery/blob/b5af06b570558612c95407dceb4200f92640f335/internal/logging/logger.go#L66

We also redirect all `ui.ColorizedOutput` prints to the log instead of `stdout`. This is a bit confusing as in other places we print to `stdout`, for example when printing policy run table results (search `tablewriter.NewWriter` for all relevant places).

This PR fixes the issue for non terminal (non interactive) environments by printing `ui.ColorizedOutput` to both.
In terminal environments, `stdout` and `stderr` are interleaved so we still need the `return` to avoid printing the same message twice.

---

Use the following steps to ensure your PR is ready to be reviewed

- [x] Read the [contribution guidelines](../blob/main/.github/CONTRIBUTING.md) 🧑‍🎓
- [x] Run `go fmt` to format your code 🖊
- [x] Lint your changes via `golangci-lint run` 🚨 (install golangci-lint [here](https://golangci-lint.run/usage/install/#local-installation))
- [x] Update or add tests 🧪
- [x] Ensure the status checks below are successful ✅
