### PR TITLE
fix: Add Github table docs back

### DIFF
--- a/plugins/source/github/docs/tables/github_action_billing.md
+++ b/plugins/source/github/docs/tables/github_action_billing.md
@@ -1,0 +1,13 @@
+
+# Table: github_action_billing
+ActionBilling represents a GitHub Action billing.
+## Columns
+| Name        | Type           | Description  |
+| ------------- | ------------- | -----  |
+|org|text|The Github Organization of the resource.|
+|total_minutes_used|bigint||
+|total_paid_minutes_used|float||
+|included_minutes|bigint||
+|minutes_used_breakdown_ubuntu|bigint||
+|minutes_used_breakdown_mac_os|bigint||
+|minutes_used_breakdown_windows|bigint||

--- a/plugins/source/github/docs/tables/github_external_group_members.md
+++ b/plugins/source/github/docs/tables/github_external_group_members.md
@@ -1,0 +1,11 @@
+
+# Table: github_external_group_members
+ExternalGroupMember represents a member of an external group.
+## Columns
+| Name        | Type           | Description  |
+| ------------- | ------------- | -----  |
+|external_group_cq_id|uuid|Unique CloudQuery ID of github_external_groups table (FK)|
+|member_id|bigint||
+|member_login|text||
+|member_name|text||
+|member_email|text||

--- a/plugins/source/github/docs/tables/github_external_group_teams.md
+++ b/plugins/source/github/docs/tables/github_external_group_teams.md
@@ -1,0 +1,9 @@
+
+# Table: github_external_group_teams
+ExternalGroupTeam represents a team connected to an external group.
+## Columns
+| Name        | Type           | Description  |
+| ------------- | ------------- | -----  |
+|external_group_cq_id|uuid|Unique CloudQuery ID of github_external_groups table (FK)|
+|team_id|bigint||
+|team_name|text||

--- a/plugins/source/github/docs/tables/github_external_groups.md
+++ b/plugins/source/github/docs/tables/github_external_groups.md
@@ -1,0 +1,10 @@
+
+# Table: github_external_groups
+ExternalGroup represents an external group.
+## Columns
+| Name        | Type           | Description  |
+| ------------- | ------------- | -----  |
+|org|text|The Github Organization of the resource.|
+|group_id|bigint||
+|group_name|text||
+|updated_at_time|timestamp without time zone||

--- a/plugins/source/github/docs/tables/github_hook_deliveries.md
+++ b/plugins/source/github/docs/tables/github_hook_deliveries.md
@@ -1,0 +1,22 @@
+
+# Table: github_hook_deliveries
+HookDelivery represents the data that is received from GitHub's Webhook Delivery API  GitHub API docs: - https://docs.github.com/en/rest/webhooks/repo-deliveries#list-deliveries-for-a-repository-webhook - https://docs.github.com/en/rest/webhooks/repo-deliveries#get-a-delivery-for-a-repository-webhook
+## Columns
+| Name        | Type           | Description  |
+| ------------- | ------------- | -----  |
+|hook_cq_id|uuid|Unique CloudQuery ID of github_hooks table (FK)|
+|id|bigint||
+|guid|text||
+|delivered_at_time|timestamp without time zone||
+|redelivery|boolean||
+|duration|float||
+|status|text||
+|status_code|bigint||
+|event|text||
+|action|text||
+|installation_id|bigint||
+|repository_id|bigint||
+|request_headers|jsonb||
+|request_raw_payload|bytea||
+|response_headers|jsonb||
+|response_raw_payload|bytea||

--- a/plugins/source/github/docs/tables/github_hooks.md
+++ b/plugins/source/github/docs/tables/github_hooks.md
@@ -1,0 +1,19 @@
+
+# Table: github_hooks
+Hook represents a GitHub (web and service) hook for a repository.
+## Columns
+| Name        | Type           | Description  |
+| ------------- | ------------- | -----  |
+|org|text|The Github Organization of the resource.|
+|created_at|timestamp without time zone||
+|updated_at|timestamp without time zone||
+|url|text||
+|id|bigint||
+|type|text||
+|name|text||
+|test_url|text||
+|ping_url|text||
+|last_response|jsonb||
+|config|jsonb|Only the following fields are used when creating a hook. Config is required.|
+|events|text[]||
+|active|boolean||

