### PR TITLE
fix: AWS EBS Snapshots attributes column type

### DIFF
--- a/plugins/source/aws/codegen/recipes/ec2.go
+++ b/plugins/source/aws/codegen/recipes/ec2.go
@@ -58,7 +58,7 @@ func EC2Resources() []*Resource {
 					},
 					{
 						Name:     "attribute",
-						Type:     schema.TypeString,
+						Type:     schema.TypeJSON,
 						Resolver: "resolveEbsSnapshotAttribute",
 					},
 				}...),


### PR DESCRIPTION
Fixes #2071 