### PR TITLE
fix(cli): Windows verification check

### DIFF
--- a/cli/pkg/plugin/registry/validate.go
+++ b/cli/pkg/plugin/registry/validate.go
@@ -1,4 +1,4 @@
-//nolint: staticcheck
+// nolint: staticcheck
 package registry
 
 import (
@@ -77,6 +77,10 @@ func validateChecksumProvider(providerName string, providerPath string, checksum
 		}
 		nameWithOSAndArch := fmt.Sprintf("%s_%s_%s", providerName, runtime.GOOS, runtime.GOARCH)
 		oldNameWithOSAndArch := fmt.Sprintf("cq-provider-%s", nameWithOSAndArch)
+		if runtime.GOOS == "windows" {
+			nameWithOSAndArch += ".exe"
+			oldNameWithOSAndArch += ".exe"
+		}
 		if nameWithOSAndArch == split[1] || oldNameWithOSAndArch == split[1] {
 			if split[0] == sha256sum {
 				return nil


### PR DESCRIPTION
<!-- 🎉 Thank you for making CloudQuery awesome by submitting a PR 🎉 -->

#### Summary

In latest v1 of the CLI checksum verification on Windows is broken due to https://github.com/cloudquery/cloudquery/pull/1637.
This PR targets a branch that should allow us to back-port fixes to v1.

Current workaround should be to run the CLI with the `--no-verify` flag on Windows

---

Use the following steps to ensure your PR is ready to be reviewed

- [ ] Read the [contribution guidelines](../blob/main/CONTRIBUTING.md) 🧑‍🎓
- [ ] Test locally on your own infrastructure
- [ ] Run `go fmt` to format your code 🖊
- [ ] Lint your changes via `golangci-lint run` 🚨 (install golangci-lint [here](https://golangci-lint.run/usage/install/#local-installation)) 
- [ ] Update or add tests 🧪
- [ ] Ensure the status checks below are successful ✅