--- a/plugins/source/github/docs/tables/github_installations.md
+++ b/plugins/source/github/docs/tables/github_installations.md
@@ -1,0 +1,157 @@
+
+# Table: github_installations
+Installation represents a GitHub Apps installation.
+## Columns
+| Name        | Type           | Description  |
+| ------------- | ------------- | -----  |
+|org|text|The Github Organization of the resource.|
+|id|bigint||
+|node_id|text||
+|app_id|bigint||
+|app_slug|text||
+|target_id|bigint||
+|account_login|text||
+|account_id|bigint||
+|account_node_id|text||
+|account_avatar_url|text||
+|account_html_url|text||
+|account_gravatar_id|text||
+|account_name|text||
+|account_company|text||
+|account_blog|text||
+|account_location|text||
+|account_email|text||
+|account_hireable|boolean||
+|account_bio|text||
+|account_twitter_username|text||
+|account_public_repos|bigint||
+|account_public_gists|bigint||
+|account_followers|bigint||
+|account_following|bigint||
+|account_created_at_time|timestamp without time zone||
+|account_updated_at_time|timestamp without time zone||
+|account_suspended_at_time|timestamp without time zone||
+|account_type|text||
+|account_site_admin|boolean||
+|account_total_private_repos|bigint||
+|account_owned_private_repos|bigint||
+|account_private_gists|bigint||
+|account_disk_usage|bigint||
+|account_collaborators|bigint||
+|account_two_factor_authentication|boolean||
+|account_plan_name|text||
+|account_plan_space|bigint||
+|account_plan_collaborators|bigint||
+|account_plan_private_repos|bigint||
+|account_plan_filled_seats|bigint||
+|account_plan_seats|bigint||
+|account_ldap_dn|text||
+|account_url|text|API URLs|
+|account_events_url|text||
+|account_following_url|text||
+|account_followers_url|text||
+|account_gists_url|text||
+|account_organizations_url|text||
+|account_received_events_url|text||
+|account_repos_url|text||
+|account_starred_url|text||
+|account_subscriptions_url|text||
+|account_text_matches|jsonb|TextMatches is only populated from search results that request text matches See: search.go and https://docs.github.com/en/rest/search/#text-match-metadata|
+|account_permissions|jsonb|Permissions and RoleName identify the permissions and role that a user has on a given repository|
+|account_role_name|text||
+|access_tokens_url|text||
+|repositories_url|text||
+|html_url|text||
+|target_type|text||
+|single_file_name|text||
+|repository_selection|text||
+|events|text[]||
+|single_file_paths|text[]||
+|permissions_actions|text||
+|permissions_administration|text||
+|permissions_blocking|text||
+|permissions_checks|text||
+|permissions_contents|text||
+|permissions_content_references|text||
+|permissions_deployments|text||
+|permissions_emails|text||
+|permissions_environments|text||
+|permissions_followers|text||
+|permissions_issues|text||
+|permissions_metadata|text||
+|permissions_members|text||
+|permissions_organization_administration|text||
+|permissions_organization_hooks|text||
+|permissions_organization_plan|text||
+|permissions_organization_pre_receive_hooks|text||
+|permissions_organization_projects|text||
+|permissions_organization_secrets|text||
+|permissions_organization_self_hosted_runners|text||
+|permissions_organization_user_blocking|text||
+|permissions_packages|text||
+|permissions_pages|text||
+|permissions_pull_requests|text||
+|permissions_repository_hooks|text||
+|permissions_repository_projects|text||
+|permissions_repository_pre_receive_hooks|text||
+|permissions_secrets|text||
+|permissions_secret_scanning_alerts|text||
+|permissions_security_events|text||
+|permissions_single_file|text||
+|permissions_statuses|text||
+|permissions_team_discussions|text||
+|permissions_vulnerability_alerts|text||
+|permissions_workflows|text||
+|created_at_time|timestamp without time zone||
+|updated_at_time|timestamp without time zone||
+|has_multiple_single_files|boolean||
+|suspended_by_login|text||
+|suspended_by_id|bigint||
+|suspended_by_node_id|text||
+|suspended_by_avatar_url|text||
+|suspended_by_html_url|text||
+|suspended_by_gravatar_id|text||
+|suspended_by_name|text||
+|suspended_by_company|text||
+|suspended_by_blog|text||
+|suspended_by_location|text||
+|suspended_by_email|text||
+|suspended_by_hireable|boolean||
+|suspended_by_bio|text||
+|suspended_by_twitter_username|text||
+|suspended_by_public_repos|bigint||
+|suspended_by_public_gists|bigint||
+|suspended_by_followers|bigint||
+|suspended_by_following|bigint||
+|suspended_by_created_at_time|timestamp without time zone||
+|suspended_by_updated_at_time|timestamp without time zone||
+|suspended_by_suspended_at_time|timestamp without time zone||
+|suspended_by_type|text||
+|suspended_by_site_admin|boolean||
+|suspended_by_total_private_repos|bigint||
+|suspended_by_owned_private_repos|bigint||
+|suspended_by_private_gists|bigint||
+|suspended_by_disk_usage|bigint||
+|suspended_by_collaborators|bigint||
+|suspended_by_two_factor_authentication|boolean||
+|suspended_by_plan_name|text||
+|suspended_by_plan_space|bigint||
+|suspended_by_plan_collaborators|bigint||
+|suspended_by_plan_private_repos|bigint||
+|suspended_by_plan_filled_seats|bigint||
+|suspended_by_plan_seats|bigint||
+|suspended_by_ldap_dn|text||
+|suspended_by_url|text|API URLs|
+|suspended_by_events_url|text||
+|suspended_by_following_url|text||
+|suspended_by_followers_url|text||
+|suspended_by_gists_url|text||
+|suspended_by_organizations_url|text||
+|suspended_by_received_events_url|text||
+|suspended_by_repos_url|text||
+|suspended_by_starred_url|text||
+|suspended_by_subscriptions_url|text||
+|suspended_by_text_matches|jsonb|TextMatches is only populated from search results that request text matches See: search.go and https://docs.github.com/en/rest/search/#text-match-metadata|
+|suspended_by_permissions|jsonb|Permissions and RoleName identify the permissions and role that a user has on a given repository|
+|suspended_by_role_name|text||
+|suspended_at_time|timestamp without time zone||

--- a/plugins/source/github/docs/tables/github_issue_assignees.md
+++ b/plugins/source/github/docs/tables/github_issue_assignees.md
@@ -1,0 +1,57 @@
+
+# Table: github_issue_assignees
+User represents a GitHub user.
+## Columns
+| Name        | Type           | Description  |
+| ------------- | ------------- | -----  |
+|issue_cq_id|uuid|Unique CloudQuery ID of github_issues table (FK)|
+|issue_id|bigint|The id of the issue|
+|login|text||
+|id|bigint||
+|node_id|text||
+|avatar_url|text||
+|html_url|text||
+|gravatar_id|text||
+|name|text||
+|company|text||
+|blog|text||
+|location|text||
+|email|text||
+|hireable|boolean||
+|bio|text||
+|twitter_username|text||
+|public_repos|bigint||
+|public_gists|bigint||
+|followers|bigint||
+|following|bigint||
+|created_at_time|timestamp without time zone||
+|updated_at_time|timestamp without time zone||
+|suspended_at_time|timestamp without time zone||
+|type|text||
+|site_admin|boolean||
+|total_private_repos|bigint||
+|owned_private_repos|bigint||
+|private_gists|bigint||
+|disk_usage|bigint||
+|collaborators|bigint||
+|two_factor_authentication|boolean||
+|plan_name|text||
+|plan_space|bigint||
+|plan_collaborators|bigint||
+|plan_private_repos|bigint||
+|plan_filled_seats|bigint||
+|plan_seats|bigint||
+|ldap_dn|text||
+|url|text|API URLs|
+|events_url|text||
+|following_url|text||
+|followers_url|text||
+|gists_url|text||
+|organizations_url|text||
+|received_events_url|text||
+|repos_url|text||
+|starred_url|text||
+|subscriptions_url|text||
+|text_matches|jsonb|TextMatches is only populated from search results that request text matches See: search.go and https://docs.github.com/en/rest/search/#text-match-metadata|
+|permissions|jsonb|Permissions and RoleName identify the permissions and role that a user has on a given repository|
+|role_name|text||

--- a/plugins/source/github/docs/tables/github_issue_labels.md
+++ b/plugins/source/github/docs/tables/github_issue_labels.md
@@ -1,0 +1,14 @@
+
+# Table: github_issue_labels
+Label represents a GitHub label on an Issue
+## Columns
+| Name        | Type           | Description  |
+| ------------- | ------------- | -----  |
+|issue_cq_id|uuid|Unique CloudQuery ID of github_issues table (FK)|
+|id|bigint||
+|url|text||
+|name|text||
+|color|text||
+|description|text||
+|default|boolean||
+|node_id|text||

