### PR TITLE
chore: Sync aws release version

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,6 +1,6 @@
 {
   "cli": "0.32.1",
-  "plugins/aws": "0.13.7",
+  "plugins/aws": "0.13.6",
   "plugins/azure": "0.12.4",
   "plugins/cloudflare": "0.0.1",
   "plugins/digitalocean": "0.6.3",


### PR DESCRIPTION
Brings back the AWS plugin version to the latest released (It was bumped as a part of my tests)