### PR TITLE
fix(cmd-doc): Generate docs for completion command

### DIFF
--- a/cmd/doc.go
+++ b/cmd/doc.go
@@ -21,10 +21,7 @@ func newCmdDoc() *cobra.Command {
 		Args:   cobra.ExactValidArgs(1),
 		Hidden: true,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			// There is no danger of infinite recursion here as it just goes through the docs
-			// and not running the doc command
-			// nolint:revive
-			return doc.GenMarkdownTreeCustom(newCmdRoot(), args[0], filePrepender, linkHandler)
+			return doc.GenMarkdownTreeCustom(cmd.Parent(), args[0], filePrepender, linkHandler)
 		},
 	}
 	return cmd


### PR DESCRIPTION
<!-- 🎉 Thank you for making CloudQuery awesome by submitting a PR 🎉 -->

#### Summary

Follow up to https://github.com/cloudquery/cloudquery/pull/1068.
Docs are not generated for the completion command and this PR fixes it.
The reason is that the default completion command is added to the root command after calling `Execute`:
https://github.com/cloudquery/cloudquery/blob/dc558d1521cdacc7be9bf7fff741f86015d65e7c/cmd/root.go#L136
https://github.com/spf13/cobra/blob/b9ca5949e2f58373e8e4c3823c213401f7d9d0e3/command.go#L949

so we can't create a new root command and need to reference the parent that the `completion` command was added to.

Exposed by https://github.com/cloudquery/docs/pull/256/files

---

Use the following steps to ensure your PR is ready to be reviewed

- [x] Read the [contribution guidelines](../blob/main/CONTRIBUTING.md) 🧑‍🎓
- [x] Run `go fmt` to format your code 🖊
- [x] Lint your changes via `golangci-lint run` 🚨 (install golangci-lint [here](https://golangci-lint.run/usage/install/#local-installation))
- [x] Update or add tests 🧪
- [x] Ensure the status checks below are successful ✅
