### PR TITLE
fix: Regenerate iam users + some fixes

### DIFF
--- a/plugins/source/aws/codegen/recipes/iam.go
+++ b/plugins/source/aws/codegen/recipes/iam.go
@@ -248,7 +248,7 @@ func IAMResources() []*Resource {
 		{
 			SubService: "users",
 			Struct:     &types.User{},
-			SkipFields: []string{"Arn", "AccountId", "Id", "Tags"},
+			SkipFields: []string{"Arn", "AccountId", "UserId", "Tags"},
 			ExtraColumns: []codegen.ColumnDefinition{
 				{
 					Name:     "arn",
@@ -256,15 +256,15 @@ func IAMResources() []*Resource {
 					Resolver: `schema.PathResolver("Arn")`,
 				},
 				{
-					Name:     "account_id",
+					Name:     "id",
 					Type:     schema.TypeString,
-					Resolver: `schema.PathResolver("AccountId")`,
+					Resolver: `schema.PathResolver("UserId")`,
 					Options:  schema.ColumnCreationOptions{PrimaryKey: true},
 				},
 				{
-					Name:     "id",
+					Name:     "account_id",
 					Type:     schema.TypeString,
-					Resolver: `schema.PathResolver("Id")`,
+					Resolver: `client.ResolveAWSAccount`,
 					Options:  schema.ColumnCreationOptions{PrimaryKey: true},
 				},
 				{
@@ -296,7 +296,7 @@ func IAMResources() []*Resource {
 					{
 						Name:     "user_id",
 						Type:     schema.TypeString,
-						Resolver: `schema.ParentResourceFieldResolver("user_id")`,
+						Resolver: `schema.ParentResourceFieldResolver("id")`,
 					},
 				}...),
 		},
@@ -315,7 +315,7 @@ func IAMResources() []*Resource {
 					{
 						Name:     "user_id",
 						Type:     schema.TypeString,
-						Resolver: `schema.ParentResourceFieldResolver("user_id")`,
+						Resolver: `schema.ParentResourceFieldResolver("id")`,
 					},
 				}...),
 		},
@@ -334,7 +334,7 @@ func IAMResources() []*Resource {
 					{
 						Name:     "user_id",
 						Type:     schema.TypeString,
-						Resolver: `schema.ParentResourceFieldResolver("user_id")`,
+						Resolver: `schema.ParentResourceFieldResolver("id")`,
 					},
 				}...),
 		},
@@ -353,7 +353,7 @@ func IAMResources() []*Resource {
 					{
 						Name:     "user_id",
 						Type:     schema.TypeString,
-						Resolver: `schema.ParentResourceFieldResolver("user_id")`,
+						Resolver: `schema.ParentResourceFieldResolver("id")`,
 					},
 					{
 						Name:     "policy_document",

--- a/plugins/source/aws/resources/services/iam/credential_reports.go
+++ b/plugins/source/aws/resources/services/iam/credential_reports.go
@@ -22,14 +22,17 @@ func CredentialReports() *schema.Table {
 				},
 			},
 			{
-				Name:     "user",
-				Type:     schema.TypeString,
-				Resolver: schema.PathResolver("User"),
-			},
-			{
 				Name:     "user_creation_time",
 				Type:     schema.TypeTimestamp,
 				Resolver: schema.PathResolver("UserCreationTime"),
+				CreationOptions: schema.ColumnCreationOptions{
+					PrimaryKey: true,
+				},
+			},
+			{
+				Name:     "user",
+				Type:     schema.TypeString,
+				Resolver: schema.PathResolver("User"),
 			},
 			{
 				Name:     "password_status",

--- a/plugins/source/aws/resources/services/iam/user_access_keys.go
+++ b/plugins/source/aws/resources/services/iam/user_access_keys.go
@@ -27,7 +27,7 @@ func UserAccessKeys() *schema.Table {
 			{
 				Name:     "user_id",
 				Type:     schema.TypeString,
-				Resolver: schema.ParentResourceFieldResolver("user_id"),
+				Resolver: schema.ParentResourceFieldResolver("id"),
 			},
 			{
 				Name:     "access_key_id",

--- a/plugins/source/aws/resources/services/iam/user_attached_policies.go
+++ b/plugins/source/aws/resources/services/iam/user_attached_policies.go
@@ -26,7 +26,7 @@ func UserAttachedPolicies() *schema.Table {
 			{
 				Name:     "user_id",
 				Type:     schema.TypeString,
-				Resolver: schema.ParentResourceFieldResolver("user_id"),
+				Resolver: schema.ParentResourceFieldResolver("id"),
 			},
 			{
 				Name:     "policy_arn",

--- a/plugins/source/aws/resources/services/iam/user_groups.go
+++ b/plugins/source/aws/resources/services/iam/user_groups.go
@@ -26,7 +26,7 @@ func UserGroups() *schema.Table {
 			{
 				Name:     "user_id",
 				Type:     schema.TypeString,
-				Resolver: schema.ParentResourceFieldResolver("user_id"),
+				Resolver: schema.ParentResourceFieldResolver("id"),
 			},
 			{
 				Name:     "arn",

--- a/plugins/source/aws/resources/services/iam/user_policies.go
+++ b/plugins/source/aws/resources/services/iam/user_policies.go
@@ -26,7 +26,7 @@ func UserPolicies() *schema.Table {
 			{
 				Name:     "user_id",
 				Type:     schema.TypeString,
-				Resolver: schema.ParentResourceFieldResolver("user_id"),
+				Resolver: schema.ParentResourceFieldResolver("id"),
 			},
 			{
 				Name:     "policy_document",

--- a/plugins/source/aws/resources/services/iam/users.go
+++ b/plugins/source/aws/resources/services/iam/users.go
@@ -17,6 +17,19 @@ func Users() *schema.Table {
 				Name:     "arn",
 				Type:     schema.TypeString,
 				Resolver: schema.PathResolver("Arn"),
+			},
+			{
+				Name:     "id",
+				Type:     schema.TypeString,
+				Resolver: schema.PathResolver("UserId"),
+				CreationOptions: schema.ColumnCreationOptions{
+					PrimaryKey: true,
+				},
+			},
+			{
+				Name:     "account_id",
+				Type:     schema.TypeString,
+				Resolver: client.ResolveAWSAccount,
 				CreationOptions: schema.ColumnCreationOptions{
 					PrimaryKey: true,
 				},
@@ -35,11 +48,6 @@ func Users() *schema.Table {
 				Name:     "path",
 				Type:     schema.TypeString,
 				Resolver: schema.PathResolver("Path"),
-			},
-			{
-				Name:     "user_id",
-				Type:     schema.TypeString,
-				Resolver: schema.PathResolver("UserId"),
 			},
 			{
 				Name:     "user_name",


### PR DESCRIPTION
I neglected to regenerate the code before merging https://github.com/cloudquery/cloudquery/pull/1876 😮‍💨 (I will add back the automated check for codegen drift soon). This fixes it and changes the `user_id` column on the `users` table to be `id`.