### PR TITLE
chore(release): Disable GitHub release notes

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -16,6 +16,5 @@
   },
   "bump-minor-pre-major": true,
   "bump-patch-for-minor-pre-major": true,
-  "tag-separator": "/",
-  "changelog-type": "github"
+  "tag-separator": "/"
 }


### PR DESCRIPTION
Disables https://github.com/cloudquery/cloudquery/pull/1194 but keeps the workflow that adds labels to PRs.
Using the GitHub style release notes fails at the moment as it relies on PR labels (instead of commits like the default one).
Since we imported commits from providers repos, but can't import their linked PRs this creates a bit of a mess.

Once we make the switch we can re-enable it, but we should still keep the workflow that adds labels, so once we switch the correct changelog will be generated.