### PR TITLE
chore: Remove GCP lint provider doc rule

### DIFF
--- a/.github/repo_settings.yml
+++ b/.github/repo_settings.yml
@@ -46,7 +46,6 @@ branchProtectionRules:
     - Linter (plugins/source/gcp)
     - Unit Tests (plugins/source/gcp)
     - Build (plugins/source/gcp)
-    - Lint Provider Doc (plugins/source/gcp)
 
     - Linter (plugins/source/github)
     - Unit Tests (plugins/source/github)


### PR DESCRIPTION
<!-- 🎉 Thank you for making CloudQuery awesome by submitting a PR 🎉 -->

#### Summary

Until we bring back doc generation

---

Use the following steps to ensure your PR is ready to be reviewed

- [ ] Read the [contribution guidelines](../blob/main/CONTRIBUTING.md) 🧑‍🎓
- [ ] Test locally on your own infrastructure
- [ ] Run `go fmt` to format your code 🖊
- [ ] Lint your changes via `golangci-lint run` 🚨 (install golangci-lint [here](https://golangci-lint.run/usage/install/#local-installation)) 
- [ ] Update or add tests 🧪
- [ ] Ensure the status checks below are successful ✅
