### PR TITLE
feat: Generate auto-filled config

### DIFF
--- a/cli/cmd/generate.go
+++ b/cli/cmd/generate.go
@@ -5,9 +5,8 @@ import (
 	"embed"
 	"fmt"
 	"os"
-	"text/template"
-
 	"strings"
+	"text/template"
 
 	"github.com/cloudquery/cloudquery/cli/internal/enum"
 	"github.com/cloudquery/cloudquery/cli/internal/plugins"

--- a/cli/cmd/generate.go
+++ b/cli/cmd/generate.go
@@ -2,8 +2,10 @@ package cmd
 
 import (
 	"bufio"
+	"embed"
 	"fmt"
 	"os"
+	"text/template"
 
 	"strings"
 
@@ -13,6 +15,9 @@ import (
 	"github.com/rs/zerolog/log"
 	"github.com/spf13/cobra"
 )
+
+//go:embed templates/*.go.tpl
+var templatesFS embed.FS
 
 const (
 	initShort   = "Generate initial config file for source and destination plugins"
@@ -73,25 +78,38 @@ func genSource(cmd *cobra.Command, path string, pm *plugins.PluginManager, regis
 		Registry: registry,
 		Version:  version,
 	}
+	sourceSpec.SetDefaults()
+
 	plugin, err := pm.NewSourcePlugin(cmd.Context(), sourceSpec)
 	if err != nil {
 		return fmt.Errorf("failed to create source plugin: %w", err)
 	}
 	defer plugin.Close()
 	client := plugin.GetClient()
+
+	name, err := client.Name(cmd.Context())
+	if err != nil {
+		return fmt.Errorf("failed to get plugin name: %w", err)
+	}
+	sourceSpec.Name = name
+
+	version, err = client.Version(cmd.Context())
+	if err != nil {
+		return fmt.Errorf("failed to get plugin name: %w", err)
+	}
+	sourceSpec.Version = version
+
 	cfg, err := client.ExampleConfig(cmd.Context())
 	if err != nil {
 		return fmt.Errorf("failed to get example config: %w", err)
 	}
+	sourceSpec.Spec = cfg
+
 	configPath := outputFile
 	if configPath == "" {
-		name, err := client.Name(cmd.Context())
-		if err != nil {
-			return fmt.Errorf("failed to get plugin name: %w", err)
-		}
 		configPath = name + ".yml"
 	}
-	err = writeFile(configPath, cfg)
+	err = writeSource(configPath, sourceSpec)
 	if err != nil {
 		return fmt.Errorf("failed to write file: %w", err)
 	}
@@ -105,25 +123,37 @@ func genDestination(cmd *cobra.Command, path string, pm *plugins.PluginManager, 
 		Path:     path,
 		Registry: registry,
 	}
+	destSpec.SetDefaults()
+
 	destPlugin, err := pm.NewDestinationPlugin(cmd.Context(), destSpec)
 	if err != nil {
 		return fmt.Errorf("failed to get plugin client: %w", err)
 	}
 	defer destPlugin.Close()
 	client := destPlugin.GetClient()
+	name, err := client.Name(cmd.Context())
+	if err != nil {
+		return fmt.Errorf("failed to get plugin name: %w", err)
+	}
+	destSpec.Name = name
+
+	version, err := client.Version(cmd.Context())
+	if err != nil {
+		return fmt.Errorf("failed to get plugin name: %w", err)
+	}
+	destSpec.Version = version
+
 	cfg, err := client.GetExampleConfig(cmd.Context())
 	if err != nil {
 		return fmt.Errorf("failed to get example config: %w", err)
 	}
+	destSpec.Spec = cfg
+
 	configPath := outputFile
 	if configPath == "" {
-		name, err := client.Name(cmd.Context())
-		if err != nil {
-			return fmt.Errorf("failed to get plugin name: %w", err)
-		}
 		configPath = name + ".yml"
 	}
-	err = writeFile(configPath, cfg)
+	err = writeDestination(configPath, destSpec)
 	if err != nil {
 		return fmt.Errorf("failed to write file: %w", err)
 	}
@@ -131,16 +161,37 @@ func genDestination(cmd *cobra.Command, path string, pm *plugins.PluginManager, 
 	return nil
 }
 
-func writeFile(path, content string) error {
+func writeSource(path string, sourceSpec specs.Source) error {
+	return writeConfig(path, "source.go.tpl", sourceSpec)
+}
+
+func writeDestination(path string, destinationSpec specs.Destination) error {
+	return writeConfig(path, "destination.go.tpl", destinationSpec)
+}
+
+func writeConfig(path, cfgTemplate string, spec interface{}) error {
 	f, err := os.OpenFile(path, os.O_CREATE|os.O_WRONLY|os.O_EXCL, 0644)
 	if err != nil {
 		return fmt.Errorf("failed to create file: %w", err)
 	}
 	defer f.Close()
-	w := bufio.NewWriter(f)
-	_, err = w.WriteString(content)
+
+	tpl, err := template.New(cfgTemplate).Funcs(template.FuncMap{
+		"indent": indentSpaces,
+	}).ParseFS(templatesFS, "templates/"+cfgTemplate)
 	if err != nil {
-		return err
+		return fmt.Errorf("failed to parse template: %w", err)
+	}
+
+	w := bufio.NewWriter(f)
+	err = tpl.Execute(w, spec)
+	if err != nil {
+		return fmt.Errorf("failed to execute template: %w", err)
 	}
 	return w.Flush()
+}
+
+func indentSpaces(text string, spaces int) string {
+	s := strings.Repeat(" ", spaces)
+	return s + strings.ReplaceAll(text, "\n", "\n"+s)
 }

--- a/cli/cmd/generate_test.go
+++ b/cli/cmd/generate_test.go
@@ -4,10 +4,69 @@ import (
 	"io/ioutil"
 	"os"
 	"path"
+	"strings"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
 )
+
+const wantSourceConfig = `
+kind: source
+spec:
+  # Name of the plugin.
+  name: "test"
+
+  # Version of the plugin to use.
+  version: "development"
+
+  # Registry to use (one of "github", "local" or "grpc").
+  registry: "github"
+
+  # Path to plugin. Required format depends on the registry.
+  path: "cloudquery/test"
+
+  # List of tables to sync.
+  tables: ["*"]
+
+  ## Tables to skip during sync. Optional.
+  # skip_tables: []
+
+  # Names of destination plugins to sync to.
+  destinations: []
+
+  ## Approximate cap on number of requests to perform concurrently. Optional.
+  # max_goroutines: 5
+
+  # Plugin-specific configuration.
+  spec:
+    
+    # This is an example config file for the test plugin.
+    account_ids: []
+`
+
+const wantDestinationConfig = `
+kind: destination
+spec:
+  # Name of the plugin.
+  name: "postgresql"
+
+  # Version of the plugin to use.
+  version: "v0.0.1"
+
+  # Registry to use (one of "github", "local" or "grpc").
+  registry: "github"
+
+  # Path to plugin. Required format depends on the registry.
+  path: "cloudquery/postgresql"
+
+  # Write mode (either "overwrite" or "append").
+  write_mode: "append"
+
+  # Plugin-specific configuration.
+  spec:
+    
+    connection_string: "postgresql://user:password@localhost:5432/dbname"
+`
 
 func TestGenerate(t *testing.T) {
 	tmpdir, tmpErr := os.MkdirTemp("", "generate_test_*")
@@ -16,9 +75,10 @@ func TestGenerate(t *testing.T) {
 	}
 	defer os.RemoveAll(tmpdir)
 
-	t.Run("with output file", func(t *testing.T) {
-		output := path.Join(tmpdir, "test.yml")
+	t.Run("generate source", func(t *testing.T) {
+		output := path.Join(tmpdir, "test-source.yml")
 		cmd := NewCmdRoot()
+
 		cmd.SetArgs([]string{"generate", "source", "test", "--output", output})
 		if err := cmd.Execute(); err != nil {
 			t.Fatal(err)
@@ -29,12 +89,35 @@ func TestGenerate(t *testing.T) {
 		if err != nil {
 			t.Fatalf("error reading config file output: %v ", err)
 		}
-		wantConfig := `
-# This is an example config file for the test plugin.
-account_ids: []
-`
-		if diff := cmp.Diff(string(cfg), wantConfig); diff != "" {
-			t.Errorf("generated config not as expected (+got, -want): %v", diff)
+		cfgStr := strings.TrimSpace(string(cfg))
+		want := strings.TrimSpace(wantSourceConfig)
+		if diff := cmp.Diff(cfgStr, want); diff != "" {
+			t.Errorf("generated source config not as expected (-got, +want): %v", diff)
+		}
+	})
+
+	t.Run("generate destination", func(t *testing.T) {
+		// TODO: Change this to use a test destination plugin when we have one.
+		//       For now, this test can be manually run against the postgresql
+		//       plugin by commenting out this skip line.
+		t.Skip()
+
+		output := path.Join(tmpdir, "test-destination.yml")
+		cmd := NewCmdRoot()
+		cmd.SetArgs([]string{"generate", "destination", "postgresql", "--output", output})
+		if err := cmd.Execute(); err != nil {
+			t.Fatal(err)
+		}
+
+		// check the generated config
+		cfg, err := ioutil.ReadFile(output)
+		if err != nil {
+			t.Fatalf("error reading config file output: %v ", err)
+		}
+		cfgStr := strings.TrimSpace(string(cfg))
+		want := strings.TrimSpace(wantDestinationConfig)
+		if diff := cmp.Diff(cfgStr, want); diff != "" {
+			t.Errorf("generated source config not as expected (-got, +want): %v", diff)
 		}
 	})
 }

--- a/cli/cmd/templates/destination.go.tpl
+++ b/cli/cmd/templates/destination.go.tpl
@@ -1,0 +1,20 @@
+kind: destination
+spec:
+  # Name of the plugin.
+  name: "{{.Name}}"
+
+  # Version of the plugin to use.
+  version: "{{.Version}}"
+
+  # Registry to use (one of "github", "local" or "grpc").
+  registry: "{{.Registry}}"
+
+  # Path to plugin. Required format depends on the registry.
+  path: "{{.Path}}"
+
+  # Write mode (either "overwrite" or "append").
+  write_mode: "{{.WriteMode}}"
+
+  # Plugin-specific configuration.
+  spec:
+{{indent .Spec 4}}

--- a/cli/cmd/templates/source.go.tpl
+++ b/cli/cmd/templates/source.go.tpl
@@ -1,0 +1,29 @@
+kind: source
+spec:
+  # Name of the plugin.
+  name: "{{.Name}}"
+
+  # Version of the plugin to use.
+  version: "{{.Version}}"
+
+  # Registry to use (one of "github", "local" or "grpc").
+  registry: "{{.Registry}}"
+
+  # Path to plugin. Required format depends on the registry.
+  path: "{{.Path}}"
+
+  # List of tables to sync.
+  tables: ["*"]
+
+  ## Tables to skip during sync. Optional.
+  # skip_tables: []
+
+  # Names of destination plugins to sync to.
+  destinations: []
+
+  ## Approximate cap on number of requests to perform concurrently. Optional.
+  # max_goroutines: {{or .MaxGoRoutines 5 }}
+
+  # Plugin-specific configuration.
+  spec:
+{{indent .Spec 4}}

--- a/cli/internal/plugins/plugins.go
+++ b/cli/internal/plugins/plugins.go
@@ -7,6 +7,7 @@ package plugins
 import (
 	"archive/zip"
 	"bufio"
+	"context"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -15,8 +16,6 @@ import (
 	"path/filepath"
 	"runtime"
 	"strings"
-
-	"context"
 
 	"github.com/cloudquery/cloudquery/cli/internal/destinations/postgresql"
 	"github.com/cloudquery/cloudquery/cli/internal/versions"

--- a/plugins/source/gcp/resources/plugin/plugin.go
+++ b/plugins/source/gcp/resources/plugin/plugin.go
@@ -10,29 +10,25 @@ var (
 )
 
 const exampleConfig = `
-kind: source
-spec:
-  tables: ["*"]
-  spec:
-    # Optional. List of folders to get projects from. Required permission: resourcemanager.projects.list
-    # folder_ids:
-    # 	- "organizations/<ORG_ID>"
-    # 	- "folders/<FOLDER_ID>"
-    # Optional. Maximum level of folders to recurse into
-    # folders_max_depth: 5
-    # Optional. If not specified either using all projects accessible.
-    # project_ids:
-    # 	- "<CHANGE_THIS_TO_YOUR_PROJECT_ID>"
-    # Optional. ServiceAccountKeyJSON passed as value instead of a file path, can be passed also via env: CQ_SERVICE_ACCOUNT_KEY_JSON
-    # service_account_key_json: <YOUR_JSON_SERVICE_ACCOUNT_KEY_DATA>
-    # Optional. GRPC Retry/backoff configuration, time units in seconds. Documented in https://github.com/grpc/grpc/blob/master/doc/connection-backoff.md
-    # backoff_base_delay: 1
-    # backoff_multiplier: 1.6
-    # backoff_max_delay: 120
-    # backoff_jitter: 0.2
-    # backoff_min_connect_timeout = 0
-    # Optional. Max amount of retries for retrier, defaults to max 3 retries.
-    # max_retries: 3
+## Optional. List of folders to get projects from. Required permission: resourcemanager.projects.list
+# folder_ids:
+# 	- "organizations/<ORG_ID>"
+# 	- "folders/<FOLDER_ID>"
+## Optional. Maximum level of folders to recurse into
+# folders_max_depth: 5
+## Optional. If not specified either using all projects accessible.
+# project_ids:
+# 	- "<CHANGE_THIS_TO_YOUR_PROJECT_ID>"
+## Optional. ServiceAccountKeyJSON passed as value instead of a file path, can be passed also via env: CQ_SERVICE_ACCOUNT_KEY_JSON
+# service_account_key_json: <YOUR_JSON_SERVICE_ACCOUNT_KEY_DATA>
+## Optional. GRPC Retry/backoff configuration, time units in seconds. Documented in https://github.com/grpc/grpc/blob/master/doc/connection-backoff.md
+# backoff_base_delay: 1
+# backoff_multiplier: 1.6
+# backoff_max_delay: 120
+# backoff_jitter: 0.2
+# backoff_min_connect_timeout = 0
+## Optional. Max amount of retries for retrier, defaults to max 3 retries.
+# max_retries: 3
 `
 
 func Plugin() *plugins.SourcePlugin {

--- a/plugins/source/heroku/plugin/plugin.go
+++ b/plugins/source/heroku/plugin/plugin.go
@@ -8,21 +8,17 @@ import (
 )
 
 const exampleConfig = `
-kind: source
-spec:
-  tables: ["*"]
-  spec:
-    # Required. OAuth token to authenticate with Heroku API
-    token: <token>
-    
-    # Optional. GRPC Retry/backoff configuration, time units in seconds. Documented in https://github.com/grpc/grpc/blob/master/doc/connection-backoff.md
-    # backoff_base_delay: 1
-    # backoff_multiplier: 1.6
-    # backoff_max_delay: 120
-    # backoff_jitter: 0.2
-    # backoff_min_connect_timeout = 0
-    # Optional. Max amount of retries for retrier, defaults to max 3 retries.
-    # max_retries: 3
+# Required. OAuth token to authenticate with Heroku API
+token: <token>
+
+## Optional. GRPC Retry/backoff configuration, time units in seconds. Documented in https://github.com/grpc/grpc/blob/master/doc/connection-backoff.md
+# backoff_base_delay: 1
+# backoff_multiplier: 1.6
+# backoff_max_delay: 120
+# backoff_jitter: 0.2
+# backoff_min_connect_timeout = 0
+## Optional. Max amount of retries for retrier, defaults to max 3 retries.
+# max_retries: 3
 `
 
 var (


### PR DESCRIPTION
Adds auto-filled config to the `generate` command. Both `source` and `destination` plugins are supported. Plugins should now only return the part of the config relevant to their own configuration. This PR already updates the GCP and Heroku plugins to do this.

Follow-up to https://github.com/cloudquery/cloudquery/pull/1746 that only updates the CLI, no SDK changes.