### PR TITLE
fix: Configure Provider Yml

### DIFF
--- a/pkg/config/config_parser.go
+++ b/pkg/config/config_parser.go
@@ -124,7 +124,7 @@ func ProcessValidateProviderBlock(plist []*Provider) (Providers, diag.Diagnostic
 			v.Alias = v.Name
 		}
 		var err error
-		v.Configuration, err = yaml.Marshal(v.ConfigKeys)
+		v.Configuration, err = yaml.Marshal(v.ConfigKeys["configuration"])
 		if err != nil {
 			diags = diags.Add(diag.FromError(err, diag.INTERNAL, diag.WithSummary("ConfigKeys marshal failed")))
 			continue


### PR DESCRIPTION
<!-- 🎉 Thank you for making CloudQuery awesome by submitting a PR 🎉 -->

#### Summary

<!--
Explain what problem this PR addresses
-->
Pass Contents of Provider Configuration

Prior to this pr this is what would be passed:
```
"configuration:\n    accounts:\n        cq-playground:\n            local_profile: playground\n        cq-provider-aws:\n            local_profile: provider\n"
```

After this pr:
```
"accounts:\n    - cq-playground: null\n      local_profile: playground\n    - cq-provider-aws: null\n      local_profile: provider\n"
```

---

Use the following steps to ensure your PR is ready to be reviewed

- [ ] Read the [contribution guidelines](../blob/main/.github/CONTRIBUTING.md) 🧑‍🎓
- [ ] Run `go fmt` to format your code 🖊
- [ ] Lint your changes via `golangci-lint run` 🚨 (install golangci-lint [here](https://golangci-lint.run/usage/install/#local-installation))
- [ ] Update or add tests 🧪
- [ ] Ensure the status checks below are successful ✅
