### PR TITLE
chore: Support zip for plugins

### DIFF
--- a/plugins/.goreleaser.yaml
+++ b/plugins/.goreleaser.yaml
@@ -23,6 +23,8 @@ builds:
 archives:
   - name_template: "{{ .Binary }}_{{ .Os }}_{{ .Arch }}"
     format: binary
+  - name_template: "{{ .Binary }}_{{ .Os }}_{{ .Arch }}"
+    format: zip
 checksum:
   name_template: "checksums.txt"
 changelog:


### PR DESCRIPTION
<!-- 🎉 Thank you for making CloudQuery awesome by submitting a PR 🎉 -->

#### Summary

Im adding zip format to goreleaser (in the future we will move just to zip to save bandwidth/storage etc...). Also the new cli will only support zip formats as no reason to support non-zip releases (brew also supports just zip). we will deprecate the other release gradually. 

---

Use the following steps to ensure your PR is ready to be reviewed

- [ ] Read the [contribution guidelines](../blob/main/CONTRIBUTING.md) 🧑‍🎓
- [ ] Test locally on your own infrastructure
- [ ] Run `go fmt` to format your code 🖊
- [ ] Lint your changes via `golangci-lint run` 🚨 (install golangci-lint [here](https://golangci-lint.run/usage/install/#local-installation)) 
- [ ] Update or add tests 🧪
- [ ] Ensure the status checks below are successful ✅
