### PR TITLE
chore(ci-release): Get component dir from name

### DIFF
--- a/.github/workflows/validate_release.yml
+++ b/.github/workflows/validate_release.yml
@@ -15,8 +15,10 @@ jobs:
         if: startsWith(github.head_ref, 'release-please--branches--main--components')
         id: component
         run: |
-          source_branch=${{github.head_ref}}
-          echo ::set-output name=name::${source_branch##*-}
+          source_branch="release-please--branches--main--components--plugins-source-test"
+          component_name=${source_branch##*--}
+          component_dir=${component_name//\-/\/}
+          echo ::set-output name=name::${component_dir}
       - name: Checkout
         if: startsWith(github.head_ref, 'release-please--branches--main--components')
         uses: actions/checkout@v3


### PR DESCRIPTION
<!-- 🎉 Thank you for making CloudQuery awesome by submitting a PR 🎉 -->

#### Summary

We changed the component names to use `-` instead of `/` so we can't use them directly as directories anymore

---

Use the following steps to ensure your PR is ready to be reviewed

- [ ] Read the [contribution guidelines](../blob/main/CONTRIBUTING.md) 🧑‍🎓
- [ ] Test locally on your own infrastructure
- [ ] Run `go fmt` to format your code 🖊
- [ ] Lint your changes via `golangci-lint run` 🚨 (install golangci-lint [here](https://golangci-lint.run/usage/install/#local-installation)) 
- [ ] Update or add tests 🧪
- [ ] Ensure the status checks below are successful ✅
