### PR TITLE
fix: Add missing fields to aws_iam_policies

### DIFF
--- a/plugins/source/aws/codegen/recipes/iam.go
+++ b/plugins/source/aws/codegen/recipes/iam.go
@@ -186,7 +186,7 @@ func IAMResources() []*Resource {
 		},
 		{
 			SubService: "policies",
-			Struct:     &types.Policy{},
+			Struct:     &types.ManagedPolicyDetail{},
 			SkipFields: []string{"PolicyId", "Tags"},
 			ExtraColumns: []codegen.ColumnDefinition{
 				{

--- a/plugins/source/aws/resources/services/iam/policies.go
+++ b/plugins/source/aws/resources/services/iam/policies.go
@@ -80,6 +80,11 @@ func Policies() *schema.Table {
 				Resolver: schema.PathResolver("PolicyName"),
 			},
 			{
+				Name:     "policy_version_list",
+				Type:     schema.TypeJSON,
+				Resolver: schema.PathResolver("PolicyVersionList"),
+			},
+			{
 				Name:     "update_date",
 				Type:     schema.TypeTimestamp,
 				Resolver: schema.PathResolver("UpdateDate"),


### PR DESCRIPTION
This adds `policy_version_list` as a JSON column (it was a separate table before). 

Closes https://github.com/cloudquery/cloudquery/issues/1980