### PR TITLE
feat!: Remove 'policy download' feature

### DIFF
--- a/cmd/policy.go
+++ b/cmd/policy.go
@@ -53,7 +53,7 @@ var (
 
 	policyDownloadCmd = &cobra.Command{
 		Use:        "download",
-		Deprecated: "Use 'policy run' command directly instead. If you need to download a policy to your machine, you can use 'git clone [https://github.com/cloudquery-policies/aws.git]'. See https://docs.cloudquery.io/docs/cli/policy/sources. ",
+		Deprecated: "Use 'policy run' command directly instead. If you need to download a policy to your machine, you can use 'git clone <URL FOR GIT REPO>'. See https://docs.cloudquery.io/docs/cli/policy/sources for more information on how to use the `policy run` command ",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return fmt.Errorf("'policy download' command has been deprecated. Use the 'policy run' command directly instead")
 		},

--- a/cmd/policy.go
+++ b/cmd/policy.go
@@ -12,7 +12,6 @@ import (
 const (
 	policyHelpMsg         = `Download and run CloudQuery policy`
 	policyDescribeHelpMsg = `Describe CloudQuery policy`
-	policyDownloadHelpMsg = "Download a policy from the CloudQuery Policy Hub"
 	policyRunHelpMsg      = "Executes a policy on CloudQuery database"
 	policySnapshotHelpMsg = `Take database snapshot of all tables included in a CloudQuery policy`
 	policyTestHelpMsg     = "Tests policy against a precompiled set of database snapshots"
@@ -53,32 +52,10 @@ var (
 	}
 
 	policyDownloadCmd = &cobra.Command{
-		Use:   "download GITHUB_REPO",
-		Short: policyDownloadHelpMsg,
-		Long:  policyDownloadHelpMsg,
-		Example: `
-  # Download official policy
-  cloudquery policy download aws
-  
-  # The following will be the same as above
-  # Official policies are hosted here: https://github.com/cloudquery-policies
-  cloudquery policy download aws//cis-1.2.0
-	
-  # Download community policy
-  cloudquery policy download github.com/COMMUNITY_GITHUB_ORG/aws
-
-  # See https://hub.cloudquery.io for additional policies.`,
-		Args: cobra.ExactArgs(1),
+		Use:        "download",
+		Deprecated: "Use 'policy run' command directly instead. If you need to download a policy to your machine, you can use 'git clone [https://github.com/cloudquery-policies/aws.git]'. See https://docs.cloudquery.io/docs/cli/policy/sources. ",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			c, err := console.CreateClient(cmd.Context(), getConfigFile(), true, nil, instanceId)
-			if err != nil {
-				return err
-			}
-			diags := c.DownloadPolicy(cmd.Context(), args)
-			if diags.HasErrors() {
-				return fmt.Errorf("policy download has one or more errors, check logs")
-			}
-			return nil
+			return fmt.Errorf("'policy download' command has been deprecated. Use the 'policy run' command directly instead")
 		},
 	}
 

--- a/pkg/ui/console/client.go
+++ b/pkg/ui/console/client.go
@@ -325,21 +325,6 @@ func (c Client) RemoveStaleData(ctx context.Context, lastUpdate time.Duration, d
 // 													Policy Commands
 // =====================================================================================================================
 
-func (c Client) DownloadPolicy(ctx context.Context, args []string) (diags diag.Diagnostics) {
-	ui.ColorizedOutput(ui.ColorProgress, "Downloading CloudQuery Policy...\n")
-	defer printDiagnostics("", &diags, viper.GetBool("redact-diags"), viper.GetBool("verbose"))
-	p, err := policy.Load(ctx, c.cfg.CloudQuery.PolicyDirectory, &policy.Policy{Name: "policy", Source: args[0]})
-	if err != nil {
-		ui.SleepBeforeError(ctx)
-		ui.ColorizedOutput(ui.ColorError, "❌ Failed to Download policy: %s.\n\n", err.Error())
-		return diags.Add(diag.FromError(err, diag.RESOLVING))
-	}
-	ui.ColorizedOutput(ui.ColorProgress, "Finished downloading policy...\n")
-	// Show policy instructions
-	ui.ColorizedOutput(ui.ColorHeader, fmt.Sprintf("To run the policy call cloudquery policy run %s", p.Source))
-	return nil
-}
-
 func (c Client) RunPolicies(ctx context.Context, policySource, outputDir string, noResults, dbPersistence bool) (diags diag.Diagnostics) {
 	defer printDiagnostics("", &diags, viper.GetBool("redact-diags"), viper.GetBool("verbose"))
 	log.Debug().Str("policy", policySource).Str("output_dir", outputDir).Bool("noResults", noResults).Bool("dbPersistence", dbPersistence).Msg("run policy received params")

--- a/scripts/test-sanity.sh
+++ b/scripts/test-sanity.sh
@@ -15,9 +15,6 @@ go run ./main.go init test --config=test_init_config.yml
 echo "Policy Describe"
 go run ./main.go policy describe k8s//nsa_cisa_v1/pod_security --config=internal/test/test_config.hcl
 
-echo "Policy Download"
-go run ./main.go policy download github.com/cloudquery-policies/aws//cis_v1.2.0 --config=internal/test/test_config.hcl
-
 echo "Policy Run bad subpath"
 go run ./main.go policy run aws//path/not/exist --config=internal/test/test_aws.hcl --disable-fetch-check && echo "test: 'Policy Run bad subpath' failed" && exit 1
 


### PR DESCRIPTION
The 'policy run' command already supports running both from local or remote sources.
'policy run' also caches policies in '.cq' directory.

The benefits of 'policy download' (that just caches a remote policy in '.cq' internal directory) is dubious.

<!-- 🎉 Thank you for making CloudQuery awesome by submitting a PR 🎉 -->

#### Summary

<!--
Explain what problem this PR addresses
-->

---

Use the following steps to ensure your PR is ready to be reviewed

- [ ] Read the [contribution guidelines](../blob/main/.github/CONTRIBUTING.md) 🧑‍🎓
- [ ] Run `go fmt` to format your code 🖊
- [ ] Lint your changes via `golangci-lint run` 🚨 (install golangci-lint [here](https://golangci-lint.run/usage/install/#local-installation))
- [ ] Update or add tests 🧪
- [ ] Ensure the status checks below are successful ✅
