### PR TITLE
fix(cmd-providers): Don't print help for sync command twice

### DIFF
--- a/cmd/provider/provider.go
+++ b/cmd/provider/provider.go
@@ -25,6 +25,6 @@ func NewCmdProvider() *cobra.Command {
 		Example: providerExample,
 		Version: core.Version,
 	}
-	cmd.AddCommand(newCmdProviderSync(), newCmdProviderDrop(), newCmdProviderPurge(), newCmdProviderSync(), newCmdProviderDownload())
+	cmd.AddCommand(newCmdProviderSync(), newCmdProviderDrop(), newCmdProviderPurge(), newCmdProviderDownload())
 	return cmd
 }


### PR DESCRIPTION
<!-- 🎉 Thank you for making CloudQuery awesome by submitting a PR 🎉 -->

#### Summary

The `sync` command is registered twice, see:
![image](https://user-images.githubusercontent.com/26760571/177168726-2119b65b-b52d-4d44-b8df-190e83129ab5.png)


---

Use the following steps to ensure your PR is ready to be reviewed

- [ ] Read the [contribution guidelines](../blob/main/CONTRIBUTING.md) 🧑‍🎓
- [ ] Run `go fmt` to format your code 🖊
- [ ] Lint your changes via `golangci-lint run` 🚨 (install golangci-lint [here](https://golangci-lint.run/usage/install/#local-installation))
- [ ] Update or add tests 🧪
- [ ] Ensure the status checks below are successful ✅
