### PR TITLE
chore: Mark test plugin as pre-release until binaries are uploaded

### DIFF
--- a/.github/repo_settings.yml
+++ b/.github/repo_settings.yml
@@ -72,3 +72,7 @@ branchProtectionRules:
     - Unit Tests (plugins/source/terraform)
     - Build (plugins/source/terraform)
     - Lint Provider Doc (plugins/source/terraform)
+
+    - Linter (plugins/source/test)
+    - Unit Tests (plugins/source/test)
+    - Build (plugins/source/test)

--- a/.github/workflows/release_pr.yml
+++ b/.github/workflows/release_pr.yml
@@ -113,3 +113,11 @@ jobs:
           TAG_NAME: ${{ steps.release.outputs['plugins/source/terraform--tag_name'] }}
         with:
           prerelease: true
+      - name: Mark as pre-release
+        if: ${{ steps.release.outputs['plugins/source/test--release_created'] }}
+        uses: tubone24/update_release@ab028bfd61be57b390262147eed52dd6121a1f30
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG_NAME: ${{ steps.release.outputs['plugins/source/test--tag_name'] }}
+        with:
+          prerelease: true


### PR DESCRIPTION
<!-- 🎉 Thank you for making CloudQuery awesome by submitting a PR 🎉 -->

#### Summary

Follow up to https://github.com/cloudquery/cloudquery/pull/1618.

## TODO

Document adding a new plugin to the monorepo, then automate what we can

---

Use the following steps to ensure your PR is ready to be reviewed

- [ ] Read the [contribution guidelines](../blob/main/CONTRIBUTING.md) 🧑‍🎓
- [ ] Test locally on your own infrastructure
- [ ] Run `go fmt` to format your code 🖊
- [ ] Lint your changes via `golangci-lint run` 🚨 (install golangci-lint [here](https://golangci-lint.run/usage/install/#local-installation)) 
- [ ] Update or add tests 🧪
- [ ] Ensure the status checks below are successful ✅
