### PR TITLE
feat(cli): Add scaffold command for destination

### DIFF
--- a/cli/cmd/root.go
+++ b/cli/cmd/root.go
@@ -134,7 +134,7 @@ func NewCmdRoot() *cobra.Command {
 	}
 	initViper()
 	cmd.SetHelpCommand(&cobra.Command{Hidden: true})
-	cmd.AddCommand(NewCmdSync(), newCmdDoc())
+	cmd.AddCommand(NewCmdSync(), newCmdDoc(), newCmdScaffold())
 	cmd.DisableAutoGenTag = true
 	return cmd
 }

--- a/cli/cmd/scaffold.go
+++ b/cli/cmd/scaffold.go
@@ -13,6 +13,6 @@ func newCmdScaffold() *cobra.Command {
 		Use:   "scaffold",
 		Short: scaffoldShort,
 	}
-	cmd.AddCommand(newCmdScaffoldDestination())
+	cmd.AddCommand(newCmdScaffoldSource(), newCmdScaffoldDestination())
 	return cmd
 }

--- a/cli/cmd/scaffold.go
+++ b/cli/cmd/scaffold.go
@@ -1,0 +1,18 @@
+package cmd
+
+import (
+	"github.com/spf13/cobra"
+)
+
+const (
+	scaffoldShort = "Create an empty plugin project"
+)
+
+func newCmdScaffold() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "scaffold",
+		Short: scaffoldShort,
+	}
+	cmd.AddCommand(newCmdScaffoldDestination())
+	return cmd
+}

--- a/cli/cmd/scaffold_destination.go
+++ b/cli/cmd/scaffold_destination.go
@@ -11,7 +11,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-//go:embed templates/*
+//go:embed templates/destination/*
 var destinationFS embed.FS
 
 const (

--- a/cli/cmd/scaffold_destination.go
+++ b/cli/cmd/scaffold_destination.go
@@ -1,0 +1,81 @@
+package cmd
+
+import (
+	"embed"
+	"fmt"
+	"go/format"
+	"os"
+	"strings"
+	"text/template"
+
+	"github.com/spf13/cobra"
+)
+
+//go:embed templates/*
+var destinationFS embed.FS
+
+const (
+	scaffoldDestinationShort = "Create an empty destination plugin project"
+)
+
+func newCmdScaffoldDestination() *cobra.Command {
+	var outputDir string
+	cmd := &cobra.Command{
+		Use:   "destination [org] [name]",
+		Short: scaffoldDestinationShort,
+		Args:  cobra.ExactValidArgs(2),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if outputDir == "" {
+				outputDir = "cq-destination-" + args[1]
+			}
+			return runScaffoldDestination(outputDir, args[0], args[1])
+		},
+	}
+	cmd.Flags().StringVar(&outputDir, "output", "", "output directory")
+	return cmd
+}
+
+type DestinationData struct {
+	Org  string
+	Name string
+}
+
+var destinationTemplates = map[string]string{
+	"main.go.tpl":   "main.go",
+	"README.md.tpl": "README.md",
+	"plugin.go.tpl": "plugin/plugin.go",
+}
+
+func runScaffoldDestination(outputDir, org, name string) error {
+	if err := os.MkdirAll(outputDir+"/plugin", 0755); err != nil {
+		return fmt.Errorf("failed to create directory: %w", err)
+	}
+	tpl, err := template.New("destination").ParseFS(destinationFS, "templates/destination/*.tpl", "templates/destination/plugin/*.tpl")
+	if err != nil {
+		return fmt.Errorf("failed to parse templates: %w", err)
+	}
+	data := DestinationData{
+		Org:  org,
+		Name: name,
+	}
+	for templatePath, filePath := range destinationTemplates {
+		var sb strings.Builder
+		if err := tpl.ExecuteTemplate(&sb, templatePath, data); err != nil {
+			return fmt.Errorf("failed to execute template: %w", err)
+		}
+		content := []byte(sb.String())
+		if strings.HasSuffix(filePath, ".go") {
+			formattedContent, err := format.Source(content)
+			if err != nil {
+				// we still write the file even if it's not formatted for easy debugging
+				os.WriteFile(outputDir+"/"+filePath, content, 0644)
+				return fmt.Errorf("failed to format source: %w", err)
+			}
+			content = formattedContent
+		}
+		if err := os.WriteFile(outputDir+"/"+filePath, content, 0644); err != nil {
+			return fmt.Errorf("failed to write file: %w", err)
+		}
+	}
+	return nil
+}