--- a/plugins/source/github/docs/tables/github_issues.md
+++ b/plugins/source/github/docs/tables/github_issues.md
@@ -1,0 +1,252 @@
+
+# Table: github_issues
+Issue represents a GitHub issue on a repository.  Note: As far as the GitHub API is concerned, every pull request is an issue, but not every issue is a pull request
+## Columns
+| Name        | Type           | Description  |
+| ------------- | ------------- | -----  |
+|org|text|The Github Organization of the resource.|
+|id|bigint||
+|number|bigint||
+|state|text||
+|locked|boolean||
+|title|text||
+|body|text||
+|author_association|text||
+|user_login|text||
+|user_id|bigint||
+|user_node_id|text||
+|user_avatar_url|text||
+|user_html_url|text||
+|user_gravatar_id|text||
+|user_name|text||
+|user_company|text||
+|user_blog|text||
+|user_location|text||
+|user_email|text||
+|user_hireable|boolean||
+|user_bio|text||
+|user_twitter_username|text||
+|user_public_repos|bigint||
+|user_public_gists|bigint||
+|user_followers|bigint||
+|user_following|bigint||
+|user_created_at_time|timestamp without time zone||
+|user_updated_at_time|timestamp without time zone||
+|user_suspended_at_time|timestamp without time zone||
+|user_type|text||
+|user_site_admin|boolean||
+|user_total_private_repos|bigint||
+|user_owned_private_repos|bigint||
+|user_private_gists|bigint||
+|user_disk_usage|bigint||
+|user_collaborators|bigint||
+|user_two_factor_authentication|boolean||
+|user_plan_name|text||
+|user_plan_space|bigint||
+|user_plan_collaborators|bigint||
+|user_plan_private_repos|bigint||
+|user_plan_filled_seats|bigint||
+|user_plan_seats|bigint||
+|user_ldap_dn|text||
+|user_url|text|API URLs|
+|user_events_url|text||
+|user_following_url|text||
+|user_followers_url|text||
+|user_gists_url|text||
+|user_organizations_url|text||
+|user_received_events_url|text||
+|user_repos_url|text||
+|user_starred_url|text||
+|user_subscriptions_url|text||
+|user_text_matches|jsonb|TextMatches is only populated from search results that request text matches See: search.go and https://docs.github.com/en/rest/search/#text-match-metadata|
+|user_permissions|jsonb|Permissions and RoleName identify the permissions and role that a user has on a given repository|
+|user_role_name|text||
+|assignee_login|text||
+|assignee_id|bigint||
+|assignee_node_id|text||
+|assignee_avatar_url|text||
+|assignee_html_url|text||
+|assignee_gravatar_id|text||
+|assignee_name|text||
+|assignee_company|text||
+|assignee_blog|text||
+|assignee_location|text||
+|assignee_email|text||
+|assignee_hireable|boolean||
+|assignee_bio|text||
+|assignee_twitter_username|text||
+|assignee_public_repos|bigint||
+|assignee_public_gists|bigint||
+|assignee_followers|bigint||
+|assignee_following|bigint||
+|assignee_created_at_time|timestamp without time zone||
+|assignee_updated_at_time|timestamp without time zone||
+|assignee_suspended_at_time|timestamp without time zone||
+|assignee_type|text||
+|assignee_site_admin|boolean||
+|assignee_total_private_repos|bigint||
+|assignee_owned_private_repos|bigint||
+|assignee_private_gists|bigint||
+|assignee_disk_usage|bigint||
+|assignee_collaborators|bigint||
+|assignee_two_factor_authentication|boolean||
+|assignee_plan_name|text||
+|assignee_plan_space|bigint||
+|assignee_plan_collaborators|bigint||
+|assignee_plan_private_repos|bigint||
+|assignee_plan_filled_seats|bigint||
+|assignee_plan_seats|bigint||
+|assignee_ldap_dn|text||
+|assignee_url|text|API URLs|
+|assignee_events_url|text||
+|assignee_following_url|text||
+|assignee_followers_url|text||
+|assignee_gists_url|text||
+|assignee_organizations_url|text||
+|assignee_received_events_url|text||
+|assignee_repos_url|text||
+|assignee_starred_url|text||
+|assignee_subscriptions_url|text||
+|assignee_text_matches|jsonb|TextMatches is only populated from search results that request text matches See: search.go and https://docs.github.com/en/rest/search/#text-match-metadata|
+|assignee_permissions|jsonb|Permissions and RoleName identify the permissions and role that a user has on a given repository|
+|assignee_role_name|text||
+|comments|bigint||
+|closed_at|timestamp without time zone||
+|created_at|timestamp without time zone||
+|updated_at|timestamp without time zone||
+|closed_by_login|text||
+|closed_by_id|bigint||
+|closed_by_node_id|text||
+|closed_by_avatar_url|text||
+|closed_by_html_url|text||
+|closed_by_gravatar_id|text||
+|closed_by_name|text||
+|closed_by_company|text||
+|closed_by_blog|text||
+|closed_by_location|text||
+|closed_by_email|text||
+|closed_by_hireable|boolean||
+|closed_by_bio|text||
+|closed_by_twitter_username|text||
+|closed_by_public_repos|bigint||
+|closed_by_public_gists|bigint||
+|closed_by_followers|bigint||
+|closed_by_following|bigint||
+|closed_by_created_at_time|timestamp without time zone||
+|closed_by_updated_at_time|timestamp without time zone||
+|closed_by_suspended_at_time|timestamp without time zone||
+|closed_by_type|text||
+|closed_by_site_admin|boolean||
+|closed_by_total_private_repos|bigint||
+|closed_by_owned_private_repos|bigint||
+|closed_by_private_gists|bigint||
+|closed_by_disk_usage|bigint||
+|closed_by_collaborators|bigint||
+|closed_by_two_factor_authentication|boolean||
+|closed_by_plan_name|text||
+|closed_by_plan_space|bigint||
+|closed_by_plan_collaborators|bigint||
+|closed_by_plan_private_repos|bigint||
+|closed_by_plan_filled_seats|bigint||
+|closed_by_plan_seats|bigint||
+|closed_by_ldap_dn|text||
+|closed_by_url|text|API URLs|
+|closed_by_events_url|text||
+|closed_by_following_url|text||
+|closed_by_followers_url|text||
+|closed_by_gists_url|text||
+|closed_by_organizations_url|text||
+|closed_by_received_events_url|text||
+|closed_by_repos_url|text||
+|closed_by_starred_url|text||
+|closed_by_subscriptions_url|text||
+|closed_by_text_matches|jsonb|TextMatches is only populated from search results that request text matches See: search.go and https://docs.github.com/en/rest/search/#text-match-metadata|
+|closed_by_permissions|jsonb|Permissions and RoleName identify the permissions and role that a user has on a given repository|
+|closed_by_role_name|text||
+|url|text||
+|html_url|text||
+|comments_url|text||
+|events_url|text||
+|labels_url|text||
+|repository_url|text||
+|milestone_url|text||
+|milestone_html_url|text||
+|milestone_labels_url|text||
+|milestone_id|bigint||
+|milestone_number|bigint||
+|milestone_state|text||
+|milestone_title|text||
+|milestone_description|text||
+|milestone_creator_login|text||
+|milestone_creator_id|bigint||
+|milestone_creator_node_id|text||
+|milestone_creator_avatar_url|text||
+|milestone_creator_html_url|text||
+|milestone_creator_gravatar_id|text||
+|milestone_creator_name|text||
+|milestone_creator_company|text||
+|milestone_creator_blog|text||
+|milestone_creator_location|text||
+|milestone_creator_email|text||
+|milestone_creator_hireable|boolean||
+|milestone_creator_bio|text||
+|milestone_creator_twitter_username|text||
+|milestone_creator_public_repos|bigint||
+|milestone_creator_public_gists|bigint||
+|milestone_creator_followers|bigint||
+|milestone_creator_following|bigint||
+|milestone_creator_created_at_time|timestamp without time zone||
+|milestone_creator_updated_at_time|timestamp without time zone||
+|milestone_creator_suspended_at_time|timestamp without time zone||
+|milestone_creator_type|text||
+|milestone_creator_site_admin|boolean||
+|milestone_creator_total_private_repos|bigint||
+|milestone_creator_owned_private_repos|bigint||
+|milestone_creator_private_gists|bigint||
+|milestone_creator_disk_usage|bigint||
+|milestone_creator_collaborators|bigint||
+|milestone_creator_two_factor_authentication|boolean||
+|milestone_creator_plan_name|text||
+|milestone_creator_plan_space|bigint||
+|milestone_creator_plan_collaborators|bigint||
+|milestone_creator_plan_private_repos|bigint||
+|milestone_creator_plan_filled_seats|bigint||
+|milestone_creator_plan_seats|bigint||
+|milestone_creator_ldap_dn|text||
+|milestone_creator_url|text|API URLs|
+|milestone_creator_events_url|text||
+|milestone_creator_following_url|text||
+|milestone_creator_followers_url|text||
+|milestone_creator_gists_url|text||
+|milestone_creator_organizations_url|text||
+|milestone_creator_received_events_url|text||
+|milestone_creator_repos_url|text||
+|milestone_creator_starred_url|text||
+|milestone_creator_subscriptions_url|text||
+|milestone_creator_text_matches|jsonb|TextMatches is only populated from search results that request text matches See: search.go and https://docs.github.com/en/rest/search/#text-match-metadata|
+|milestone_creator_permissions|jsonb|Permissions and RoleName identify the permissions and role that a user has on a given repository|
+|milestone_creator_role_name|text||
+|milestone_open_issues|bigint||
+|milestone_closed_issues|bigint||
+|milestone_created_at|timestamp without time zone||
+|milestone_updated_at|timestamp without time zone||
+|milestone_closed_at|timestamp without time zone||
+|milestone_due_on|timestamp without time zone||
+|milestone_node_id|text||
+|pull_request_links_url|text||
+|pull_request_links_html_url|text||
+|pull_request_links_diff_url|text||
+|pull_request_links_patch_url|text||
+|repository_id|bigint||
+|reactions_total_count|bigint||
+|reactions_plus_one|bigint||
+|reactions_laugh|bigint||
+|reactions_confused|bigint||
+|reactions_heart|bigint||
+|reactions_hooray|bigint||
+|reactions_rocket|bigint||
+|reactions_eyes|bigint||
+|reactions_url|text||
+|node_id|text||
+|text_matches|jsonb|TextMatches is only populated from search results that request text matches See: search.go and https://docs.github.com/en/rest/search/#text-match-metadata|
+|active_lock_reason|text|ActiveLockReason is populated only when LockReason is provided while locking the issue. Possible values are: "off-topic", "too heated", "resolved", and "spam".|

