### PR TITLE
fix: Handle Diags

### DIFF
--- a/pkg/core/fetch.go
+++ b/pkg/core/fetch.go
@@ -311,9 +311,9 @@ func runProviderFetch(ctx context.Context, pm *plugin.Manager, info ProviderInfo
 	}
 
 	pLog.Info().Msg("provider configured successfully")
-	summary, diags := executeFetch(ctx, pLog, providerPlugin, info, metadata, opts.UpdateCallback)
-	diags = append(diags, resp.Diagnostics...)
-	return summary, convertToFetchDiags(diags, info.Provider.Name, providerPlugin.Version())
+	summary, fetchDiags := executeFetch(ctx, pLog, providerPlugin, info, metadata, opts.UpdateCallback)
+	fetchDiags.Add(convertToConfigureDiags(resp.Diagnostics))
+	return summary, convertToFetchDiags(fetchDiags, info.Provider.Name, providerPlugin.Version())
 }
 
 func executeFetch(ctx context.Context, pLog zerolog.Logger, providerPlugin plugin.Plugin, info ProviderInfo, metadata map[string]interface{}, callback FetchUpdateCallback) (*ProviderFetchSummary, diag.Diagnostics) {

--- a/pkg/core/fetch.go
+++ b/pkg/core/fetch.go
@@ -310,11 +310,11 @@ func runProviderFetch(ctx context.Context, pm *plugin.Manager, info ProviderInfo
 			Status:           FetchConfigureFailed,
 		}, convertToConfigureDiags(resp.Diagnostics)
 	}
-	diags.Add(convertToConfigureDiags(resp.Diagnostics))
+	diags = diags.Add(convertToConfigureDiags(resp.Diagnostics))
 
 	pLog.Info().Msg("provider configured successfully")
 	summary, fetchDiags := executeFetch(ctx, pLog, providerPlugin, info, metadata, opts.UpdateCallback)
-	diags.Add(convertToFetchDiags(fetchDiags, info.Provider.Name, providerPlugin.Version()))
+	diags = diags.Add(convertToFetchDiags(fetchDiags, info.Provider.Name, providerPlugin.Version()))
 
 	return summary, diags
 }

--- a/pkg/core/fetch.go
+++ b/pkg/core/fetch.go
@@ -301,16 +301,16 @@ func runProviderFetch(ctx context.Context, pm *plugin.Manager, info ProviderInfo
 			Status:           sts,
 		}, d
 	}
-	if resp.Diagnostics.HasErrors() {
+	diags = diags.Add(convertToConfigureDiags(resp.Diagnostics))
+	if diags.HasErrors() {
 		return &ProviderFetchSummary{
 			Name:             info.Provider.Name,
 			Alias:            info.Config.Alias,
 			Version:          providerPlugin.Version(),
 			FetchedResources: make(map[string]ResourceFetchSummary),
 			Status:           FetchConfigureFailed,
-		}, convertToConfigureDiags(resp.Diagnostics)
+		}, diags
 	}
-	diags = diags.Add(convertToConfigureDiags(resp.Diagnostics))
 
 	pLog.Info().Msg("provider configured successfully")
 	summary, fetchDiags := executeFetch(ctx, pLog, providerPlugin, info, metadata, opts.UpdateCallback)

--- a/pkg/core/fetch.go
+++ b/pkg/core/fetch.go
@@ -312,6 +312,7 @@ func runProviderFetch(ctx context.Context, pm *plugin.Manager, info ProviderInfo
 
 	pLog.Info().Msg("provider configured successfully")
 	summary, diags := executeFetch(ctx, pLog, providerPlugin, info, metadata, opts.UpdateCallback)
+	diags = append(diags, resp.Diagnostics...)
 	return summary, convertToFetchDiags(diags, info.Provider.Name, providerPlugin.Version())
 }
 

--- a/pkg/core/fetch.go
+++ b/pkg/core/fetch.go
@@ -312,8 +312,7 @@ func runProviderFetch(ctx context.Context, pm *plugin.Manager, info ProviderInfo
 
 	pLog.Info().Msg("provider configured successfully")
 	summary, fetchDiags := executeFetch(ctx, pLog, providerPlugin, info, metadata, opts.UpdateCallback)
-	fetchDiags.Add(convertToConfigureDiags(resp.Diagnostics))
-	return summary, convertToFetchDiags(fetchDiags, info.Provider.Name, providerPlugin.Version())
+	return summary, convertToFetchDiags(fetchDiags, info.Provider.Name, providerPlugin.Version()).Add(convertToConfigureDiags(resp.Diagnostics))
 }
 
 func executeFetch(ctx context.Context, pLog zerolog.Logger, providerPlugin plugin.Plugin, info ProviderInfo, metadata map[string]interface{}, callback FetchUpdateCallback) (*ProviderFetchSummary, diag.Diagnostics) {


### PR DESCRIPTION
<!-- 🎉 Thank you for making CloudQuery awesome by submitting a PR 🎉 -->

#### Summary

Handle warning diags created during provider configure

You can see here not all accounts were fully configured, but with the fix the warnings still were printed

```
Fetch Diagnostics:
Type: Access Severity: Warning
        Summary: failed to refresh cached credentials, operation error STS: AssumeRole, https response error StatusCode: 403, RequestID: REDACTED, api error AccessDenied: User: arn:aws:sts::REDACTED:assumed-role/REDACTED is not authorized to perform: sts:AssumeRole on resource: arn:aws:iam::REDACTED:role/OrganizationAccountAccessRole2
        Detail: ensure that arn:aws:sts::REDACTED:assumed-role/REDACTED has access to be able perform `sts:AssumeRole` on arn:aws:iam::REDACTED:role/REDACTED 

Provider aws fetch summary: ✓ Total Resources fetched: 1         ⚠️ Warnings: 0   ❌ Errors: 0
```



---

Use the following steps to ensure your PR is ready to be reviewed

- [ ] Read the [contribution guidelines](../blob/main/.github/CONTRIBUTING.md) 🧑‍🎓
- [ ] Run `go fmt` to format your code 🖊
- [ ] Lint your changes via `golangci-lint run` 🚨 (install golangci-lint [here](https://golangci-lint.run/usage/install/#local-installation))
- [ ] Update or add tests 🧪
- [ ] Ensure the status checks below are successful ✅
