### PR TITLE
chore(ci): Remove broken links workflow concurrency group

### DIFF
--- a/.github/workflows/broken_links.yml
+++ b/.github/workflows/broken_links.yml
@@ -21,9 +21,6 @@ jobs:
   check-broken-links:
     runs-on: ubuntu-latest
     timeout-minutes: 30
-    concurrency:
-      group: ${{ github.workflow }}-${{ github.ref }}
-      cancel-in-progress: true
     steps:
       - id: check-labels
         if: github.event_name == 'pull_request'


### PR DESCRIPTION
<!-- 🎉 Thank you for making CloudQuery awesome by submitting a PR 🎉 -->

#### Summary

We don't run this workflow that often now due to https://github.com/cloudquery/cloudquery/pull/1699 so no need for the concurrency group as it cancels in progress workflows, see https://github.com/cloudquery/cloudquery/actions/runs/2992996017
![image](https://user-images.githubusercontent.com/26760571/188451114-f2954bfa-4f47-4cf4-912e-a1c326ee30c7.png)

---

Use the following steps to ensure your PR is ready to be reviewed

- [ ] Read the [contribution guidelines](../blob/main/CONTRIBUTING.md) 🧑‍🎓
- [ ] Test locally on your own infrastructure
- [ ] Run `go fmt` to format your code 🖊
- [ ] Lint your changes via `golangci-lint run` 🚨 (install golangci-lint [here](https://golangci-lint.run/usage/install/#local-installation)) 
- [ ] Update or add tests 🧪
- [ ] Ensure the status checks below are successful ✅
