### PR TITLE
chore: Fix approve Vercel workflow

### DIFF
--- a/.github/workflows/approve_vercel.yml
+++ b/.github/workflows/approve_vercel.yml
@@ -12,9 +12,13 @@ jobs:
   set-vercel-to-success:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - uses: ouzi-dev/commit-status-updater@v1.1.0
+      - uses: actions/github-script@v6
         with:
-          status: success
-          name: "Vercel – cloudquery-web"
-          ignoreForks: false
+          script: |
+            github.rest.repos.createCommitStatus({
+              owner: `cloudquery`,
+              repo: `cloudquery`,
+              context: 'Vercel – cloudquery-web'
+              state: 'success'
+              sha: context.pull_request.head.sha
+            })


### PR DESCRIPTION
<!-- 🎉 Thank you for making CloudQuery awesome by submitting a PR 🎉 -->

#### Summary

`ouzi-dev/commit-status-updater` doesn't support `pull_request_target`

---

Use the following steps to ensure your PR is ready to be reviewed

- [x] Read the [contribution guidelines](../blob/main/CONTRIBUTING.md) 🧑‍🎓
- [x] Test locally on your own infrastructure
- [x] Run `go fmt` to format your code 🖊
- [x] Lint your changes via `golangci-lint run` 🚨 (install golangci-lint [here](https://golangci-lint.run/usage/install/#local-installation)) 
- [x] Update or add tests 🧪
- [x] Ensure the status checks below are successful ✅