--- a/cli/cmd/scaffold_destination_test.go
+++ b/cli/cmd/scaffold_destination_test.go
@@ -1,0 +1,21 @@
+package cmd
+
+import (
+	"os"
+	"path"
+	"testing"
+)
+
+func TestScaffoldDestination(t *testing.T) {
+	outputDir := t.TempDir()
+	cmd := NewCmdRoot()
+	cmd.SetArgs([]string{"scaffold", "destination", "cloudquery", "test", "--output", outputDir})
+	if err := cmd.Execute(); err != nil {
+		t.Fatal(err)
+	}
+	for _, filePath := range destinationTemplates {
+		if _, err := os.Stat(path.Join(outputDir, filePath)); err != nil {
+			t.Fatal("file not found", err)
+		}
+	}
+}

--- a/cli/cmd/scaffold_source.go
+++ b/cli/cmd/scaffold_source.go
@@ -1,0 +1,1 @@
+package cmd

--- a/cli/cmd/scaffold_source.go
+++ b/cli/cmd/scaffold_source.go
@@ -1,1 +1,92 @@
 package cmd
+
+import (
+	"embed"
+	"fmt"
+	"go/format"
+	"os"
+	"strings"
+	"text/template"
+
+	"github.com/spf13/cobra"
+)
+
+//go:embed templates/source/*
+var sourceFS embed.FS
+
+const (
+	scaffoldSourceShort = "Create an empty source plugin project"
+)
+
+func newCmdScaffoldSource() *cobra.Command {
+	var outputDir string
+	cmd := &cobra.Command{
+		Use:   "source [org] [name]",
+		Short: scaffoldSourceShort,
+		Args:  cobra.ExactValidArgs(2),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if outputDir == "" {
+				outputDir = "cq-source-" + args[1]
+			}
+			return runScaffoldSource(outputDir, args[0], args[1])
+		},
+	}
+	cmd.Flags().StringVar(&outputDir, "output", "", "output directory")
+	return cmd
+}
+
+type SourceData struct {
+	Org  string
+	Name string
+}
+
+var sourceTemplates = map[string]string{
+	"main.go.tpl":   "main.go",
+	"README.md.tpl": "README.md",
+	"client.go.tpl": "client/client.go",
+	"plugin.go.tpl": "plugin/plugin.go",
+	"table.go.tpl": "resources/table.go",
+}
+
+
+func runScaffoldSource(outputDir, org, name string) error {
+	var dirs = []string{"client", "plugin", "resources"}
+	for _, dir := range dirs {
+		if err := os.MkdirAll(outputDir+"/" + dir, 0755); err != nil {
+			return fmt.Errorf("failed to create directory: %w", err)
+		}
+	}
+	tpl, err := template.New("source").ParseFS(sourceFS,
+		"templates/source/*.tpl",
+		"templates/source/plugin/*.tpl",
+		"templates/source/client/*.tpl",
+		"templates/source/resources/*.tpl",
+	)
+	if err != nil {
+		return fmt.Errorf("failed to parse templates: %w", err)
+	}
+	data := SourceData{
+		Org:  org,
+		Name: name,
+	}
+	for templatePath, filePath := range sourceTemplates {
+		var sb strings.Builder
+		if err := tpl.ExecuteTemplate(&sb, templatePath, data); err != nil {
+			return fmt.Errorf("failed to execute template: %w", err)
+		}
+		content := []byte(sb.String())
+		if strings.HasSuffix(filePath, ".go") {
+			formattedContent, err := format.Source(content)
+			if err != nil {
+				// we still write the file even if it's not formatted for easy debugging
+				os.WriteFile(outputDir+"/"+filePath, content, 0644)
+				return fmt.Errorf("failed to format source %s: %w", filePath, err)
+			}
+			content = formattedContent
+		}
+		if err := os.WriteFile(outputDir+"/"+filePath, content, 0644); err != nil {
+			return fmt.Errorf("failed to write file: %w", err)
+		}
+	}
+	return nil
+}

