### PR TITLE
fix: Add config_exists field back to aws_s3_accounts (v2)

### DIFF
--- a/plugins/source/aws/codegen/recipes/s3.go
+++ b/plugins/source/aws/codegen/recipes/s3.go
@@ -2,10 +2,11 @@ package recipes
 
 import (
 	"github.com/aws/aws-sdk-go-v2/service/s3/types"
-	s3controlTypes "github.com/aws/aws-sdk-go-v2/service/s3control/types"
 	"github.com/cloudquery/cloudquery/plugins/source/aws/resources/services/s3"
 	"github.com/cloudquery/plugin-sdk/codegen"
 	"github.com/cloudquery/plugin-sdk/schema"
+	"reflect"
+	"strings"
 )
 
 func S3Resources() []*Resource {
@@ -13,7 +14,7 @@ func S3Resources() []*Resource {
 
 		{
 			SubService: "accounts",
-			Struct:     &s3controlTypes.PublicAccessBlockConfiguration{},
+			Struct:     &s3.PublicAccessBlockConfigurationWrapper{},
 			SkipFields: []string{"ARN"},
 			ExtraColumns: []codegen.ColumnDefinition{
 				{
@@ -107,6 +108,10 @@ func S3Resources() []*Resource {
 	for _, r := range resources {
 		r.Service = "s3"
 		r.Multiplex = "client.AccountMultiplex"
+		structName := reflect.ValueOf(r.Struct).Elem().Type().Name()
+		if strings.Contains(structName, "Wrapper") {
+			r.UnwrapEmbeddedStructs = true
+		}
 	}
 	return resources
 }

--- a/plugins/source/aws/resources/services/s3/accounts.go
+++ b/plugins/source/aws/resources/services/s3/accounts.go
@@ -41,6 +41,11 @@ func Accounts() *schema.Table {
 				Type:     schema.TypeBool,
 				Resolver: schema.PathResolver("RestrictPublicBuckets"),
 			},
+			{
+				Name:     "config_exists",
+				Type:     schema.TypeBool,
+				Resolver: schema.PathResolver("ConfigExists"),
+			},
 		},
 	}
 }

--- a/plugins/source/aws/resources/services/s3/accounts_fetch.go
+++ b/plugins/source/aws/resources/services/s3/accounts_fetch.go
@@ -11,7 +11,7 @@ import (
 	"github.com/pkg/errors"
 )
 
-type S3AccountConfig struct {
+type PublicAccessBlockConfigurationWrapper struct {
 	s3controlTypes.PublicAccessBlockConfiguration
 	ConfigExists bool
 }
@@ -30,9 +30,9 @@ func fetchS3Accounts(ctx context.Context, meta schema.ClientMeta, _ *schema.Reso
 		if !errors.As(err, &nspabc) {
 			return err
 		}
-		res <- S3AccountConfig{s3controlTypes.PublicAccessBlockConfiguration{}, false}
+		res <- PublicAccessBlockConfigurationWrapper{s3controlTypes.PublicAccessBlockConfiguration{}, false}
 	} else {
-		res <- S3AccountConfig{*resp.PublicAccessBlockConfiguration, true}
+		res <- PublicAccessBlockConfigurationWrapper{*resp.PublicAccessBlockConfiguration, true}
 	}
 
 	return nil


### PR DESCRIPTION
Closes https://github.com/cloudquery/cloudquery/issues/1925
