### PR TITLE
chore(ci): Fix files diff

### DIFF
--- a/.github/workflows/wait_for_required_workflows.yml
+++ b/.github/workflows/wait_for_required_workflows.yml
@@ -18,6 +18,8 @@ jobs:
         uses: tj-actions/changed-files@v31
         with:
           dir_names: true
+          sha: ${{ github.event.pull_request.head.sha }}
+          base_sha: ${{ github.event.pull_request.base.sha }}
       - uses: actions/github-script@v6
         env:
           DIRS: ${{ steps.changed-files.outputs.all_changed_files }}


### PR DESCRIPTION
https://github.com/cloudquery/cloudquery/pull/2093 updated the action we use to diff files, which seems to use the wrong `sha` in the latest version, see https://github.com/cloudquery/cloudquery/actions/runs/3153783624/jobs/5130648152#step:3:496.

This PR should fix it