### PR TITLE
feat(sync): Default input directory to '.'

### DIFF
--- a/cli/cmd/sync.go
+++ b/cli/cmd/sync.go
@@ -26,7 +26,7 @@ func NewCmdSync() *cobra.Command {
 		Short:   fetchShort,
 		Long:    fetchShort,
 		Example: fetchExample,
-		Args:    cobra.ExactArgs(1),
+		Args:    cobra.MaximumNArgs(1),
 		RunE:    sync,
 	}
 	return cmd
@@ -34,7 +34,10 @@ func NewCmdSync() *cobra.Command {
 
 func sync(cmd *cobra.Command, args []string) error {
 	ctx := cmd.Context()
-	directory := args[0]
+	directory := "."
+	if len(args) > 0 {
+		directory = args[0]
+	}
 	fmt.Println("Loading specs from directory: ", directory)
 	specReader, err := specs.NewSpecReader(directory)
 	if err != nil {


### PR DESCRIPTION
<!-- 🎉 Thank you for making CloudQuery awesome by submitting a PR 🎉 -->

#### Summary

The `gen` command defaults to writing configuration files to the current directory.
I'd expect the `sync` command to have the same default.

---

Use the following steps to ensure your PR is ready to be reviewed

- [ ] Read the [contribution guidelines](../blob/main/CONTRIBUTING.md) 🧑‍🎓
- [ ] Test locally on your own infrastructure
- [ ] Run `go fmt` to format your code 🖊
- [ ] Lint your changes via `golangci-lint run` 🚨 (install golangci-lint [here](https://golangci-lint.run/usage/install/#local-installation)) 
- [ ] Update or add tests 🧪
- [ ] Ensure the status checks below are successful ✅
