### PR TITLE
chore: Fix plugins link in header tab

### DIFF
--- a/website/pages/_meta.json
+++ b/website/pages/_meta.json
@@ -21,7 +21,7 @@
   },
   "plugins": {
     "title": "Plugins",
-    "href": "/docs/plugins/source"
+    "href": "/docs/plugins/sources"
   },
   "confirm": {
     "title": "Confirm",


### PR DESCRIPTION
<!-- 🎉 Thank you for making CloudQuery awesome by submitting a PR 🎉 -->

#### Summary

The following link 
![image](https://user-images.githubusercontent.com/26760571/193791616-89f4acaf-47bd-4475-8d92-a10ae4168a51.png)
is broken. This PR fixes it

<!--
Use the following steps to ensure your PR is ready to be reviewed

- [ ] Read the [contribution guidelines](../blob/main/CONTRIBUTING.md) 🧑‍🎓
- [ ] Test locally on your own infrastructure
- [ ] Run `go fmt` to format your code 🖊
- [ ] Lint your changes via `golangci-lint run` 🚨 (install golangci-lint [here](https://golangci-lint.run/usage/install/#local-installation))
- [ ] Update or add tests 🧪
- [ ] Ensure the status checks below are successful ✅
--->
