### PR TITLE
chore(release): Set dir for projects

### DIFF
--- a/cli/.goreleaser.prerelease.yaml
+++ b/cli/.goreleaser.prerelease.yaml
@@ -6,7 +6,8 @@ monorepo:
 
 before:
   hooks:
-    - cd cli && go mod download
+    - cmd: go mod download
+      dir: ./cli
 builds:
   - flags:
       - -buildmode=exe

--- a/plugins/.goreleaser.yaml
+++ b/plugins/.goreleaser.yaml
@@ -1,6 +1,7 @@
 before:
   hooks:
-    - cd plugins/{{ .Var.component }} && go mod download
+    - cmd: go mod download
+      dir: ./plugins/{{ .Var.component }}
 builds:
   - flags:
       - -buildmode=exe


### PR DESCRIPTION
This is the way to set a directory for global build hooks, see https://goreleaser.com/customization/hooks/?h=hooks