### PR TITLE
fix: Default alias to name

### DIFF
--- a/pkg/config/config_parser.go
+++ b/pkg/config/config_parser.go
@@ -140,6 +140,9 @@ func decodeConfigYAML(r io.Reader) (*Config, diag.Diagnostics) {
 	for k := range yc.Providers {
 		v := yc.Providers[k]
 		v.Name = k
+		if v.Alias == "" {
+			v.Alias = v.Name
+		}
 		c.Providers = append(c.Providers, v)
 	}
 


### PR DESCRIPTION
🎉 Thank you for making CloudQuery awesome by submitting a PR 🎉

#### Summary

Fixes YAML parsing as we expect provider alias to default to name
---

Use the following steps to ensure your PR is ready to be reviewed

- [x] Read the [contribution guidelines](../blob/main/.github/CONTRIBUTING.md) 🧑‍🎓
- [x] Run `go fmt` to format your code 🖊
- [x] Lint your changes via `golangci-lint run` 🚨 (install golangci-lint [here](https://golangci-lint.run/usage/install/#local-installation))
- [x] Update or add tests 🧪
- [x] Ensure the status checks below are successful ✅
