### PR TITLE
fix: Request correct config format (YAML) from provider

### DIFF
--- a/cmd/init.go
+++ b/cmd/init.go
@@ -133,7 +133,7 @@ func generateYAMLConfig(ctx context.Context, c *console.Client, providers []stri
 	}
 
 	provNode := &yaml.Node{
-		Kind:        yaml.MappingNode,
+		Kind:        yaml.SequenceNode,
 		HeadComment: "provider configurations",
 	}
 
@@ -155,10 +155,18 @@ func generateYAMLConfig(ctx context.Context, c *console.Client, providers []stri
 		}
 
 		provNode.Content = append(provNode.Content, &yaml.Node{
-			Kind:  yaml.ScalarNode,
-			Value: p,
+			Kind: yaml.MappingNode,
+			Content: append([]*yaml.Node{
+				{
+					Kind:  yaml.ScalarNode,
+					Value: "name",
+				},
+				{
+					Kind:  yaml.ScalarNode,
+					Value: p,
+				},
+			}, yCfg.Content[0].Content...),
 		})
-		provNode.Content = append(provNode.Content, yCfg.Content...)
 	}
 
 	nd := struct {

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.17
 
 require (
 	github.com/VividCortex/ewma v1.2.0 // indirect
-	github.com/cloudquery/cq-provider-sdk v0.12.0
+	github.com/cloudquery/cq-provider-sdk v0.12.1-0.20220621151758-ef6923127e05
 	github.com/fatih/color v1.13.0
 	github.com/golang-migrate/migrate/v4 v4.15.2
 	github.com/google/go-github/v35 v35.2.0

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.17
 
 require (
 	github.com/VividCortex/ewma v1.2.0 // indirect
-	github.com/cloudquery/cq-provider-sdk v0.12.1-0.20220621151758-ef6923127e05
+	github.com/cloudquery/cq-provider-sdk v0.12.1
 	github.com/fatih/color v1.13.0
 	github.com/golang-migrate/migrate/v4 v4.15.2
 	github.com/google/go-github/v35 v35.2.0

--- a/go.sum
+++ b/go.sum
@@ -377,8 +377,8 @@ github.com/circonus-labs/circonusllhist v0.1.3/go.mod h1:kMXHVDlOchFAehlya5ePtbp
 github.com/clbanning/x2j v0.0.0-20191024224557-825249438eec/go.mod h1:jMjuTZXRI4dUb/I5gc9Hdhagfvm9+RyrPryS/auMzxE=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
 github.com/cloudflare/golz4 v0.0.0-20150217214814-ef862a3cdc58/go.mod h1:EOBUe0h4xcZ5GoxqC5SDxFQ8gwyZPKQoEzownBlhI80=
-github.com/cloudquery/cq-provider-sdk v0.12.1-0.20220621151758-ef6923127e05 h1:j+aY169lsC0FQp+i8KaZHTyE//Bx0xwXExkaPEiNon4=
-github.com/cloudquery/cq-provider-sdk v0.12.1-0.20220621151758-ef6923127e05/go.mod h1:o5czsmX3MeP8cY/KtabkqavkS7asF8HwFAO1n5+CvoQ=
+github.com/cloudquery/cq-provider-sdk v0.12.1 h1:Y4/VWjb/HLRX1pUoA7H82JoEu5mizNCDlfIeLGXOXSA=
+github.com/cloudquery/cq-provider-sdk v0.12.1/go.mod h1:o5czsmX3MeP8cY/KtabkqavkS7asF8HwFAO1n5+CvoQ=
 github.com/cloudquery/faker/v3 v3.7.5 h1:G7ANdEEcm8TvAAjIwNWSLrYK36CFCiSlrCqOTGCccL0=
 github.com/cloudquery/faker/v3 v3.7.5/go.mod h1:1b8WVG9Gh0T2hVo1a8dWeXfu0AhqSB6J/mmJaesqOeo=
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=

--- a/go.sum
+++ b/go.sum
@@ -377,8 +377,8 @@ github.com/circonus-labs/circonusllhist v0.1.3/go.mod h1:kMXHVDlOchFAehlya5ePtbp
 github.com/clbanning/x2j v0.0.0-20191024224557-825249438eec/go.mod h1:jMjuTZXRI4dUb/I5gc9Hdhagfvm9+RyrPryS/auMzxE=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
 github.com/cloudflare/golz4 v0.0.0-20150217214814-ef862a3cdc58/go.mod h1:EOBUe0h4xcZ5GoxqC5SDxFQ8gwyZPKQoEzownBlhI80=
-github.com/cloudquery/cq-provider-sdk v0.12.0 h1:S3AAkxmXhoGwvn7E77GmcOzkIFAxOjXEhPr+F0jW+Pg=
-github.com/cloudquery/cq-provider-sdk v0.12.0/go.mod h1:o5czsmX3MeP8cY/KtabkqavkS7asF8HwFAO1n5+CvoQ=
+github.com/cloudquery/cq-provider-sdk v0.12.1-0.20220621151758-ef6923127e05 h1:j+aY169lsC0FQp+i8KaZHTyE//Bx0xwXExkaPEiNon4=
+github.com/cloudquery/cq-provider-sdk v0.12.1-0.20220621151758-ef6923127e05/go.mod h1:o5czsmX3MeP8cY/KtabkqavkS7asF8HwFAO1n5+CvoQ=
 github.com/cloudquery/faker/v3 v3.7.5 h1:G7ANdEEcm8TvAAjIwNWSLrYK36CFCiSlrCqOTGCccL0=
 github.com/cloudquery/faker/v3 v3.7.5/go.mod h1:1b8WVG9Gh0T2hVo1a8dWeXfu0AhqSB6J/mmJaesqOeo=
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -23,6 +23,9 @@ type Provider struct {
 	MaxParallelResourceFetchLimit uint64   `yaml:"max_parallel_resource_fetch_limit,omitempty" json:"max_parallel_resource_fetch_limit,omitempty" hcl:"max_parallel_resource_fetch_limit"`
 	MaxGoroutines                 uint64   `yaml:"max_goroutines,omitempty" json:"max_goroutines,omitempty" hcl:"max_goroutines"`
 	ResourceTimeout               uint64   `yaml:"resource_timeout,omitempty" json:"resource_timeout,omitempty" hcl:"resource_timeout"`
+
+	// ConfigKeys is only used temporarily for provider-specific configuration when decoding YAML
+	ConfigKeys map[string]interface{} `yaml:",inline"`
 }
 
 type Providers []*Provider

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 
 	"github.com/cloudquery/cloudquery/internal/logging"
+	"github.com/cloudquery/cq-provider-sdk/cqproto"
 	"github.com/spf13/viper"
 	"github.com/xo/dburl"
 )
@@ -29,6 +30,8 @@ type Providers []*Provider
 type Config struct {
 	CloudQuery CloudQuery `hcl:"cloudquery,block" yaml:"cloudquery" json:"cloudquery"`
 	Providers  Providers  `hcl:"provider,block" yaml:"providers" json:"providers"`
+
+	format cqproto.ConfigFormat
 }
 
 type CloudQuery struct {
@@ -74,6 +77,10 @@ func (pp Providers) Names() []string {
 		pNames[i] = p.Name
 	}
 	return pNames
+}
+
+func (c Config) Format() cqproto.ConfigFormat {
+	return c.format
 }
 
 func (c Config) GetProvider(name string) (*Provider, error) {

--- a/pkg/config/config_parser.go
+++ b/pkg/config/config_parser.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 
 	"github.com/cloudquery/cloudquery/internal/logging"
+	"github.com/cloudquery/cq-provider-sdk/cqproto"
 	"github.com/cloudquery/cq-provider-sdk/provider/diag"
 	"github.com/hashicorp/hcl/v2"
 	"github.com/hashicorp/hcl/v2/gohcl"
@@ -136,6 +137,7 @@ func decodeConfigYAML(r io.Reader) (*Config, diag.Diagnostics) {
 
 	c := &Config{
 		CloudQuery: yc.CloudQuery,
+		format:     cqproto.ConfigYAML,
 	}
 	for k := range yc.Providers {
 		v := yc.Providers[k]
@@ -156,7 +158,9 @@ func decodeConfigYAML(r io.Reader) (*Config, diag.Diagnostics) {
 
 func (p *Parser) decodeConfigHCL(body hcl.Body, diags diag.Diagnostics) (*Config, diag.Diagnostics) {
 	existingProviders := make(map[string]bool)
-	config := &Config{}
+	config := &Config{
+		format: cqproto.ConfigHCL,
+	}
 
 	content, contentDiags := body.Content(configSchemaHCL)
 	diags = diags.Add(hclToSdkDiags(contentDiags))

--- a/pkg/core/fetch.go
+++ b/pkg/core/fetch.go
@@ -77,8 +77,9 @@ type FetchResponse struct {
 }
 
 type ProviderInfo struct {
-	Provider registry.Provider
-	Config   *config.Provider
+	Provider     registry.Provider
+	Config       *config.Provider
+	ConfigFormat cqproto.ConfigFormat
 }
 
 // FetchOptions is provided to the Client to execute a fetch on one or more providers
@@ -274,6 +275,7 @@ func runProviderFetch(ctx context.Context, pm *plugin.Manager, info ProviderInfo
 		},
 		Config:      cfg.Configuration,
 		ExtraFields: opts.ExtraFields,
+		Format:      info.ConfigFormat,
 	})
 	if err != nil {
 		pLog.Error().Err(err).Msg("failed to configure provider")

--- a/pkg/core/provider.go
+++ b/pkg/core/provider.go
@@ -19,6 +19,7 @@ type GetProviderConfigOptions struct {
 type TestOptions struct {
 	Connection   cqproto.ConnectionDetails
 	Config       []byte
+	ConfigFormat cqproto.ConfigFormat
 	CreationInfo *plugin.CreationOptions
 }
 
@@ -68,6 +69,7 @@ func Test(ctx context.Context, pm *plugin.Manager, opts TestOptions) (bool, erro
 		CloudQueryVersion: Version,
 		Connection:        opts.Connection,
 		Config:            opts.Config,
+		Format:            opts.ConfigFormat,
 	})
 	if err != nil {
 		return false, fmt.Errorf("provider test connection failed. Reason: %w", err)

--- a/pkg/ui/console/client.go
+++ b/pkg/ui/console/client.go
@@ -208,7 +208,7 @@ func (c Client) Fetch(ctx context.Context) (*core.FetchResponse, diag.Diagnostic
 			printDiagnostics("Fetch", &diags, viper.GetBool("redact-diags"), viper.GetBool("verbose"))
 			return nil, diags
 		}
-		providers[i] = core.ProviderInfo{Provider: rp, Config: p}
+		providers[i] = core.ProviderInfo{Provider: rp, Config: p, ConfigFormat: c.cfg.Format()}
 	}
 	result, diags := core.Fetch(ctx, c.StateManager, c.Storage, c.PluginManager, &core.FetchOptions{
 		UpdateCallback: fetchCallback,


### PR DESCRIPTION
Otherwise ConfigureProvider is called with no format, which would default to HCL.

init/config providers format also moved from map to list of providers.