### PR TITLE
chore: Pass PR sha to Vercel workflow

### DIFF
--- a/.github/workflows/approve_vercel.yml
+++ b/.github/workflows/approve_vercel.yml
@@ -20,6 +20,7 @@ jobs:
       - name: Get changed files
         id: changed-files
         uses: tj-actions/changed-files@v26
+        sha: ${{ github.event.pull_request.head.sha }}
         with:
           files: |
             website


### PR DESCRIPTION
<!-- 🎉 Thank you for making CloudQuery awesome by submitting a PR 🎉 -->

#### Summary

Fixes https://github.com/cloudquery/cloudquery/runs/8109105741?check_suite_focus=true
Since we're using `pull_request_target` event type the `changed-files` can't detect the correct sha for diffing

---

Use the following steps to ensure your PR is ready to be reviewed

- [ ] Read the [contribution guidelines](../blob/main/CONTRIBUTING.md) 🧑‍🎓
- [ ] Test locally on your own infrastructure
- [ ] Run `go fmt` to format your code 🖊
- [ ] Lint your changes via `golangci-lint run` 🚨 (install golangci-lint [here](https://golangci-lint.run/usage/install/#local-installation)) 
- [ ] Update or add tests 🧪
- [ ] Ensure the status checks below are successful ✅
