### PR TITLE
chore: Update CLI version in docs after release

### DIFF
--- a/.github/workflows/approve_vercel.yml
+++ b/.github/workflows/approve_vercel.yml
@@ -11,6 +11,8 @@ on:
 jobs:
   set-vercel-to-success:
     runs-on: ubuntu-latest
+    # We need to override the Vercel status only for PRs coming from forks
+    if: github.event.pull_request.head.repo.fork == true
     steps:
       - uses: actions/github-script@v6
         with:

--- a/.github/workflows/release_cli.yml
+++ b/.github/workflows/release_cli.yml
@@ -71,6 +71,15 @@ jobs:
         if: steps.semver_parser.outputs.prerelease == ''
         run: 'echo "{ \"latest\": \"${{github.ref_name}}\" }" > ./sites/versions/v1/cli.json'
 
+      - name: Update docs
+        if: steps.semver_parser.outputs.prerelease == ''
+        uses: jacobtomlinson/gha-find-replace@657b0d1fe020da9943d1702b576f5d37d43b9c03
+        continue-on-error: true
+        with:
+          include: "website/**/*.md*"
+          find: 'releases\/download\/cli\/v[^\/]+'
+          replace: "releases/download/${{github.ref_name}}"
+          
       - name: Create Pull Request
         if: steps.semver_parser.outputs.prerelease == ''
         uses: peter-evans/create-pull-request@v4


### PR DESCRIPTION
<!-- 🎉 Thank you for making CloudQuery awesome by submitting a PR 🎉 -->

#### Summary

Follow up to https://github.com/cloudquery/cloudquery/pull/1595.
Updates the CLI version in the docs to the latest version after a release was published

---

Use the following steps to ensure your PR is ready to be reviewed

- [x] Read the [contribution guidelines](../blob/main/CONTRIBUTING.md) 🧑‍🎓
- [x] Test locally on your own infrastructure
- [x] Run `go fmt` to format your code 🖊
- [x] Lint your changes via `golangci-lint run` 🚨 (install golangci-lint [here](https://golangci-lint.run/usage/install/#local-installation)) 
- [x] Update or add tests 🧪
- [x] Ensure the status checks below are successful ✅
