### PR TITLE
fix: Resolve plugin version from GitHub registry instead of gRPC call

### DIFF
--- a/cli/cmd/generate.go
+++ b/cli/cmd/generate.go
@@ -80,7 +80,7 @@ func genSource(cmd *cobra.Command, path string, pm *plugins.PluginManager, regis
 	}
 	sourceSpec.SetDefaults()
 
-	plugin, err := pm.NewSourcePlugin(cmd.Context(), sourceSpec)
+	plugin, err := pm.NewSourcePlugin(cmd.Context(), &sourceSpec)
 	if err != nil {
 		return fmt.Errorf("failed to create source plugin: %w", err)
 	}
@@ -92,13 +92,6 @@ func genSource(cmd *cobra.Command, path string, pm *plugins.PluginManager, regis
 		return fmt.Errorf("failed to get plugin name: %w", err)
 	}
 	sourceSpec.Name = name
-
-	version, err = client.Version(cmd.Context())
-	if err != nil {
-		return fmt.Errorf("failed to get plugin name: %w", err)
-	}
-	sourceSpec.Version = version
-
 	cfg, err := client.ExampleConfig(cmd.Context())
 	if err != nil {
 		return fmt.Errorf("failed to get example config: %w", err)

--- a/cli/cmd/generate_test.go
+++ b/cli/cmd/generate_test.go
@@ -16,7 +16,7 @@ spec:
   name: "test"
 
   # Version of the plugin to use.
-  version: "development"
+  version: "v1.1.4"
 
   # Registry to use (one of "github", "local" or "grpc").
   registry: "github"

--- a/cli/cmd/sync.go
+++ b/cli/cmd/sync.go
@@ -59,7 +59,7 @@ func sync(cmd *cobra.Command, args []string) error {
 }
 
 func syncConnection(ctx context.Context, pm *plugins.PluginManager, specReader *specs.SpecReader, sourceSpec specs.Source) error {
-	sourcePlugin, err := pm.NewSourcePlugin(ctx, sourceSpec)
+	sourcePlugin, err := pm.NewSourcePlugin(ctx, &sourceSpec)
 	if err != nil {
 		return fmt.Errorf("failed to get source plugin client for %s: %w", sourceSpec.Name, err)
 	}

--- a/cli/internal/plugins/plugin_test.go
+++ b/cli/internal/plugins/plugin_test.go
@@ -49,7 +49,7 @@ func TestPluginManagerDownloadSource(t *testing.T) {
 	// this test is mainly a smoke test as we test all permutations in GetSourceClientTest
 	// which calls to download anyways.
 	pm := NewPluginManager(WithDirectory(dirName), WithLogger(l))
-	if _, err := pm.DownloadSource(ctx, specs.Source{
+	if _, err := pm.DownloadSource(ctx, &specs.Source{
 		Name:     "test",
 		Registry: specs.RegistryGithub,
 		Path:     "cloudquery/test",
@@ -70,7 +70,7 @@ func TestPluginManagerGetSourceClient(t *testing.T) {
 			}
 			defer os.RemoveAll(dirName)
 			pm := NewPluginManager(WithDirectory(dirName), WithLogger(l))
-			pl, err := pm.NewSourcePlugin(ctx, specs.Source{
+			pl, err := pm.NewSourcePlugin(ctx, &specs.Source{
 				Name:     tc.Name,
 				Registry: tc.Registry,
 				Path:     tc.Path,

--- a/cli/internal/plugins/plugins.go
+++ b/cli/internal/plugins/plugins.go
@@ -115,7 +115,7 @@ func NewPluginManager(opts ...PluginManagerOption) *PluginManager {
 }
 
 // DownloadSource downloads a plugin from the specified registry and return the path to plugin
-func (p *PluginManager) DownloadSource(ctx context.Context, spec specs.Source) (string, error) {
+func (p *PluginManager) DownloadSource(ctx context.Context, spec *specs.Source) (string, error) {
 	switch spec.Registry {
 	case specs.RegistryLocal, specs.RegistryGrpc:
 		fmt.Printf("Skipping plugin download. registry: %s, path: %s\n", spec.Registry, spec.Path)
@@ -128,7 +128,7 @@ func (p *PluginManager) DownloadSource(ctx context.Context, spec specs.Source) (
 	}
 }
 
-func (p *PluginManager) downloadSourceGitHub(ctx context.Context, spec specs.Source) (string, error) {
+func (p *PluginManager) downloadSourceGitHub(ctx context.Context, spec *specs.Source) (string, error) {
 	var err error
 	pathSplit := strings.Split(spec.Path, "/")
 	org, repo := pathSplit[0], pathSplit[1]
@@ -204,7 +204,7 @@ func (p *PluginManager) NewDestinationPlugin(ctx context.Context, spec specs.Des
 	}
 }
 
-func (p *PluginManager) NewSourcePlugin(ctx context.Context, spec specs.Source) (*SourcePlugin, error) {
+func (p *PluginManager) NewSourcePlugin(ctx context.Context, spec *specs.Source) (*SourcePlugin, error) {
 	pl := SourcePlugin{}
 	// var grpcTarget string
 	var pluginPath string


### PR DESCRIPTION
<!-- 🎉 Thank you for making CloudQuery awesome by submitting a PR 🎉 -->

#### Summary

This PR fixes https://github.com/cloudquery/docs/issues/216 which is still present in v2 and causing failures in https://github.com/cloudquery/cloudquery/pull/1848. Also somehow related to https://github.com/cloudquery/cloudquery/issues/908

If you try:
1. `gen source test`
2. `gen destination postgresql`
3. `gen sync .`
you'll get the follow error:
```
Loading specs from directory:  .
Downloading plugin from: https://github.com/cloudquery/cloudquery/releases/download/plugins/source/test/development/test_darwin_arm64.zip to: .cq/plugins/github/cloudquery/test/development/cq-source-test_darwin_arm64.zip 
Error: failed to sync source test: failed to get source plugin client for test: failed to download plugin: bad status: 404 Not Found. downloading https://github.com/cloudquery/cloudquery/releases/download/plugins/source/test/development/test_darwin_arm64.zip
exit status 1
```

This is because the test plugin doesn't embed the version correctly when released (and probably others too), thus reports a `development` version which is embedded in the config:
```yml
kind: "source"
spec:
  # Name of the plugin.
  name: "test"

  # Version of the plugin to use.
  version: "development"
...
```

Then the CLI tries to download that version from GitHub and fails.
Since we already know the version from GitHub I suggest we use that one instead of the gRPC call. For local/gRPC plugins the version is not important (at the moment).
The version is already set in https://github.com/cloudquery/cloudquery/blob/7a83a65446119b5339f5f3a3759f7f160a3716b4/cli/internal/plugins/plugins.go#L137 so I only needed to pass in a pointer

---

Use the following steps to ensure your PR is ready to be reviewed

- [ ] Read the [contribution guidelines](../blob/main/CONTRIBUTING.md) 🧑‍🎓
- [ ] Test locally on your own infrastructure
- [ ] Run `go fmt` to format your code 🖊
- [ ] Lint your changes via `golangci-lint run` 🚨 (install golangci-lint [here](https://golangci-lint.run/usage/install/#local-installation)) 
- [ ] Update or add tests 🧪
- [ ] Ensure the status checks below are successful ✅
