### PR TITLE
fix: Version not embedded in test plugin

### DIFF
--- a/plugins/source/test/.goreleaser.yaml
+++ b/plugins/source/test/.goreleaser.yaml
@@ -1,5 +1,5 @@
 variables:
-  component: source/gcp
+  component: source/test
 
 project_name: plugins/source/test
 


### PR DESCRIPTION
<!-- 🎉 Thank you for making CloudQuery awesome by submitting a PR 🎉 -->

#### Summary

Apparently the issue with versions not being embedded is smaller than I thought. It was only related to the `test` plugin I was testing with

---

Use the following steps to ensure your PR is ready to be reviewed

- [ ] Read the [contribution guidelines](../blob/main/CONTRIBUTING.md) 🧑‍🎓
- [ ] Test locally on your own infrastructure
- [ ] Run `go fmt` to format your code 🖊
- [ ] Lint your changes via `golangci-lint run` 🚨 (install golangci-lint [here](https://golangci-lint.run/usage/install/#local-installation)) 
- [ ] Update or add tests 🧪
- [ ] Ensure the status checks below are successful ✅
