### PR TITLE
fix: Add missing space when printing provider update message

### DIFF
--- a/pkg/ui/console/client.go
+++ b/pkg/ui/console/client.go
@@ -188,7 +188,7 @@ func (c Client) DownloadProviders(ctx context.Context) (diags diag.Diagnostics) 
 		return diags.Add(dd)
 	}
 	for _, u := range updates {
-		ui.ColorizedOutput(ui.ColorInfo, fmt.Sprintf("Update available for provider %s: %s ➡️ %s\n\n", u.Name, u.CurrentVersion, u.AvailableVersion))
+		ui.ColorizedOutput(ui.ColorInfo, fmt.Sprintf("Update available for provider %s: %s ➡️  %s\n\n", u.Name, u.CurrentVersion, u.AvailableVersion))
 	}
 	return diags
 }


### PR DESCRIPTION
🎉 Thank you for making CloudQuery awesome by submitting a PR 🎉

#### Summary

Added a space after the -> symbol

Before:
![image](https://user-images.githubusercontent.com/26760571/173623500-e3c509f6-d021-4241-92c5-7590b08f4a1b.png)

After:
![image](https://user-images.githubusercontent.com/26760571/173623601-19ce7174-eb9e-4c10-afb1-75a8cdb9e643.png)


---

Use the following steps to ensure your PR is ready to be reviewed

- [x] Read the [contribution guidelines](../blob/main/.github/CONTRIBUTING.md) 🧑‍🎓
- [x] Run `go fmt` to format your code 🖊
- [x] Lint your changes via `golangci-lint run` 🚨 (install golangci-lint [here](https://golangci-lint.run/usage/install/#local-installation))
- [x] Update or add tests 🧪
- [x] Ensure the status checks below are successful ✅
