### PR TITLE
chore(ci): Trigger markdown linting on all md files

### DIFF
--- a/.github/workflows/lint_markdown.yml
+++ b/.github/workflows/lint_markdown.yml
@@ -4,7 +4,7 @@ on:
   pull_request:
     paths:
       - ".github/workflow/lint_markdown.yml"
-      - "*.md"
+      - "**.md"
 
 jobs:
   lint-grammar:


### PR DESCRIPTION
<!-- 🎉 Thank you for making CloudQuery awesome by submitting a PR 🎉 -->

#### Summary

Currently the linting is triggered only on files in the root directory

---

Use the following steps to ensure your PR is ready to be reviewed

- [ ] Read the [contribution guidelines](../blob/main/CONTRIBUTING.md) 🧑‍🎓
- [ ] Test locally on your own infrastructure
- [ ] Run `go fmt` to format your code 🖊
- [ ] Lint your changes via `golangci-lint run` 🚨 (install golangci-lint [here](https://golangci-lint.run/usage/install/#local-installation)) 
- [ ] Update or add tests 🧪
- [ ] Ensure the status checks below are successful ✅
