### PR TITLE
fix: Disallow running of db-using policy operations without config

### DIFF
--- a/cmd/policy.go
+++ b/cmd/policy.go
@@ -103,7 +103,7 @@ var (
   # See https://hub.cloudquery.io for additional policies.`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			source := args[0]
-			c, err := console.CreateClient(cmd.Context(), getConfigFile(), true, nil, instanceId)
+			c, err := console.CreateClient(cmd.Context(), getConfigFile(), false, nil, instanceId)
 			if err != nil {
 				return err
 			}
@@ -143,7 +143,7 @@ var (
 		Long:  policySnapshotHelpMsg,
 		Args:  cobra.ExactArgs(2),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			c, err := console.CreateClient(cmd.Context(), getConfigFile(), true, nil, instanceId)
+			c, err := console.CreateClient(cmd.Context(), getConfigFile(), false, nil, instanceId)
 			if err != nil {
 				return err
 			}
@@ -178,7 +178,7 @@ var (
   cloudquery policy prune 24h`,
 		Args: cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			c, err := console.CreateClient(cmd.Context(), getConfigFile(), true, nil, instanceId)
+			c, err := console.CreateClient(cmd.Context(), getConfigFile(), false, nil, instanceId)
 			if err != nil {
 				return err
 			}

--- a/pkg/ui/console/client.go
+++ b/pkg/ui/console/client.go
@@ -663,7 +663,7 @@ func loadConfig(file string) (*config.Config, bool) {
 		config.WithFileFunc(filepath.Dir(file)),
 	)
 	cfg, diags := parser.LoadConfigFile(file)
-	if diags != nil {
+	if diags.HasDiags() {
 		ui.ColorizedOutput(ui.ColorHeader, "Configuration Error Diagnostics:\n")
 		for _, d := range diags {
 			c := ui.ColorInfo


### PR DESCRIPTION
`cloudquery policy run` shouldn't allow running without db (panics on c.Storage access later on)