### PR TITLE
chore: Fix Approve Vercel workflow

### DIFF
--- a/.github/workflows/approve_vercel.yml
+++ b/.github/workflows/approve_vercel.yml
@@ -2,10 +2,6 @@ name: Approve Vercel Website Build
 
 on:
   pull_request_target:
-    paths:
-      - "**/*"
-      - "!website/**"
-      - "!plugins/**/docs/**"
     branches:
       - main
 
@@ -15,7 +11,22 @@ jobs:
     # We need to override the Vercel status only for PRs coming from forks
     if: github.event.pull_request.head.repo.fork == true
     steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+          # This is secure since we don't execute any code, we only want to get the changed file
+          # Visit https://securitylab.github.com/research/github-actions-preventing-pwn-requests/ for more information
+          ref: ${{ github.event.pull_request.head.sha }}
+      - name: Get changed files
+        id: changed-files
+        uses: tj-actions/changed-files@v26
+        with:
+          files: |
+            website
+            plugins/**/docs/**
       - uses: actions/github-script@v6
+        # Only override the status if no website files have changed
+        if: steps.changed-files.outputs.any_changed == 'false'
         with:
           script: |
             github.rest.repos.createCommitStatus({


### PR DESCRIPTION
<!-- 🎉 Thank you for making CloudQuery awesome by submitting a PR 🎉 -->

#### Summary

Fixes the approve Vercel workflow as it currently runs even when website files have changed.
See https://github.com/cloudquery/cloudquery/pull/1631 which changed the website files but still got approved:
![image](https://user-images.githubusercontent.com/26760571/187625271-f54f53fd-e1fe-4c4c-a2ad-ed10db7f2524.png)


---

Use the following steps to ensure your PR is ready to be reviewed

- [ ] Read the [contribution guidelines](../blob/main/CONTRIBUTING.md) 🧑‍🎓
- [ ] Test locally on your own infrastructure
- [ ] Run `go fmt` to format your code 🖊
- [ ] Lint your changes via `golangci-lint run` 🚨 (install golangci-lint [here](https://golangci-lint.run/usage/install/#local-installation)) 
- [ ] Update or add tests 🧪
- [ ] Ensure the status checks below are successful ✅
