### PR TITLE
chore: Fix Go Releaser configs

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,6 +1,6 @@
 {
   "cli": "0.32.1",
-  "plugins/aws": "0.13.8",
+  "plugins/aws": "0.13.6",
   "plugins/azure": "0.12.4",
   "plugins/cloudflare": "0.0.1",
   "plugins/digitalocean": "0.6.3",

--- a/cli/.goreleaser.prerelease.yaml
+++ b/cli/.goreleaser.prerelease.yaml
@@ -6,7 +6,7 @@ monorepo:
 
 before:
   hooks:
-    - go mod download
+    - cd cli && go mod download
 builds:
   - flags:
       - -buildmode=exe
@@ -47,17 +47,6 @@ archives:
       386: i386
       amd64: x86_64
     format: zip
-dockers:
-  -
-    goos: linux
-    goarch: amd64
-    dockerfile: Dockerfile.goreleaser
-    image_templates:
-      - "ghcr.io/cloudquery/cloudquery:latest"
-      - "ghcr.io/cloudquery/cloudquery:{{.Version}}"
-      - "ghcr.io/cloudquery/cloudquery:{{ .Major }}.{{ .Minor }}"
-    build_flag_templates:
-      - "--label=org.opencontainers.image.source=https://github.com/cloudquery/cloudquery"
 checksum:
   name_template: 'checksums.txt'
 changelog:
@@ -66,6 +55,5 @@ changelog:
     exclude:
       - '^docs:'
       - '^test:'
-      
 release:
   prerelease: true

--- a/cli/.goreleaser.yaml
+++ b/cli/.goreleaser.yaml
@@ -4,49 +4,12 @@ monorepo:
   tag_prefix: cli/
   dir: cli
 
-before:
-  hooks:
-    - go mod download
-builds:
-  - flags:
-      - -buildmode=exe
-    env:
-      - GOGC=off
-      - CGO_ENABLED=0
-      - GO111MODULE=on
-    main: ./main.go
-    ldflags:
-      - -s -w -X github.com/cloudquery/cloudquery/cli/pkg/core.Version={{.Version}} -X github.com/cloudquery/cloudquery/cli/cmd.Commit={{.Commit}} -X github.com/cloudquery/cloudquery/cli/cmd.Date={{.Date}} -X github.com/cloudquery/cloudquery/cli/cmd.APIKey=28iMwucm5GXsoevNGSfDl1LC6zV
-    goos:
-      - windows
-      - linux
-      - darwin
-    goarch:
-      - amd64
-      - arm64
-    ignore:
-      - goos: windows
-        goarch: arm64
-archives:
-  -
-    name_template: "{{ .Binary }}_{{ .Os }}_{{ .Arch }}"
-    replacements:
-      darwin: Darwin
-      linux: Linux
-      windows: Windows
-      386: i386
-      amd64: x86_64
-    format: binary
-  -
-    id: homebrew
-    name_template: "{{ .Binary }}_{{ .Os }}_{{ .Arch }}"
-    replacements:
-      darwin: Darwin
-      linux: Linux
-      windows: Windows
-      386: i386
-      amd64: x86_64
-    format: zip
+includes:
+  - from_file:
+      # Relative to the directory Go Releaser is run from (which is the root of the repository)
+      # Include everything from pre-release (build & publish to GitHub), plus publish to docker and Homebrew
+      path: ./cli/.goreleaser.prerelease.yaml
+
 # dockers:
 #   -
 #     goos: linux
@@ -58,17 +21,6 @@ archives:
 #       - "ghcr.io/cloudquery/cloudquery:{{ .Major }}.{{ .Minor }}"
 #     build_flag_templates:
 #       - "--label=org.opencontainers.image.source=https://github.com/cloudquery/cloudquery"
-checksum:
-  name_template: 'checksums.txt'
-changelog:
-  sort: asc
-  filters:
-    exclude:
-      - '^docs:'
-      - '^test:'
-      
-release:
-  prerelease: true
 
 # brews:
 #   -

--- a/plugins/.goreleaser.yaml
+++ b/plugins/.goreleaser.yaml
@@ -1,6 +1,6 @@
 before:
   hooks:
-    - go mod download
+    - cd plugins/{{ .Var.component }} && go mod download
 builds:
   - flags:
       - -buildmode=exe

--- a/plugins/aws/.goreleaser.yaml
+++ b/plugins/aws/.goreleaser.yaml
@@ -1,11 +1,11 @@
 variables:
   component: aws
 
-project_name: plugins/{{ .Var.component }}
+project_name: plugins/aws
 
 monorepo:
-  tag_prefix: plugins/{{ .Var.component }}/
-  dir: plugins/{{ .Var.component }}
+  tag_prefix: plugins/aws/
+  dir: plugins/aws
 
 includes:
   - from_file:

--- a/plugins/azure/.goreleaser.yaml
+++ b/plugins/azure/.goreleaser.yaml
@@ -1,11 +1,11 @@
 variables:
   component: azure
 
-project_name: plugins/{{ .Var.component }}
+project_name: plugins/azure
 
 monorepo:
-  tag_prefix: plugins/{{ .Var.component }}/
-  dir: plugins/{{ .Var.component }}
+  tag_prefix: plugins/azure/
+  dir: plugins/azure
 
 includes:
   - from_file:

--- a/plugins/cloudflare/.goreleaser.yaml
+++ b/plugins/cloudflare/.goreleaser.yaml
@@ -1,11 +1,11 @@
 variables:
   component: cloudflare
 
-project_name: plugins/{{ .Var.component }}
+project_name: plugins/cloudflare
 
 monorepo:
-  tag_prefix: plugins/{{ .Var.component }}/
-  dir: plugins/{{ .Var.component }}
+  tag_prefix: plugins/cloudflare/
+  dir: plugins/cloudflare
 
 includes:
   - from_file:

--- a/plugins/digitalocean/.goreleaser.yaml
+++ b/plugins/digitalocean/.goreleaser.yaml
@@ -1,11 +1,11 @@
 variables:
   component: digitalocean
 
-project_name: plugins/{{ .Var.component }}
+project_name: plugins/digitalocean
 
 monorepo:
-  tag_prefix: plugins/{{ .Var.component }}/
-  dir: plugins/{{ .Var.component }}
+  tag_prefix: plugins/digitalocean/
+  dir: plugins/digitalocean
 
 includes:
   - from_file:

--- a/plugins/fuzz/.goreleaser.yaml
+++ b/plugins/fuzz/.goreleaser.yaml
@@ -1,11 +1,11 @@
 variables:
   component: fuzz
 
-project_name: plugins/{{ .Var.component }}
+project_name: plugins/fuzz
 
 monorepo:
-  tag_prefix: plugins/{{ .Var.component }}/
-  dir: plugins/{{ .Var.component }}
+  tag_prefix: plugins/fuzz/
+  dir: plugins/fuzz
 
 includes:
   - from_file:

--- a/plugins/gcp/.goreleaser.yaml
+++ b/plugins/gcp/.goreleaser.yaml
@@ -1,11 +1,11 @@
 variables:
   component: gcp
 
-project_name: plugins/{{ .Var.component }}
+project_name: plugins/gcp
 
 monorepo:
-  tag_prefix: plugins/{{ .Var.component }}/
-  dir: plugins/{{ .Var.component }}
+  tag_prefix: plugins/gcp/
+  dir: plugins/gcp
 
 includes:
   - from_file:

--- a/plugins/github/.goreleaser.yaml
+++ b/plugins/github/.goreleaser.yaml
@@ -1,11 +1,11 @@
 variables:
   component: github
 
-project_name: plugins/{{ .Var.component }}
+project_name: plugins/github
 
 monorepo:
-  tag_prefix: plugins/{{ .Var.component }}/
-  dir: plugins/{{ .Var.component }}
+  tag_prefix: plugins/github/
+  dir: plugins/github
 
 includes:
   - from_file:

--- a/plugins/k8s/.goreleaser.yaml
+++ b/plugins/k8s/.goreleaser.yaml
@@ -1,11 +1,11 @@
 variables:
   component: k8s
 
-project_name: plugins/{{ .Var.component }}
+project_name: plugins/k8s
 
 monorepo:
-  tag_prefix: plugins/{{ .Var.component }}/
-  dir: plugins/{{ .Var.component }}
+  tag_prefix: plugins/k8s/
+  dir: plugins/k8s
 
 includes:
   - from_file:

--- a/plugins/okta/.goreleaser.yaml
+++ b/plugins/okta/.goreleaser.yaml
@@ -1,11 +1,11 @@
 variables:
   component: okta
 
-project_name: plugins/{{ .Var.component }}
+project_name: plugins/okta
 
 monorepo:
-  tag_prefix: plugins/{{ .Var.component }}/
-  dir: plugins/{{ .Var.component }}
+  tag_prefix: plugins/okta/
+  dir: plugins/okta
 
 includes:
   - from_file:

--- a/plugins/terraform/.goreleaser.yaml
+++ b/plugins/terraform/.goreleaser.yaml
@@ -1,11 +1,11 @@
 variables:
   component: terraform
 
-project_name: plugins/{{ .Var.component }}
+project_name: plugins/terraform
 
 monorepo:
-  tag_prefix: plugins/{{ .Var.component }}/
-  dir: plugins/{{ .Var.component }}
+  tag_prefix: plugins/terraform/
+  dir: plugins/terraform
 
 includes:
   - from_file:


### PR DESCRIPTION
Looks like variables don't work for `project_name` and `monorepo` configurations.
Also global hooks run from the CWD and not from the project directory.