### PR TITLE
feat: Generate `postgresql` as default destination in `gen` command

### DIFF
--- a/cli/cmd/generate_test.go
+++ b/cli/cmd/generate_test.go
@@ -31,7 +31,7 @@ spec:
   # skip_tables: []
 
   # Names of destination plugins to sync to.
-  destinations: []
+  destinations: ["postgresql"]
 
   ## Approximate cap on number of requests to perform concurrently. Optional.
   # max_goroutines: 5

--- a/cli/cmd/templates/source.go.tpl
+++ b/cli/cmd/templates/source.go.tpl
@@ -19,7 +19,7 @@ spec:
   # skip_tables: []
 
   # Names of destination plugins to sync to.
-  destinations: []
+  destinations: ["postgresql"]
 
   ## Approximate cap on number of requests to perform concurrently. Optional.
   # max_goroutines: {{or .MaxGoRoutines 5 }}


### PR DESCRIPTION
Fixes https://github.com/cloudquery/cloudquery/issues/1808