### PR TITLE
fix(config): Align provider version validation

### DIFF
--- a/cmd/init/init.go
+++ b/cmd/init/init.go
@@ -6,7 +6,6 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/Masterminds/semver/v3"
 	"github.com/cloudquery/cloudquery/cmd/utils"
 	"github.com/cloudquery/cloudquery/pkg/config"
 	"github.com/cloudquery/cloudquery/pkg/core"
@@ -211,10 +210,10 @@ func ParseProviderCLIArg(providerCLIArg string) (org string, name string, versio
 		return "", "", "", err
 	}
 
-	ver, err := semver.NewVersion(argParts[1])
+	ver, err := config.ParseVersion(argParts[1])
 	if err != nil {
 		return "", "", "", fmt.Errorf("invalid version %q: %w", argParts[1], err)
 	}
 
-	return org, name, "v" + ver.String(), nil
+	return org, name, config.FormatVersion(ver), nil
 }

--- a/pkg/config/fixtures/bad_version.yml
+++ b/pkg/config/fixtures/bad_version.yml
@@ -4,4 +4,4 @@ cloudquery:
   providers:
     - name: test
       source: cloudquery
-      version: "0.0.0"
+      version: "invalid"

--- a/pkg/config/loader_test.go
+++ b/pkg/config/loader_test.go
@@ -92,7 +92,7 @@ func TestLoader_BadVersion(t *testing.T) {
 	p := NewParser()
 	_, diags := p.LoadConfigFile("fixtures/bad_version.yml")
 	assert.NotNil(t, diags)
-	assert.Equal(t, "Provider test version 0.0.0 is invalid", diags[0].Error())
+	assert.Equal(t, "Provider \"test\" version \"invalid\" is invalid. Please set to 'latest' a or valid semantic version", diags[0].Description().Summary)
 }
 
 func TestLoader_DuplicateProviderNaming(t *testing.T) {


### PR DESCRIPTION
🎉 Thank you for making CloudQuery awesome by submitting a PR 🎉

#### Summary

Builds on top of https://github.com/cloudquery/cloudquery/pull/913.
Correct diff available in https://github.com/erezrokah/cloudquery/compare/refactor/config_parsing...erezrokah:fix/version_validation?expand=1

When someone runs `init <provider>@<version>`, `version` can be `latest` or a valid loose Semver version (e.g. `0.10`, `v0.10`, etc.).
However the logic to validate the configuration file is a bit different and we allow `latest` and strings starting with `v`.
This PR align the logic so validating the configuration is loose SemVer compliant.

---

Use the following steps to ensure your PR is ready to be reviewed

- [x] Read the [contribution guidelines](../blob/main/.github/CONTRIBUTING.md) 🧑‍🎓
- [x] Run `go fmt` to format your code 🖊
- [x] Lint your changes via `golangci-lint run` 🚨 (install golangci-lint [here](https://golangci-lint.run/usage/install/#local-installation))
- [x] Update or add tests 🧪
- [x] Ensure the status checks below are successful ✅
