### PR TITLE
fix(console): Don't print @latest when fetching

### DIFF
--- a/pkg/ui/console/client.go
+++ b/pkg/ui/console/client.go
@@ -662,9 +662,9 @@ func buildFetchProgress(ctx context.Context, providers []*config.Provider) (*Pro
 		}
 
 		if p.Alias != p.Name {
-			fetchProgress.Add(fmt.Sprintf("%s_%s", p.Name, p.Alias), fmt.Sprintf("cq-provider-%s@%s-%s", p.Name, "latest", p.Alias), "fetching", int64(len(p.Resources)))
+			fetchProgress.Add(fmt.Sprintf("%s_%s", p.Name, p.Alias), fmt.Sprintf("cq-provider-%s (%s)", p.Name, p.Alias), "fetching", int64(len(p.Resources)))
 		} else {
-			fetchProgress.Add(fmt.Sprintf("%s_%s", p.Name, p.Alias), fmt.Sprintf("cq-provider-%s@%s", p.Name, "latest"), "fetching", int64(len(p.Resources)))
+			fetchProgress.Add(fmt.Sprintf("%s_%s", p.Name, p.Alias), fmt.Sprintf("cq-provider-%s", p.Name), "fetching", int64(len(p.Resources)))
 		}
 	}
 	fetchCallback := func(update core.FetchUpdate) {


### PR DESCRIPTION
🎉 Thank you for making CloudQuery awesome by submitting a PR 🎉

#### Summary

Currently we always print `@latest` on fetch progress. This is a bit confusing (see with alias):
![image](https://user-images.githubusercontent.com/26760571/174486546-a967777b-e3db-4c4c-b1fd-1fa59e92c58b.png)

Since we currently don't have that information in the code, I removed it for now, see:
![image](https://user-images.githubusercontent.com/26760571/174486584-c54608fe-d051-4fb3-be22-ca5a9842b9cb.png)


---

Use the following steps to ensure your PR is ready to be reviewed

- [x] Read the [contribution guidelines](../blob/main/.github/CONTRIBUTING.md) 🧑‍🎓
- [x] Run `go fmt` to format your code 🖊
- [x] Lint your changes via `golangci-lint run` 🚨 (install golangci-lint [here](https://golangci-lint.run/usage/install/#local-installation))
- [x] Update or add tests 🧪
- [x] Ensure the status checks below are successful ✅