--- a/plugins/source/github/docs/tables/github_organization_member_membership.md
+++ b/plugins/source/github/docs/tables/github_organization_member_membership.md
@@ -1,0 +1,11 @@
+
+# Table: github_organization_member_membership
+Membership represents the status of a user's membership in an organization or team.
+## Columns
+| Name        | Type           | Description  |
+| ------------- | ------------- | -----  |
+|organization_member_cq_id|uuid|Unique CloudQuery ID of github_organization_members table (FK)|
+|url|text||
+|state|text|State is the user's status within the organization or team. Possible values are: "active", "pending"|
+|role|text|Role identifies the user's role within the organization or team. Possible values for organization membership:     member - non-owner organization member     admin - organization owner  Possible values for team membership are:     member - a normal member of the team     maintainer - a team maintainer|
+|organization_url|text|For organization membership, the API URL of the organization.|

--- a/plugins/source/github/docs/tables/github_organization_members.md
+++ b/plugins/source/github/docs/tables/github_organization_members.md
@@ -1,0 +1,57 @@
+
+# Table: github_organization_members
+User represents a GitHub user.
+## Columns
+| Name        | Type           | Description  |
+| ------------- | ------------- | -----  |
+|organization_cq_id|uuid|Unique CloudQuery ID of github_organizations table (FK)|
+|org|text|The Github Organization of the resource.|
+|login|text||
+|id|bigint||
+|node_id|text||
+|avatar_url|text||
+|html_url|text||
+|gravatar_id|text||
+|name|text||
+|company|text||
+|blog|text||
+|location|text||
+|email|text||
+|hireable|boolean||
+|bio|text||
+|twitter_username|text||
+|public_repos|bigint||
+|public_gists|bigint||
+|followers|bigint||
+|following|bigint||
+|created_at_time|timestamp without time zone||
+|updated_at_time|timestamp without time zone||
+|suspended_at_time|timestamp without time zone||
+|type|text||
+|site_admin|boolean||
+|total_private_repos|bigint||
+|owned_private_repos|bigint||
+|private_gists|bigint||
+|disk_usage|bigint||
+|collaborators|bigint||
+|two_factor_authentication|boolean||
+|plan_name|text||
+|plan_space|bigint||
+|plan_collaborators|bigint||
+|plan_private_repos|bigint||
+|plan_filled_seats|bigint||
+|plan_seats|bigint||
+|ldap_dn|text||
+|url|text|API URLs|
+|events_url|text||
+|following_url|text||
+|followers_url|text||
+|gists_url|text||
+|organizations_url|text||
+|received_events_url|text||
+|repos_url|text||
+|starred_url|text||
+|subscriptions_url|text||
+|text_matches|jsonb|TextMatches is only populated from search results that request text matches See: search.go and https://docs.github.com/en/rest/search/#text-match-metadata|
+|permissions|jsonb|Permissions and RoleName identify the permissions and role that a user has on a given repository|
+|role_name|text||

