### PR TITLE
fix: Checksum validation

### DIFF
--- a/cli/pkg/plugin/registry/hub.go
+++ b/cli/pkg/plugin/registry/hub.go
@@ -189,7 +189,7 @@ func (h Hub) verifyProvider(ctx context.Context, provider Provider, version stri
 		return false
 	}
 	providerPath := h.getProviderPath(provider.Source, provider.Name, version)
-	if err = validateChecksumProvider(providerPath, checksumsPath); err != nil {
+	if err = validateChecksumProvider(provider.Name, providerPath, checksumsPath); err != nil {
 		l.Error().Err(err).Msg("validating provider checksum failed")
 		if h.ProgressUpdater != nil {
 			h.ProgressUpdater.Update(provider.Name, ui.StatusError, "Bad checksum", 0)

--- a/cli/pkg/plugin/registry/validate.go
+++ b/cli/pkg/plugin/registry/validate.go
@@ -76,7 +76,8 @@ func validateChecksumProvider(providerName string, providerPath string, checksum
 			return fmt.Errorf("checksum file in incorrect format")
 		}
 		nameWithOSAndArch := fmt.Sprintf("%s_%s_%s", providerName, runtime.GOOS, runtime.GOARCH)
-		if nameWithOSAndArch == split[1] {
+		oldNameWithOSAndArch := fmt.Sprintf("cq-provider-%s", nameWithOSAndArch)
+		if nameWithOSAndArch == split[1] || oldNameWithOSAndArch == split[1] {
 			if split[0] == sha256sum {
 				return nil
 			}

--- a/cli/pkg/plugin/registry/validate.go
+++ b/cli/pkg/plugin/registry/validate.go
@@ -58,7 +58,7 @@ NdQkdLbveQ+US4vVAzRFJjRAvGVq14lRxiTreQ==
 
 const checksumSeparator = "  "
 
-func validateChecksumProvider(providerPath string, checksumPath string) error {
+func validateChecksumProvider(providerName string, providerPath string, checksumPath string) error {
 	sha256sum, err := sha256File(providerPath)
 	if err != nil {
 		return err
@@ -75,7 +75,8 @@ func validateChecksumProvider(providerPath string, checksumPath string) error {
 		if len(split) != 2 {
 			return fmt.Errorf("checksum file in incorrect format")
 		}
-		if strings.Contains(split[1], runtime.GOOS) && strings.Contains(split[1], runtime.GOARCH) {
+		nameWithOSAndArch := fmt.Sprintf("%s_%s_%s", providerName, runtime.GOOS, runtime.GOARCH)
+		if nameWithOSAndArch == split[1] {
 			if split[0] == sha256sum {
 				return nil
 			}


### PR DESCRIPTION
<!-- 🎉 Thank you for making CloudQuery awesome by submitting a PR 🎉 -->

#### Summary

With the release of the test plugin our tests have started failing on `main`. The reason is that we use `strings.Contains` to match the binary to the checksum in the checksums file, and the zipped entries also match by OS and Arch:
```bash
44d95de58751bb726f17a79c42e33faed7dad2210b9faf5ebbcf08a5079e41eb  test_linux_amd64.zip
46f587c64821a807ea12d43d08a20e7258452acc3b7e12887b176a14a12d0dc4  test_linux_amd64 
556cc5ae71b261a86c6951ee6bfb9ba5d01492babc31fb8d5b0e58abd23142c5  test_darwin_arm64
9b0796dac187339ae74c765cbdc81924149df3c7aab695e4b010011494cf079f  test_linux_arm64.zip
a2ac8ddeed89ca68a11f7f68e564244d1fcc04d05300cb7c62f8277de9e7ce18  test_darwin_amd64.zip
c2c8f2d10319100f465b7c1c354eb300611e81929c1315c624d30bddc15991ab  test_darwin_arm64.zip
c8f58f99a6c70ab29c0d367b1161686593ee02d762adde9576508cf9980dd936  test_windows_amd64.zip
dde97808619eb4d4198408e0f381dbdb1302d85c65707e4614e509d5da2b43b8  test_linux_arm64
e18f71bb8eb13ee811ec244a395ab1672367a6b308556bd06cbd8d2726e4b128  test_windows_amd64.exe
e6fb9607094d1677796e7ed0cb7276c1d00333828a37997757329ad503a342c2  test_darwin_amd64
```

For example both `test_linux_amd64` and `test_linux_amd64.zip` match the condition `strings.Contains(split[1], runtime.GOOS) && strings.Contains(split[1], runtime.GOARCH)`

**Latest version of AWS also have this issue**
```
09548817ae25e62fa856abd321e3c32eedbb5336328fba0324bd9b4fc2ab7b61  aws_darwin_amd64.zip
2cad5badb22851483f2936ef114d3cc67767abd28b33ffabf76345f61570495e  aws_windows_amd64.zip
2e35d3918fee1b7d2f2e3ef4b7ac521ddcf7a593a5446d9dc37910c681cc8d9f  aws_darwin_arm64.zip
2feeffbef67ff748f0b686ce60b6ef00d367203015248dd3164fa3e13d435676  aws_windows_amd64.exe
31344a9a7f3af69773984265ae56e368286c643a5ba0ac192d4fcc9c3c2baa36  aws_darwin_arm64
3b540f15803944356037f273d6622140eae32fc1b2f1e904141f5568626a271c  aws_linux_amd64
3f1b9a637813afee083a1ea1db86b6792376dc0ec41a745588d56f72a39cda21  aws_linux_arm64
8975f8c884cfa631c6024ba83ff8b7dc1b3941708ce25d97505987051df8919d  aws_darwin_amd64
8d2b729dc8003e1f88c22370d52532ac981ead7473916b6096bb2ca97f05d90c  aws_linux_arm64.zip
9b012319c6a1a6277fbc2febf79a6791f1c851e8a5b57a5486c52881609e32ca  aws_linux_amd64.zip
``` 

---

Use the following steps to ensure your PR is ready to be reviewed

- [ ] Read the [contribution guidelines](../blob/main/CONTRIBUTING.md) 🧑‍🎓
- [ ] Test locally on your own infrastructure
- [ ] Run `go fmt` to format your code 🖊
- [ ] Lint your changes via `golangci-lint run` 🚨 (install golangci-lint [here](https://golangci-lint.run/usage/install/#local-installation)) 
- [ ] Update or add tests 🧪
- [ ] Ensure the status checks below are successful ✅
