### PR TITLE
fix: Fix output path of build-cli make command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ build-changed:
 
 .PHONY: build-cli
 build-cli:
-	(cd cli && go build -o ../bin/cli/cloudquery .)
+	(cd cli && go build -o ../bin/cloudquery .)
 
 # Test unit
 .PHONY: test-unit

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ For other providers, you can follow their specific guide on [Cloudquery Hub](htt
 
 ```
 make build-cli
-./bin/cli/cloudquery # --help to see all options
+./bin/cloudquery # --help to see all options
 ```
 
 ## Deployment via Helm


### PR DESCRIPTION
This ensures the output path of the`build-cli` command is the same as for the `build` command.