### PR TITLE
fix: Improve invalid provider version error

### DIFF
--- a/pkg/core/sync.go
+++ b/pkg/core/sync.go
@@ -68,7 +68,7 @@ func Sync(ctx context.Context, sta *state.Client, pm *plugin.Manager, provider r
 	}
 
 	if want.ParsedVersion == nil {
-		return nil, diag.FromError(fmt.Errorf("failing provider with invalid version %q", provider.Version), diag.INTERNAL)
+		return nil, diag.FromError(fmt.Errorf("unsupported version %q for provider. If you're trying to debug a provider see https://docs.cloudquery.io/docs/developers/debugging", provider.Version), diag.USER)
 	}
 
 	cur, err := sta.GetProvider(ctx, provider)


### PR DESCRIPTION
🎉 Thank you for making CloudQuery awesome by submitting a PR 🎉

#### Summary

Fixes https://github.com/cloudquery/cloudquery-issues/issues/387 (internal issue)

To reproduce:
1. `cloudquery init aws`
2. `git clone https://github.com/cloudquery/cq-provider-aws`
3. `make build` in the repo ⬆️ 
4. Copy complied provider to `.cq/providers/cloudquery/aws` and replace the existing one.
5. Run `cloudquery fetch --no-verify`

---

Use the following steps to ensure your PR is ready to be reviewed

- [x] Read the [contribution guidelines](../blob/main/.github/CONTRIBUTING.md) 🧑‍🎓
- [x] Run `go fmt` to format your code 🖊
- [x] Lint your changes via `golangci-lint run` 🚨 (install golangci-lint [here](https://golangci-lint.run/usage/install/#local-installation))
- [x] Update or add tests 🧪
- [x] Ensure the status checks below are successful ✅