--- a/plugins/source/github/docs/tables/github_organizations.md
+++ b/plugins/source/github/docs/tables/github_organizations.md
@@ -1,0 +1,59 @@
+
+# Table: github_organizations
+Organization represents a GitHub organization account.
+## Columns
+| Name        | Type           | Description  |
+| ------------- | ------------- | -----  |
+|login|text||
+|id|bigint||
+|node_id|text||
+|avatar_url|text||
+|html_url|text||
+|name|text||
+|company|text||
+|blog|text||
+|location|text||
+|email|text||
+|twitter_username|text||
+|description|text||
+|public_repos|bigint||
+|public_gists|bigint||
+|followers|bigint||
+|following|bigint||
+|created_at|timestamp without time zone||
+|updated_at|timestamp without time zone||
+|total_private_repos|bigint||
+|owned_private_repos|bigint||
+|private_gists|bigint||
+|disk_usage|bigint||
+|collaborators|bigint||
+|billing_email|text||
+|type|text||
+|plan_name|text||
+|plan_space|bigint||
+|plan_collaborators|bigint||
+|plan_private_repos|bigint||
+|plan_filled_seats|bigint||
+|plan_seats|bigint||
+|two_factor_requirement_enabled|boolean||
+|is_verified|boolean||
+|has_organization_projects|boolean||
+|has_repository_projects|boolean||
+|default_repo_permission|text|DefaultRepoPermission can be one of: "read", "write", "admin", or "none"|
+|default_repo_settings|text|DefaultRepoSettings can be one of: "read", "write", "admin", or "none"|
+|members_can_create_repos|boolean|MembersCanCreateRepos default value is true and is only used in Organizations.Edit.|
+|members_can_create_public_repos|boolean|https://developer.github.com/changes/2019-12-03-internal-visibility-changes/#rest-v3-api|
+|members_can_create_private_repos|boolean||
+|members_can_create_internal_repos|boolean||
+|members_can_fork_private_repos|boolean|MembersCanForkPrivateRepos toggles whether organization members can fork private organization repositories.|
+|members_allowed_repository_creation_type|text|MembersAllowedRepositoryCreationType denotes if organization members can create repositories and the type of repositories they can create|
+|members_can_create_pages|boolean|MembersCanCreatePages toggles whether organization members can create GitHub Pages sites.|
+|members_can_create_public_pages|boolean|MembersCanCreatePublicPages toggles whether organization members can create public GitHub Pages sites.|
+|members_can_create_private_pages|boolean|MembersCanCreatePrivatePages toggles whether organization members can create private GitHub Pages sites.|
+|url|text|API URLs|
+|events_url|text||
+|hooks_url|text||
+|issues_url|text||
+|members_url|text||
+|public_members_url|text||
+|repos_url|text||

--- a/plugins/source/github/docs/tables/github_package_billing.md
+++ b/plugins/source/github/docs/tables/github_package_billing.md
@@ -1,0 +1,10 @@
+
+# Table: github_package_billing
+PackageBilling represents a GitHub Package billing.
+## Columns
+| Name        | Type           | Description  |
+| ------------- | ------------- | -----  |
+|org|text|The Github Organization of the resource.|
+|total_gigabytes_bandwidth_used|bigint||
+|total_paid_gigabytes_bandwidth_used|bigint||
+|included_gigabytes_bandwidth|bigint||