--- a/cli/cmd/scaffold_source_test.go
+++ b/cli/cmd/scaffold_source_test.go
@@ -1,0 +1,21 @@
+package cmd
+
+import (
+	"os"
+	"path"
+	"testing"
+)
+
+func TestScaffoldSource(t *testing.T) {
+	outputDir := t.TempDir()
+	cmd := NewCmdRoot()
+	cmd.SetArgs([]string{"scaffold", "source", "cloudquery", "test", "--output", outputDir})
+	if err := cmd.Execute(); err != nil {
+		t.Fatal(err)
+	}
+	for _, filePath := range destinationTemplates {
+		if _, err := os.Stat(path.Join(outputDir, filePath)); err != nil {
+			t.Fatal("file not found", err)
+		}
+	}
+}

--- a/cli/cmd/templates/destination/README.md.tpl
+++ b/cli/cmd/templates/destination/README.md.tpl
@@ -1,0 +1,1 @@
+# CloudQuery {{.Name}} Destination Plugin

--- a/cli/cmd/templates/destination/main.go.tpl
+++ b/cli/cmd/templates/destination/main.go.tpl
@@ -1,0 +1,10 @@
+package main
+
+import (
+	"github.com/cloudquery/plugin-sdk/serve"
+	"github.com/{{.Org}}/cq-destination-{{.Name}}/client"
+)
+
+func main() {
+	serve.Destination(client.New())
+}

--- a/cli/cmd/templates/destination/plugin/plugin.go.tpl
+++ b/cli/cmd/templates/destination/plugin/plugin.go.tpl
@@ -1,0 +1,48 @@
+package plugin
+
+import (
+	"fmt"
+	"context"
+	"github.com/rs/zerolog"
+	"github.com/rs/zerolog/log"
+	"github.com/cloudquery/plugin-sdk/specs"
+	"github.com/cloudquery/plugin-sdk/schema"
+)
+
+var (
+	Version = "Development"
+)
+
+type Client struct {
+	logger zerolog.Logger
+}
+
+func New() * Client {
+	return &Client{
+		logger: log.With().Str("module", "{{.Name}}").Logger(),
+	}
+}
+
+func (*Client) Name() string {
+	return "{{.Name}}"
+}
+
+func (*Client) Version() string {
+	return Version
+}
+
+func (p *Client) Initialize(ctx context.Context, spec specs.Destination) error {
+	return fmt.Errorf("not implemented")
+}
+
+func (p *Client) SetLogger(logger zerolog.Logger) {
+	p.logger = logger
+}
+
+func (p *Client) Migrate(ctx context.Context, tables schema.Tables) error {
+	return fmt.Errorf("not implemented")
+}
+
+func (p *Client) Write(ctx context.Context, table string, data map[string]interface{}) error {
+	return fmt.Errorf("not implemented")
+}

--- a/cli/cmd/templates/source/README.md.tpl
+++ b/cli/cmd/templates/source/README.md.tpl
@@ -1,0 +1,1 @@
+# CloudQuery {{.Name}} Source Plugin

