### PR TITLE
fix: Don't parse plugin and policy dirs from HCL

### DIFF
--- a/cmd/init.go
+++ b/cmd/init.go
@@ -84,10 +84,6 @@ func Initialize(ctx context.Context, providers []string) error {
 		},
 	}, "cloudquery")
 
-	// Remove deprecated "plugin_directory" and "policy_directory"
-	cqBlock.Body().RemoveAttribute("plugin_directory")
-	cqBlock.Body().RemoveAttribute("policy_directory")
-
 	// Update connection block to remove unwanted keys
 	if b := cqBlock.Body().FirstMatchingBlock("connection", nil); b != nil {
 		bd := b.Body()

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -28,10 +28,8 @@ type History struct {
 }
 
 type CloudQuery struct {
-	// Deprecated. Value from hcl is overrwritten.
-	PluginDirectory string `hcl:"plugin_directory,optional"`
-	// Deprecated. Value from hcl is overrwritten.
-	PolicyDirectory string `hcl:"policy_directory,optional"`
+	PluginDirectory string
+	PolicyDirectory string
 
 	Logger     *logging.Config   `hcl:"logging,block"`
 	Providers  RequiredProviders `hcl:"provider,block"`
@@ -39,6 +37,9 @@ type CloudQuery struct {
 	Policy     *Policy           `hcl:"policy,block"`
 	// Deprecated
 	History *History `hcl:"history,block"`
+
+	// Allow extra properties in the configuration
+	Remain hcl.Body `hcl:",remain"`
 }
 
 type Connection struct {

--- a/pkg/config/config_parser.go
+++ b/pkg/config/config_parser.go
@@ -127,6 +127,8 @@ func decodeCloudQueryBlock(block *hcl.Block, ctx *hcl.EvalContext) (CloudQuery, 
 	cq.Logger = &logging.GlobalConfig
 	var diags hcl.Diagnostics
 	diags = diags.Extend(gohcl.DecodeBody(block.Body, ctx, &cq))
+	// We don't care about additional configuration blocks, so just ignore them
+	cq.Remain = nil
 
 	// TODO: decode in a more generic way
 	if cq.Connection == nil {


### PR DESCRIPTION
🎉 Thank you for making CloudQuery awesome by submitting a PR 🎉

#### Summary

Follow up to https://github.com/cloudquery/cloudquery/pull/855

ignores `plugin_directory` and `policy_directory` when parsing the configuration (also related to https://github.com/cloudquery/cloudquery-issues/issues/384 (internal issue)

---

Use the following steps to ensure your PR is ready to be reviewed

- [x] Read the [contribution guidelines](../blob/main/.github/CONTRIBUTING.md) 🧑‍🎓
- [x] Run `go fmt` to format your code 🖊
- [x] Lint your changes via `golangci-lint run` 🚨 (install golangci-lint [here](https://golangci-lint.run/usage/install/#local-installation))
- [x] Update or add tests 🧪
- [x] Ensure the status checks below are successful ✅