--- a/plugins/source/github/docs/tables/github_repositories.md
+++ b/plugins/source/github/docs/tables/github_repositories.md
@@ -1,0 +1,221 @@
+
+# Table: github_repositories
+Repository represents a GitHub repository.
+## Columns
+| Name        | Type           | Description  |
+| ------------- | ------------- | -----  |
+|org|text|The Github Organization of the resource.|
+|id|bigint||
+|node_id|text||
+|owner_login|text||
+|owner_id|bigint||
+|owner_node_id|text||
+|owner_avatar_url|text||
+|owner_html_url|text||
+|owner_gravatar_id|text||
+|owner_name|text||
+|owner_company|text||
+|owner_blog|text||
+|owner_location|text||
+|owner_email|text||
+|owner_hireable|boolean||
+|owner_bio|text||
+|owner_twitter_username|text||
+|owner_public_repos|bigint||
+|owner_public_gists|bigint||
+|owner_followers|bigint||
+|owner_following|bigint||
+|owner_created_at_time|timestamp without time zone||
+|owner_updated_at_time|timestamp without time zone||
+|owner_suspended_at_time|timestamp without time zone||
+|owner_type|text||
+|owner_site_admin|boolean||
+|owner_total_private_repos|bigint||
+|owner_owned_private_repos|bigint||
+|owner_private_gists|bigint||
+|owner_disk_usage|bigint||
+|owner_collaborators|bigint||
+|owner_two_factor_authentication|boolean||
+|owner_plan_name|text||
+|owner_plan_space|bigint||
+|owner_plan_collaborators|bigint||
+|owner_plan_private_repos|bigint||
+|owner_plan_filled_seats|bigint||
+|owner_plan_seats|bigint||
+|owner_ldap_dn|text||
+|owner_url|text|API URLs|
+|owner_events_url|text||
+|owner_following_url|text||
+|owner_followers_url|text||
+|owner_gists_url|text||
+|owner_organizations_url|text||
+|owner_received_events_url|text||
+|owner_repos_url|text||
+|owner_starred_url|text||
+|owner_subscriptions_url|text||
+|owner_text_matches|jsonb|TextMatches is only populated from search results that request text matches See: search.go and https://docs.github.com/en/rest/search/#text-match-metadata|
+|owner_permissions|jsonb|Permissions and RoleName identify the permissions and role that a user has on a given repository|
+|owner_role_name|text||
+|name|text||
+|full_name|text||
+|description|text||
+|homepage|text||
+|code_of_conduct_name|text||
+|code_of_conduct_key|text||
+|code_of_conduct_url|text||
+|code_of_conduct_body|text||
+|default_branch|text||
+|master_branch|text||
+|created_at_time|timestamp without time zone||
+|pushed_at_time|timestamp without time zone||
+|updated_at_time|timestamp without time zone||
+|html_url|text||
+|clone_url|text||
+|git_url|text||
+|mirror_url|text||
+|ssh_url|text||
+|svn_url|text||
+|language|text||
+|fork|boolean||
+|forks_count|bigint||
+|network_count|bigint||
+|open_issues_count|bigint||
+|open_issues|bigint|Deprecated: Replaced by OpenIssuesCount|
+|stargazers_count|bigint||
+|subscribers_count|bigint||
+|watchers_count|bigint|Deprecated: Replaced by StargazersCount|
+|watchers|bigint|Deprecated: Replaced by StargazersCount|
+|size|bigint||
+|auto_init|boolean||
+|parent|bigint||
+|source|bigint||
+|template_repository|bigint||
+|organization_login|text||
+|organization_id|bigint||
+|organization_node_id|text||
+|organization_avatar_url|text||
+|organization_html_url|text||
+|organization_name|text||
+|organization_company|text||
+|organization_blog|text||
+|organization_location|text||
+|organization_email|text||
+|organization_twitter_username|text||
+|organization_description|text||
+|organization_public_repos|bigint||
+|organization_public_gists|bigint||
+|organization_followers|bigint||
+|organization_following|bigint||
+|organization_created_at|timestamp without time zone||
+|organization_updated_at|timestamp without time zone||
+|organization_total_private_repos|bigint||
+|organization_owned_private_repos|bigint||
+|organization_private_gists|bigint||
+|organization_disk_usage|bigint||
+|organization_collaborators|bigint||
+|organization_billing_email|text||
+|organization_type|text||
+|organization_plan_name|text||
+|organization_plan_space|bigint||
+|organization_plan_collaborators|bigint||
+|organization_plan_private_repos|bigint||
+|organization_plan_filled_seats|bigint||
+|organization_plan_seats|bigint||
+|organization_two_factor_requirement_enabled|boolean||
+|organization_is_verified|boolean||
+|organization_has_organization_projects|boolean||
+|organization_has_repository_projects|boolean||
+|organization_default_repo_permission|text|DefaultRepoPermission can be one of: "read", "write", "admin", or "none"|
+|organization_default_repo_settings|text|DefaultRepoSettings can be one of: "read", "write", "admin", or "none"|
+|organization_members_can_create_repos|boolean|MembersCanCreateRepos default value is true and is only used in Organizations.Edit.|
+|organization_members_can_create_public_repos|boolean|https://developer.github.com/changes/2019-12-03-internal-visibility-changes/#rest-v3-api|
+|organization_members_can_create_private_repos|boolean||
+|organization_members_can_create_internal_repos|boolean||
+|organization_members_can_fork_private_repos|boolean|MembersCanForkPrivateRepos toggles whether organization members can fork private organization repositories.|
+|organization_members_allowed_repository_creation_type|text|MembersAllowedRepositoryCreationType denotes if organization members can create repositories and the type of repositories they can create|
+|organization_members_can_create_pages|boolean|MembersCanCreatePages toggles whether organization members can create GitHub Pages sites.|
+|organization_members_can_create_public_pages|boolean|MembersCanCreatePublicPages toggles whether organization members can create public GitHub Pages sites.|
+|organization_members_can_create_private_pages|boolean|MembersCanCreatePrivatePages toggles whether organization members can create private GitHub Pages sites.|
+|organization_url|text|API URLs|
+|organization_events_url|text||
+|organization_hooks_url|text||
+|organization_issues_url|text||
+|organization_members_url|text||
+|organization_public_members_url|text||
+|organization_repos_url|text||
+|permissions|jsonb||
+|allow_rebase_merge|boolean||
+|allow_update_branch|boolean||
+|allow_squash_merge|boolean||
+|allow_merge_commit|boolean||
+|allow_auto_merge|boolean||
+|allow_forking|boolean||
+|delete_branch_on_merge|boolean||
+|use_squash_pr_title_as_default|boolean||
+|topics|text[]||
+|archived|boolean||
+|disabled|boolean||
+|license_key|text||
+|license_name|text||
+|license_url|text||
+|license_spdx_id|text||
+|license_html_url|text||
+|license_featured|boolean||
+|license_description|text||
+|license_implementation|text||
+|license_permissions|text[]||
+|license_conditions|text[]||
+|license_limitations|text[]||
+|license_body|text||
+|private|boolean|Additional mutable fields when creating and editing a repository|
+|has_issues|boolean||
+|has_wiki|boolean||
+|has_pages|boolean||
+|has_projects|boolean||
+|has_downloads|boolean||
+|is_template|boolean||
+|license_template|text||
+|gitignore_template|text||
+|security_and_analysis_advanced_security_status|text||
+|security_and_analysis_secret_scanning_status|text||
+|team_id|bigint|Creating an organization repository|
+|url|text|API URLs|
+|archive_url|text||
+|assignees_url|text||
+|blobs_url|text||
+|branches_url|text||
+|collaborators_url|text||
+|comments_url|text||
+|commits_url|text||
+|compare_url|text||
+|contents_url|text||
+|contributors_url|text||
+|deployments_url|text||
+|downloads_url|text||
+|events_url|text||
+|forks_url|text||
+|git_commits_url|text||
+|git_refs_url|text||
+|git_tags_url|text||
+|hooks_url|text||
+|issue_comment_url|text||
+|issue_events_url|text||
+|issues_url|text||
+|keys_url|text||
+|labels_url|text||
+|languages_url|text||
+|merges_url|text||
+|milestones_url|text||
+|notifications_url|text||
+|pulls_url|text||
+|releases_url|text||
+|stargazers_url|text||
+|statuses_url|text||
+|subscribers_url|text||
+|subscription_url|text||
+|tags_url|text||
+|trees_url|text||
+|teams_url|text||
+|text_matches|jsonb|TextMatches is only populated from search results that request text matches See: search.go and https://docs.github.com/en/rest/search/#text-match-metadata|
+|visibility|text|Visibility is only used for Create and Edit endpoints|
+|role_name|text|RoleName is only returned by the API 'check team permissions for a repository'. See: teams.go (IsTeamRepoByID) https://docs.github.com/en/rest/teams/teams#check-team-permissions-for-a-repository|

