### PR TITLE
chore: Ignore go work files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,5 @@ dest/*
 outfile
 test_init_config.yml
 telemetry-random-id
+go.work
+go.work.sum


### PR DESCRIPTION
For now each developer can chose to opt-in to Go workspaces via `go work init`