### PR TITLE
chore(ci-wait-for-all): Don't print entire checkRuns array, simplify logic

### DIFF
--- a/.github/workflows/wait_for_required_workflows.yml
+++ b/.github/workflows/wait_for_required_workflows.yml
@@ -27,7 +27,10 @@ jobs:
             console.log(dirs)
             let now = new Date().getTime()
             const deadline = now + 60 * 1000 * 15
-            let actions = ["cli",
+            const matchesDir = (action) => {
+              return dirs.some(dir => dir.startsWith(action))
+            }
+            const actions = ["cli",
                            "plugins/source/aws",
                            "plugins/source/azure",
                            "plugins/source/cloudflare",
@@ -42,11 +45,7 @@ jobs:
                            
                            "plugins/destination/postgresql",
                            "plugins/destination/test",
-                           ]
-            const matchesDir = (action) => {
-              return dirs.some(dir => dir.startsWith(action))
-            }
-            actions = actions.filter(action => matchesDir(action))
+                           ].filter(action => matchesDir(action))
             if (actions.length === 0) {
               console.log("No actions to wait for")
               return
@@ -60,17 +59,15 @@ jobs:
                 status: 'completed',
                 per_page: 100
               })
-              console.log(checkRuns)
-              checkRuns.forEach(item => {
-                if (actions.includes(item.name)) {
-                  if (item.conclusion !== 'success') {
-                    throw new Error(`Check ${item.name} failed`)
-                  }
-                  actions = actions.filter(action => action !== item.name)
-                }
-              })
-              if (actions.length === 0) {
-                console.log("Done waiting for actions")
+              const runs = checkRuns.map(({ name, conclusion }) => ({ name, conclusion }))
+              console.log(`Got the following check runs: ${runs}`)
+              const matchingRuns = runs.filter(({ name }) => actions.includes(name))
+              const failedRuns = matchingRuns.filter(({ conclusion }) => conclusion !== 'success')
+              if (failedRuns.length > 0) {
+                throw new Error(`The following required workflows failed: ${failedRuns.map(({ name }) => name).join(", ")}`)
+              }
+              if (matchingRuns.length === actions.length) {
+                console.log("All required workflows have passed")
                 return
               }
               


### PR DESCRIPTION


<!-- 🎉 Thank you for making CloudQuery awesome by submitting a PR 🎉 -->

#### Summary

Currently this workflows prints on each polling iteration the entire `checkRuns` array which is very spammy. This changes it so we only print `name` and `conclusion`. It also simplifies the logic.

<!--
Use the following steps to ensure your PR is ready to be reviewed

- [ ] Read the [contribution guidelines](../blob/main/CONTRIBUTING.md) 🧑‍🎓
- [ ] Test locally on your own infrastructure
- [ ] Run `go fmt` to format your code 🖊
- [ ] Lint your changes via `golangci-lint run` 🚨 (install golangci-lint [here](https://golangci-lint.run/usage/install/#local-installation))
- [ ] Update or add tests 🧪
- [ ] Ensure the status checks below are successful ✅
--->
