### PR TITLE
fix(cli): Fix cli version checking to work with monorepo

### DIFF
--- a/cli/internal/versions/versions_test.go
+++ b/cli/internal/versions/versions_test.go
@@ -48,3 +48,26 @@ func TestClient_GetLatestProviderRelease(t *testing.T) {
 		t.Errorf("got community provider version = %q, want %q", version, "v4.5.6")
 	}
 }
+
+func TestClient_GetLatestCLIRelease(t *testing.T) {
+	cloudQueryServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/v1/cli.json" {
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
+		fmt.Fprintf(w, `{"latest":"cli/v1.2.3"}`)
+	}))
+	defer cloudQueryServer.Close()
+
+	c := NewClient()
+	c.cloudQueryBaseURL = cloudQueryServer.URL
+
+	ctx := context.Background()
+	version, err := c.GetLatestCLIRelease(ctx)
+	if err != nil {
+		t.Fatalf("error calling GetLatestCLIRelease: %v", err)
+	}
+	if version != "v1.2.3" {
+		t.Errorf("got cloudquery cli version = %q, want %q", version, "v1.2.3")
+	}
+}

--- a/cli/pkg/core/provider_test.go
+++ b/cli/pkg/core/provider_test.go
@@ -30,7 +30,7 @@ resources:
 `
 
 func Test_CheckAvailableUpdates(t *testing.T) {
-	latestVersion := getLatestVersion(t, "test")
+	latestVersion := mockGetLatestVersion(t, "test")
 
 	testCases := []struct {
 		Name    string
@@ -133,7 +133,7 @@ func Test_GetProviderConfig(t *testing.T) {
 	assert.NoError(t, err)
 }
 
-func getLatestVersion(t *testing.T, name string) string {
+func mockGetLatestVersion(t *testing.T, name string) string {
 	reg := registry.NewRegistryHub(firebase.CloudQueryRegistryURL, registry.WithPluginDirectory(t.TempDir()))
 	latest, diags := CheckAvailableUpdates(context.Background(), reg, &CheckUpdatesOptions{Providers: []registry.Provider{
 		{Name: name, Version: "v0.0.0", Source: registry.DefaultOrganization},

--- a/cli/pkg/core/version.go
+++ b/cli/pkg/core/version.go
@@ -3,13 +3,13 @@ package core
 import (
 	"context"
 	"fmt"
-	"github.com/cloudquery/cloudquery/cli/internal/versions"
 	"net/http"
 	"strconv"
 	"strings"
 	"time"
 
 	"github.com/cloudquery/cloudquery/cli/internal/persistentdata"
+	"github.com/cloudquery/cloudquery/cli/internal/versions"
 	"github.com/hashicorp/go-version"
 	"github.com/spf13/afero"
 )

--- a/cli/pkg/core/version_test.go
+++ b/cli/pkg/core/version_test.go
@@ -6,7 +6,6 @@ import (
 	"net/http"
 	"testing"
 
-	"github.com/google/go-github/v35/github"
 	"github.com/hashicorp/go-version"
 	"github.com/spf13/afero"
 	"github.com/spf13/viper"
@@ -167,10 +166,10 @@ func TestMaybeCheckForUpdate(t *testing.T) {
 			defer func() { Version = saveVersion }()
 			Version = tt.currentVersion
 
-			saveGetLatestRelease := getLatestRelease
-			defer func() { getLatestRelease = saveGetLatestRelease }()
-			getLatestRelease = func(ctx context.Context, client *http.Client, owner, repo string) (*github.RepositoryRelease, error) {
-				return &github.RepositoryRelease{TagName: &tt.githubVersion}, tt.githubError
+			saveGetLatestVersion := getLatestVersion
+			defer func() { getLatestVersion = saveGetLatestVersion }()
+			getLatestVersion = func(ctx context.Context, client *http.Client, owner, repo string) (string, error) {
+				return tt.githubVersion, tt.githubError
 			}
 
 			fs := afero.Afero{Fs: afero.NewMemMapFs()}


### PR DESCRIPTION
This updates the CLI to use https://versions.cloudquery.io/v1/cli.json when checking for newer versions, rather than Github releases (which now uses a different tag format).
