### PR TITLE
fix: Remove deprecated firebase

### DIFF
--- a/cli/pkg/core/download_test.go
+++ b/cli/pkg/core/download_test.go
@@ -8,7 +8,6 @@ import (
 	"github.com/cloudquery/cloudquery/cli/pkg/config"
 	"github.com/cloudquery/cloudquery/cli/pkg/plugin"
 	"github.com/cloudquery/cloudquery/cli/pkg/plugin/registry"
-	"github.com/cloudquery/cq-provider-sdk/provider/diag"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -82,58 +81,6 @@ func TestDownloadExisting(t *testing.T) {
 }
 
 // TODO: latest + unverified provider won't work on download
-
-func TestDownloadUnverified(t *testing.T) {
-	tempDir := t.TempDir()
-	pm, err := plugin.NewManager(registry.NewRegistryHub(firebase.CloudQueryRegistryURL, registry.WithPluginDirectory(tempDir)))
-	if !assert.Nil(t, err) {
-		t.FailNow()
-	}
-
-	// Plugin shouldn't exist
-	_, err = pm.CreatePlugin(&plugin.CreationOptions{
-		Provider: registry.Provider{
-			Name:    "unverified",
-			Version: "latest",
-			Source:  "cloudquery",
-		},
-		Alias: "",
-		Env:   nil,
-	})
-	assert.Error(t, err)
-	// Download plugin for the first time
-	_, diags := Download(context.Background(), pm, &DownloadOptions{
-		Providers: []registry.Provider{
-			{
-				Name:    "unverified",
-				Version: "v0.0.3",
-				Source:  "cloudquery",
-			},
-		},
-		NoVerify: false,
-	})
-	assert.NotNil(t, diags)
-	assert.Equal(t, diag.FlatDiags{{
-		Err:      "provider plugin unverified@v0.0.3 not registered at https://hub.cloudquery.io",
-		Resource: "",
-		Type:     diag.INTERNAL,
-		Severity: diag.ERROR,
-		Summary:  "failed to download providers: provider plugin unverified@v0.0.3 not registered at https://hub.cloudquery.io"}},
-		diag.FlattenDiags(diags, true))
-
-	_, diags = Download(context.Background(), pm, &DownloadOptions{
-		Providers: []registry.Provider{
-			{
-				Name:    "unverified",
-				Version: "v0.0.3",
-				Source:  "cloudquery",
-			},
-		},
-		NoVerify: true,
-	})
-	assert.Nil(t, diags)
-}
-
 func TestDownloadCommunity(t *testing.T) {
 	tempDir := t.TempDir()
 	pm, err := plugin.NewManager(registry.NewRegistryHub(firebase.CloudQueryRegistryURL, registry.WithPluginDirectory(tempDir)))


### PR DESCRIPTION
This is a P1 bug removing dependency on deprecated firebase which prevents downloading plugins.

---

Use the following steps to ensure your PR is ready to be reviewed

- [ ] Read the [contribution guidelines](../blob/main/CONTRIBUTING.md) 🧑‍🎓
- [ ] Test locally on your own infrastructure
- [ ] Run `go fmt` to format your code 🖊
- [ ] Lint your changes via `golangci-lint run` 🚨 (install golangci-lint [here](https://golangci-lint.run/usage/install/#local-installation)) 
- [ ] Update or add tests 🧪
- [ ] Ensure the status checks below are successful ✅
