### PR TITLE
fix(command-options): Hide internal debug flags

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -125,6 +125,10 @@ func init() {
 	rootCmd.PersistentFlags().Bool("debug-telemetry", false, "enable telemetry debug logging")
 	rootCmd.PersistentFlags().String("telemetry-apikey", APIKey, "set telemetry API Key")
 
+	rootCmd.PersistentFlags().MarkHidden("inspect-telemetry")
+	rootCmd.PersistentFlags().MarkHidden("debug-telemetry")
+	rootCmd.PersistentFlags().MarkHidden("telemetry-apikey")
+
 	_ = viper.BindPFlag("verbose", rootCmd.PersistentFlags().Lookup("verbose"))
 	_ = viper.BindPFlag("enable-console-log", rootCmd.PersistentFlags().Lookup("enable-console-log"))
 	_ = viper.BindPFlag("data-dir", rootCmd.PersistentFlags().Lookup("data-dir"))

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -125,9 +125,9 @@ func init() {
 	rootCmd.PersistentFlags().Bool("debug-telemetry", false, "enable telemetry debug logging")
 	rootCmd.PersistentFlags().String("telemetry-apikey", APIKey, "set telemetry API Key")
 
-	rootCmd.PersistentFlags().MarkHidden("inspect-telemetry")
-	rootCmd.PersistentFlags().MarkHidden("debug-telemetry")
-	rootCmd.PersistentFlags().MarkHidden("telemetry-apikey")
+	_ = rootCmd.PersistentFlags().MarkHidden("inspect-telemetry")
+	_ = rootCmd.PersistentFlags().MarkHidden("debug-telemetry")
+	_ = rootCmd.PersistentFlags().MarkHidden("telemetry-apikey")
 
 	_ = viper.BindPFlag("verbose", rootCmd.PersistentFlags().Lookup("verbose"))
 	_ = viper.BindPFlag("enable-console-log", rootCmd.PersistentFlags().Lookup("enable-console-log"))

--- a/cmd/sentry.go
+++ b/cmd/sentry.go
@@ -21,7 +21,7 @@ func registerSentryFlags(cmd *cobra.Command) {
 	cmd.PersistentFlags().Bool("debug-sentry", false, "enable Sentry debug mode")
 	cmd.PersistentFlags().String("sentry-dsn", "https://5ff9e378a79d4ba2821f540b036286e9@o912044.ingest.sentry.io/6106324", "Sentry DSN")
 
-	rootCmd.PersistentFlags().MarkHidden("debug-sentry")
+	_ = rootCmd.PersistentFlags().MarkHidden("debug-sentry")
 	_ = cmd.PersistentFlags().MarkHidden("sentry-dsn")
 
 	_ = viper.BindPFlag("debug-sentry", cmd.PersistentFlags().Lookup("debug-sentry"))

--- a/cmd/sentry.go
+++ b/cmd/sentry.go
@@ -21,6 +21,7 @@ func registerSentryFlags(cmd *cobra.Command) {
 	cmd.PersistentFlags().Bool("debug-sentry", false, "enable Sentry debug mode")
 	cmd.PersistentFlags().String("sentry-dsn", "https://5ff9e378a79d4ba2821f540b036286e9@o912044.ingest.sentry.io/6106324", "Sentry DSN")
 
+	rootCmd.PersistentFlags().MarkHidden("debug-sentry")
 	_ = cmd.PersistentFlags().MarkHidden("sentry-dsn")
 
 	_ = viper.BindPFlag("debug-sentry", cmd.PersistentFlags().Lookup("debug-sentry"))


### PR DESCRIPTION
🎉 Thank you for making CloudQuery awesome by submitting a PR 🎉

#### Summary

Noticed this while doing https://github.com/cloudquery/docs/pull/198. I think we can hide these debug flags from users (e.g. when running `cloudquery options`

---

Use the following steps to ensure your PR is ready to be reviewed

- [x] Read the [contribution guidelines](../blob/main/.github/CONTRIBUTING.md) 🧑‍🎓
- [x] Run `go fmt` to format your code 🖊
- [x] Lint your changes via `golangci-lint run` 🚨 (install golangci-lint [here](https://golangci-lint.run/usage/install/#local-installation))
- [x] Update or add tests 🧪
- [x] Ensure the status checks below are successful ✅
