### PR TITLE
chore: Don't re-run workflows on main

### DIFF
--- a/.github/repo_settings.yml
+++ b/.github/repo_settings.yml
@@ -7,7 +7,7 @@ branchProtectionRules:
   isAdminEnforced: false
   requiredApprovingReviewCount: 1
   requiresCodeOwnerReviews: false
-  requiresStrictStatusChecks: false
+  requiresStrictStatusChecks: true
   requiredStatusCheckContexts:
     - Validate PR title
     - release-dry-run

--- a/.github/workflows/lint_doc.yml
+++ b/.github/workflows/lint_doc.yml
@@ -1,8 +1,5 @@
 name: Lint Docs
 on:
-  push:
-    branches:
-      - main
   pull_request:
     branches:
       - main

--- a/.github/workflows/lint_golang.yml
+++ b/.github/workflows/lint_golang.yml
@@ -1,8 +1,5 @@
 name: Lint Go
 on:
-  push:
-    branches:
-      - main
   pull_request:
     branches:
       - main

--- a/.github/workflows/test_build.yml
+++ b/.github/workflows/test_build.yml
@@ -1,9 +1,6 @@
 name: Build
 
 on:
-  push:
-    branches:
-      - main
   pull_request:
     branches:
       - main

--- a/.github/workflows/test_policy_sql.yml
+++ b/.github/workflows/test_policy_sql.yml
@@ -1,8 +1,5 @@
 name: SQL Policy Tests
 on:
-  push:
-    branches:
-      - main
   pull_request:
     branches:
       - main

--- a/.github/workflows/test_unit.yml
+++ b/.github/workflows/test_unit.yml
@@ -1,9 +1,6 @@
 name: Unit Tests
 
 on:
-  push:
-    branches:
-      - main
   pull_request:
     branches:
       - main


### PR DESCRIPTION
<!-- 🎉 Thank you for making CloudQuery awesome by submitting a PR 🎉 -->

#### Summary

Seems wasteful to re-run the same workflows again on `main`. If we keep PR branches up to date before merging we can skip testing on `main`

---

Use the following steps to ensure your PR is ready to be reviewed

- [x] Read the [contribution guidelines](../blob/main/CONTRIBUTING.md) 🧑‍🎓
- [x] Test locally on your own infrastructure
- [x] Run `go fmt` to format your code 🖊
- [x] Lint your changes via `golangci-lint run` 🚨 (install golangci-lint [here](https://golangci-lint.run/usage/install/#local-installation)) 
- [x] Update or add tests 🧪
- [x] Ensure the status checks below are successful ✅
