### PR TITLE
fix: Quote kind string in generated yml files

### DIFF
--- a/cli/cmd/generate_test.go
+++ b/cli/cmd/generate_test.go
@@ -10,7 +10,7 @@ import (
 )
 
 const wantSourceConfig = `
-kind: source
+kind: "source"
 spec:
   # Name of the plugin.
   name: "test"
@@ -44,7 +44,7 @@ spec:
 `
 
 const wantDestinationConfig = `
-kind: destination
+kind: "destination"
 spec:
   # Name of the plugin.
   name: "postgresql"

--- a/cli/cmd/templates/destination.go.tpl
+++ b/cli/cmd/templates/destination.go.tpl
@@ -1,4 +1,4 @@
-kind: destination
+kind: "destination"
 spec:
   # Name of the plugin.
   name: "{{.Name}}"

--- a/cli/cmd/templates/source.go.tpl
+++ b/cli/cmd/templates/source.go.tpl
@@ -1,4 +1,4 @@
-kind: source
+kind: "source"
 spec:
   # Name of the plugin.
   name: "{{.Name}}"


### PR DESCRIPTION
<!-- 🎉 Thank you for making CloudQuery awesome by submitting a PR 🎉 -->

#### Summary

I noticed all strings are quoted except the `kind` property

---

Use the following steps to ensure your PR is ready to be reviewed

- [ ] Read the [contribution guidelines](../blob/main/CONTRIBUTING.md) 🧑‍🎓
- [ ] Test locally on your own infrastructure
- [ ] Run `go fmt` to format your code 🖊
- [ ] Lint your changes via `golangci-lint run` 🚨 (install golangci-lint [here](https://golangci-lint.run/usage/install/#local-installation)) 
- [ ] Update or add tests 🧪
- [ ] Ensure the status checks below are successful ✅
