### PR TITLE
fix: Don't decrease ulimit. Change ulimit logs from 'debug' to 'info'

### DIFF
--- a/cmd/ulimit_unix.go
+++ b/cmd/ulimit_unix.go
@@ -26,14 +26,21 @@ func setUlimit(ulimit uint64) error {
 	logger := zerolog.Logger
 	rLimit, err := GetUlimit()
 	if err != nil {
-		logger.Err(fmt.Errorf("error getting ulimit: %w", err))
+		return fmt.Errorf("error getting ulimit: %w", err)
 	}
+
+	logger.Info().Uint64("hard_ulimit", rLimit.Max).Uint64("soft_ulimit", rLimit.Cur).Msg("limits (before adjustment)")
+
 	if rLimit.Max < ulimit {
-		logger.Debug().Uint64("previous_ulimit", rLimit.Max).Uint64("new_ulimit", ulimit).Msg("adjusting max ulimit")
+		logger.Info().Uint64("previous_ulimit", rLimit.Max).Uint64("new_ulimit", ulimit).Msg("adjusting max ulimit")
 		rLimit.Max = ulimit
 	}
-	logger.Debug().Uint64("previous_ulimit", rLimit.Cur).Uint64("new_ulimit", ulimit).Msg("adjusting current ulimit")
-	rLimit.Cur = ulimit
+
+	if rLimit.Cur < ulimit {
+		logger.Info().Uint64("previous_ulimit", rLimit.Cur).Uint64("new_ulimit", ulimit).Msg("adjusting current ulimit")
+		rLimit.Cur = ulimit
+	}
+
 	return syscall.Setrlimit(syscall.RLIMIT_NOFILE, &rLimit)
 }
 


### PR DESCRIPTION
1. We should never decrease ulimit, if it's big enough.
2. The logs can definitely be 'info', since this is only logged once per 'cloudquery' invocation. Will also assist in debugging when we get customer logs.

<!-- 🎉 Thank you for making CloudQuery awesome by submitting a PR 🎉 -->

#### Summary

<!--
Explain what problem this PR addresses
-->

---

Use the following steps to ensure your PR is ready to be reviewed

- [ ] Read the [contribution guidelines](../blob/main/.github/CONTRIBUTING.md) 🧑‍🎓
- [ ] Run `go fmt` to format your code 🖊
- [ ] Lint your changes via `golangci-lint run` 🚨 (install golangci-lint [here](https://golangci-lint.run/usage/install/#local-installation))
- [ ] Update or add tests 🧪
- [ ] Ensure the status checks below are successful ✅
