### PR TITLE
fix: IAM users PK should be account_id + id, not ARN

### DIFF
--- a/plugins/source/aws/codegen/recipes/iam.go
+++ b/plugins/source/aws/codegen/recipes/iam.go
@@ -228,13 +228,24 @@ func IAMResources() []*Resource {
 		{
 			SubService:           "users",
 			Struct:               &iamService.UserWrapper{},
-			SkipFields:           []string{"Arn", "Tags"},
+			SkipFields:           []string{"Arn", "AccountId", "Id", "Tags"},
 			PostResourceResolver: `postIamUserResolver`,
 			ExtraColumns: []codegen.ColumnDefinition{
 				{
 					Name:     "arn",
 					Type:     schema.TypeString,
 					Resolver: `schema.PathResolver("Arn")`,
+				},
+				{
+					Name:     "account_id",
+					Type:     schema.TypeString,
+					Resolver: `schema.PathResolver("AccountId")`,
+					Options:  schema.ColumnCreationOptions{PrimaryKey: true},
+				},
+				{
+					Name:     "id",
+					Type:     schema.TypeString,
+					Resolver: `schema.PathResolver("Id")`,
 					Options:  schema.ColumnCreationOptions{PrimaryKey: true},
 				},
 				{


### PR DESCRIPTION
There is an edge case where ARN should not be used as the primary key: if a user gets deleted and then a new user gets created, the same ARN may get assigned. Instead, we should use account_id + id