### PR TITLE
chore: Revert "chore: Use GitHub changelog format (#1571)"

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -20,6 +20,5 @@
   "bump-patch-for-minor-pre-major": true,
   "tag-separator": "/",
   "separate-pull-requests": true,
-  "pull-request-title-pattern": "chore${scope}: Release${component} v${version}",
-  "changelog-type": "github"
+  "pull-request-title-pattern": "chore${scope}: Release${component} v${version}"
 }


### PR DESCRIPTION
This reverts commit 4d6d2b974e47fda003b352389f8f6283318172ed.

<!-- 🎉 Thank you for making CloudQuery awesome by submitting a PR 🎉 -->

#### Summary

Still doesn't work. We need at least 1 release of each component for this to work as GitHub API compares to a previous tag. We don't have previous tags for Okta and Terraform so the API call fails:
https://github.com/cloudquery/cloudquery/runs/8057536451?check_suite_focus=true#step:2:265

---

Use the following steps to ensure your PR is ready to be reviewed

- [ ] Read the [contribution guidelines](../blob/main/CONTRIBUTING.md) 🧑‍🎓
- [ ] Test locally on your own infrastructure
- [ ] Run `go fmt` to format your code 🖊
- [ ] Lint your changes via `golangci-lint run` 🚨 (install golangci-lint [here](https://golangci-lint.run/usage/install/#local-installation)) 
- [ ] Update or add tests 🧪
- [ ] Ensure the status checks below are successful ✅
