### PR TITLE
fix: Don't print duplicate error during init

### DIFF
--- a/cmd/init.go
+++ b/cmd/init.go
@@ -51,8 +51,8 @@ func initialize(ctx context.Context, providers []string) error {
 	configPath := getConfigFile() // by definition, this will get us an existing file if possible
 
 	if info, _ := fs.Stat(configPath); info != nil {
-		ui.ColorizedOutput(ui.ColorError, "Error: Config file %s already exists\n", configPath)
-		return diag.FromError(fmt.Errorf("config file %q already exists", configPath), diag.USER)
+		message := ui.Colorize(ui.ColorError, false, "Error: Config file %s already exists\n", configPath)
+		return diag.FromError(fmt.Errorf(message), diag.USER)
 	}
 
 	requiredProviders := make([]*config.RequiredProvider, len(providers))


### PR DESCRIPTION
<!-- 🎉 Thank you for making CloudQuery awesome by submitting a PR 🎉 -->

#### Summary

Cobra already prints the received error.
To reproduce run `cloudquery init gcp --config config.yml` twice

### Before

![image](https://user-images.githubusercontent.com/26760571/175050220-fc33652f-0c9a-4254-98e7-0095e212868f.png)

### After

![image](https://user-images.githubusercontent.com/26760571/175806572-0b7e1c86-d9c6-4504-9fa9-d861be1a5aa3.png)

---

Use the following steps to ensure your PR is ready to be reviewed

- [x] Read the [contribution guidelines](../blob/main/.github/CONTRIBUTING.md) 🧑‍🎓
- [x] Run `go fmt` to format your code 🖊
- [x] Lint your changes via `golangci-lint run` 🚨 (install golangci-lint [here](https://golangci-lint.run/usage/install/#local-installation))
- [x] Update or add tests 🧪
- [x] Ensure the status checks below are successful ✅
