### PR TITLE
fix: Add ARNs to resources that were missing them

### DIFF
--- a/plugins/source/aws/codegen/recipes/autoscaling.go
+++ b/plugins/source/aws/codegen/recipes/autoscaling.go
@@ -59,7 +59,7 @@ func AutoscalingResources() []*Resource {
 		{
 			SubService: "group_scaling_policies",
 			Struct:     &types.ScalingPolicy{},
-			SkipFields: []string{},
+			SkipFields: []string{"PolicyARN"},
 			ExtraColumns: append(
 				defaultRegionalColumns,
 				[]codegen.ColumnDefinition{
@@ -67,6 +67,12 @@ func AutoscalingResources() []*Resource {
 						Name:     "group_arn",
 						Type:     schema.TypeString,
 						Resolver: `schema.ParentResourceFieldResolver("arn")`,
+					},
+					{
+						Name:     "arn",
+						Type:     schema.TypeString,
+						Resolver: `schema.PathResolver("PolicyARN")`,
+						Options:  schema.ColumnCreationOptions{PrimaryKey: true},
 					},
 				}...),
 		},

--- a/plugins/source/aws/codegen/recipes/backup.go
+++ b/plugins/source/aws/codegen/recipes/backup.go
@@ -116,7 +116,7 @@ func BackupResources() []*Resource {
 		{
 			SubService: "vault_recovery_points",
 			Struct:     &types.RecoveryPointByBackupVault{},
-			SkipFields: []string{},
+			SkipFields: []string{"RecoveryPointArn"},
 			ExtraColumns: append(
 				defaultRegionalColumns,
 				[]codegen.ColumnDefinition{
@@ -124,6 +124,12 @@ func BackupResources() []*Resource {
 						Name:     "vault_arn",
 						Type:     schema.TypeString,
 						Resolver: `schema.ParentResourceFieldResolver("arn")`,
+					},
+					{
+						Name:     "arn",
+						Type:     schema.TypeString,
+						Resolver: `schema.PathResolver("RecoveryPointArn")`,
+						Options:  schema.ColumnCreationOptions{PrimaryKey: true},
 					},
 					{
 						Name:     "tags",

--- a/plugins/source/aws/codegen/recipes/ecs.go
+++ b/plugins/source/aws/codegen/recipes/ecs.go
@@ -102,10 +102,16 @@ func ECSResources() []*Resource {
 		{
 			SubService: "task_definitions",
 			Struct:     &models.TaskDefinitionWrapper{},
-			SkipFields: []string{"Tags"},
+			SkipFields: []string{"TaskDefinitionArn", "Tags"},
 			ExtraColumns: append(
 				defaultRegionalColumns,
 				[]codegen.ColumnDefinition{
+					{
+						Name:     "arn",
+						Type:     schema.TypeString,
+						Resolver: `schema.PathResolver("TaskDefinitionArn")`,
+						Options:  schema.ColumnCreationOptions{PrimaryKey: true},
+					},
 					{
 						Name:     "tags",
 						Type:     schema.TypeJSON,

--- a/plugins/source/aws/codegen/recipes/elasticbeanstalk.go
+++ b/plugins/source/aws/codegen/recipes/elasticbeanstalk.go
@@ -50,13 +50,18 @@ func ElasticbeanstalkResources() []*Resource {
 		{
 			SubService: "environments",
 			Struct:     &types.EnvironmentDescription{},
-			SkipFields: []string{"EnvironmentId"},
+			SkipFields: []string{"EnvironmentId", "EnvironmentArn"},
 			ExtraColumns: []codegen.ColumnDefinition{
 				{
 					Name:     "account_id",
 					Type:     schema.TypeString,
 					Resolver: `client.ResolveAWSAccount`,
 					Options:  schema.ColumnCreationOptions{PrimaryKey: true},
+				},
+				{
+					Name:     "arn",
+					Type:     schema.TypeString,
+					Resolver: `schema.PathResolver("EnvironmentArn")`,
 				},
 				{
 					Name:     "region",

--- a/plugins/source/aws/codegen/recipes/lambda.go
+++ b/plugins/source/aws/codegen/recipes/lambda.go
@@ -69,7 +69,7 @@ func LambdaResources() []*Resource {
 		{
 			SubService: "function_aliases",
 			Struct:     &models.AliasWrapper{},
-			SkipFields: []string{},
+			SkipFields: []string{"AliasArn"},
 			ExtraColumns: append(
 				defaultRegionalColumns,
 				[]codegen.ColumnDefinition{
@@ -77,6 +77,12 @@ func LambdaResources() []*Resource {
 						Name:     "function_arn",
 						Type:     schema.TypeString,
 						Resolver: `schema.ParentResourceFieldResolver("arn")`,
+					},
+					{
+						Name:     "arn",
+						Type:     schema.TypeString,
+						Resolver: `schema.PathResolver("AliasArn")`,
+						Options:  schema.ColumnCreationOptions{PrimaryKey: true},
 					},
 				}...),
 		},

--- a/plugins/source/aws/codegen/recipes/resourcegroups.go
+++ b/plugins/source/aws/codegen/recipes/resourcegroups.go
@@ -15,10 +15,16 @@ func ResourceGroupsResources() []*Resource {
 		{
 			SubService: "resource_groups",
 			Struct:     &models.ResourceGroupWrapper{},
-			SkipFields: []string{"ARN"},
+			SkipFields: []string{},
 			ExtraColumns: append(
 				defaultRegionalColumns,
 				[]codegen.ColumnDefinition{
+					{
+						Name:     "arn",
+						Type:     schema.TypeString,
+						Resolver: `schema.PathResolver("GroupArn")`,
+						Options:  schema.ColumnCreationOptions{PrimaryKey: true},
+					},
 					{
 						Name:     "tags",
 						Type:     schema.TypeJSON,

--- a/plugins/source/aws/codegen/recipes/xray.go
+++ b/plugins/source/aws/codegen/recipes/xray.go
@@ -35,6 +35,12 @@ func XRayResources() []*Resource {
 			Struct:     &types.SamplingRuleRecord{},
 			ExtraColumns: []codegen.ColumnDefinition{
 				{
+					Name:     "arn",
+					Type:     schema.TypeString,
+					Resolver: `schema.PathResolver("SamplingRule.RuleARN")`,
+					Options:  schema.ColumnCreationOptions{PrimaryKey: true},
+				},
+				{
 					Name:     "tags",
 					Type:     schema.TypeJSON,
 					Resolver: `resolveXraySamplingRuleTags`,

--- a/plugins/source/aws/resources/services/autoscaling/group_scaling_policies.go
+++ b/plugins/source/aws/resources/services/autoscaling/group_scaling_policies.go
@@ -29,6 +29,14 @@ func GroupScalingPolicies() *schema.Table {
 				Resolver: schema.ParentResourceFieldResolver("arn"),
 			},
 			{
+				Name:     "arn",
+				Type:     schema.TypeString,
+				Resolver: schema.PathResolver("PolicyARN"),
+				CreationOptions: schema.ColumnCreationOptions{
+					PrimaryKey: true,
+				},
+			},
+			{
 				Name:     "adjustment_type",
 				Type:     schema.TypeString,
 				Resolver: schema.PathResolver("AdjustmentType"),
@@ -72,11 +80,6 @@ func GroupScalingPolicies() *schema.Table {
 				Name:     "min_adjustment_step",
 				Type:     schema.TypeInt,
 				Resolver: schema.PathResolver("MinAdjustmentStep"),
-			},
-			{
-				Name:     "policy_arn",
-				Type:     schema.TypeString,
-				Resolver: schema.PathResolver("PolicyARN"),
 			},
 			{
 				Name:     "policy_name",

--- a/plugins/source/aws/resources/services/backup/vault_recovery_points.go
+++ b/plugins/source/aws/resources/services/backup/vault_recovery_points.go
@@ -29,6 +29,14 @@ func VaultRecoveryPoints() *schema.Table {
 				Resolver: schema.ParentResourceFieldResolver("arn"),
 			},
 			{
+				Name:     "arn",
+				Type:     schema.TypeString,
+				Resolver: schema.PathResolver("RecoveryPointArn"),
+				CreationOptions: schema.ColumnCreationOptions{
+					PrimaryKey: true,
+				},
+			},
+			{
 				Name:     "tags",
 				Type:     schema.TypeJSON,
 				Resolver: resolveRecoveryPointTags,
@@ -92,11 +100,6 @@ func VaultRecoveryPoints() *schema.Table {
 				Name:     "lifecycle",
 				Type:     schema.TypeJSON,
 				Resolver: schema.PathResolver("Lifecycle"),
-			},
-			{
-				Name:     "recovery_point_arn",
-				Type:     schema.TypeString,
-				Resolver: schema.PathResolver("RecoveryPointArn"),
 			},
 			{
 				Name:     "resource_arn",

--- a/plugins/source/aws/resources/services/ecs/task_definitions.go
+++ b/plugins/source/aws/resources/services/ecs/task_definitions.go
@@ -24,6 +24,14 @@ func TaskDefinitions() *schema.Table {
 				Resolver: client.ResolveAWSRegion,
 			},
 			{
+				Name:     "arn",
+				Type:     schema.TypeString,
+				Resolver: schema.PathResolver("TaskDefinitionArn"),
+				CreationOptions: schema.ColumnCreationOptions{
+					PrimaryKey: true,
+				},
+			},
+			{
 				Name:     "tags",
 				Type:     schema.TypeJSON,
 				Resolver: resolveEcsTaskDefinitionTags,
@@ -132,11 +140,6 @@ func TaskDefinitions() *schema.Table {
 				Name:     "status",
 				Type:     schema.TypeString,
 				Resolver: schema.PathResolver("Status"),
-			},
-			{
-				Name:     "task_definition_arn",
-				Type:     schema.TypeString,
-				Resolver: schema.PathResolver("TaskDefinitionArn"),
 			},
 			{
 				Name:     "task_role_arn",

--- a/plugins/source/aws/resources/services/elasticbeanstalk/environments.go
+++ b/plugins/source/aws/resources/services/elasticbeanstalk/environments.go
@@ -22,6 +22,11 @@ func Environments() *schema.Table {
 				},
 			},
 			{
+				Name:     "arn",
+				Type:     schema.TypeString,
+				Resolver: schema.PathResolver("EnvironmentArn"),
+			},
+			{
 				Name:     "region",
 				Type:     schema.TypeString,
 				Resolver: client.ResolveAWSRegion,
@@ -78,11 +83,6 @@ func Environments() *schema.Table {
 				Name:     "endpoint_url",
 				Type:     schema.TypeString,
 				Resolver: schema.PathResolver("EndpointURL"),
-			},
-			{
-				Name:     "environment_arn",
-				Type:     schema.TypeString,
-				Resolver: schema.PathResolver("EnvironmentArn"),
 			},
 			{
 				Name:     "environment_links",

--- a/plugins/source/aws/resources/services/lambda/function_aliases.go
+++ b/plugins/source/aws/resources/services/lambda/function_aliases.go
@@ -29,9 +29,12 @@ func FunctionAliases() *schema.Table {
 				Resolver: schema.ParentResourceFieldResolver("arn"),
 			},
 			{
-				Name:     "alias_arn",
+				Name:     "arn",
 				Type:     schema.TypeString,
 				Resolver: schema.PathResolver("AliasArn"),
+				CreationOptions: schema.ColumnCreationOptions{
+					PrimaryKey: true,
+				},
 			},
 			{
 				Name:     "description",

--- a/plugins/source/aws/resources/services/resourcegroups/resource_groups.go
+++ b/plugins/source/aws/resources/services/resourcegroups/resource_groups.go
@@ -24,6 +24,14 @@ func ResourceGroups() *schema.Table {
 				Resolver: client.ResolveAWSRegion,
 			},
 			{
+				Name:     "arn",
+				Type:     schema.TypeString,
+				Resolver: schema.PathResolver("GroupArn"),
+				CreationOptions: schema.ColumnCreationOptions{
+					PrimaryKey: true,
+				},
+			},
+			{
 				Name:     "tags",
 				Type:     schema.TypeJSON,
 				Resolver: resolveResourcegroupsResourceGroupTags,

--- a/plugins/source/aws/resources/services/xray/sampling_rules.go
+++ b/plugins/source/aws/resources/services/xray/sampling_rules.go
@@ -24,6 +24,14 @@ func SamplingRules() *schema.Table {
 				Resolver: client.ResolveAWSRegion,
 			},
 			{
+				Name:     "arn",
+				Type:     schema.TypeString,
+				Resolver: schema.PathResolver("SamplingRule.RuleARN"),
+				CreationOptions: schema.ColumnCreationOptions{
+					PrimaryKey: true,
+				},
+			},
+			{
 				Name:     "tags",
 				Type:     schema.TypeJSON,
 				Resolver: resolveXraySamplingRuleTags,


### PR DESCRIPTION
(...or had them under a non-standard name). For AWS resources, we use the column name `arn` if the resource has a unique ARN.

- [x] `aws_autoscaling_group_scaling_policies`: renamed `policy_arn` -> `arn`
- [x] `aws_backup_vault_recovery_points`: renamed `recovery_point_arn` -> `arn`
- [x] `aws_ecs_task_definitions`: renamed `task_definition_arn` -> `arn`
- [x] `aws_elasticbeanstalk_environments`: renamed `environment_arn` -> `arn`
- [x] `aws_fsx_backups`: the `ResourceARN` field was previously named `arn`, but that refers to the resource, not the backup, so we should keep it `resource_arn` and have no `arn` field for backups.
- [x] `aws_lambda_function_aliases`: renamed `alias_arn` -> `arn`
- [x] `aws_resourcegroups_resource_groups`: renamed `group_arn` -> `arn`
- [x] `aws_xray_sampling_rules`: extracted `arn` from `SamplingRule.RuleARN`

Closes https://github.com/cloudquery/cloudquery/issues/2029
