### PR TITLE
feat: Add destination when generating sources

### DIFF
--- a/cli/cmd/generate.go
+++ b/cli/cmd/generate.go
@@ -73,7 +73,6 @@ func getDestinations(directory string) []string {
 	destinations := make([]string, 0)
 	for _, destination := range specReader.GetDestinations() {
 		destinations = append(destinations, destination.Name)
-
 	}
 
 	return destinations

--- a/cli/cmd/templates/source.go.tpl
+++ b/cli/cmd/templates/source.go.tpl
@@ -18,9 +18,12 @@ spec:
   ## Tables to skip during sync. Optional.
   # skip_tables: []
 
-  # Names of destination plugins to sync to.
+  # Names of destination plugins to sync to.{{ if .Destinations }}
+  destinations:{{ range .Destinations }}
+    - "{{.}}"{{ end }}
+  {{ else }}
   destinations: []
-
+  {{ end }}
   ## Approximate cap on number of requests to perform concurrently. Optional.
   # max_goroutines: {{or .MaxGoRoutines 5 }}
 


### PR DESCRIPTION
<!-- 🎉 Thank you for making CloudQuery awesome by submitting a PR 🎉 -->

#### Summary

Requires https://github.com/cloudquery/plugin-sdk/pull/120

Somehow fixes https://github.com/cloudquery/cloudquery/issues/1808.
When generating sources, if there's a destination generated already, add it to the source configuration.

Then I think our docs should first instruct users to generate the destination, then the sources.

---

Use the following steps to ensure your PR is ready to be reviewed

- [x] Read the [contribution guidelines](../blob/main/CONTRIBUTING.md) 🧑‍🎓
- [x] Test locally on your own infrastructure
- [x] Run `go fmt` to format your code 🖊
- [x] Lint your changes via `golangci-lint run` 🚨 (install golangci-lint [here](https://golangci-lint.run/usage/install/#local-installation)) 
- [x] Update or add tests 🧪
- [x] Ensure the status checks below are successful ✅
