### PR TITLE
chore: Run broken links check periodically

### DIFF
--- a/.github/workflows/broken_links.yml
+++ b/.github/workflows/broken_links.yml
@@ -1,9 +1,8 @@
 name: Check for broken links
 
 on:
-  pull_request:
-    paths:
-      - "website/**"
+  schedule:
+    - cron:  "0 12 * * *"
 
 jobs:
   check-broken-links:

--- a/.github/workflows/broken_links.yml
+++ b/.github/workflows/broken_links.yml
@@ -1,6 +1,7 @@
 name: Check for broken links
 
 on:
+  workflow_dispatch:
   schedule:
     - cron:  "0 12 * * *"
 

--- a/.github/workflows/broken_links.yml
+++ b/.github/workflows/broken_links.yml
@@ -4,6 +4,18 @@ on:
   workflow_dispatch:
   schedule:
     - cron:  "0 12 * * *"
+  pull_request:
+    branches:
+      - main
+    paths:
+      - .github/workflows/broken_links.yml
+      - plugins/**/docs/**
+      - "website/**"
+    types:
+      - opened
+      - synchronize
+      - reopened
+      - labeled
 
 jobs:
   check-broken-links:
@@ -13,25 +25,28 @@ jobs:
       group: ${{ github.workflow }}-${{ github.ref }}
       cancel-in-progress: true
     steps:
+      - id: check-labels
+        if: github.event_name == 'pull_request'
+        uses: mheap/github-action-required-labels@a0c3d802afdc992e48f03bc90c0a1ee51a8f6b28
+        with:
+          mode: exactly
+          count: 1
+          labels: "check_broken_links"
+          exit_type: success
+
       - uses: actions/checkout@v3
+        if: steps.check-labels.outputs.status == 'success' || github.event_name != 'pull_request'
         with:
           fetch-depth: 2
 
       - name: Setup node
         uses: actions/setup-node@v3
+        if: steps.check-labels.outputs.status == 'success' || github.event_name != 'pull_request'
         with:
           node-version: "lts/*"
 
-      - name: Get changed files
-        id: changed-files
-        uses: tj-actions/changed-files@v26
-        with:
-          files: |
-            website
-            plugins/**/docs/**
-
       - name: Waiting for Vercel Preview
-        if: steps.changed-files.outputs.any_changed == 'true'
+        if: steps.check-labels.outputs.status == 'success' || github.event_name != 'pull_request'
         uses: patrickedqvist/wait-for-vercel-preview@v1.2.0
         id: vercel-deployment
         with:
@@ -41,7 +56,7 @@ jobs:
           check_interval: 10
 
       - name: Check for broken links
-        if: steps.changed-files.outputs.any_changed == 'true'
+        if: steps.check-labels.outputs.status == 'success' || github.event_name != 'pull_request'
         run: |
           set -o pipefail
 

--- a/.github/workflows/broken_links.yml
+++ b/.github/workflows/broken_links.yml
@@ -36,8 +36,6 @@ jobs:
 
       - uses: actions/checkout@v3
         if: steps.check-labels.outputs.status == 'success' || github.event_name != 'pull_request'
-        with:
-          fetch-depth: 2
 
       - name: Setup node
         uses: actions/setup-node@v3


### PR DESCRIPTION
<!-- 🎉 Thank you for making CloudQuery awesome by submitting a PR 🎉 -->

#### Summary

This workflow is quite slow (takes 10-20 minutes) and seems wasteful to run on each Website PR.
Also links can be broken regardless of code changes we make (for example we link to something external that was changed).

---

Use the following steps to ensure your PR is ready to be reviewed

- [x] Read the [contribution guidelines](../blob/main/CONTRIBUTING.md) 🧑‍🎓
- [x] Test locally on your own infrastructure
- [x] Run `go fmt` to format your code 🖊
- [x] Lint your changes via `golangci-lint run` 🚨 (install golangci-lint [here](https://golangci-lint.run/usage/install/#local-installation)) 
- [x] Update or add tests 🧪
- [x] Ensure the status checks below are successful ✅
