### PR TITLE
chore: Try and set more fine-tuned codeowners

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,3 +1,6 @@
 /.github/  @erezrokah @hermanschaaf @yevgenypats
 /cli/       @yevgenypats
 /plugins/ @cloudquery/cloudquery-opensource
+/plugins/source/aws @hermanschaaf @yevgenypats
+/plugins/source/azure @erezrokah @yevgenypats
+/plugins/source/gcp @yevgenypats @disq


### PR DESCRIPTION
The source plugins for the hyperscale cloud plugins are complex and I think it is worth that we always have one or two main reviewers/maintainers if we want to keep high quality for those plugins and avoid many breaking changes.

Let me know what you think?

I chose with the following logic:
  for azure - @erezrokah  (as you worked on the v2 plugin)
  for aws - @hermanschaaf (as you worked on the v2 plugin)
  for gcp - myself as I worked on the v2 plugin