### PR TITLE
chore!: Remove support for cq init HCL

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,5 +25,5 @@ config_old.hcl
 database-data/*
 dest/*
 outfile
-test_init_config.hcl
+test_init_config.yml
 telemetry-random-id

--- a/cmd/init.go
+++ b/cmd/init.go
@@ -55,6 +55,11 @@ func initialize(ctx context.Context, providers []string) error {
 		return diag.FromError(fmt.Errorf("config file %q already exists", configPath), diag.USER)
 	}
 
+	if !config.IsNameYAML(configPath) {
+		ui.ColorizedOutput(ui.ColorError, "Error: HCL config format is deprecated and should not be used for new installations\n")
+		return diag.FromError(fmt.Errorf("deprecated format %q", configPath), diag.USER)
+	}
+
 	requiredProviders := make([]*config.RequiredProvider, len(providers))
 	for i, p := range providers {
 		organization, providerName, provVersion, err := parseProviderCLIArg(p)
@@ -273,7 +278,7 @@ func init() {
 }
 
 // getConfigFile returns the config filename
-// if it ends with ".*", .hcl and .yml extensions are tried in order to find the existing file, if available
+// if it ends with ".*", .yml and .hcl extensions are tried in order to find the existing file, if available
 func getConfigFile() string {
 	configPath := viper.GetString("configPath")
 	if !strings.HasSuffix(configPath, ".*") {
@@ -282,12 +287,12 @@ func getConfigFile() string {
 
 	fs := file.NewOsFs()
 	noSuffix := strings.TrimSuffix(configPath, ".*")
-	for _, tryExt := range []string{".hcl", ".yml"} {
+	for _, tryExt := range []string{".yml", ".hcl"} {
 		tryFn := noSuffix + tryExt
 		if _, err := fs.Stat(tryFn); err == nil {
 			return tryFn
 		}
 	}
 
-	return noSuffix + ".hcl"
+	return noSuffix + ".yml"
 }

--- a/scripts/test-sanity.sh
+++ b/scripts/test-sanity.sh
@@ -10,7 +10,7 @@ echo "Fetch Multiple Provider"
 go run ./main.go fetch --config=internal/test/test_double_provider_config.hcl --enable-console-log
 
 echo "Init"
-go run ./main.go init test --config=test_init_config.hcl
+go run ./main.go init test --config=test_init_config.yml
 
 echo "Policy Describe"
 go run ./main.go policy describe k8s//nsa_cisa_v1/pod_security --config=internal/test/test_config.hcl


### PR DESCRIPTION
- [x] `cq init --config config.hcl` should fail
- [x] `config.hcl` should be a fallback only if `config.yml` is not found.