--- a/plugins/source/github/docs/tables/github_storage_billing.md
+++ b/plugins/source/github/docs/tables/github_storage_billing.md
@@ -1,0 +1,10 @@
+
+# Table: github_storage_billing
+StorageBilling represents a GitHub Storage billing.
+## Columns
+| Name        | Type           | Description  |
+| ------------- | ------------- | -----  |
+|org|text|The Github Organization of the resource.|
+|days_left_in_billing_cycle|bigint||
+|estimated_paid_storage_for_month|float||
+|estimated_storage_for_month|bigint||

--- a/plugins/source/github/docs/tables/github_team_members.md
+++ b/plugins/source/github/docs/tables/github_team_members.md
@@ -1,0 +1,58 @@
+
+# Table: github_team_members
+User represents a GitHub user.
+## Columns
+| Name        | Type           | Description  |
+| ------------- | ------------- | -----  |
+|team_cq_id|uuid|Unique CloudQuery ID of github_teams table (FK)|
+|team_id|bigint|The id of the team|
+|org|text|The Github Organization of the resource.|
+|login|text||
+|id|bigint||
+|node_id|text||
+|avatar_url|text||
+|html_url|text||
+|gravatar_id|text||
+|name|text||
+|company|text||
+|blog|text||
+|location|text||
+|email|text||
+|hireable|boolean||
+|bio|text||
+|twitter_username|text||
+|public_repos|bigint||
+|public_gists|bigint||
+|followers|bigint||
+|following|bigint||
+|created_at_time|timestamp without time zone||
+|updated_at_time|timestamp without time zone||
+|suspended_at_time|timestamp without time zone||
+|type|text||
+|site_admin|boolean||
+|total_private_repos|bigint||
+|owned_private_repos|bigint||
+|private_gists|bigint||
+|disk_usage|bigint||
+|collaborators|bigint||
+|two_factor_authentication|boolean||
+|plan_name|text||
+|plan_space|bigint||
+|plan_collaborators|bigint||
+|plan_private_repos|bigint||
+|plan_filled_seats|bigint||
+|plan_seats|bigint||
+|ldap_dn|text||
+|url|text|API URLs|
+|events_url|text||
+|following_url|text||
+|followers_url|text||
+|gists_url|text||
+|organizations_url|text||
+|received_events_url|text||
+|repos_url|text||
+|starred_url|text||
+|subscriptions_url|text||
+|text_matches|jsonb|TextMatches is only populated from search results that request text matches See: search.go and https://docs.github.com/en/rest/search/#text-match-metadata|
+|permissions|jsonb|Permissions and RoleName identify the permissions and role that a user has on a given repository|
+|role_name|text||

