### PR TITLE
chore(docs): Fix filename of source plugins release stages (V1)

### DIFF
--- a/website/pages/docs/plugins/source-plugin-release-stages.md
+++ b/website/pages/docs/plugins/source-plugin-release-stages.md
@@ -1,6 +1,6 @@
 # Source Plugin Release Stages
 
-[Official](./sources) source plugins go through multiple release stages: Alpha, Beta and GA.
+[Official](source) source plugins go through multiple release stages: Alpha, Beta and GA.
 
 ## Comparison Matrix
 

--- a/website/pages/docs/plugins/source.md
+++ b/website/pages/docs/plugins/source.md
@@ -4,7 +4,7 @@
 
 Documentation, configuration and available tables for every plugin are available in the relevant GitHub repository.
 
-Official source plugins follow [release stages](./source_plugins_release_stages).
+Official source plugins follow [release stages](source-plugin-release-stages).
 
 | **Name**                                                                                                 | Stage |
 |----------------------------------------------------------------------------------------------------------| ----- |


### PR DESCRIPTION
The `Source Plugin Release Stages` file was named with underscores, causing it to appear as such in the sidebar and URL path
![Screenshot 2022-09-30 at 10 37 09](https://user-images.githubusercontent.com/1121616/193241541-43e5fe8a-6569-4130-80a4-157fb7b4179d.png)
