### PR TITLE
chore: Set bootstap sha

### DIFF
--- a/.github/workflows/release-pr.yml
+++ b/.github/workflows/release-pr.yml
@@ -8,7 +8,7 @@ jobs:
   release-pr-monorepo:
     runs-on: ubuntu-latest
     outputs:
-      releases: ${{ steps.release.outputs }}
+      releases: ${{ toJSON(steps.release.outputs) }}
     steps:
       - uses: google-github-actions/release-please-action@v3
         id: release
@@ -37,10 +37,10 @@ jobs:
       # We mark all releases as pre-release until we finish building & uploading the binaries
       # GoReleaser will upload the binaries to GitHub and mark the release as ready
       - name: Mark as pre-release
-        if: ${{ needs.release-please.outputs.releases['${{ matrix.release }}--release_created'] }}
+        if: ${{ fromJSON(needs.release-please.outputs.releases)['${{ matrix.release }}--release_created'] }}
         uses: tubone24/update_release@2146f1550a23d883b8ea0c036298ed74cd65eac6
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          TAG_NAME: ${{ steps.release.outputs['${{ matrix.release }}--tag_name'] }}
+          TAG_NAME: ${{ fromJSON(steps.release.outputs)['${{ matrix.release }}--tag_name'] }}
         with:
           prerelease: true

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -1,4 +1,5 @@
 {
+  "bootstrap-sha": "a19c572b7c8dac79dd63b5e84414fc9dd36b1fb3",
   "release-type": "go",
   "packages": {
     "cli": { "component": "cli" },


### PR DESCRIPTION
This should tell release please to generate the diff from the `a19c572b7c8dac79dd63b5e84414fc9dd36b1fb3` commit instead of the entire history