### PR TITLE
fix: Retry routine logging fix

### DIFF
--- a/plugins/source/aws/client/retry.go
+++ b/plugins/source/aws/client/retry.go
@@ -31,7 +31,7 @@ func (r *retryer) RetryDelay(attempt int, err error) (time.Duration, error) {
 	logParams := []interface{}{
 		"duration", dur.String(),
 		"attempt", attempt,
-		"err", err,
+		"err", err.Error(),
 	}
 	if retErr != nil {
 		logParams = append(logParams, "retrier_err", retErr)


### PR DESCRIPTION
<!-- 🎉 Thank you for making CloudQuery awesome by submitting a PR 🎉 -->

#### Summary

<!--
Explain what problem this PR addresses
-->

fixes logging during retries
was:
`{"level":"debug","logParams":["duration","770.063713ms","attempt",1,"err",{}],"time":"2022-10-04T14:54:04+03:00","message":"waiting before retry..."}
`
now:
`{"level":"debug","logParams":["duration","770.063713ms","attempt",1,"err","test"],"time":"2022-10-04T14:54:04+03:00","message":"waiting before retry..."}
`
migt close #2299
<!--
Use the following steps to ensure your PR is ready to be reviewed

- [ ] Read the [contribution guidelines](../blob/main/CONTRIBUTING.md) 🧑‍🎓
- [ ] Test locally on your own infrastructure
- [ ] Run `go fmt` to format your code 🖊
- [ ] Lint your changes via `golangci-lint run` 🚨 (install golangci-lint [here](https://golangci-lint.run/usage/install/#local-installation))
- [ ] Update or add tests 🧪
- [ ] Ensure the status checks below are successful ✅
--->
