### PR TITLE
chore: Fix Go releaser

### DIFF
--- a/plugins/.goreleaser.yaml
+++ b/plugins/.goreleaser.yaml
@@ -1,7 +1,7 @@
 before:
   hooks:
     - cmd: go mod download
-      dir: ./plugins/source/{{ .Var.component }}
+      dir: ./plugins/{{ .Var.component }}
 builds:
   - flags:
       - -buildmode=exe
@@ -9,7 +9,7 @@ builds:
       - CGO_ENABLED=0
       - GO111MODULE=on
     ldflags:
-      - -s -w -X github.com/cloudquery/cloudquery/plugins/source/{{ .Var.component }}/resources/provider.Version={{.Version}}
+      - -s -w -X github.com/cloudquery/cloudquery/plugins/{{ .Var.component }}/resources/provider.Version={{.Version}}
     goos:
       - windows
       - linux

--- a/plugins/source/aws/.goreleaser.yaml
+++ b/plugins/source/aws/.goreleaser.yaml
@@ -1,5 +1,5 @@
 variables:
-  component: aws
+  component: source/aws
 
 project_name: plugins/source/aws
 
@@ -10,4 +10,4 @@ monorepo:
 includes:
   - from_file:
       # Relative to the directory Go Releaser is run from (which is the root of the repository)
-      path: ./plugins/source/.goreleaser.yaml
+      path: ./plugins/.goreleaser.yaml

--- a/plugins/source/azure/.goreleaser.yaml
+++ b/plugins/source/azure/.goreleaser.yaml
@@ -1,5 +1,5 @@
 variables:
-  component: azure
+  component: source/azure
 
 project_name: plugins/source/azure
 
@@ -10,4 +10,4 @@ monorepo:
 includes:
   - from_file:
       # Relative to the directory Go Releaser is run from (which is the root of the repository)
-      path: ./plugins/source/.goreleaser.yaml
+      path: ./plugins/.goreleaser.yaml

--- a/plugins/source/cloudflare/.goreleaser.yaml
+++ b/plugins/source/cloudflare/.goreleaser.yaml
@@ -1,5 +1,5 @@
 variables:
-  component: cloudflare
+  component: source/cloudflare
 
 project_name: plugins/source/cloudflare
 
@@ -10,4 +10,4 @@ monorepo:
 includes:
   - from_file:
       # Relative to the directory Go Releaser is run from (which is the root of the repository)
-      path: ./plugins/source/.goreleaser.yaml
+      path: ./plugins/.goreleaser.yaml

--- a/plugins/source/digitalocean/.goreleaser.yaml
+++ b/plugins/source/digitalocean/.goreleaser.yaml
@@ -1,5 +1,5 @@
 variables:
-  component: digitalocean
+  component: source/digitalocean
 
 project_name: plugins/source/digitalocean
 
@@ -10,4 +10,4 @@ monorepo:
 includes:
   - from_file:
       # Relative to the directory Go Releaser is run from (which is the root of the repository)
-      path: ./plugins/source/.goreleaser.yaml
+      path: ./plugins/.goreleaser.yaml

--- a/plugins/source/fuzz/.goreleaser.yaml
+++ b/plugins/source/fuzz/.goreleaser.yaml
@@ -1,5 +1,5 @@
 variables:
-  component: fuzz
+  component: source/fuzz
 
 project_name: plugins/source/fuzz
 
@@ -10,4 +10,4 @@ monorepo:
 includes:
   - from_file:
       # Relative to the directory Go Releaser is run from (which is the root of the repository)
-      path: ./plugins/source/.goreleaser.yaml
+      path: ./plugins/.goreleaser.yaml

--- a/plugins/source/gcp/.goreleaser.yaml
+++ b/plugins/source/gcp/.goreleaser.yaml
@@ -1,5 +1,5 @@
 variables:
-  component: gcp
+  component: source/gcp
 
 project_name: plugins/source/gcp
 
@@ -10,4 +10,4 @@ monorepo:
 includes:
   - from_file:
       # Relative to the directory Go Releaser is run from (which is the root of the repository)
-      path: ./plugins/source/.goreleaser.yaml
+      path: ./plugins/.goreleaser.yaml

--- a/plugins/source/github/.goreleaser.yaml
+++ b/plugins/source/github/.goreleaser.yaml
@@ -1,5 +1,5 @@
 variables:
-  component: github
+  component: source/github
 
 project_name: plugins/source/github
 
@@ -10,4 +10,4 @@ monorepo:
 includes:
   - from_file:
       # Relative to the directory Go Releaser is run from (which is the root of the repository)
-      path: ./plugins/source/.goreleaser.yaml
+      path: ./plugins/.goreleaser.yaml

--- a/plugins/source/k8s/.goreleaser.yaml
+++ b/plugins/source/k8s/.goreleaser.yaml
@@ -1,5 +1,5 @@
 variables:
-  component: k8s
+  component: source/k8s
 
 project_name: plugins/source/k8s
 
@@ -10,4 +10,4 @@ monorepo:
 includes:
   - from_file:
       # Relative to the directory Go Releaser is run from (which is the root of the repository)
-      path: ./plugins/source/.goreleaser.yaml
+      path: ./plugins/.goreleaser.yaml

--- a/plugins/source/okta/.goreleaser.yaml
+++ b/plugins/source/okta/.goreleaser.yaml
@@ -1,5 +1,5 @@
 variables:
-  component: okta
+  component: source/okta
 
 project_name: plugins/source/okta
 
@@ -10,4 +10,4 @@ monorepo:
 includes:
   - from_file:
       # Relative to the directory Go Releaser is run from (which is the root of the repository)
-      path: ./plugins/source/.goreleaser.yaml
+      path: ./plugins/.goreleaser.yaml

--- a/plugins/source/terraform/.goreleaser.yaml
+++ b/plugins/source/terraform/.goreleaser.yaml
@@ -1,5 +1,5 @@
 variables:
-  component: terraform
+  component: source/terraform
 
 project_name: plugins/source/terraform
 
@@ -10,4 +10,4 @@ monorepo:
 includes:
   - from_file:
       # Relative to the directory Go Releaser is run from (which is the root of the repository)
-      path: ./plugins/source/.goreleaser.yaml
+      path: ./plugins/.goreleaser.yaml


### PR DESCRIPTION
Leftovers from moving to `source` directory