### PR TITLE
fix: Url for plugins in README.md file under root folder doesn't existed

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,11 +17,11 @@ CloudQuery key use-cases and features:
 - Homepage: https://www.cloudquery.io
 - Releases: https://github.com/cloudquery/cloudquery/releases
 - Documentation: https://www.cloudquery.io/docs
-- Plugins: https://www.cloudquery.io/plugins
+- Plugins: https://www.cloudquery.io/docs/plugins/source
 
 ### Supported plugins (Actively expanding)
 
-Visit https://www.cloudquery.io/plugins.
+Visit https://www.cloudquery.io/docs/plugins/source
 
 If you want us to add a new plugin or resource, please open an [Issue](https://github.com/cloudquery/cloudquery/issues).
 
@@ -35,7 +35,7 @@ Please check out our 'Getting Started' guides:
 - [Getting Started with GCP](https://www.cloudquery.io/docs/getting-started/getting-started-with-gcp)
 - [Getting Started with Azure](https://www.cloudquery.io/docs/getting-started/getting-started-with-azure)
 
-For other plugins, you can visit our [plugins directory](https://www.cloudquery.io/plugins), as well as reference the [Getting Started with AWS](https://www.cloudquery.io/docs/getting-started/getting-started-with-aws) for general installation and configuration tips.
+For other plugins, you can visit our [plugins directory](https://www.cloudquery.io/docs/plugins/source), as well as reference the [Getting Started with AWS](https://www.cloudquery.io/docs/getting-started/getting-started-with-aws) for general installation and configuration tips.
 
 ## Compile and run CLI
 


### PR DESCRIPTION
#### Summary
The url for plugins doesn't existed(https://www.cloudquery.io/plugins) and shows 404. 

### Changes
I update the links from `https://www.cloudquery.io/plugins` to `https://www.cloudquery.io/docs/plugins/source`

Use the following steps to ensure your PR is ready to be reviewed

- [x] Read the [contribution guidelines](../blob/main/CONTRIBUTING.md) 🧑‍🎓
- [x] Test locally on your own infrastructure
- [x] Run `go fmt` to format your code 🖊
- [x] Lint your changes via `golangci-lint run` 🚨 (install golangci-lint [here](https://golangci-lint.run/usage/install/#local-installation)) 
- [x] Update or add tests 🧪
- [ ] Ensure the status checks below are successful ✅
