### PR TITLE
fix: Can't gen with specific version

### DIFF
--- a/cli/cmd/generate.go
+++ b/cli/cmd/generate.go
@@ -77,9 +77,6 @@ func getSourceSpec(path string, registry specs.Registry) specs.Source {
 		version := "latest"
 		if len(versionParts) > 1 {
 			version = versionParts[1]
-			if !strings.HasPrefix(version, "v") {
-				version = "v" + version
-			}
 		}
 		return specs.Source{
 			Name:     name,


### PR DESCRIPTION
<!-- 🎉 Thank you for making CloudQuery awesome by submitting a PR 🎉 -->

#### Summary

`gen` With a specific plugin version doesn't work, which means we can't test pre-releases.

e.g. `gen source heroku@v0.1.0-pre.0` fails.

This PR fixes it

---

Use the following steps to ensure your PR is ready to be reviewed

- [ ] Read the [contribution guidelines](../blob/main/CONTRIBUTING.md) 🧑‍🎓
- [ ] Test locally on your own infrastructure
- [ ] Run `go fmt` to format your code 🖊
- [ ] Lint your changes via `golangci-lint run` 🚨 (install golangci-lint [here](https://golangci-lint.run/usage/install/#local-installation)) 
- [ ] Update or add tests 🧪
- [ ] Ensure the status checks below are successful ✅
