### PR TITLE
fix(cli): Don't prepend cq-provider to monorepo binary name

### DIFF
--- a/cli/pkg/plugin/registry/hub.go
+++ b/cli/pkg/plugin/registry/hub.go
@@ -254,7 +254,7 @@ func (h Hub) downloadProvider(ctx context.Context, provider Provider, requestedV
 	switch provider.Source {
 	case DefaultOrganization:
 		// we use a special convention for the CloudQuery monorepo
-		providerURL := fmt.Sprintf("https://github.com/%s/cloudquery/releases/download/%s/%s", DefaultOrganization, getMonorepoPluginTag("source", provider.Name, requestedVersion), getPluginBinaryName(provider.Name))
+		providerURL := fmt.Sprintf("https://github.com/%s/cloudquery/releases/download/%s/%s", DefaultOrganization, getMonorepoPluginTag("source", provider.Name, requestedVersion), fmt.Sprintf("%s_%s", provider.Name, GetBinarySuffix()))
 		err = osFs.DownloadFile(ctx, providerPath, providerURL, progressCB)
 		if err == nil {
 			break


### PR DESCRIPTION
<!-- 🎉 Thank you for making CloudQuery awesome by submitting a PR 🎉 -->

#### Summary

`getPluginBinaryName` prepends `cq-provider-` to the binary name

---

Use the following steps to ensure your PR is ready to be reviewed

- [x] Read the [contribution guidelines](../blob/main/CONTRIBUTING.md) 🧑‍🎓
- [x] Test locally on your own infrastructure
- [x] Run `go fmt` to format your code 🖊
- [x] Lint your changes via `golangci-lint run` 🚨 (install golangci-lint [here](https://golangci-lint.run/usage/install/#local-installation)) 
- [x] Update or add tests 🧪
- [x] Ensure the status checks below are successful ✅
