### PR TITLE
refactor: Rename ParseProviderNameWithVersion, move to relevant file, add test

### DIFF
--- a/cmd/init.go
+++ b/cmd/init.go
@@ -6,8 +6,6 @@ import (
 	"fmt"
 	"strings"
 
-	"strings"
-
 	"github.com/cloudquery/cloudquery/internal/file"
 
 	"github.com/Masterminds/semver/v3"

--- a/cmd/init.go
+++ b/cmd/init.go
@@ -234,7 +234,6 @@ func generateHCLConfig(ctx context.Context, c *console.Client, providers []strin
 	return hclwrite.Format(buffer.Bytes()), nil
 }
 
-// ParseProviderCLIArg parses the CLI arg passed to `cloudquery init <provider>`
 func parseProviderCLIArg(providerCLIArg string) (org string, name string, version string, err error) {
 	argParts := strings.Split(providerCLIArg, "@")
 

--- a/cmd/init.go
+++ b/cmd/init.go
@@ -6,9 +6,8 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/cloudquery/cloudquery/internal/file"
-
 	"github.com/Masterminds/semver/v3"
+	"github.com/cloudquery/cloudquery/internal/file"
 	"github.com/cloudquery/cloudquery/pkg/config"
 	"github.com/cloudquery/cloudquery/pkg/core"
 	"github.com/cloudquery/cloudquery/pkg/plugin/registry"

--- a/cmd/init_test.go
+++ b/cmd/init_test.go
@@ -7,6 +7,22 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+func Test_Init(t *testing.T) {
+	testCases := []CommandTestCases{
+		{
+			Name:           "init-no-args",
+			Command:        "init",
+			ExpectError:    true,
+			ExpectedOutput: "Error: requires at least 1 arg(s), only received 0",
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.Name, func(t *testing.T) {
+			testCommand(t, tc)
+		})
+	}
+}
+
 func Test_parseProviderCLIArg(t *testing.T) {
 	type args struct {
 		providerCLIArg string

--- a/cmd/init_test.go
+++ b/cmd/init_test.go
@@ -2,20 +2,100 @@ package cmd
 
 import (
 	"testing"
+
+	"github.com/cloudquery/cloudquery/pkg/plugin/registry"
+	"github.com/stretchr/testify/assert"
 )
 
-func Test_Init(t *testing.T) {
-	testCases := []CommandTestCases{
+func Test_parseProviderCLIArg(t *testing.T) {
+	type args struct {
+		providerCLIArg string
+	}
+	tests := []struct {
+		name        string
+		args        args
+		wantOrg     string
+		wantName    string
+		wantVersion string
+		wantErr     bool
+	}{
 		{
-			Name:           "init-no-args",
-			Command:        "init",
-			ExpectError:    true,
-			ExpectedOutput: "Error: requires at least 1 arg(s), only received 0",
+			name:        "should return default org, latest version and name when given only name",
+			args:        args{providerCLIArg: "aws"},
+			wantOrg:     registry.DefaultOrganization,
+			wantName:    "aws",
+			wantVersion: "latest",
+			wantErr:     false,
+		},
+		{
+			name:        "should return default org, latest version and name when given name@latest",
+			args:        args{providerCLIArg: "aws@latest"},
+			wantOrg:     registry.DefaultOrganization,
+			wantName:    "aws",
+			wantVersion: "latest",
+			wantErr:     false,
+		},
+		{
+			name:        "should return default org, specific version and name when given name@version",
+			args:        args{providerCLIArg: "aws@1.2.3"},
+			wantOrg:     registry.DefaultOrganization,
+			wantName:    "aws",
+			wantVersion: "v1.2.3",
+			wantErr:     false,
+		},
+		{
+			name:        "should return org, latest version and name when given org/name",
+			args:        args{providerCLIArg: "org/test"},
+			wantOrg:     "org",
+			wantName:    "test",
+			wantVersion: "latest",
+			wantErr:     false,
+		},
+		{
+			name:        "should return org, latest version and name when given org/name@latest",
+			args:        args{providerCLIArg: "org/test"},
+			wantOrg:     "org",
+			wantName:    "test",
+			wantVersion: "latest",
+			wantErr:     false,
+		},
+		{
+			name:        "should return org, specific version and name when given org/name@version",
+			args:        args{providerCLIArg: "org/test@1.2.3"},
+			wantOrg:     "org",
+			wantName:    "test",
+			wantVersion: "v1.2.3",
+			wantErr:     false,
+		},
+		{
+			name:        "should fail when version doesn't follow semver",
+			args:        args{providerCLIArg: "test@invalid"},
+			wantOrg:     "",
+			wantName:    "",
+			wantVersion: "",
+			wantErr:     true,
+		},
+		{
+			name:        "should fail when version starts with a 'v'",
+			args:        args{providerCLIArg: "org/test@v1.2.3"},
+			wantOrg:     "org",
+			wantName:    "test",
+			wantVersion: "v1.2.3",
+			wantErr:     false,
 		},
 	}
-	for _, tc := range testCases {
-		t.Run(tc.Name, func(t *testing.T) {
-			testCommand(t, tc)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotOrg, gotName, gotVersion, err := parseProviderCLIArg(tt.args.providerCLIArg)
+			if tt.wantErr {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
+
+			assert.Equal(t, tt.wantOrg, gotOrg)
+			assert.Equal(t, tt.wantName, gotName)
+			assert.Equal(t, tt.wantVersion, gotVersion)
 		})
 	}
 }

--- a/pkg/plugin/registry/organization.go
+++ b/pkg/plugin/registry/organization.go
@@ -3,8 +3,6 @@ package registry
 import (
 	"fmt"
 	"strings"
-
-	"github.com/Masterminds/semver/v3"
 )
 
 const (
@@ -28,28 +26,4 @@ func ParseProviderName(name string) (org string, providerName string, err error)
 // ProviderRepoName returns a repository name for a given provider name.
 func ProviderRepoName(name string) string {
 	return fmt.Sprintf("cq-provider-%s", name)
-}
-
-// ParseProviderNameWithVersion parses the given string as "repository/provider@version" or "provider@version" (or @version omitted, defaulting to "latest")
-func ParseProviderNameWithVersion(nameWithVersion string) (org string, name string, version string, err error) {
-	versionParts := strings.Split(nameWithVersion, "@")
-
-	if l := len(versionParts); l == 1 || (l == 2 && versionParts[1] == "latest") {
-		org, name, err = ParseProviderName(versionParts[0])
-		return org, name, "latest", err
-	} else if l != 2 {
-		return "", "", "", fmt.Errorf("invalid provider name@version %q", nameWithVersion)
-	}
-
-	org, name, err = ParseProviderName(versionParts[0])
-	if err != nil {
-		return "", "", "", err
-	}
-
-	ver, err := semver.NewVersion(versionParts[1])
-	if err != nil {
-		return "", "", "", fmt.Errorf("invalid version %q: %w", versionParts[1], err)
-	}
-
-	return org, name, "v" + ver.String(), err
 }

--- a/pkg/plugin/registry/organization_test.go
+++ b/pkg/plugin/registry/organization_test.go
@@ -1,0 +1,78 @@
+package registry
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestParseProviderName(t *testing.T) {
+	type args struct {
+		name string
+	}
+	tests := []struct {
+		name             string
+		args             args
+		wantOrg          string
+		wantProviderName string
+		wantErr          bool
+	}{
+		{
+			name:             "should return default org and name when given only name",
+			args:             args{name: "test-name"},
+			wantOrg:          DefaultOrganization,
+			wantProviderName: "test-name",
+			wantErr:          false,
+		},
+		{
+			name:             "should return org and name when given org and name",
+			args:             args{name: "test-org/test-name"},
+			wantOrg:          "test-org",
+			wantProviderName: "test-name",
+			wantErr:          false,
+		},
+		{
+			name:             "should error on invalid format",
+			args:             args{name: "test-org/test-name/invalid"},
+			wantOrg:          "",
+			wantProviderName: "",
+			wantErr:          true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotOrg, gotProviderName, err := ParseProviderName(tt.args.name)
+			if tt.wantErr {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
+
+			assert.Equal(t, tt.wantOrg, gotOrg)
+			assert.Equal(t, tt.wantProviderName, gotProviderName)
+		})
+	}
+}
+
+func TestProviderRepoName(t *testing.T) {
+	type args struct {
+		name string
+	}
+	tests := []struct {
+		name string
+		args args
+		want string
+	}{
+		{
+			name: "should return repo when give name",
+			args: args{name: "test"},
+			want: "cq-provider-test",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := ProviderRepoName(tt.args.name)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}


### PR DESCRIPTION
🎉 Thank you for making CloudQuery awesome by submitting a PR 🎉

#### Summary

Related to https://github.com/cloudquery/cloudquery/issues/908

This PR does a bit of refactoring around the code that parses the arguments passed to the `init` command, and add tests

---

Use the following steps to ensure your PR is ready to be reviewed

- [x] Read the [contribution guidelines](../blob/main/.github/CONTRIBUTING.md) 🧑‍🎓
- [x] Run `go fmt` to format your code 🖊
- [x] Lint your changes via `golangci-lint run` 🚨 (install golangci-lint [here](https://golangci-lint.run/usage/install/#local-installation))
- [x] Update or add tests 🧪
- [x] Ensure the status checks below are successful ✅
