### PR TITLE
fix: Support env var substitution in YAML config

### DIFF
--- a/pkg/config/config_parser.go
+++ b/pkg/config/config_parser.go
@@ -1,11 +1,11 @@
 package config
 
 import (
-	"bytes"
 	_ "embed"
 	"errors"
 	"fmt"
 	"io"
+	"os"
 	"path/filepath"
 	"strings"
 
@@ -46,7 +46,8 @@ var configSchemaHCL = &hcl.BodySchema{
 
 func (p *Parser) LoadConfigFromSource(name string, data []byte) (*Config, diag.Diagnostics) {
 	if IsNameYAML(name) {
-		return decodeConfigYAML(bytes.NewBuffer(data))
+		newData := os.Expand(string(data), p.getVariableValue)
+		return decodeConfigYAML(strings.NewReader(newData))
 	}
 
 	body, diags := p.LoadFromSource(name, data)

--- a/pkg/config/fixtures/config_with_alias.hcl
+++ b/pkg/config/fixtures/config_with_alias.hcl
@@ -10,7 +10,7 @@ cloudquery {
 
 provider "aws" {
   configuration {
-    account "dev" {
+    accounts "dev" {
       role_arn = "12312312"
     }
     account "ron" {}
@@ -21,10 +21,10 @@ provider "aws" {
 provider "aws" {
   alias = "another-aws"
   configuration {
-    account "dev" {
+    accounts "dev" {
       role_arn = "12312312"
     }
-    account "ron" {}
+    accounts "ron" {}
   }
   resources = ["slow_resource"]
 }

--- a/pkg/config/fixtures/duplicate_provider_alias.hcl
+++ b/pkg/config/fixtures/duplicate_provider_alias.hcl
@@ -11,10 +11,10 @@ cloudquery {
 provider "aws" {
   alias = "same-aws"
   configuration {
-    account "dev" {
+    accounts "dev" {
       role_arn = "12312312"
     }
-    account "ron" {}
+    accounts "ron" {}
   }
   resources = ["slow_resource"]
 }
@@ -22,10 +22,10 @@ provider "aws" {
 provider "aws" {
   alias = "same-aws"
   configuration {
-    account "dev" {
+    accounts "dev" {
       role_arn = "12312312"
     }
-    account "ron" {}
+    accounts "ron" {}
   }
   resources = ["slow_resource"]
 }

--- a/pkg/config/fixtures/duplicate_provider_name.hcl
+++ b/pkg/config/fixtures/duplicate_provider_name.hcl
@@ -10,20 +10,20 @@ cloudquery {
 
 provider "aws" {
   configuration {
-    account "dev" {
+    accounts "dev" {
       role_arn = "12312312"
     }
-    account "ron" {}
+    accounts "ron" {}
   }
   resources = ["slow_resource"]
 }
 
 provider "aws" {
   configuration {
-    account "dev" {
+    accounts "dev" {
       role_arn = "12312312"
     }
-    account "ron" {}
+    accounts "ron" {}
   }
   resources = ["slow_resource"]
 }

--- a/pkg/config/fixtures/env_vars.hcl
+++ b/pkg/config/fixtures/env_vars.hcl
@@ -10,10 +10,10 @@ cloudquery {
 
 provider "aws" {
   configuration {
-    account "dev" {
+    accounts "dev" {
       role_arn = "${ROLE_ARN}"
     }
-    account "ron" {}
+    accounts "ron" {}
   }
   resources = ["slow_resource"]
 }

--- a/pkg/config/fixtures/env_vars.yml
+++ b/pkg/config/fixtures/env_vars.yml
@@ -1,0 +1,16 @@
+cloudquery:
+  connection:
+    dsn: "${DSN}"
+  providers:
+    - name: test
+      source: cloudquery
+      version: v0.0.0
+providers:
+  - name: aws
+    configuration:
+      accounts:
+        - id: "dev"
+          role_arn: "${ROLE_ARN}"
+        - id: "ron"
+    resources:
+      - slow_resource

--- a/pkg/config/fixtures/no_source.hcl
+++ b/pkg/config/fixtures/no_source.hcl
@@ -9,10 +9,10 @@ cloudquery {
 
 provider "test" {
   configuration {
-    account "dev" {
+    accounts "dev" {
       role_arn = "12312312"
     }
-    account "ron" {}
+    accounts "ron" {}
   }
   resources = ["slow_resource"]
 }

--- a/pkg/config/fixtures/valid_config.hcl
+++ b/pkg/config/fixtures/valid_config.hcl
@@ -10,10 +10,10 @@ cloudquery {
 
 provider "aws" {
   configuration {
-    account "dev" {
+    accounts "dev" {
       role_arn = "12312312"
     }
-    account "ron" {}
+    accounts "ron" {}
   }
   resources = ["slow_resource"]
 }

--- a/pkg/config/loader_test.go
+++ b/pkg/config/loader_test.go
@@ -55,7 +55,7 @@ type Account struct {
 
 type AwsConfig struct {
 	Regions    []string  `yaml:"regions,omitempty" hcl:"regions,optional"`
-	Accounts   []Account `yaml:"accounts" hcl:"account,block"`
+	Accounts   []Account `yaml:"accounts" hcl:"accounts,block"`
 	AWSDebug   bool      `yaml:"aws_debug,omitempty" hcl:"aws_debug,optional"`
 	MaxRetries int       `yaml:"max_retries,omitempty" hcl:"max_retries,optional" default:"5"`
 	MaxBackoff int       `yaml:"max_backoff,omitempty" hcl:"max_backoff,optional" default:"30"`

--- a/pkg/config/loader_test.go
+++ b/pkg/config/loader_test.go
@@ -55,7 +55,7 @@ type Account struct {
 
 type AwsConfig struct {
 	Regions    []string  `yaml:"regions,omitempty" hcl:"regions,optional"`
-	Accounts   []Account `yaml:"accounts" hcl:"accounts,block"`
+	Accounts   []Account `yaml:"accounts" hcl:"account,block"`
 	AWSDebug   bool      `yaml:"aws_debug,omitempty" hcl:"aws_debug,optional"`
 	MaxRetries int       `yaml:"max_retries,omitempty" hcl:"max_retries,optional" default:"5"`
 	MaxBackoff int       `yaml:"max_backoff,omitempty" hcl:"max_backoff,optional" default:"30"`

--- a/pkg/core/core_test.go
+++ b/pkg/core/core_test.go
@@ -43,7 +43,9 @@ func setupDB(t *testing.T) (dsn string) {
 		}
 
 		if _, err := conn.Exec(context.Background(), "DROP DATABASE "+newDB+" WITH(FORCE)"); err != nil {
-			t.Logf("teardown: drop database failed: %v", err)
+			if _, err := conn.Exec(context.Background(), "DROP DATABASE "+newDB); err != nil {
+				t.Logf("teardown: drop database failed: %v", err)
+			}
 		}
 	})
 


### PR DESCRIPTION
Apparently this wasn't ported over...