### PR TITLE
feat: Add newlines to errors printed in CLI

### DIFF
--- a/cli/cmd/doc.go
+++ b/cli/cmd/doc.go
@@ -20,9 +20,9 @@ func newCmdDoc() *cobra.Command {
 		Short:  docShort,
 		Args:   cobra.ExactValidArgs(1),
 		Hidden: true,
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: commandWithPrettyErrors(func(cmd *cobra.Command, args []string) error {
 			return doc.GenMarkdownTreeCustom(cmd.Parent(), args[0], filePrepender, linkHandler)
-		},
+		}),
 	}
 	return cmd
 }

--- a/cli/cmd/errors.go
+++ b/cli/cmd/errors.go
@@ -1,0 +1,31 @@
+package cmd
+
+import (
+	"github.com/spf13/cobra"
+	"strings"
+)
+
+type prettyError struct {
+	err error
+}
+
+type command func(*cobra.Command, []string) error
+
+func commandWithPrettyErrors(original command) command {
+	return func(cmd *cobra.Command, args []string) error {
+		err := original(cmd, args)
+		return prettifyError(err)
+	}
+}
+
+func (p prettyError) Error() string {
+	msg := p.err.Error()
+	return strings.Join(strings.Split(msg, ": "), ":\n  ")
+}
+
+func prettifyError(err error) error {
+	if err == nil {
+		return err
+	}
+	return prettyError{err: err}
+}

--- a/cli/cmd/sync.go
+++ b/cli/cmd/sync.go
@@ -30,7 +30,7 @@ func NewCmdSync() *cobra.Command {
 		Long:    fetchShort,
 		Example: fetchExample,
 		Args:    cobra.MinimumNArgs(1),
-		RunE:    sync,
+		RunE:    commandWithPrettyErrors(sync),
 	}
 	return cmd
 }


### PR DESCRIPTION
Rather than printing a long string of errors on a single line, this splits errors onto multiple lines (separated by `: `).

Before:

```
../cloudquery/cli/cli sync --log-level debug v2
Loading spec(s) from v2
Starting sync for:  heroku -> [postgresql]
| Syncing resources... (0/-, 0 resources/hr) [0s] Error: failed to sync source heroku: failed to fetch resources: failed to sync source heroku: failed to fetch resources from stream: rpc error: code = Unknown desc = failed to sync resources: invalid "*" resource, with explicit resources
```

After:
```
../cloudquery/cli/cli sync --log-level debug v2
Loading spec(s) from v2
Starting sync for:  heroku -> [postgresql]
| Syncing resources... (0/-, 0 resources/hr) [0s] Error: failed to sync source heroku:
  failed to fetch resources:
  failed to sync source heroku:
  failed to fetch resources from stream:
  rpc error:
  code = Unknown desc = failed to sync resources:
  invalid "*" resource, with explicit resources
```

Hopefully small quality-of-life improvement for CloudQuery users, with little cost for us to maintain.

Closes https://github.com/cloudquery/cloudquery/issues/2382