### PR TITLE
fix: Add schema option to connection config

### DIFF
--- a/pkg/config/loader_test.go
+++ b/pkg/config/loader_test.go
@@ -226,7 +226,7 @@ cloudquery:
     - name: aws
       version: latest
 `,
-			"postgres://postgres:pass@localhost:15432/cq?sslmode=disable",
+			"postgres://postgres:pass@localhost:15432/cq?search_path=public&sslmode=disable",
 			false,
 		},
 		{

--- a/pkg/config/schema.json
+++ b/pkg/config/schema.json
@@ -38,6 +38,10 @@
               "description": "Connection port",
               "type": "integer"
             },
+            "schema": {
+              "description": "Connection schema",
+              "type": "string"
+            },
             "sslmode": {
               "description": "Connection sslmode",
               "type": "string"


### PR DESCRIPTION
Fixes #901, needs https://github.com/cloudquery/cq-provider-sdk/pull/371 reverted (and a new SDK tag)

This allows to:
- Resume compatibility if `search_path` was being set in `extras`
- Otherwise, use the `schema` key for search path
- If none, defaults to `public`

`search_path` is not touched if `DSN` is being used directly.