### PR TITLE
test: Fix GCP mock test

### DIFF
--- a/plugins/source/gcp/resources/services/kms/keyrings_mock_test.go
+++ b/plugins/source/gcp/resources/services/kms/keyrings_mock_test.go
@@ -35,12 +35,6 @@ func createKeyrings() (*client.Services, error) {
 		}
 	}()
 
-	item := kmsold.ListCryptoKeysResponse{}
-	if err := faker.FakeObject(&item); err != nil {
-		return nil, fmt.Errorf("failed to fake data: %w", err)
-	}
-	item.NextPageToken = ""
-
 	mux := httprouter.New()
 	mux.GET("/v1/projects/testProject/locations", func(w http.ResponseWriter, r *http.Request, _ httprouter.Params) {
 		resp := &kmsold.ListLocationsResponse{
@@ -91,6 +85,15 @@ type fakeKeyringsServer struct {
 
 func (*fakeKeyringsServer) ListKeyRings(context.Context, *pb.ListKeyRingsRequest) (*pb.ListKeyRingsResponse, error) {
 	resp := pb.ListKeyRingsResponse{}
+	if err := faker.FakeObject(&resp); err != nil {
+		return nil, fmt.Errorf("failed to fake data: %w", err)
+	}
+	resp.NextPageToken = ""
+	return &resp, nil
+}
+
+func (*fakeKeyringsServer) ListCryptoKeys(context.Context, *pb.ListCryptoKeysRequest) (*pb.ListCryptoKeysResponse, error) {
+	resp := pb.ListCryptoKeysResponse{}
 	if err := faker.FakeObject(&resp); err != nil {
 		return nil, fmt.Errorf("failed to fake data: %w", err)
 	}


### PR DESCRIPTION
<!-- 🎉 Thank you for making CloudQuery awesome by submitting a PR 🎉 -->

#### Summary

The tests on GCP started failing and I believe https://github.com/cloudquery/plugin-sdk/pull/85 is the reason.
This should fix it

---

Use the following steps to ensure your PR is ready to be reviewed

- [ ] Read the [contribution guidelines](../blob/main/CONTRIBUTING.md) 🧑‍🎓
- [ ] Test locally on your own infrastructure
- [ ] Run `go fmt` to format your code 🖊
- [ ] Lint your changes via `golangci-lint run` 🚨 (install golangci-lint [here](https://golangci-lint.run/usage/install/#local-installation)) 
- [ ] Update or add tests 🧪
- [ ] Ensure the status checks below are successful ✅
