### PR TITLE
chore(ci-wait-for-all): Use correct sha when listing checks, exit early when done

### DIFF
--- a/.github/workflows/wait_for_required_workflows.yml
+++ b/.github/workflows/wait_for_required_workflows.yml
@@ -21,10 +21,9 @@ jobs:
       - uses: actions/github-script@v6
         env:
           DIRS: ${{ steps.changed-files.outputs.all_changed_files }}
-          REF: ${{ github.ref }}
         with:
           script: |
-            const { REF, DIRS } = process.env
+            const { DIRS: dirs } = process.env
             let now = new Date().getTime()
             const deadline = now + 60 * 1000 * 15
             let actions = ["cli",
@@ -43,7 +42,7 @@ jobs:
                            "plugins/destination/postgresql",
                            "plugins/destination/test",
                            ]
-            actions = actions.filter(item => DIRS.includes(item))
+            actions = actions.filter(item => dirs.includes(item))
             if (actions.length === 0) {
               console.log("No actions to wait for")
               return
@@ -52,7 +51,7 @@ jobs:
               const checkRuns = await github.paginate(github.rest.checks.listForRef, {
                 owner: 'cloudquery',
                 repo: 'cloudquery',
-                ref: context.sha,
+                ref: context.payload.pull_request.head.sha,
                 status: 'completed',
                 per_page: 100
               })
@@ -65,12 +64,14 @@ jobs:
                   actions = actions.filter(action => action !== item.name)
                 }
               })
-              await new Promise(r => setTimeout(r, 1000));
+              if (actions.length === 0) {
+                console.log("Done waiting for actions")
+                return
+              }
+              
+              await new Promise(r => setTimeout(r, 5000));
               now = new Date().getTime()
             }
-            if (actions.length === 0) {
-              console.log("No actions to wait for")
-              return
-            } else {
-              throw new Error(`Timed out waiting for ${actions.join(', ')}`)
-            }
+            throw new Error(`Timed out waiting for ${actions.join(', ')}`)
+
+            


### PR DESCRIPTION
<!-- 🎉 Thank you for making CloudQuery awesome by submitting a PR 🎉 -->

#### Summary

It seems the API call for `listForRef` always returns an empty array (even for non forked PRs, see https://github.com/cloudquery/cloudquery/actions/runs/3151802511/jobs/5126220370)

This PR fixes it for non forked PRs by using the correct `sha` and also fixes the workflow to exit early once we finished waiting

<!--
Use the following steps to ensure your PR is ready to be reviewed

- [ ] Read the [contribution guidelines](../blob/main/CONTRIBUTING.md) 🧑‍🎓
- [ ] Test locally on your own infrastructure
- [ ] Run `go fmt` to format your code 🖊
- [ ] Lint your changes via `golangci-lint run` 🚨 (install golangci-lint [here](https://golangci-lint.run/usage/install/#local-installation))
- [ ] Update or add tests 🧪
- [ ] Ensure the status checks below are successful ✅
--->
