### PR TITLE
fix(cmd-doc): Don't add autogenerated tag

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -122,6 +122,7 @@ func newCmdRoot() *cobra.Command {
 	rootCmd.AddCommand(
 		initCmd.NewCmdInit(), fetch.NewCmdFetch(), policy.NewCmdPolicy(), provider.NewCmdProvider(),
 		options.NewCmdOptions(), newCmdVersion(), newCmdDoc())
+	rootCmd.DisableAutoGenTag = true
 	return rootCmd
 }
 


### PR DESCRIPTION
<!-- 🎉 Thank you for making CloudQuery awesome by submitting a PR 🎉 -->

#### Summary

Removes the auto generated tag from the docs

---

Use the following steps to ensure your PR is ready to be reviewed

- [x] Read the [contribution guidelines](../blob/main/CONTRIBUTING.md) 🧑‍🎓
- [x] Run `go fmt` to format your code 🖊
- [x] Lint your changes via `golangci-lint run` 🚨 (install golangci-lint [here](https://golangci-lint.run/usage/install/#local-installation))
- [x] Update or add tests 🧪
- [x] Ensure the status checks below are successful ✅
