### PR TITLE
doc: GitHub Plugin Grammar fixes

### DIFF
--- a/plugins/source/github/docs/index.md
+++ b/plugins/source/github/docs/index.md
@@ -10,17 +10,17 @@ cloudquery init github
 
 ## Authentication
 
-CloudQuery requires only a Personal Access Token. follow this [guide](https://docs.github.com/en/enterprise-server@3.4/authentication/keeping-your-account-and-data-secure/creating-a-personal-access-token) by github
+CloudQuery requires only a Personal Access Token. follow this [guide](https://docs.github.com/en/enterprise-server@3.4/authentication/keeping-your-account-and-data-secure/creating-a-personal-access-token) by GitHub
 on how to create a personal access token for CloudQuery.
 
 ## Configuration
 
-CloudQuery needs to be authenticated with your Github account's Personal Token in order to fetch information about your Github organizations.
-CloudQuery requires only *read* permissions (we will never make any changes to your github account or organizations),
+CloudQuery needs to be authenticated with your GitHub account's Personal Token in order to fetch information about your GitHub organizations.
+CloudQuery requires only *read* permissions (we will never make any changes to your GitHub account or organizations),
 so, following the principle of least privilege, it's recommended to grant it read-only permissions.
 
-Add the following Block your your providers list in your `cloudquery.yml` configuration. Cloudquery will
-fetch information about all the organizations you specify in `orgs`.
+Add the following block to your providers list in your `cloudquery.yml` configuration. CloudQuery will
+fetch information about all the organizations specified in `orgs`.
 
 ```yaml
 - name: github


### PR DESCRIPTION
GitHub and CloudQuery have inconsistent casing.
A few grammar fixes.
