### PR TITLE
chore: Set empty code owners for dependencies updates

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -4,3 +4,6 @@
 /plugins/source/aws @hermanschaaf @yevgenypats
 /plugins/source/azure @erezrokah @yevgenypats
 /plugins/source/gcp @yevgenypats @disq
+
+**/go.mod
+**/go.sum


### PR DESCRIPTION
<!-- 🎉 Thank you for making CloudQuery awesome by submitting a PR 🎉 -->

#### Summary

Since we auto merge most updates, having code owners for `go.*` files create quite a lot of noise for developers.
I think we can handle reviews (if needed) for dep updates manually for now

<!--
Use the following steps to ensure your PR is ready to be reviewed

- [ ] Read the [contribution guidelines](../blob/main/CONTRIBUTING.md) 🧑‍🎓
- [ ] Test locally on your own infrastructure
- [ ] Run `go fmt` to format your code 🖊
- [ ] Lint your changes via `golangci-lint run` 🚨 (install golangci-lint [here](https://golangci-lint.run/usage/install/#local-installation))
- [ ] Update or add tests 🧪
- [ ] Ensure the status checks below are successful ✅
--->
