### PR TITLE
feat: Sentry: Report provider version as release

### DIFF
--- a/cmd/sentry.go
+++ b/cmd/sentry.go
@@ -87,6 +87,10 @@ func initSentry() {
 			if len(event.Exception) > 0 {
 				if event.Tags["provider"] != "" {
 					event.Exception[0].Type = "Diag:" + event.Tags["provider"] + "@" + event.Tags["provider_version"]
+
+					// Save core version in separate tag and report provider version as Release
+					event.Tags["core_version"] = event.Release
+					event.Release = event.Tags["provider"] + "@" + event.Tags["provider_version"]
 				}
 			}
 

--- a/cmd/sentry.go
+++ b/cmd/sentry.go
@@ -74,6 +74,16 @@ func initSentry() {
 			return analytics.HashAttribute(hn)
 		}(),
 		BeforeSend: func(event *sentry.Event, hint *sentry.EventHint) *sentry.Event {
+			if event.Tags["provider"] != "" {
+				// Save core version in separate tag and report provider version as Release
+				event.Tags["core_version"] = event.Release
+				event.Release = event.Tags["provider"] + "@" + event.Tags["provider_version"]
+			}
+
+			if len(event.Exception) > 0 && event.Tags["provider"] != "" {
+				event.Exception[0].Type = "Diag:" + event.Tags["provider"] + "@" + event.Tags["provider_version"]
+			}
+
 			if hint != nil && hint.RecoveredException != nil {
 				// Keep stack trace on recover() events
 				return event
@@ -82,16 +92,6 @@ func initSentry() {
 			// Remove stack trace otherwise
 			for i := range event.Exception {
 				event.Exception[i].Stacktrace = nil
-			}
-
-			if len(event.Exception) > 0 {
-				if event.Tags["provider"] != "" {
-					event.Exception[0].Type = "Diag:" + event.Tags["provider"] + "@" + event.Tags["provider_version"]
-
-					// Save core version in separate tag and report provider version as Release
-					event.Tags["core_version"] = event.Release
-					event.Release = event.Tags["provider"] + "@" + event.Tags["provider_version"]
-				}
 			}
 
 			return event

--- a/cmd/sentry.go
+++ b/cmd/sentry.go
@@ -4,6 +4,7 @@ import (
 	"os"
 	"runtime"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/cloudquery/cloudquery/internal/analytics"
@@ -77,7 +78,7 @@ func initSentry() {
 			if event.Tags["provider"] != "" {
 				// Save core version in separate tag and report provider version as Release
 				event.Tags["core_version"] = event.Release
-				event.Release = event.Tags["provider"] + "@" + event.Tags["provider_version"]
+				event.Release = event.Tags["provider"] + "@" + strings.TrimPrefix(event.Tags["provider_version"], "v")
 			}
 
 			if len(event.Exception) > 0 && event.Tags["provider"] != "" {

--- a/pkg/core/diagnostics.go
+++ b/pkg/core/diagnostics.go
@@ -21,7 +21,7 @@ type SentryDiagnostic struct {
 	Ignore bool
 }
 
-func (d SentryDiagnostic) Redacted() diag.Diagnostic {
+func (d *SentryDiagnostic) Redacted() diag.Diagnostic {
 	v, ok := d.Diagnostic.(diag.Redactable)
 	if !ok {
 		return d


### PR DESCRIPTION
Reports provider version as the release, if we're reporting a provider-generated diagnostic.