### PR TITLE
chore: Update cli latest v2 version to pre-release

### DIFF
--- a/sites/versions/v2/cli.json
+++ b/sites/versions/v2/cli.json
@@ -1,1 +1,1 @@
-{ "latest": "" }
+{ "latest": "cli-v1.1.0-pre.1" }


### PR DESCRIPTION
This updates `sites/versions/v2/cli.json` to `cli-v1.1.0-pre.1`, which is a pre-release. Normally we wouldn't use pre-releases here, but having this would be better than having an empty string as we can then test the flow of end-to-end (related: https://github.com/cloudquery/cloudquery/issues/2076). It will be updated automatically as soon as we do a real v1 release.