### PR TITLE
chore(release): Set Heroku initial version

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -13,6 +13,8 @@
   "plugins/source/gcp+FILLER": "0.0.0",
   "plugins/source/github": "0.1.10-pre.0",
   "plugins/source/github+FILLER": "0.0.0",
+  "plugins/source/heroku": "0.0.1-pre.0",
+  "plugins/source/heroku+FILLER": "0.0.0",
   "plugins/source/k8s": "0.6.4-pre.0",
   "plugins/source/k8s+FILLER": "0.0.0",
   "plugins/source/okta": "0.6.6-pre.0",


### PR DESCRIPTION
<!-- 🎉 Thank you for making CloudQuery awesome by submitting a PR 🎉 -->

#### Summary

Sets the initial version for Heroku so it doesn't start from `v1.0.0`

---

Use the following steps to ensure your PR is ready to be reviewed

- [ ] Read the [contribution guidelines](../blob/main/CONTRIBUTING.md) 🧑‍🎓
- [ ] Test locally on your own infrastructure
- [ ] Run `go fmt` to format your code 🖊
- [ ] Lint your changes via `golangci-lint run` 🚨 (install golangci-lint [here](https://golangci-lint.run/usage/install/#local-installation)) 
- [ ] Update or add tests 🧪
- [ ] Ensure the status checks below are successful ✅
