### PR TITLE
fix(docs): Add the missing path 'cli' for compiled bin

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ For other providers, you can follow their specific guide on [Cloudquery Hub](htt
 
 ```
 make build-cli
-./bin/cloudquery # --help to see all options
+./bin/cli/cloudquery # --help to see all options
 ```
 
 ## Deployment via Helm


### PR DESCRIPTION
<!-- 🎉 Thank you for making CloudQuery awesome by submitting a PR 🎉 -->

#### Summary

Add the missing path 'cli' for compiled binary file.
---

Use the following steps to ensure your PR is ready to be reviewed

- [ ] Read the [contribution guidelines](../blob/main/CONTRIBUTING.md) 🧑‍🎓
- [ ] Test locally on your own infrastructure
- [ ] Run `go fmt` to format your code 🖊
- [ ] Lint your changes via `golangci-lint run` 🚨 (install golangci-lint [here](https://golangci-lint.run/usage/install/#local-installation)) 
- [ ] Update or add tests 🧪
- [ ] Ensure the status checks below are successful ✅
