### PR TITLE
feat: Use new tag format to download plugins

### DIFF
--- a/cli/cmd/generate_test.go
+++ b/cli/cmd/generate_test.go
@@ -16,7 +16,7 @@ spec:
   name: "test"
 
   # Version of the plugin to use.
-  version: "v1.1.4"
+  version: "v1.1.5"
 
   # Registry to use (one of "github", "local" or "grpc").
   registry: "github"

--- a/cli/internal/versions/versions.go
+++ b/cli/internal/versions/versions.go
@@ -58,7 +58,7 @@ func (c *Client) GetLatestPluginRelease(ctx context.Context, org, pluginType, pl
 }
 
 func (c *Client) readCLIManifest(ctx context.Context) (string, error) {
-	url := fmt.Sprintf(c.cloudQueryBaseURL + "/v1/cli.json")
+	url := fmt.Sprintf(c.cloudQueryBaseURL + "/v2/cli.json")
 	b, err := c.doRequest(ctx, url)
 	if err != nil {
 		return "", fmt.Errorf("reading manifest for cli: %w", err)
@@ -72,7 +72,7 @@ func (c *Client) readCLIManifest(ctx context.Context) (string, error) {
 }
 
 func (c *Client) readManifest(ctx context.Context, name string) (string, error) {
-	url := fmt.Sprintf(c.cloudQueryBaseURL+"/v1/%s-%s.json", "source", name)
+	url := fmt.Sprintf(c.cloudQueryBaseURL+"/v2/%s-%s.json", "source", name)
 	b, err := c.doRequest(ctx, url)
 	if err != nil {
 		return "", fmt.Errorf("reading manifest for %v: %w", name, err)
@@ -85,10 +85,10 @@ func (c *Client) readManifest(ctx context.Context, name string) (string, error) 
 	return extractVersionFromTag(mr.Latest), nil
 }
 
-// extractVersionFromTag takes a tag of the form "plugins/source/test/v0.1.21" and returns
+// extractVersionFromTag takes a tag of the form "plugins-source-test-v0.1.21" and returns
 // the version, i.e. "v0.1.21"
 func extractVersionFromTag(tag string) string {
-	parts := strings.Split(tag, "/")
+	parts := strings.Split(tag, "-")
 	return parts[len(parts)-1]
 }
 

--- a/cli/internal/versions/versions_test.go
+++ b/cli/internal/versions/versions_test.go
@@ -10,11 +10,11 @@ import (
 
 func TestClient_GetLatestPluginRelease(t *testing.T) {
 	cloudQueryServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.URL.Path != "/v1/source-aws.json" {
+		if r.URL.Path != "/v2/source-aws.json" {
 			w.WriteHeader(http.StatusNotFound)
 			return
 		}
-		fmt.Fprintf(w, `{"latest":"plugins/source/test/v1.2.3"}`)
+		fmt.Fprintf(w, `{"latest":"plugins-source-aws-v1.2.3"}`)
 	}))
 	defer cloudQueryServer.Close()
 
@@ -51,11 +51,11 @@ func TestClient_GetLatestPluginRelease(t *testing.T) {
 
 func TestClient_GetLatestCLIRelease(t *testing.T) {
 	cloudQueryServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.URL.Path != "/v1/cli.json" {
+		if r.URL.Path != "/v2/cli.json" {
 			w.WriteHeader(http.StatusNotFound)
 			return
 		}
-		fmt.Fprintf(w, `{"latest":"cli/v1.2.3"}`)
+		fmt.Fprintf(w, `{"latest":"cli-v1.2.3"}`)
 	}))
 	defer cloudQueryServer.Close()
 


### PR DESCRIPTION
<!-- 🎉 Thank you for making CloudQuery awesome by submitting a PR 🎉 -->

#### Summary

Updates the CLI to take plugins versions from the `v2` versions site which has a different structure for tags.
It still tries to download using the old format too to not break existing configurations.
Once we release all plugins under the v2 site we can remove the fallback code

---

Use the following steps to ensure your PR is ready to be reviewed

- [ ] Read the [contribution guidelines](../blob/main/CONTRIBUTING.md) 🧑‍🎓
- [ ] Test locally on your own infrastructure
- [ ] Run `go fmt` to format your code 🖊
- [ ] Lint your changes via `golangci-lint run` 🚨 (install golangci-lint [here](https://golangci-lint.run/usage/install/#local-installation)) 
- [ ] Update or add tests 🧪
- [ ] Ensure the status checks below are successful ✅
