### PR TITLE
chore: Rename plugin/source/fuzz module and imports

### DIFF
--- a/plugins/source/fuzz/go.mod
+++ b/plugins/source/fuzz/go.mod
@@ -1,4 +1,4 @@
-module github.com/cloudquery/cq-provider-fuzz
+module github.com/cloudquery/cloudquery/plugins/source/fuzz
 
 go 1.18
 

--- a/plugins/source/fuzz/main.go
+++ b/plugins/source/fuzz/main.go
@@ -1,7 +1,7 @@
 package main
 
 import (
-	"github.com/cloudquery/cq-provider-fuzz/resources/provider"
+	"github.com/cloudquery/cloudquery/plugins/source/fuzz/resources/provider"
 	"github.com/cloudquery/cq-provider-sdk/serve"
 )
 


### PR DESCRIPTION
Same as https://github.com/cloudquery/cloudquery/pull/1199 for the fuzz source