### PR TITLE
feat: Added ability to configure proxy via config file

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -28,15 +28,16 @@ type History struct {
 }
 
 type CloudQuery struct {
-	// Deprecated. Value from hcl is overrwritten.
+	// Deprecated. Value from hcl is overwritten.
 	PluginDirectory string `hcl:"plugin_directory,optional"`
-	// Deprecated. Value from hcl is overrwritten.
+	// Deprecated. Value from hcl is overwritten.
 	PolicyDirectory string `hcl:"policy_directory,optional"`
 
 	Logger     *logging.Config   `hcl:"logging,block"`
 	Providers  RequiredProviders `hcl:"provider,block"`
 	Connection *Connection       `hcl:"connection,block"`
 	Policy     *Policy           `hcl:"policy,block"`
+	Proxy      *Proxy            `hcl:"proxy,block"`
 	// Deprecated
 	History *History `hcl:"history,block"`
 }
@@ -63,6 +64,13 @@ type RequiredProvider struct {
 	Name    string  `hcl:"name,label"`
 	Source  *string `hcl:"source,optional"`
 	Version string  `hcl:"version"`
+}
+
+// Proxy allows to set or owerwrite proxy configuration environment variables.
+type Proxy struct {
+	HttpProxy     *string `hcl:"http_proxy,optional"`
+	HttpsProxy    *string `hcl:"https_proxy,optional"`
+	RequestMethod *string `hcl:"request_method,optional"`
 }
 
 type RequiredProviders []*RequiredProvider

--- a/pkg/core/proxy.go
+++ b/pkg/core/proxy.go
@@ -1,8 +1,9 @@
 package core
 
 import (
-	"github.com/cloudquery/cloudquery/pkg/config"
 	"os"
+
+	"github.com/cloudquery/cloudquery/pkg/config"
 )
 
 func ConfigureProxy(pCfg *config.Proxy) {

--- a/pkg/core/proxy.go
+++ b/pkg/core/proxy.go
@@ -1,0 +1,22 @@
+package core
+
+import (
+	"github.com/cloudquery/cloudquery/pkg/config"
+	"os"
+)
+
+func ConfigureProxy(pCfg *config.Proxy) {
+	if pCfg == nil {
+		return
+	}
+
+	if pCfg.HttpProxy != nil {
+		os.Setenv("HTTP_PROXY", *pCfg.HttpProxy)
+	}
+	if pCfg.HttpsProxy != nil {
+		os.Setenv("HTTPS_PROXY", *pCfg.HttpsProxy)
+	}
+	if pCfg.RequestMethod != nil {
+		os.Setenv("REQUEST_METHOD", *pCfg.HttpsProxy)
+	}
+}

--- a/pkg/ui/console/client.go
+++ b/pkg/ui/console/client.go
@@ -155,7 +155,10 @@ func CreateClientFromConfig(ctx context.Context, cfg *config.Config, instanceId 
 		c.Providers[i] = registry.Provider{Name: name, Version: rp.Version, Source: src}
 	}
 
-	core.ConfigureProxy(cfg.CloudQuery.Proxy)
+	if cfg.CloudQuery.Proxy != nil {
+		log.Info().Msg("Proxy settings are detected in config file. The system proxy settings will be overwritten")
+		core.ConfigureProxy(cfg.CloudQuery.Proxy)
+	}
 
 	c.checkForUpdate(ctx)
 	return c, nil

--- a/pkg/ui/console/client.go
+++ b/pkg/ui/console/client.go
@@ -155,6 +155,8 @@ func CreateClientFromConfig(ctx context.Context, cfg *config.Config, instanceId 
 		c.Providers[i] = registry.Provider{Name: name, Version: rp.Version, Source: src}
 	}
 
+	core.ConfigureProxy(cfg.CloudQuery.Proxy)
+
 	c.checkForUpdate(ctx)
 	return c, nil
 }


### PR DESCRIPTION
🎉 Thank you for making CloudQuery awesome by submitting a PR 🎉

#### Summary

I have tested proxy configuration with cq-provider-aws cq-provider-gcp cq-provider-azure. All of them work with proxy setting environment variables so they can be used to set proxy config.  Added proxy block to hcl config. added setting of proxy env vars if they are exist in config.

closes #499 

---

Use the following steps to ensure your PR is ready to be reviewed

- [x] Read the [contribution guidelines](../blob/main/.github/CONTRIBUTING.md) 🧑‍🎓
- [x] Run `go fmt` to format your code 🖊
- [x] Lint your changes via `golangci-lint run` 🚨 (install golangci-lint [here](https://golangci-lint.run/usage/install/#local-installation))
- [x] Update or add tests 🧪
- [x] Ensure the status checks below are successful ✅
