### PR TITLE
fix: AWS EBS Snapshots attributes column type (take two)

### DIFF
--- a/plugins/source/aws/resources/services/ec2/ebs_snapshots.go
+++ b/plugins/source/aws/resources/services/ec2/ebs_snapshots.go
@@ -33,7 +33,7 @@ func EbsSnapshots() *schema.Table {
 			},
 			{
 				Name:     "attribute",
-				Type:     schema.TypeString,
+				Type:     schema.TypeJSON,
 				Resolver: resolveEbsSnapshotAttribute,
 			},
 			{


### PR DESCRIPTION
fix for https://github.com/cloudquery/cloudquery/pull/2075 ... run codegen 🙄 