### PR TITLE
chore(ci): Use fetch-depth: 2, remove hard coded modules

### DIFF
--- a/.github/workflows/approve_vercel.yml
+++ b/.github/workflows/approve_vercel.yml
@@ -13,7 +13,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
         with:
-          fetch-depth: 0
+          fetch-depth: 2
           # This is secure since we don't execute any code, we only want to get the changed file
           # Visit https://securitylab.github.com/research/github-actions-preventing-pwn-requests/ for more information
           ref: ${{ github.event.pull_request.head.sha }}

--- a/.github/workflows/lint_doc.yml
+++ b/.github/workflows/lint_doc.yml
@@ -32,7 +32,7 @@ jobs:
                 return
               }
             }))).filter(Boolean)
-            return JSON.stringify({ include: withDocs })
+            return { include: withDocs }
   lint_doc:
     name: Lint Provider Doc
     needs: resolve-modules

--- a/.github/workflows/lint_doc.yml
+++ b/.github/workflows/lint_doc.yml
@@ -26,7 +26,7 @@ jobs:
             const { include: modules } = JSON.parse(MODULES)
             const withDocs = (await Promise.all(modules.map(async (module) => {
               try {
-                await fs.readdir(`./${module.workdir}/docs`)
+                await fs.access(`./${module.workdir}/docs/docs.go`, fs.F_OK)
                 return module
               } catch (e) {
                 return

--- a/.github/workflows/lint_doc.yml
+++ b/.github/workflows/lint_doc.yml
@@ -5,28 +5,45 @@ on:
       - main
 
 jobs:
+  resolve-modules:
+    name: Resolve Modules
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.set-matrix.outputs.result }}
+    steps:
+      - name: Checkout Sources
+        uses: actions/checkout@v3
+      - id: matrix
+        run: ./scripts/resolve-modules.sh
+      - uses: actions/github-script@v6
+        id: set-matrix
+        env:
+          MODULES: '${{ steps.matrix.outputs.matrix }}'
+        with:
+          script: |
+            const { promises: fs } = require('fs');
+            const { MODULES } = process.env
+            const { include: modules } = JSON.parse(MODULES)
+            const withDocs = (await Promise.all(modules.map(async (module) => {
+              try {
+                await fs.readdir(`./${module.workdir}/docs`)
+                return module
+              } catch (e) {
+                return
+              }
+            }))).filter(Boolean)
+            return JSON.stringify({ include: withDocs })
   lint_doc:
     name: Lint Provider Doc
+    needs: resolve-modules
     runs-on: ubuntu-latest
     strategy:
-      matrix:
-        workdir: [
-          "plugins/source/aws",
-          "plugins/source/azure",
-          "plugins/source/cloudflare",
-          "plugins/source/digitalocean",
-          "plugins/source/gcp",
-          "plugins/source/github",
-          "plugins/source/heroku",
-          "plugins/source/k8s",
-          "plugins/source/okta",
-          "plugins/source/terraform",
-        ]
+      matrix: ${{ fromJson(needs.resolve-modules.outputs.matrix) }}
       fail-fast: false
     steps:
       - uses: actions/checkout@v3
         with:
-          fetch-depth: 0
+          fetch-depth: 2
       - name: Get changed files
         id: changed-files
         uses: tj-actions/changed-files@v26
@@ -37,11 +54,11 @@ jobs:
           files_ignore: |
             ${{ matrix.workdir }}/CHANGELOG.md
       - uses: actions/setup-go@v3
-        if: steps.changed-files.outputs.any_changed == 'true' || github.event_name != 'pull_request'
+        if: steps.changed-files.outputs.any_changed == 'true'
         with:
           go-version: 1.18
       - uses: actions/cache@v3
-        if: steps.changed-files.outputs.any_changed == 'true' || github.event_name != 'pull_request'
+        if: steps.changed-files.outputs.any_changed == 'true'
         with:
           path: |
             ~/.cache/go-build
@@ -50,17 +67,17 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-go-1.18-${{ matrix.workdir }}
       - name: remove all docs
-        if: steps.changed-files.outputs.any_changed == 'true' || github.event_name != 'pull_request'
+        if: steps.changed-files.outputs.any_changed == 'true'
         run: |
           rm -f ./docs/tables/*.md
         working-directory: ${{ matrix.workdir }}
       - name: build-docs
-        if: steps.changed-files.outputs.any_changed == 'true' || github.event_name != 'pull_request'
+        if: steps.changed-files.outputs.any_changed == 'true'
         run: |
           go run ./docs/docs.go
         working-directory: ${{ matrix.workdir }}
       - name: Fail if docs are changed
-        if: steps.changed-files.outputs.any_changed == 'true' || github.event_name != 'pull_request'
+        if: steps.changed-files.outputs.any_changed == 'true'
         run: |
           test "$(git status -s ./docs/tables | wc -l)" -eq 0
         working-directory: ${{ matrix.workdir }}

--- a/.github/workflows/lint_golang.yml
+++ b/.github/workflows/lint_golang.yml
@@ -24,7 +24,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
         with:
-          fetch-depth: 0
+          fetch-depth: 2
       - name: Get changed files
         id: changed-files
         uses: tj-actions/changed-files@v26
@@ -35,19 +35,19 @@ jobs:
           files_ignore: |
             ${{ matrix.workdir }}/CHANGELOG.md
       - uses: actions/setup-go@v3
-        if: steps.changed-files.outputs.any_changed == 'true' || github.event_name != 'pull_request'
+        if: steps.changed-files.outputs.any_changed == 'true'
         with:
           go-version: 1.18
       # Plugins and CLI have different linting configurations
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v3
-        if: (steps.changed-files.outputs.any_changed == 'true' || github.event_name != 'pull_request') && matrix.workdir == 'cli'
+        if: steps.changed-files.outputs.any_changed == 'true' && matrix.workdir == 'cli'
         with:
           version: v1.47.3
           working-directory: ${{ matrix.workdir }}
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v3
-        if: (steps.changed-files.outputs.any_changed == 'true' || github.event_name != 'pull_request') && matrix.workdir != 'cli'
+        if: steps.changed-files.outputs.any_changed == 'true' && matrix.workdir != 'cli'
         with:
           version: v1.47.3
           working-directory: ${{ matrix.workdir }}

--- a/.github/workflows/release_cli.yml
+++ b/.github/workflows/release_cli.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
         with:
-          fetch-depth: 0
+          fetch-depth: 2
       - name: Set up Go
         uses: actions/setup-go@v3
         with:

--- a/.github/workflows/release_plugin.yml
+++ b/.github/workflows/release_plugin.yml
@@ -32,7 +32,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
         with:
-          fetch-depth: 0
+          fetch-depth: 2
       - name: Set up Go
         uses: actions/setup-go@v3
         with:

--- a/.github/workflows/test_build.yml
+++ b/.github/workflows/test_build.yml
@@ -31,7 +31,7 @@ jobs:
       - name: Check out code into the Go module directory
         uses: actions/checkout@v3
         with:
-          fetch-depth: 0
+          fetch-depth: 2
       - name: Get changed files
         id: changed-files
         uses: tj-actions/changed-files@v26
@@ -42,12 +42,12 @@ jobs:
           files_ignore: |
             ${{ matrix.workdir }}/CHANGELOG.md
       - name: Set up Go 1.x
-        if: steps.changed-files.outputs.any_changed == 'true' || github.event_name != 'pull_request'
+        if: steps.changed-files.outputs.any_changed == 'true'
         uses: actions/setup-go@v3
         with:
           go-version: 1.18
       - uses: actions/cache@v3
-        if: steps.changed-files.outputs.any_changed == 'true' || github.event_name != 'pull_request'
+        if: steps.changed-files.outputs.any_changed == 'true'
         with:
           path: |
             ~/.cache/go-build
@@ -57,11 +57,11 @@ jobs:
             ${{ runner.os }}-go-1.18-${{ matrix.workdir }}
 
       - name: Get dependencies
-        if: steps.changed-files.outputs.any_changed == 'true' || github.event_name != 'pull_request'
+        if: steps.changed-files.outputs.any_changed == 'true'
         working-directory: ${{ matrix.workdir }}
         run: go get -v -t -d ./...
 
       - name: Build
-        if: steps.changed-files.outputs.any_changed == 'true' || github.event_name != 'pull_request'
+        if: steps.changed-files.outputs.any_changed == 'true'
         run: go build .
         working-directory: ${{ matrix.workdir }}

--- a/.github/workflows/test_policy_sql.yml
+++ b/.github/workflows/test_policy_sql.yml
@@ -36,7 +36,7 @@ jobs:
                 return
               }
             }))).filter(Boolean)
-            return JSON.stringify({ include: withPolicies })
+            return { include: withPolicies }
   SQLPolicyTest:
     needs: resolve-modules
     runs-on: ubuntu-latest

--- a/.github/workflows/test_policy_sql.yml
+++ b/.github/workflows/test_policy_sql.yml
@@ -9,15 +9,40 @@ env:
   PGPASSWORD: pass
 
 jobs:
+  resolve-modules:
+    name: Resolve Modules
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.set-matrix.outputs.result }}
+    steps:
+      - name: Checkout Sources
+        uses: actions/checkout@v3
+      - id: matrix
+        run: ./scripts/resolve-modules.sh
+      - uses: actions/github-script@v6
+        id: set-matrix
+        env:
+          MODULES: '${{ steps.matrix.outputs.matrix }}'
+        with:
+          script: |
+            const { promises: fs } = require('fs');
+            const { MODULES } = process.env
+            const { include: modules } = JSON.parse(MODULES)
+            const withPolicies = (await Promise.all(modules.map(async (module) => {
+              try {
+                await fs.readdir(`./${module.workdir}/policies`)
+                return module
+              } catch (e) {
+                return
+              }
+            }))).filter(Boolean)
+            return JSON.stringify({ include: withPolicies })
   SQLPolicyTest:
+    needs: resolve-modules
+    runs-on: ubuntu-latest
     strategy:
-      matrix:
-        workdir: [
-          "plugins/source/aws",
-          "plugins/source/azure",
-          "plugins/source/gcp",
-        ]
-    runs-on: ubuntu-latest # can not run in macOS and widnowsOS
+      matrix: ${{ fromJson(needs.resolve-modules.outputs.matrix) }}
+      fail-fast: false
     services:
       postgres:
         image: postgres:11
@@ -36,7 +61,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
         with:
-          fetch-depth: 0
+          fetch-depth: 2
           
       - name: Get changed files
         id: changed-files
@@ -49,12 +74,12 @@ jobs:
             ${{ matrix.workdir }}/CHANGELOG.md
 
       - name: Set up Go 1.x
-        if: steps.changed-files.outputs.any_changed == 'true' || github.event_name != 'pull_request'
+        if: steps.changed-files.outputs.any_changed == 'true'
         uses: actions/setup-go@v3
         with:
           go-version: 1.18
       - uses: actions/cache@v3
-        if: steps.changed-files.outputs.any_changed == 'true' || github.event_name != 'pull_request'
+        if: steps.changed-files.outputs.any_changed == 'true'
         with:
           path: |
             ~/.cache/go-build
@@ -64,13 +89,13 @@ jobs:
             ${{ runner.os }}-go-1.18-${{ matrix.workdir }}
 
       - name: Prepare for test - Create tables
-        if: steps.changed-files.outputs.any_changed == 'true' || github.event_name != 'pull_request'
+        if: steps.changed-files.outputs.any_changed == 'true'
         run: |
           go run ./test/gen-tables.go | psql -h localhost -p 5432 -U postgres -d postgres -w
         working-directory: ${{ matrix.workdir }}
 
       - name: Run all policies
-        if: steps.changed-files.outputs.any_changed == 'true' || github.event_name != 'pull_request'
+        if: steps.changed-files.outputs.any_changed == 'true'
         run: |
           cd policies && psql -h localhost -p 5432 -U postgres -d postgres -w -f ./policy.sql
         working-directory: ${{ matrix.workdir }}

--- a/.github/workflows/test_unit.yml
+++ b/.github/workflows/test_unit.yml
@@ -45,7 +45,7 @@ jobs:
       - name: Check out code into the Go module directory
         uses: actions/checkout@v3
         with:
-          fetch-depth: 0
+          fetch-depth: 2
       - name: Get changed files
         id: changed-files
         uses: tj-actions/changed-files@v26
@@ -56,12 +56,12 @@ jobs:
           files_ignore: |
             ${{ matrix.workdir }}/CHANGELOG.md
       - name: Set up Go 1.x
-        if: steps.changed-files.outputs.any_changed == 'true' || github.event_name != 'pull_request'
+        if: steps.changed-files.outputs.any_changed == 'true'
         uses: actions/setup-go@v3
         with:
           go-version: 1.18
       - uses: actions/cache@v3
-        if: steps.changed-files.outputs.any_changed == 'true' || github.event_name != 'pull_request'
+        if: steps.changed-files.outputs.any_changed == 'true'
         with:
           path: |
             ~/.cache/go-build
@@ -71,11 +71,11 @@ jobs:
             ${{ runner.os }}-go-1.18-${{ matrix.workdir }}
 
       - name: Get dependencies
-        if: steps.changed-files.outputs.any_changed == 'true' || github.event_name != 'pull_request'
+        if: steps.changed-files.outputs.any_changed == 'true'
         working-directory: ${{ matrix.workdir }}
         run: go get -v -t -d ./...
 
       - name: Test
-        if: steps.changed-files.outputs.any_changed == 'true' || github.event_name != 'pull_request'
+        if: steps.changed-files.outputs.any_changed == 'true'
         run: go test -v ./...
         working-directory: ${{ matrix.workdir }}

--- a/.github/workflows/validate_release.yml
+++ b/.github/workflows/validate_release.yml
@@ -20,8 +20,6 @@ jobs:
       - name: Checkout
         if: startsWith(github.head_ref, 'release-please--branches--main--components')
         uses: actions/checkout@v3
-        with:
-          fetch-depth: 0
       - name: Set up Go
         if: startsWith(github.head_ref, 'release-please--branches--main--components')
         uses: actions/setup-go@v3


### PR DESCRIPTION
<!-- 🎉 Thank you for making CloudQuery awesome by submitting a PR 🎉 -->

#### Summary

Some CI improvments:
1. `fetch-depth: 0` fetches all branches, tags, history etc. For diffing `fetch-depth: 2` should be fine
2. Remove dead code - `github.event_name != 'pull_request'` checks are not needed anymore
3.  Remove hard coded components in SQL and Docs CI as we can check if the relevant files for the tests exist

---

Use the following steps to ensure your PR is ready to be reviewed

- [x] Read the [contribution guidelines](../blob/main/CONTRIBUTING.md) 🧑‍🎓
- [x] Test locally on your own infrastructure
- [x] Run `go fmt` to format your code 🖊
- [x] Lint your changes via `golangci-lint run` 🚨 (install golangci-lint [here](https://golangci-lint.run/usage/install/#local-installation)) 
- [x] Update or add tests 🧪
- [x] Ensure the status checks below are successful ✅
