### PR TITLE
test: Move test from parse_test.go to config_parser_test.go

### DIFF
--- a/pkg/config/config_parser_test.go
+++ b/pkg/config/config_parser_test.go
@@ -60,3 +60,82 @@ func TestHandleConnectionBlock(t *testing.T) {
 		})
 	}
 }
+
+func TestParser_LoadConfigFromSourceConnectionOptionality(t *testing.T) {
+	cases := []struct {
+		cfg           string
+		expectedDSN   string
+		expectedError bool
+	}{
+		{
+			`
+cloudquery {
+  connection {
+    dsn =  "postgres://postgres:pass@localhost:5432/postgres"
+  }
+}
+`,
+			"postgres://postgres:pass@localhost:5432/postgres",
+			false,
+		},
+		{
+			`
+cloudquery {
+  connection {
+    dsn =  "postgres://postgres:pass@localhost:5432/postgres"
+    database = "cq"
+  }
+}
+`,
+			"",
+			true,
+		},
+		{
+			`
+cloudquery {
+  connection {
+    username = "postgres"
+    password = "pass"
+    host = "localhost"
+    port = 15432
+    database = "cq"
+    sslmode = "disable"
+  }
+}
+`,
+			"postgres://postgres:pass@localhost:15432/cq?sslmode=disable",
+			false,
+		},
+		{
+			`
+cloudquery {
+  connection {
+    username = "postgres"
+    password = "pass"
+    type = "postgres"
+    host = "localhost"
+    port = 15432
+    database = "cq"
+    sslmode = "disable"
+	extras = [ "search_path=myschema" ]
+  }
+}
+`,
+			"postgres://postgres:pass@localhost:15432/cq?search_path=myschema&sslmode=disable",
+			false,
+		},
+	}
+	for i := range cases {
+		tc := cases[i]
+		t.Run("case #"+strconv.Itoa(i+1), func(t *testing.T) {
+			p := NewParser()
+			parsedCfg, diags := p.LoadConfigFromSource("test.hcl", []byte(tc.cfg))
+			if tc.expectedError {
+				assert.True(t, diags.HasErrors())
+			} else {
+				assert.Len(t, diags.Errs(), 0)
+				assert.Equal(t, tc.expectedDSN, parsedCfg.CloudQuery.Connection.DSN)
+			}
+		})
+	}
+}

--- a/pkg/config/parser_test.go
+++ b/pkg/config/parser_test.go
@@ -1,7 +1,6 @@
 package config
 
 import (
-	"strconv"
 	"testing"
 
 	"github.com/cloudquery/cloudquery/internal/logging"
@@ -314,83 +313,4 @@ func TestParser_LoadConfigNoSourceField(t *testing.T) {
 		},
 	}, cfg)
 	assert.Equal(t, cfg.CloudQuery.Providers[0].String(), "cq-provider-test@v0.0.0")
-}
-
-func TestParser_LoadConfigFromSourceConnectionOptionality(t *testing.T) {
-	cases := []struct {
-		cfg           string
-		expectedDSN   string
-		expectedError bool
-	}{
-		{
-			`
-cloudquery {
-  connection {
-    dsn =  "postgres://postgres:pass@localhost:5432/postgres"
-  }
-}
-`,
-			"postgres://postgres:pass@localhost:5432/postgres",
-			false,
-		},
-		{
-			`
-cloudquery {
-  connection {
-    dsn =  "postgres://postgres:pass@localhost:5432/postgres"
-    database = "cq"
-  }
-}
-`,
-			"",
-			true,
-		},
-		{
-			`
-cloudquery {
-  connection {
-    username = "postgres"
-    password = "pass"
-    host = "localhost"
-    port = 15432
-    database = "cq"
-    sslmode = "disable"
-  }
-}
-`,
-			"postgres://postgres:pass@localhost:15432/cq?sslmode=disable",
-			false,
-		},
-		{
-			`
-cloudquery {
-  connection {
-    username = "postgres"
-    password = "pass"
-    type = "postgres"
-    host = "localhost"
-    port = 15432
-    database = "cq"
-    sslmode = "disable"
-	extras = [ "search_path=myschema" ]
-  }
-}
-`,
-			"postgres://postgres:pass@localhost:15432/cq?search_path=myschema&sslmode=disable",
-			false,
-		},
-	}
-	for i := range cases {
-		tc := cases[i]
-		t.Run("case #"+strconv.Itoa(i+1), func(t *testing.T) {
-			p := NewParser()
-			parsedCfg, diags := p.LoadConfigFromSource("test.hcl", []byte(tc.cfg))
-			if tc.expectedError {
-				assert.True(t, diags.HasErrors())
-			} else {
-				assert.Len(t, diags.Errs(), 0)
-				assert.Equal(t, tc.expectedDSN, parsedCfg.CloudQuery.Connection.DSN)
-			}
-		})
-	}
 }


### PR DESCRIPTION
🎉 Thank you for making CloudQuery awesome by submitting a PR 🎉

#### Summary

Related to https://github.com/cloudquery/cloudquery/pull/912
The purpose of this test is to test code in `config_parser_test.go` (the one in `handleConnectionBlock` and also `config.go`) so I moved it to that file

Tests in `parser_test.go` seem to follow a pattern of testing loading the config data (from files or strings)

---

Use the following steps to ensure your PR is ready to be reviewed

- [ ] Read the [contribution guidelines](../blob/main/.github/CONTRIBUTING.md) 🧑‍🎓
- [ ] Run `go fmt` to format your code 🖊
- [ ] Lint your changes via `golangci-lint run` 🚨 (install golangci-lint [here](https://golangci-lint.run/usage/install/#local-installation))
- [ ] Update or add tests 🧪
- [ ] Ensure the status checks below are successful ✅