--- a/cli/cmd/templates/source/client/client.go.tpl
+++ b/cli/cmd/templates/source/client/client.go.tpl
@@ -1,0 +1,16 @@
+package client
+
+type Client struct {
+  logger zerolog.Logger
+}
+
+func (c *Client) Logger() *zerolog.Logger {
+  return &logger
+}
+
+func Configure(ctx context.Context, logger zerolog.Logger, spec specs.Source) (schema.ClientMeta, error) {
+  c := Client{
+    logger: logger,
+  }
+  return &c, fmt.Errorf("not implemented")
+}

--- a/cli/cmd/templates/source/client/client.go.tpl
+++ b/cli/cmd/templates/source/client/client.go.tpl
@@ -5,7 +5,7 @@ type Client struct {
 }
 
 func (c *Client) Logger() *zerolog.Logger {
-  return &logger
+  return &c.logger
 }
 
 func Configure(ctx context.Context, logger zerolog.Logger, spec specs.Source) (schema.ClientMeta, error) {

--- a/cli/cmd/templates/source/main.go.tpl
+++ b/cli/cmd/templates/source/main.go.tpl
@@ -1,0 +1,10 @@
+package main
+
+import (
+	"github.com/cloudquery/plugin-sdk/serve"
+	"github.com/{{.Org}}/cq-source-{{.Name}}/client"
+)
+
+func main() {
+	serve.Source(client.New())
+}

--- a/cli/cmd/templates/source/plugin/plugin.go.tpl
+++ b/cli/cmd/templates/source/plugin/plugin.go.tpl
@@ -1,0 +1,22 @@
+package plugin
+
+import (
+	"github.com/cloudquery/plugin-sdk/plugins"
+	"github.com/{{.Org}}/cq-source-{{.Name}}/client"
+	"github.com/{{.Org}}/cq-source-{{.Name}}/resources"
+)
+
+var (
+	Version = "development"
+)
+
+func Plugin() *plugins.SourcePlugin {
+	return plugins.NewSourcePlugin(
+		"{{.Name}}",
+		Version,
+		schema.Tables{
+			resources.SampleTable(),
+		},
+		client.New,
+	)
+}

--- a/cli/cmd/templates/source/resources/table.go.tpl
+++ b/cli/cmd/templates/source/resources/table.go.tpl
@@ -1,7 +1,8 @@
 package resources
 
 import (
-	"github.com/{{.Org}}/cq-source-{{.Name}}/client"
+	"context"
+	"fmt"
 	"github.com/cloudquery/plugin-sdk/schema"
 )
 

--- a/cli/cmd/templates/source/resources/table.go.tpl
+++ b/cli/cmd/templates/source/resources/table.go.tpl
@@ -13,7 +13,7 @@ func SampleTable() *schema.Table {
 		Columns: []schema.Column{
       {
         Name: "column",
-        Type: schema.String,
+        Type: schema.TypeString,
       },
     },
   }

--- a/cli/cmd/templates/source/resources/table.go.tpl
+++ b/cli/cmd/templates/source/resources/table.go.tpl
@@ -1,0 +1,23 @@
+package resources
+
+import (
+	"github.com/{{.Org}}/cq-source-{{.Name}}/client"
+	"github.com/cloudquery/plugin-sdk/schema"
+)
+
+func SampleTable() *schema.Table {
+	return &schema.Table{
+		Name:     "{{.Name}}_sample_table",
+		Resolver: fetchSampleTable,
+		Columns: []schema.Column{
+      {
+        Name: "column",
+        Type: schema.String,
+      },
+    },
+  }
+}
+
+func fetchSampleTable(ctx context.Context, meta schema.ClientMeta, parent *schema.Resource, res chan<- interface{}) error {
+  return fmt.Errorf("not implemented")
+}


### PR DESCRIPTION
source will follow shortly.

This will enable us to deprecate https://github.com/cloudquery/cq-provider-template and update v2 documentation accordingly


