### PR TITLE
fix: Add back missing plugin logs

### DIFF
--- a/cli/cmd/sync.go
+++ b/cli/cmd/sync.go
@@ -37,6 +37,8 @@ func NewCmdSync() *cobra.Command {
 
 func sync(cmd *cobra.Command, args []string) error {
 	ctx := cmd.Context()
+	log.Info().Msg("Start sync")
+	defer log.Info().Msg("End sync")
 
 	fmt.Printf("Loading spec(s) from %s\n", strings.Join(args, ", "))
 	specReader, err := specs.NewSpecReader(args)
@@ -66,7 +68,8 @@ func sync(cmd *cobra.Command, args []string) error {
 
 func syncConnection(ctx context.Context, sourceSpec specs.Source, destinationsSpecs []specs.Destination) error {
 	syncTime := time.Now().UTC()
-	sourceClient, err := clients.NewSourceClient(ctx, sourceSpec.Registry, sourceSpec.Path, sourceSpec.Version)
+	sourceClient, err := clients.NewSourceClient(ctx, sourceSpec.Registry, sourceSpec.Path, sourceSpec.Version,
+		clients.WithSourceLogger(log.Logger))
 	if err != nil {
 		return fmt.Errorf("failed to get source plugin client for %s: %w", sourceSpec.Name, err)
 	}

--- a/cli/cmd/sync.go
+++ b/cli/cmd/sync.go
@@ -69,7 +69,8 @@ func sync(cmd *cobra.Command, args []string) error {
 func syncConnection(ctx context.Context, sourceSpec specs.Source, destinationsSpecs []specs.Destination) error {
 	syncTime := time.Now().UTC()
 	sourceClient, err := clients.NewSourceClient(ctx, sourceSpec.Registry, sourceSpec.Path, sourceSpec.Version,
-		clients.WithSourceLogger(log.Logger))
+		clients.WithSourceLogger(log.Logger),
+	)
 	if err != nil {
 		return fmt.Errorf("failed to get source plugin client for %s: %w", sourceSpec.Name, err)
 	}
@@ -94,7 +95,9 @@ func syncConnection(ctx context.Context, sourceSpec specs.Source, destinationsSp
 		}
 	}()
 	for i, destinationSpec := range destinationsSpecs {
-		destClients[i], err = clients.NewDestinationClient(ctx, destinationSpec.Registry, destinationSpec.Path, destinationSpec.Version)
+		destClients[i], err = clients.NewDestinationClient(ctx, destinationSpec.Registry, destinationSpec.Path, destinationSpec.Version,
+			clients.WithDestinationLogger(log.Logger),
+		)
 		if err != nil {
 			return fmt.Errorf("failed to create destination plugin client for %s: %w", destinationSpec.Name, err)
 		}

--- a/cli/cmd/sync.go
+++ b/cli/cmd/sync.go
@@ -70,10 +70,11 @@ func syncConnection(ctx context.Context, sourceSpec specs.Source, destinationsSp
 	for i := range destinationsSpecs {
 		destinationNames[i] = destinationsSpecs[i].Name
 	}
-	log.Info().Str("source", sourceSpec.Name).Strs("destinations", destinationNames).Msg("Start sync")
-	defer log.Info().Str("source", sourceSpec.Name).Strs("destinations", destinationNames).Msg("End sync")
-
 	syncTime := time.Now().UTC()
+
+	log.Info().Str("source", sourceSpec.Name).Strs("destinations", destinationNames).Time("syncTime", syncTime).Msg("Start sync")
+	defer log.Info().Str("source", sourceSpec.Name).Strs("destinations", destinationNames).Time("syncTime", syncTime).Msg("End sync")
+
 	sourceClient, err := clients.NewSourceClient(ctx, sourceSpec.Registry, sourceSpec.Path, sourceSpec.Version,
 		clients.WithSourceLogger(log.Logger),
 	)

--- a/cli/cmd/sync.go
+++ b/cli/cmd/sync.go
@@ -37,12 +37,11 @@ func NewCmdSync() *cobra.Command {
 
 func sync(cmd *cobra.Command, args []string) error {
 	ctx := cmd.Context()
-	log.Info().Msg("Start sync")
-	defer log.Info().Msg("End sync")
-
+	log.Info().Strs("args", args).Msg("Loading spec(s)")
 	fmt.Printf("Loading spec(s) from %s\n", strings.Join(args, ", "))
 	specReader, err := specs.NewSpecReader(args)
 	if err != nil {
+		log.Error().Strs("args", args).Err(err).Msg("Failed to load spec(s)")
 		return fmt.Errorf("failed to load spec(s) from %s. Error: %w", strings.Join(args, ", "), err)
 	}
 
@@ -67,6 +66,13 @@ func sync(cmd *cobra.Command, args []string) error {
 }
 
 func syncConnection(ctx context.Context, sourceSpec specs.Source, destinationsSpecs []specs.Destination) error {
+	destinationNames := make([]string, len(destinationsSpecs))
+	for i := range destinationsSpecs {
+		destinationNames[i] = destinationsSpecs[i].Name
+	}
+	log.Info().Str("source", sourceSpec.Name).Strs("destinations", destinationNames).Msg("Start sync")
+	defer log.Info().Str("source", sourceSpec.Name).Strs("destinations", destinationNames).Msg("End sync")
+
 	syncTime := time.Now().UTC()
 	sourceClient, err := clients.NewSourceClient(ctx, sourceSpec.Registry, sourceSpec.Path, sourceSpec.Version,
 		clients.WithSourceLogger(log.Logger),

--- a/cli/cmd/sync.go
+++ b/cli/cmd/sync.go
@@ -72,8 +72,8 @@ func syncConnection(ctx context.Context, sourceSpec specs.Source, destinationsSp
 	}
 	syncTime := time.Now().UTC()
 
-	log.Info().Str("source", sourceSpec.Name).Strs("destinations", destinationNames).Time("syncTime", syncTime).Msg("Start sync")
-	defer log.Info().Str("source", sourceSpec.Name).Strs("destinations", destinationNames).Time("syncTime", syncTime).Msg("End sync")
+	log.Info().Str("source", sourceSpec.Name).Strs("destinations", destinationNames).Time("sync_time", syncTime).Msg("Start sync")
+	defer log.Info().Str("source", sourceSpec.Name).Strs("destinations", destinationNames).Time("sync_time", syncTime).Msg("End sync")
 
 	sourceClient, err := clients.NewSourceClient(ctx, sourceSpec.Registry, sourceSpec.Path, sourceSpec.Version,
 		clients.WithSourceLogger(log.Logger),

--- a/cli/cmd/sync_test.go
+++ b/cli/cmd/sync_test.go
@@ -1,12 +1,18 @@
 package cmd
 
 import (
+	"os"
 	"path"
 	"runtime"
+	"strings"
 	"testing"
 )
 
 func TestSync(t *testing.T) {
+	t.Cleanup(func() {
+		os.RemoveAll("cloudquery.log")
+	})
+
 	// this works but some funny stuff is going on
 	_, filename, _, _ := runtime.Caller(0)
 	currentDir := path.Dir(filename)
@@ -15,5 +21,18 @@ func TestSync(t *testing.T) {
 	cmd.SetArgs([]string{"sync", testDataDir})
 	if err := cmd.Execute(); err != nil {
 		t.Fatal(err)
+	}
+
+	// check that log was written and contains some lines from the plugin
+	b, err := os.ReadFile("cloudquery.log")
+	if err != nil {
+		t.Fatal("failed to read cloudquery.log:", err)
+	}
+	content := string(b)
+	if len(content) == 0 {
+		t.Fatalf("cloudquery.log empty, but expected some logs")
+	}
+	if !strings.Contains(content, "plugin=") {
+		t.Errorf("cloudquery.log is expected to contain lines with string plugin=, but none found. Logs were: \n%v", content)
 	}
 }

--- a/cli/cmd/sync_test.go
+++ b/cli/cmd/sync_test.go
@@ -4,7 +4,6 @@ import (
 	"os"
 	"path"
 	"runtime"
-	"strings"
 	"testing"
 )
 
@@ -30,9 +29,6 @@ func TestSync(t *testing.T) {
 	}
 	content := string(b)
 	if len(content) == 0 {
-		t.Fatalf("cloudquery.log empty, but expected some logs")
-	}
-	if !strings.Contains(content, "plugin=") {
-		t.Errorf("cloudquery.log is expected to contain lines with string plugin=, but none found. Logs were: \n%v", content)
+		t.Fatalf("cloudquery.log empty; expected some logs")
 	}
 }


### PR DESCRIPTION
This fixes an issue where plugin logs were not being streamed to `cloudquery.log`. It also adds a test for this to catch future regressions.