### PR TITLE
fix: Ulimit bug

### DIFF
--- a/cmd/ulimit_unix_test.go
+++ b/cmd/ulimit_unix_test.go
@@ -1,0 +1,34 @@
+//go:build darwin || linux
+
+package cmd
+
+import (
+	"syscall"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// This test call 'setUlimit', and expects the 'softUlimit' to increase up to 'hardUlimit'.
+// Note that because ulimit is a process-wide variable, this test has some risk of causing flakiness in
+// unrelated tests..
+func Test_setUlimit_when_low(t *testing.T) {
+	// We choose relatively "high" numbers because ulimit is a process-wide resource, and we don't
+	// want to choose values so small that they make other tests fail.
+	const smallSoftLimit = 500
+	const smallHardLimit = 512
+
+	// set to low values
+	err := syscall.Setrlimit(syscall.RLIMIT_NOFILE, &syscall.Rlimit{Cur: smallSoftLimit, Max: smallHardLimit})
+	require.NoError(t, err)
+
+	err = setUlimit()
+	require.NoError(t, err)
+
+	var limits syscall.Rlimit
+	err = syscall.Getrlimit(syscall.RLIMIT_NOFILE, &limits)
+	require.NoError(t, err)
+
+	assert.Equal(t, limits, syscall.Rlimit{Cur: smallHardLimit, Max: smallHardLimit})
+}


### PR DESCRIPTION
Ulimit has a 'soft'(current) value and 'hard'(maximum) value. 'soft' can always be increased up to the 'hard' limit.
But, increasing the 'hard' limit requires some very arcane permissions (often even root is not enough).
Before this fix, we did just one 'setrlimit' call for increasing both 'hard' and 'soft' limit. But, since increasing
the 'hard' fails on EPERM, the soft limit is also not increased.. This PR fixes this by splitting the 'set hard limit' and 'set soft limit' into two different invocations.

<!-- 🎉 Thank you for making CloudQuery awesome by submitting a PR 🎉 -->

#### Summary

<!--
Explain what problem this PR addresses
-->

---

Use the following steps to ensure your PR is ready to be reviewed

- [ ] Read the [contribution guidelines](../blob/main/CONTRIBUTING.md) 🧑‍🎓
- [ ] Run `go fmt` to format your code 🖊
- [ ] Lint your changes via `golangci-lint run` 🚨 (install golangci-lint [here](https://golangci-lint.run/usage/install/#local-installation))
- [ ] Update or add tests 🧪
- [ ] Ensure the status checks below are successful ✅
