### PR TITLE
fix: CLI dev version

### DIFF
--- a/cli/.goreleaser.prerelease.yaml
+++ b/cli/.goreleaser.prerelease.yaml
@@ -17,7 +17,7 @@ builds:
       - GO111MODULE=on
     main: ./main.go
     ldflags:
-      - -s -w -X github.com/cloudquery/cloudquery/cli/cmd.Version={{.Version}} -X github.com/cloudquery/cloudquery/cli/cmd.Commit={{.Commit}} -X github.com/cloudquery/cloudquery/cli/cmd.Date={{.Date}} -X github.com/cloudquery/cloudquery/cli/cmd.APIKey=28iMwucm5GXsoevNGSfDl1LC6zV
+      - -s -w -X github.com/cloudquery/cloudquery/cli/cmd.Version={{.Version}}
     goos:
       - windows
       - linux

--- a/cli/cmd/root.go
+++ b/cli/cmd/root.go
@@ -16,12 +16,7 @@ import (
 const sentryDsnDefault = "https://3d2f1b94bdb64884ab1a52f56ce56652@o1396617.ingest.sentry.io/6720193"
 
 var (
-	// Values for Commit and Date should be injected at build time with -ldflags "-X github.com/cloudquery/cloudquery/cli/cmd.Variable=Value"
-
-	Commit    = "development"
-	Date      = "unknown"
-	APIKey    = ""
-	Version   = "dev"
+	Version   = "development"
 	rootShort = "CloudQuery CLI"
 	rootLong  = `CloudQuery CLI
 
@@ -80,7 +75,7 @@ func NewCmdRoot() *cobra.Command {
 			err = sentry.Init(sentry.ClientOptions{
 				Debug:   false,
 				Dsn:     sentryDsn,
-				Release: "cloudquery@" + Commit,
+				Release: "cloudquery@" + Version,
 				// https://docs.sentry.io/platforms/go/configuration/options/#removing-default-integrations
 				Integrations: func(integrations []sentry.Integration) []sentry.Integration {
 					var filteredIntegrations []sentry.Integration


### PR DESCRIPTION
<!-- 🎉 Thank you for making CloudQuery awesome by submitting a PR 🎉 -->

#### Summary

In plugins we use `development` so we should have the same in the CLI (instead of `dev`).
Also I think we need only `Version` as we can get the other values from the Version tag

---

Use the following steps to ensure your PR is ready to be reviewed

- [ ] Read the [contribution guidelines](../blob/main/CONTRIBUTING.md) 🧑‍🎓
- [ ] Test locally on your own infrastructure
- [ ] Run `go fmt` to format your code 🖊
- [ ] Lint your changes via `golangci-lint run` 🚨 (install golangci-lint [here](https://golangci-lint.run/usage/install/#local-installation)) 
- [ ] Update or add tests 🧪
- [ ] Ensure the status checks below are successful ✅
