### PR TITLE
fix: Small fix in deprecation warning for "policy in config"

### DIFF
--- a/pkg/config/config_parser.go
+++ b/pkg/config/config_parser.go
@@ -77,7 +77,7 @@ func (p *Parser) decodeConfig(body hcl.Body, diags hcl.Diagnostics) (*Config, hc
 			&hcl.Diagnostic{
 				Severity: hcl.DiagWarning,
 				Summary:  "Deprecated 'policy' block in config file",
-				Detail:   "Specifying 'policy' blocks in 'config.hcl' has been deprecated. See https://docs.cloudquery.io/docs/tutorials/policies/writing-your-first-policy for instructions on running a local policy.",
+				Detail:   "Specifying 'policy' blocks in 'config.hcl' has been deprecated. See https://docs.cloudquery.io/docs/tutorials/policies/policies-overview for instructions on running policies (either from cloudquery-hub or a local file).",
 			},
 		)
 	}


### PR DESCRIPTION
🎉 Thank you for making CloudQuery awesome by submitting a PR 🎉

#### Summary

A user with policy in config block doesn't necessarily need to write their own local policy.
If they were using the "source" feature, they might just need the link to how to run them from CLI.

<!--
Explain what problem this PR addresses
-->

---

Use the following steps to ensure your PR is ready to be reviewed

- [ ] Read the [contribution guidelines](../blob/main/.github/CONTRIBUTING.md) 🧑‍🎓
- [ ] Run `go fmt` to format your code 🖊
- [ ] Lint your changes via `golangci-lint run` 🚨 (install golangci-lint [here](https://golangci-lint.run/usage/install/#local-installation))
- [ ] Update or add tests 🧪
- [ ] Ensure the status checks below are successful ✅