--- a/plugins/source/github/docs/tables/github_team_repositories.md
+++ b/plugins/source/github/docs/tables/github_team_repositories.md
@@ -1,0 +1,221 @@
+
+# Table: github_team_repositories
+Repository represents a GitHub repository.
+## Columns
+| Name        | Type           | Description  |
+| ------------- | ------------- | -----  |
+|team_cq_id|uuid|Unique CloudQuery ID of github_teams table (FK)|
+|team_id|bigint|The id of the team|
+|id|bigint||
+|node_id|text||
+|owner_login|text||
+|owner_id|bigint||
+|owner_node_id|text||
+|owner_avatar_url|text||
+|owner_html_url|text||
+|owner_gravatar_id|text||
+|owner_name|text||
+|owner_company|text||
+|owner_blog|text||
+|owner_location|text||
+|owner_email|text||
+|owner_hireable|boolean||
+|owner_bio|text||
+|owner_twitter_username|text||
+|owner_public_repos|bigint||
+|owner_public_gists|bigint||
+|owner_followers|bigint||
+|owner_following|bigint||
+|owner_created_at_time|timestamp without time zone||
+|owner_updated_at_time|timestamp without time zone||
+|owner_suspended_at_time|timestamp without time zone||
+|owner_type|text||
+|owner_site_admin|boolean||
+|owner_total_private_repos|bigint||
+|owner_owned_private_repos|bigint||
+|owner_private_gists|bigint||
+|owner_disk_usage|bigint||
+|owner_collaborators|bigint||
+|owner_two_factor_authentication|boolean||
+|owner_plan_name|text||
+|owner_plan_space|bigint||
+|owner_plan_collaborators|bigint||
+|owner_plan_private_repos|bigint||
+|owner_plan_filled_seats|bigint||
+|owner_plan_seats|bigint||
+|owner_ldap_dn|text||
+|owner_url|text|API URLs|
+|owner_events_url|text||
+|owner_following_url|text||
+|owner_followers_url|text||
+|owner_gists_url|text||
+|owner_organizations_url|text||
+|owner_received_events_url|text||
+|owner_repos_url|text||
+|owner_starred_url|text||
+|owner_subscriptions_url|text||
+|owner_text_matches|jsonb|TextMatches is only populated from search results that request text matches See: search.go and https://docs.github.com/en/rest/search/#text-match-metadata|
+|owner_permissions|jsonb|Permissions and RoleName identify the permissions and role that a user has on a given repository|
+|owner_role_name|text||
+|name|text||
+|full_name|text||
+|description|text||
+|homepage|text||
+|code_of_conduct_name|text||
+|code_of_conduct_key|text||
+|code_of_conduct_url|text||
+|code_of_conduct_body|text||
+|default_branch|text||
+|master_branch|text||
+|created_at_time|timestamp without time zone||
+|pushed_at_time|timestamp without time zone||
+|updated_at_time|timestamp without time zone||
+|html_url|text||
+|clone_url|text||
+|git_url|text||
+|mirror_url|text||
+|ssh_url|text||
+|s_v_n_url|text||
+|language|text||
+|fork|boolean||
+|forks_count|bigint||
+|network_count|bigint||
+|open_issues_count|bigint||
+|open_issues|bigint|Deprecated: Replaced by OpenIssuesCount|
+|stargazers_count|bigint||
+|subscribers_count|bigint||
+|watchers_count|bigint|Deprecated: Replaced by StargazersCount|
+|watchers|bigint|Deprecated: Replaced by StargazersCount|
+|size|bigint||
+|auto_init|boolean||
+|parent|bigint||
+|source|bigint||
+|template_repository|bigint||
+|organization_login|text||
+|organization_id|bigint||
+|organization_node_id|text||
+|organization_avatar_url|text||
+|organization_html_url|text||
+|organization_name|text||
+|organization_company|text||
+|organization_blog|text||
+|organization_location|text||
+|organization_email|text||
+|organization_twitter_username|text||
+|organization_description|text||
+|organization_public_repos|bigint||
+|organization_public_gists|bigint||
+|organization_followers|bigint||
+|organization_following|bigint||
+|organization_created_at|timestamp without time zone||
+|organization_updated_at|timestamp without time zone||
+|organization_total_private_repos|bigint||
+|organization_owned_private_repos|bigint||
+|organization_private_gists|bigint||
+|organization_disk_usage|bigint||
+|organization_collaborators|bigint||
+|organization_billing_email|text||
+|organization_type|text||
+|organization_plan_name|text||
+|organization_plan_space|bigint||
+|organization_plan_collaborators|bigint||
+|organization_plan_private_repos|bigint||
+|organization_plan_filled_seats|bigint||
+|organization_plan_seats|bigint||
+|organization_two_factor_requirement_enabled|boolean||
+|organization_is_verified|boolean||
+|organization_has_organization_projects|boolean||
+|organization_has_repository_projects|boolean||
+|organization_default_repo_permission|text|DefaultRepoPermission can be one of: "read", "write", "admin", or "none"|
+|organization_default_repo_settings|text|DefaultRepoSettings can be one of: "read", "write", "admin", or "none"|
+|organization_members_can_create_repos|boolean|MembersCanCreateRepos default value is true and is only used in Organizations.Edit.|
+|organization_members_can_create_public_repos|boolean|https://developer.github.com/changes/2019-12-03-internal-visibility-changes/#rest-v3-api|
+|organization_members_can_create_private_repos|boolean||
+|organization_members_can_create_internal_repos|boolean||
+|organization_members_can_fork_private_repos|boolean|MembersCanForkPrivateRepos toggles whether organization members can fork private organization repositories.|
+|organization_members_allowed_repository_creation_type|text|MembersAllowedRepositoryCreationType denotes if organization members can create repositories and the type of repositories they can create|
+|organization_members_can_create_pages|boolean|MembersCanCreatePages toggles whether organization members can create GitHub Pages sites.|
+|organization_members_can_create_public_pages|boolean|MembersCanCreatePublicPages toggles whether organization members can create public GitHub Pages sites.|
+|organization_members_can_create_private_pages|boolean|MembersCanCreatePrivatePages toggles whether organization members can create private GitHub Pages sites.|
+|organization_url|text|API URLs|
+|organization_events_url|text||
+|organization_hooks_url|text||
+|organization_issues_url|text||
+|organization_members_url|text||
+|organization_public_members_url|text||
+|organization_repos_url|text||
+|permissions|jsonb||
+|allow_rebase_merge|boolean||
+|allow_update_branch|boolean||
+|allow_squash_merge|boolean||
+|allow_merge_commit|boolean||
+|allow_auto_merge|boolean||
+|allow_forking|boolean||
+|delete_branch_on_merge|boolean||
+|use_squash_p_r_title_as_default|boolean||
+|topics|text[]||
+|archived|boolean||
+|disabled|boolean||
+|license_key|text||
+|license_name|text||
+|license_url|text||
+|license_s_p_d_x_id|text||
+|license_html_url|text||
+|license_featured|boolean||
+|license_description|text||
+|license_implementation|text||
+|license_permissions|text[]||
+|license_conditions|text[]||
+|license_limitations|text[]||
+|license_body|text||
+|private|boolean|Additional mutable fields when creating and editing a repository|
+|has_issues|boolean||
+|has_wiki|boolean||
+|has_pages|boolean||
+|has_projects|boolean||
+|has_downloads|boolean||
+|is_template|boolean||
+|license_template|text||
+|gitignore_template|text||
+|security_and_analysis_advanced_security_status|text||
+|security_and_analysis_secret_scanning_status|text||
+|url|text|API URLs|
+|archive_url|text||
+|assignees_url|text||
+|blobs_url|text||
+|branches_url|text||
+|collaborators_url|text||
+|comments_url|text||
+|commits_url|text||
+|compare_url|text||
+|contents_url|text||
+|contributors_url|text||
+|deployments_url|text||
+|downloads_url|text||
+|events_url|text||
+|forks_url|text||
+|git_commits_url|text||
+|git_refs_url|text||
+|git_tags_url|text||
+|hooks_url|text||
+|issue_comment_url|text||
+|issue_events_url|text||
+|issues_url|text||
+|keys_url|text||
+|labels_url|text||
+|languages_url|text||
+|merges_url|text||
+|milestones_url|text||
+|notifications_url|text||
+|pulls_url|text||
+|releases_url|text||
+|stargazers_url|text||
+|statuses_url|text||
+|subscribers_url|text||
+|subscription_url|text||
+|tags_url|text||
+|trees_url|text||
+|teams_url|text||
+|text_matches|jsonb|TextMatches is only populated from search results that request text matches See: search.go and https://docs.github.com/en/rest/search/#text-match-metadata|
+|visibility|text|Visibility is only used for Create and Edit endpoints|
+|role_name|text|RoleName is only returned by the API 'check team permissions for a repository'. See: teams.go (IsTeamRepoByID) https://docs.github.com/en/rest/teams/teams#check-team-permissions-for-a-repository|

--- a/plugins/source/github/docs/tables/github_teams.md
+++ b/plugins/source/github/docs/tables/github_teams.md
@@ -1,0 +1,23 @@
+
+# Table: github_teams
+Team represents a team within a GitHub organization
+## Columns
+| Name        | Type           | Description  |
+| ------------- | ------------- | -----  |
+|org|text|The Github Organization of the resource.|
+|id|bigint||
+|node_id|text||
+|name|text||
+|description|text||
+|url|text||
+|slug|text||
+|permission|text|Permission specifies the default permission for repositories owned by the team.|
+|permissions|jsonb|Permissions identifies the permissions that a team has on a given repository|
+|privacy|text|Privacy identifies the level of privacy this team should have. Possible values are:     secret - only visible to organization owners and members of this team     closed - visible to all members of this organization Default is "secret".|
+|members_count|bigint||
+|repos_count|bigint||
+|html_url|text||
+|members_url|text||
+|repositories_url|text||
+|parent|bigint||
+|ldapdn|text|LDAPDN is only available in GitHub Enterprise and when the team membership is synchronized with LDAP.|


### PR DESCRIPTION
We should keep this so that the links from the website are not broken until we release v2. 

Added back by running:

```
git checkout 12643fe403f65061621ddea115486ad19ef0b274 -- plugins/source/github/docs/
tables
```