### PR TITLE
feat: Convert policies to v1

### DIFF
--- a/plugins/source/k8s/policies_v1/README.md
+++ b/plugins/source/k8s/policies_v1/README.md
@@ -1,7 +1,3 @@
-# Deprecation Notice
-
-These are the policy files for CloudQuery **v0.x.x**. Please use the [policies_v1/](../policies_v1/) directory for CloudQuery v1.x.x policies.
-
 # CloudQuery Policies
 
 CloudQuery SQL Policies for Kubernetes

--- a/plugins/source/k8s/policies_v1/create_k8s_policy_results.sql
+++ b/plugins/source/k8s/policies_v1/create_k8s_policy_results.sql
@@ -1,0 +1,12 @@
+create table if not exists k8s_policy_results
+(
+    execution_time timestamp with time zone,
+    framework      varchar(255),
+    check_id       varchar(255),
+    title          text,
+    context        text,
+    namespace      text,
+    resource_id    varchar(1024),
+    resource_name  text,
+    status         varchar(16)
+)

--- a/plugins/source/k8s/policies_v1/nsa_cisa_v1/network_hardening.sql
+++ b/plugins/source/k8s/policies_v1/nsa_cisa_v1/network_hardening.sql
@@ -1,0 +1,132 @@
+\echo "Executing K8S Network Hardening NSA CISA v1"
+
+\echo "Enforce CPU resource limits"
+
+\echo "Deamonsets enforce cpu limit"
+\set check_id "daemonset_cpu_limit"
+\ir ../queries/network_hardening/daemonset_cpu_limit.sql
+
+\echo "Deployments enforce cpu limit"
+\set check_id "deployment_cpu_limit"
+\ir ../queries/network_hardening/deployment_cpu_limit.sql
+
+\echo "Jobs enforce cpu limit"
+\set check_id "job_cpu_limit"
+\ir ../queries/network_hardening/job_cpu_limit.sql
+
+
+\echo "Namespaces CPU limit range default"
+\set check_id "namespace_limit_range_default_cpu_limit"
+\ir ../queries/network_hardening/namespace_limit_range_default_cpu_limit.sql
+
+
+\echo "Namespaces CPU limit resource quota"
+\set check_id "namespace_resource_quota_cpu_limit"
+\ir ../queries/network_hardening/namespace_resource_quota_cpu_limit.sql
+
+
+\echo "ReplciaSets enforce cpu limit"
+\set check_id "replicaset_cpu_limit"
+\ir ../queries/network_hardening/replicaset_cpu_limit.sql
+
+
+\echo "Enforce CPU request"
+
+\echo "Deamonsets enforce cpu request"
+\set check_id "daemonset_cpu_request"
+\ir ../queries/network_hardening/daemonset_cpu_request.sql
+
+\echo "Deployments enforce cpu request"
+\set check_id "deployment_cpu_request"
+\ir ../queries/network_hardening/deployment_cpu_request.sql
+
+\echo "Jobs enforce cpu request"
+\set check_id "job_cpu_limit"
+\ir ../queries/network_hardening/job_cpu_limit.sql
+
+
+\echo "Namespaces CPU request range default"
+\set check_id "namespace_limit_range_default_cpu_request"
+\ir ../queries/network_hardening/namespace_limit_range_default_cpu_request.sql
+
+
+\echo "Namespaces CPU request resource quota"
+\set check_id "namespace_resource_quota_cpu_request"
+\ir ../queries/network_hardening/namespace_resource_quota_cpu_request.sql
+
+
+\echo "ReplciaSets enforce cpu request"
+\set check_id "replicaset_cpu_request"
+\ir ../queries/network_hardening/replicaset_cpu_request.sql
+
+\echo "Ensure memory limits set"
+
+\echo "Deamonsets enforce memory limit"
+\set check_id "daemonset_memory_limit"
+\ir ../queries/network_hardening/daemonset_memory_limit.sql
+
+\echo "Deployments enforce memory limit"
+\set check_id "deployment_memory_limit"
+\ir ../queries/network_hardening/deployment_memory_limit.sql
+
+\echo "Jobs enforce memory limit"
+\set check_id "job_memory_limit"
+\ir ../queries/network_hardening/job_memory_limit.sql
+
+
+\echo "Namespaces CPU memory range default"
+\set check_id "namespace_limit_range_default_memory_limit"
+\ir ../queries/network_hardening/namespace_limit_range_default_memory_limit.sql
+
+
+\echo "Namespaces CPU memory resource quota"
+\set check_id "namespace_resource_quota_memory_limit"
+\ir ../queries/network_hardening/namespace_resource_quota_memory_limit.sql
+
+
+\echo "ReplciaSets enforce memory limit"
+\set check_id "replicaset_memory_limit"
+\ir ../queries/network_hardening/replicaset_memory_limit.sql
+
+
+\echo "Enforce Memory request"
+
+\echo "Deamonsets enforce memory request"
+\set check_id "daemonset_memory_request"
+\ir ../queries/network_hardening/daemonset_memory_request.sql
+
+\echo "Deployments enforce memory request"
+\set check_id "deployment_memory_request"
+\ir ../queries/network_hardening/deployment_memory_request.sql
+
+\echo "Jobs enforce memory request"
+\set check_id "job_memory_request"
+\ir ../queries/network_hardening/job_memory_request.sql
+
+
+\echo "Namespaces Memory request range default"
+\set check_id "namespace_limit_range_default_memory_request"
+\ir ../queries/network_hardening/namespace_limit_range_default_memory_request.sql
+
+
+\echo "Namespaces Memory request resource quota"
+\set check_id "namespace_resource_quota_memory_request"
+\ir ../queries/network_hardening/namespace_resource_quota_memory_request.sql
+
+
+\echo "ReplciaSets enforce cpu request"
+\set check_id "replicaset_memory_request"
+\ir ../queries/network_hardening/replicaset_memory_request.sql
+
+
+\echo "Enforce default deny network policy"
+
+\echo "Network policy default deny egress"
+\set check_id "network_policy_default_deny_egress"
+\ir ../queries/network_hardening/network_policy_default_deny_egress.sql
+
+
+\echo "Network policy default deny ingress"
+\set check_id "network_policy_default_deny_ingress"
+\ir ../queries/network_hardening/network_policy_default_deny_ingress.sql
+

--- a/plugins/source/k8s/policies_v1/nsa_cisa_v1/pod_security.sql
+++ b/plugins/source/k8s/policies_v1/nsa_cisa_v1/pod_security.sql
@@ -1,0 +1,152 @@
+\echo "Executing K8S Pod Security NSA CISA v1"
+
+\set check_id "container_disallow_host_path"
+\echo "Disallow host path access"
+\ir ../queries/pod_security/pod_volume_host_path.sql
+
+\echo "Verify containers have privileged access disabled"
+
+\echo "Deamonset privileges disabled"
+\set check_id "daemonset_container_privilege_disabled"
+\ir ../queries/pod_security/daemonset_container_privilege_disabled.sql
+
+\echo "Deployment containers privileged access disabled"
+\set check_id "deployment_container_privilege_disabled"
+\ir ../queries/pod_security/deployment_container_privilege_disabled.sql
+
+\echo "Jobs container privileged access disabled"
+\set check_id "job_container_privilege_disabled"
+\ir ../queries/pod_security/job_container_privilege_disabled.sql
+
+\echo "Pod container privileged access disabled"
+\set check_id "pod_container_privilege_disabled"
+\ir ../queries/pod_security/pod_container_privilege_disabled.sql
+
+\echo "ReplicaSet container privileged access disabled"
+\set check_id "replicaset_container_privilege_disabled"
+\ir ../queries/pod_security/replicaset_container_privilege_disabled.sql
+
+\echo "Container privileged escalation disabled"
+
+\echo "DaemonSet container privileged escalation disabled"
+\set check_id "daemonset_container_privilege_escalation_disabled"
+\ir ../queries/pod_security/daemonset_container_privilege_escalation_disabled.sql
+
+\echo "Deployment container privileged escalation disabled"
+\set check_id "deployment_container_privilege_escalation_disabled"
+\ir ../queries/pod_security/deployment_container_privilege_escalation_disabled.sql
+
+\echo "Job container privileged escalation disabled"
+\set check_id "job_container_privilege_escalation_disabled"
+\ir ../queries/pod_security/job_container_privilege_escalation_disabled.sql
+
+\echo "Pod container privileged escalation disabled"
+\set check_id "pod_container_privilege_escalation_disabled"
+\ir ../queries/pod_security/pod_container_privilege_escalation_disabled.sql
+
+\echo "ReplicaSet container privileged escalation disabled"
+\set check_id "replicaset_container_privilege_escalation_disabled"
+\ir ../queries/pod_security/replicaset_container_privilege_escalation_disabled.sql
+
+
+\echo "Host network access disabled"
+
+\echo "DaemonSet container hostNetwork disabled"
+\set check_id "daemonset_host_network_access_disabled"
+\ir ../queries/pod_security/daemonset_host_network_access_disabled.sql
+
+\echo "Deployment container hostNetwork disabled"
+\set check_id "deployment_host_network_access_disabled"
+\ir ../queries/pod_security/deployment_host_network_access_disabled.sql
+
+\echo "Job container hostNetwork disabled"
+\set check_id "job_host_network_access_disabled"
+\ir ../queries/pod_security/job_host_network_access_disabled.sql
+
+\echo "Pod container hostNetwork disabled"
+\set check_id "pod_container_privilege_escalation_disabled"
+\ir ../queries/pod_security/pod_host_network_access_disabled.sql
+
+\echo "ReplicaSet container hostNetwork disabled"
+\set check_id "replicaset_container_privilege_escalation_disabled"
+\ir ../queries/pod_security/replicaset_host_network_access_disabled.sql
+
+
+\echo "HostPID and HostIPC sharing disabled"
+
+\echo "DeamonSet containers HostPID and HostIPC sharing disabled"
+\set check_id "daemonset_hostpid_hostipc_sharing_disabled"
+\ir ../queries/pod_security/daemonset_hostpid_hostipc_sharing_disabled.sql
+
+\echo "Deployment containers HostPID and HostIPC sharing disabled"
+\set check_id "deployment_hostpid_hostipc_sharing_disabled"
+\ir ../queries/pod_security/deployment_hostpid_hostipc_sharing_disabled.sql
+
+\echo "Job containers HostPID and HostIPC sharing disabled"
+\set check_id "job_hostpid_hostipc_sharing_disabled"
+\ir ../queries/pod_security/job_hostpid_hostipc_sharing_disabled.sql
+
+\echo "Pod containers HostPID and HostIPC sharing disabled"
+\set check_id "pod_hostpid_hostipc_sharing_disabled"
+\ir ../queries/pod_security/pod_hostpid_hostipc_sharing_disabled.sql
+
+\echo "ReplicaSet containers HostPID and HostIPC sharing disabled"
+\set check_id "replicaset_hostpid_hostipc_sharing_disabled"
+\ir ../queries/pod_security/replicaset_hostpid_hostipc_sharing_disabled.sql
+
+\echo "Containers root file system is read-only"
+
+\echo "DeamonSet containers root file system is read-only"
+\set check_id "daemonset_immutable_container_filesystem"
+\ir ../queries/pod_security/daemonset_immutable_container_filesystem.sql
+
+\echo "Deployment containers root file system is read-only"
+\set check_id "deployment_immutable_container_filesystem"
+\ir ../queries/pod_security/deployment_immutable_container_filesystem.sql
+
+\echo "Job containers root file system is read-only"
+\set check_id "job_immutable_container_filesystem"
+\ir ../queries/pod_security/job_immutable_container_filesystem.sql
+
+\echo "Pod containers root file system is read-only"
+\set check_id "pod_immutable_container_filesystem"
+\ir ../queries/pod_security/pod_immutable_container_filesystem.sql
+
+\echo "ReplicaSet containers root file system is read-only"
+\set check_id "replicaset_immutable_container_filesystem"
+\ir ../queries/pod_security/replicaset_immutable_container_filesystem.sql
+
+
+\echo "Enforce containers to run as non-root"
+
+\echo "DeamonSet containers to run as non-root"
+\set check_id "daemonset_non_root_container"
+\ir ../queries/pod_security/daemonset_non_root_container.sql
+
+\echo "Deployment containers to run as non-root"
+\set check_id "deployment_non_root_container"
+\ir ../queries/pod_security/deployment_non_root_container.sql
+
+\echo "Job containers to run as non-root"
+\set check_id "job_non_root_container"
+\ir ../queries/pod_security/job_non_root_container.sql
+
+\echo "Pod containers to run as non-root"
+\set check_id "pod_non_root_container"
+\ir ../queries/pod_security/pod_non_root_container.sql
+
+\echo "ReplicaSet containers to run as non-root"
+\set check_id "replicaset_non_root_container"
+\ir ../queries/pod_security/replicaset_non_root_container.sql
+
+
+\echo "Automatic mapping of the service account tokens disabled"
+
+\echo "Pod service account tokens disabled"
+\set check_id "pod_service_account_token_disabled"
+\ir ../queries/pod_security/pod_service_account_token_disabled.sql
+
+\echo "Service account tokens disabled"
+\set check_id "service_account_token_disabled"
+\ir ../queries/pod_security/service_account_token_disabled.sql
+

--- a/plugins/source/k8s/policies_v1/nsa_cisa_v1/policy.sql
+++ b/plugins/source/k8s/policies_v1/nsa_cisa_v1/policy.sql
@@ -1,0 +1,15 @@
+\set ON_ERROR_STOP on
+SET TIME ZONE 'UTC';
+-- neat trick to set execution_time if not already set
+-- https://stackoverflow.com/questions/32582600/only-set-variable-in-psql-script-if-not-specified-on-the-command-line
+\set execution_time :execution_time
+SELECT CASE 
+  WHEN :'execution_time' = ':execution_time' THEN to_char(now(), 'YYYY-MM-dd HH24:MI:SS.US')
+  ELSE :'execution_time'
+END AS "execution_time"  \gset
+
+\set framework 'cis_v1.2.0'
+
+\ir ../create_k8s_policy_results.sql
+\ir ./network_hardening.sql
+\ir ./pod_security.sql

--- a/plugins/source/k8s/policies_v1/policy.sql
+++ b/plugins/source/k8s/policies_v1/policy.sql
@@ -1,0 +1,11 @@
+\set ON_ERROR_STOP on
+SET TIME ZONE 'UTC';
+-- neat trick to set execution_time if not already set
+-- https://stackoverflow.com/questions/32582600/only-set-variable-in-psql-script-if-not-specified-on-the-command-line
+\set execution_time :execution_time
+SELECT CASE 
+  WHEN :'execution_time' = ':execution_time' THEN to_char(now(), 'YYYY-MM-dd HH24:MI:SS.US')
+  ELSE :'execution_time'
+END AS "execution_time"  \gset
+
+\ir nsa_cisa_v1/policy.sql

--- a/plugins/source/k8s/policies_v1/queries/network_hardening/daemonset_cpu_limit.sql
+++ b/plugins/source/k8s/policies_v1/queries/network_hardening/daemonset_cpu_limit.sql
@@ -1,0 +1,25 @@
+-- Join every row in the daemonset table with its json array of containers.
+WITH daemonset_containers AS (SELECT uid, value AS container 
+                               FROM k8s_apps_daemon_sets
+                               CROSS JOIN jsonb_array_elements(spec_template->'spec'->'containers') AS value)
+
+INSERT INTO k8s_policy_results (resource_id, execution_time, framework, check_id, title, context, namespace,
+                                resource_name, status)
+select uid                              AS resource_id,
+        :'execution_time'::timestamp     AS execution_time,
+        :'framework'                     AS framework,
+        :'check_id'                      AS check_id,
+        'Daemonset enforces cpu limits' AS title,
+        context                          AS context,
+        namespace                        AS namespace,
+        name                             AS resource_name,
+        CASE
+            WHEN
+                  -- Every container needs to have a CPU limit for the check to pass
+                  (SELECT COUNT(*) FROM daemonset_containers WHERE daemonset_containers.uid = k8s_apps_daemon_sets.uid AND
+                  daemonset_containers.container->'resources'->'limits'->>'cpu' IS NULL) > 0
+                THEN 'fail'
+                ELSE 'pass'
+            END                          AS status
+FROM k8s_apps_daemon_sets
+

--- a/plugins/source/k8s/policies_v1/queries/network_hardening/daemonset_cpu_request.sql
+++ b/plugins/source/k8s/policies_v1/queries/network_hardening/daemonset_cpu_request.sql
@@ -1,0 +1,24 @@
+-- Join every row in the daemonset table with its json array of containers.
+WITH daemonset_containers AS (SELECT uid, value AS container 
+                               FROM k8s_apps_daemon_sets
+                               CROSS JOIN jsonb_array_elements(spec_template->'spec'->'containers') AS value)
+
+INSERT INTO k8s_policy_results (resource_id, execution_time, framework, check_id, title, context, namespace,
+                                resource_name, status)
+select uid                              AS resource_id,
+        :'execution_time'::timestamp     AS execution_time,
+        :'framework'                     AS framework,
+        :'check_id'                      AS check_id,
+        'Daemonset enforces cpu requests' AS title,
+        context                          AS context,
+        namespace                        AS namespace,
+        name                             AS resource_name,
+        CASE
+            WHEN
+                  -- Every container needs to have a CPU request for the check to pass
+                  (SELECT COUNT(*) FROM daemonset_containers WHERE daemonset_containers.uid = k8s_apps_daemon_sets.uid AND
+                  daemonset_containers.container->'resources'->'requests'->>'cpu' IS NULL) > 0
+                THEN 'fail'
+                ELSE 'pass'
+            END                          AS status
+FROM k8s_apps_daemon_sets

--- a/plugins/source/k8s/policies_v1/queries/network_hardening/daemonset_memory_limit.sql
+++ b/plugins/source/k8s/policies_v1/queries/network_hardening/daemonset_memory_limit.sql
@@ -1,0 +1,24 @@
+-- Join every row in the daemonset table with its json array of containers.
+WITH daemonset_containers AS (SELECT uid, value AS container 
+                               FROM k8s_apps_daemon_sets
+                               CROSS JOIN jsonb_array_elements(spec_template->'spec'->'containers') AS value)
+
+INSERT INTO k8s_policy_results (resource_id, execution_time, framework, check_id, title, context, namespace,
+                                resource_name, status)
+select uid                              AS resource_id,
+        :'execution_time'::timestamp     AS execution_time,
+        :'framework'                     AS framework,
+        :'check_id'                      AS check_id,
+        'Daemonset enforces memory limits' AS title,
+        context                          AS context,
+        namespace                        AS namespace,
+        name                             AS resource_name,
+        CASE
+            WHEN
+                  -- Every container needs to have a Memory limit for the check to pass
+                  (SELECT COUNT(*) FROM daemonset_containers WHERE daemonset_containers.uid = k8s_apps_daemon_sets.uid AND
+                  daemonset_containers.container->'resources'->'limits'->>'memory' IS NULL) > 0
+                THEN 'fail'
+                ELSE 'pass'
+            END                          AS status
+FROM k8s_apps_daemon_sets

--- a/plugins/source/k8s/policies_v1/queries/network_hardening/daemonset_memory_request.sql
+++ b/plugins/source/k8s/policies_v1/queries/network_hardening/daemonset_memory_request.sql
@@ -1,0 +1,24 @@
+-- Join every row in the daemonset table with its json array of containers.
+WITH daemonset_containers AS (SELECT uid, value AS container 
+                               FROM k8s_apps_daemon_sets
+                               CROSS JOIN jsonb_array_elements(spec_template->'spec'->'containers') AS value)
+
+INSERT INTO k8s_policy_results (resource_id, execution_time, framework, check_id, title, context, namespace,
+                                resource_name, status)
+select uid                              AS resource_id,
+        :'execution_time'::timestamp     AS execution_time,
+        :'framework'                     AS framework,
+        :'check_id'                      AS check_id,
+        'Daemonset enforces memory requests' AS title,
+        context                          AS context,
+        namespace                        AS namespace,
+        name                             AS resource_name,
+        CASE
+            WHEN
+                  -- Every container needs to have a Memory request for the check to pass
+                  (SELECT COUNT(*) FROM daemonset_containers WHERE daemonset_containers.uid = k8s_apps_daemon_sets.uid AND
+                  daemonset_containers.container->'resources'->'requests'->>'memory' IS NULL) > 0
+                THEN 'fail'
+                ELSE 'pass'
+            END                          AS status
+FROM k8s_apps_daemon_sets

--- a/plugins/source/k8s/policies_v1/queries/network_hardening/deployment_cpu_limit.sql
+++ b/plugins/source/k8s/policies_v1/queries/network_hardening/deployment_cpu_limit.sql
@@ -1,0 +1,24 @@
+-- Join every row in the deployment table with its json array of containers.
+WITH deployment_containers AS (SELECT uid, value AS container 
+                               FROM k8s_apps_deployments
+                               CROSS JOIN jsonb_array_elements(spec_template->'spec'->'containers') AS value)
+
+INSERT INTO k8s_policy_results (resource_id, execution_time, framework, check_id, title, context, namespace,
+                               resource_name, status)
+select uid                              AS resource_id,
+       :'execution_time'::timestamp     AS execution_time,
+       :'framework'                     AS framework,
+       :'check_id'                      AS check_id,
+       'Deployment enforces cpu limits' AS title,
+       context                          AS context,
+       namespace                        AS namespace,
+       name                             AS resource_name,
+       CASE
+           WHEN
+                -- Every container needs to have a CPU limit for the check to pass
+                (SELECT COUNT(*) FROM deployment_containers WHERE deployment_containers.uid = k8s_apps_deployments.uid AND
+                 deployment_containers.container->'resources'->'limits'->>'cpu' IS NULL) > 0
+              THEN 'fail'
+              ELSE 'pass'
+           END                          AS status
+FROM k8s_apps_deployments

--- a/plugins/source/k8s/policies_v1/queries/network_hardening/deployment_cpu_request.sql
+++ b/plugins/source/k8s/policies_v1/queries/network_hardening/deployment_cpu_request.sql
@@ -1,0 +1,24 @@
+-- Join every row in the deployment table with its json array of containers.
+WITH deployment_containers AS (SELECT uid, value AS container 
+                               FROM k8s_apps_deployments
+                               CROSS JOIN jsonb_array_elements(spec_template->'spec'->'containers') AS value)
+
+INSERT INTO k8s_policy_results (resource_id, execution_time, framework, check_id, title, context, namespace,
+                                resource_name, status)
+select uid                              AS resource_id,
+        :'execution_time'::timestamp     AS execution_time,
+        :'framework'                     AS framework,
+        :'check_id'                      AS check_id,
+        'Deployment enforces cpu requests' AS title,
+        context                          AS context,
+        namespace                        AS namespace,
+        name                             AS resource_name,
+        CASE
+            WHEN
+                  -- Every container needs to have a CPU request for the check to pass
+                  (SELECT COUNT(*) FROM deployment_containers WHERE deployment_containers.uid = k8s_apps_deployments.uid AND
+                  deployment_containers.container->'resources'->'requests'->>'cpu' IS NULL) > 0
+                THEN 'fail'
+                ELSE 'pass'
+            END                          AS status
+FROM k8s_apps_deployments

--- a/plugins/source/k8s/policies_v1/queries/network_hardening/deployment_memory_limit.sql
+++ b/plugins/source/k8s/policies_v1/queries/network_hardening/deployment_memory_limit.sql
@@ -1,0 +1,25 @@
+-- Join every row in the deployment table with its json array of containers.
+WITH deployment_containers AS (SELECT uid, value AS container 
+                               FROM k8s_apps_deployments
+                               CROSS JOIN jsonb_array_elements(spec_template->'spec'->'containers') AS value)
+
+INSERT INTO k8s_policy_results (resource_id, execution_time, framework, check_id, title, context, namespace,
+                                resource_name, status)
+select uid                              AS resource_id,
+        :'execution_time'::timestamp     AS execution_time,
+        :'framework'                     AS framework,
+        :'check_id'                      AS check_id,
+        'Deployment enforces memory limits' AS title,
+        context                          AS context,
+        namespace                        AS namespace,
+        name                             AS resource_name,
+        CASE
+            WHEN
+                  -- Every container needs to have a Memory limit for the check to pass
+                  (SELECT COUNT(*) FROM deployment_containers WHERE deployment_containers.uid = k8s_apps_deployments.uid AND
+                  deployment_containers.container->'resources'->'limits'->>'memory' IS NULL) > 0
+                THEN 'fail'
+                ELSE 'pass'
+            END                          AS status
+
+FROM k8s_apps_deployments

--- a/plugins/source/k8s/policies_v1/queries/network_hardening/deployment_memory_request.sql
+++ b/plugins/source/k8s/policies_v1/queries/network_hardening/deployment_memory_request.sql
@@ -1,0 +1,24 @@
+-- Join every row in the deployment table with its json array of containers.
+WITH deployment_containers AS (SELECT uid, value AS container 
+                               FROM k8s_apps_deployments
+                               CROSS JOIN jsonb_array_elements(spec_template->'spec'->'containers') AS value)
+
+INSERT INTO k8s_policy_results (resource_id, execution_time, framework, check_id, title, context, namespace,
+                                resource_name, status)
+select uid                              AS resource_id,
+        :'execution_time'::timestamp     AS execution_time,
+        :'framework'                     AS framework,
+        :'check_id'                      AS check_id,
+        'Deployment enforces memory requests' AS title,
+        context                          AS context,
+        namespace                        AS namespace,
+        name                             AS resource_name,
+        CASE
+            WHEN
+                  -- Every container needs to have a Memory request for the check to pass
+                  (SELECT COUNT(*) FROM deployment_containers WHERE deployment_containers.uid = k8s_apps_deployments.uid AND
+                  deployment_containers.container->'resources'->'requests'->>'memory' IS NULL) > 0
+                THEN 'fail'
+                ELSE 'pass'
+            END                          AS status
+FROM k8s_apps_deployments

--- a/plugins/source/k8s/policies_v1/queries/network_hardening/job_cpu_limit.sql
+++ b/plugins/source/k8s/policies_v1/queries/network_hardening/job_cpu_limit.sql
@@ -1,0 +1,22 @@
+WITH job_containers AS (SELECT uid, value AS container 
+                        FROM k8s_batch_jobs
+                        CROSS JOIN jsonb_array_elements(spec_template->'spec'->'containers') AS value)
+
+INSERT INTO k8s_policy_results (resource_id, execution_time, framework, check_id, title, context, namespace,
+                                resource_name, status)
+select uid                                         AS resource_id,
+        :'execution_time'::timestamp                AS execution_time,
+        :'framework'                                AS framework,
+        :'check_id'                                 AS check_id,
+        'Job enforces cpu limits'                            AS title,
+        context                                     AS context,
+        namespace                                   AS namespace,
+        name                                        AS resource_name,
+        CASE
+            WHEN
+                (SELECT COUNT(*) FROM job_containers WHERE job_containers.uid = k8s_batch_jobs.uid AND
+                  job_containers.container->'resources'->'limits'->>'cpu' IS NULL) > 0
+                THEN 'fail'
+            ELSE 'pass'
+            END                                     AS status
+FROM k8s_batch_jobs

--- a/plugins/source/k8s/policies_v1/queries/network_hardening/job_cpu_request.sql
+++ b/plugins/source/k8s/policies_v1/queries/network_hardening/job_cpu_request.sql
@@ -1,0 +1,22 @@
+WITH job_containers AS (SELECT uid, value AS container 
+                        FROM k8s_batch_jobs
+                        CROSS JOIN jsonb_array_elements(spec_template->'spec'->'containers') AS value)
+                        
+INSERT INTO k8s_policy_results (resource_id, execution_time, framework, check_id, title, context, namespace,
+                                resource_name, status)
+select uid                                         AS resource_id,
+        :'execution_time'::timestamp                AS execution_time,
+        :'framework'                                AS framework,
+        :'check_id'                                 AS check_id,
+        'Job enforces cpu requests'                 AS title,
+        context                                     AS context,
+        namespace                                   AS namespace,
+        name                                        AS resource_name,
+        CASE
+            WHEN
+                (SELECT COUNT(*) FROM job_containers WHERE job_containers.uid = k8s_batch_jobs.uid AND
+                  job_containers.container->'resources'->'requests'->>'cpu' IS NULL) > 0
+                THEN 'fail'
+            ELSE 'pass'
+            END                                     AS status
+FROM k8s_batch_jobs

--- a/plugins/source/k8s/policies_v1/queries/network_hardening/job_memory_limit.sql
+++ b/plugins/source/k8s/policies_v1/queries/network_hardening/job_memory_limit.sql
@@ -1,0 +1,22 @@
+WITH job_containers AS (SELECT uid, value AS container 
+                        FROM k8s_batch_jobs
+                        CROSS JOIN jsonb_array_elements(spec_template->'spec'->'containers') AS value)
+
+INSERT INTO k8s_policy_results (resource_id, execution_time, framework, check_id, title, context, namespace,
+                                resource_name, status)
+select uid                                         AS resource_id,
+        :'execution_time'::timestamp                AS execution_time,
+        :'framework'                                AS framework,
+        :'check_id'                                 AS check_id,
+        'Job enforces memory limit'                 AS title,
+        context                                     AS context,
+        namespace                                   AS namespace,
+        name                                        AS resource_name,
+        CASE
+            WHEN
+                (SELECT COUNT(*) FROM job_containers WHERE job_containers.uid = k8s_batch_jobs.uid AND
+                  job_containers.container->'resources'->'limits'->>'memory' IS NULL) > 0
+                THEN 'fail'
+            ELSE 'pass'
+            END                                     AS status
+FROM k8s_batch_jobs

--- a/plugins/source/k8s/policies_v1/queries/network_hardening/job_memory_request.sql
+++ b/plugins/source/k8s/policies_v1/queries/network_hardening/job_memory_request.sql
@@ -1,0 +1,22 @@
+WITH job_containers AS (SELECT uid, value AS container 
+                        FROM k8s_batch_jobs
+                        CROSS JOIN jsonb_array_elements(spec_template->'spec'->'containers') AS value)
+
+INSERT INTO k8s_policy_results (resource_id, execution_time, framework, check_id, title, context, namespace,
+                                resource_name, status)
+select uid                                         AS resource_id,
+        :'execution_time'::timestamp                AS execution_time,
+        :'framework'                                AS framework,
+        :'check_id'                                 AS check_id,
+        'Job enforces memory requests'              AS title,
+        context                                     AS context,
+        namespace                                   AS namespace,
+        name                                        AS resource_name,
+        CASE
+            WHEN
+                (SELECT COUNT(*) FROM job_containers WHERE job_containers.uid = k8s_batch_jobs.uid AND
+                  job_containers.container->'resources'->'requests'->>'memory' IS NULL) > 0
+                THEN 'fail'
+            ELSE 'pass'
+            END                                     AS status
+FROM k8s_batch_jobs

--- a/plugins/source/k8s/policies_v1/queries/network_hardening/namespace_limit_range_default_cpu_limit.sql
+++ b/plugins/source/k8s/policies_v1/queries/network_hardening/namespace_limit_range_default_cpu_limit.sql
@@ -1,0 +1,24 @@
+WITH default_cpu_limits AS (
+   SELECT context, namespace, value->'default'->>'cpu' AS default_cpu_limit
+   FROM k8s_core_limit_ranges CROSS JOIN jsonb_array_elements(k8s_core_limit_ranges.spec_limits))
+
+INSERT
+INTO k8s_policy_results (resource_id, execution_time, framework, check_id, title, context, namespace,
+                        resource_name, status)
+select uid                                     AS resource_id,
+       :'execution_time'::timestamp            AS execution_time,
+       :'framework'                            AS framework,
+       :'check_id'                             AS check_id,
+       'Namespaces CPU default resource limit' AS title,
+       context                                 AS context,
+       name                                    AS namespace,
+       name                                    AS resource_name,
+       CASE
+           WHEN
+               (SELECT COUNT(default_cpu_limit) FROM default_cpu_limits
+                  WHERE namespace = k8s_core_namespaces.name
+                  AND context = k8s_core_namespaces.context) = 0
+               THEN 'fail'
+           ELSE 'pass'
+           END                                 AS status
+FROM k8s_core_namespaces;

--- a/plugins/source/k8s/policies_v1/queries/network_hardening/namespace_limit_range_default_cpu_request.sql
+++ b/plugins/source/k8s/policies_v1/queries/network_hardening/namespace_limit_range_default_cpu_request.sql
@@ -1,0 +1,24 @@
+WITH default_request_cpu_limits AS (
+   SELECT context, namespace, value->'default_request'->>'cpu' AS default_request_cpu_limit
+   FROM k8s_core_limit_ranges CROSS JOIN jsonb_array_elements(k8s_core_limit_ranges.spec_limits))
+
+INSERT
+INTO k8s_policy_results (resource_id, execution_time, framework, check_id, title, context, namespace,
+                        resource_name, status)
+select uid                                         AS resource_id,
+       :'execution_time'::timestamp                AS execution_time,
+       :'framework'                                AS framework,
+       :'check_id'                                 AS check_id,
+       'Namespaces CPU request resource quota' AS title,
+       context                                     AS context,
+       name                                        AS namespace,
+       name                                        AS resource_name,
+       CASE
+           WHEN
+               (SELECT COUNT(default_request_cpu_limit) FROM default_request_cpu_limits 
+                  WHERE namespace = k8s_core_namespaces.name
+                  AND context = k8s_core_namespaces.context) = 0
+               THEN 'fail'
+           ELSE 'pass'
+           END                                     AS status
+FROM k8s_core_namespaces;

--- a/plugins/source/k8s/policies_v1/queries/network_hardening/namespace_limit_range_default_memory_limit.sql
+++ b/plugins/source/k8s/policies_v1/queries/network_hardening/namespace_limit_range_default_memory_limit.sql
@@ -1,0 +1,24 @@
+WITH default_memory_limits AS (
+   SELECT context, namespace, value->'default'->>'memory' AS default_memory_limit
+   FROM k8s_core_limit_ranges CROSS JOIN jsonb_array_elements(k8s_core_limit_ranges.spec_limits))
+
+INSERT
+INTO k8s_policy_results (resource_id, execution_time, framework, check_id, title, context, namespace,
+                        resource_name, status)
+select uid                                     AS resource_id,
+       :'execution_time'::timestamp            AS execution_time,
+       :'framework'                            AS framework,
+       :'check_id'                             AS check_id,
+       'Namespaces Memory default resource limit' AS title,
+       context                                 AS context,
+       name                                    AS namespace,
+       name                                    AS resource_name,
+       CASE
+           WHEN
+               (SELECT COUNT(default_memory_limit) FROM default_memory_limits 
+                  WHERE namespace = k8s_core_namespaces.name
+                  AND context = k8s_core_namespaces.context) = 0
+               THEN 'fail'
+           ELSE 'pass'
+           END                                 AS status
+FROM k8s_core_namespaces;

--- a/plugins/source/k8s/policies_v1/queries/network_hardening/namespace_limit_range_default_memory_request.sql
+++ b/plugins/source/k8s/policies_v1/queries/network_hardening/namespace_limit_range_default_memory_request.sql
@@ -1,0 +1,26 @@
+
+
+WITH default_request_memory_limits AS (
+   SELECT namespace, value->'default_request'->>'memory' AS default_request_memory_limit
+   FROM k8s_core_limit_ranges CROSS JOIN jsonb_array_elements(k8s_core_limit_ranges.spec_limits))
+
+INSERT
+INTO k8s_policy_results (resource_id, execution_time, framework, check_id, title, context, namespace,
+                        resource_name, status)
+select uid                                         AS resource_id,
+       :'execution_time'::timestamp                AS execution_time,
+       :'framework'                                AS framework,
+       :'check_id'                                 AS check_id,
+       'Namespaces Memory request resource quota' AS title,
+       context                                     AS context,
+       name                                        AS namespace,
+       name                                        AS resource_name,
+       CASE
+           WHEN
+               (SELECT COUNT(default_request_memory_limit) FROM default_request_memory_limits  
+                  WHERE namespace = k8s_core_namespaces.name
+                  AND context = k8s_core_namespaces.context) = 0
+               THEN 'fail'
+           ELSE 'pass'
+           END                                     AS status
+FROM k8s_core_namespaces;

--- a/plugins/source/k8s/policies_v1/queries/network_hardening/namespace_resource_quota_cpu_limit.sql
+++ b/plugins/source/k8s/policies_v1/queries/network_hardening/namespace_resource_quota_cpu_limit.sql
@@ -1,0 +1,20 @@
+INSERT INTO k8s_policy_results (resource_id, execution_time, framework, check_id, title, context, namespace,
+                               resource_name, status)
+select DISTINCT (k8s_core_namespaces.uid)                      AS resource_id,
+                :'execution_time'::timestamp                   AS execution_time,
+                :'framework'                                   AS framework,
+                :'check_id'                                    AS check_id,
+                'Namespace enforces resource quota cpu limits' AS title,
+                k8s_core_namespaces.context                    AS context,
+                k8s_core_namespaces.name                       AS namespace,
+                k8s_core_namespaces.name                       AS resource_name,
+                CASE
+                    WHEN
+                        (SELECT COUNT(*) FROM k8s_core_resource_quotas
+                            WHERE namespace = k8s_core_namespaces.name
+                            AND context = k8s_core_namespaces.context
+                            AND spec_hard->>'limits.cpu' IS NOT NULL) = 0
+                        THEN 'fail'
+                    ELSE 'pass'
+                    END                                        AS status
+FROM k8s_core_namespaces;

--- a/plugins/source/k8s/policies_v1/queries/network_hardening/namespace_resource_quota_cpu_request.sql
+++ b/plugins/source/k8s/policies_v1/queries/network_hardening/namespace_resource_quota_cpu_request.sql
@@ -1,0 +1,20 @@
+INSERT INTO k8s_policy_results (resource_id, execution_time, framework, check_id, title, context, namespace,
+                               resource_name, status)
+select DISTINCT (k8s_core_namespaces.uid)                       AS resource_id,
+                :'execution_time'::timestamp                    AS execution_time,
+                :'framework'                                    AS framework,
+                :'check_id'                                     AS check_id,
+                'Namespace enforces resource quota cpu request' AS title,
+                k8s_core_namespaces.context                     AS context,
+                k8s_core_namespaces.name                        AS namespace,
+                k8s_core_namespaces.name                        AS resource_name,
+                CASE
+                    WHEN
+                        (SELECT COUNT(*) FROM k8s_core_resource_quotas
+                            WHERE namespace = k8s_core_namespaces.name
+                            AND context = k8s_core_namespaces.context
+                            AND spec_hard->>'requests.cpu' IS NOT NULL) = 0
+                        THEN 'fail'
+                    ELSE 'pass'
+                    END                                         AS status
+FROM k8s_core_namespaces;

--- a/plugins/source/k8s/policies_v1/queries/network_hardening/namespace_resource_quota_memory_limit.sql
+++ b/plugins/source/k8s/policies_v1/queries/network_hardening/namespace_resource_quota_memory_limit.sql
@@ -1,0 +1,20 @@
+INSERT INTO k8s_policy_results (resource_id, execution_time, framework, check_id, title, context, namespace,
+                               resource_name, status)
+select DISTINCT (k8s_core_namespaces.uid)                         AS resource_id,
+                :'execution_time'::timestamp                      AS execution_time,
+                :'framework'                                      AS framework,
+                :'check_id'                                       AS check_id,
+                'Namespace enforces resource quota memory limits' AS title,
+                k8s_core_namespaces.context                       AS context,
+                k8s_core_namespaces.name                          AS namespace,
+                k8s_core_namespaces.name                          AS resource_name,
+                CASE
+                    WHEN
+                        (SELECT COUNT(*) FROM k8s_core_resource_quotas 
+                            WHERE namespace = k8s_core_namespaces.name
+                            AND context = k8s_core_namespaces.context
+                            AND spec_hard->>'limits.memory' IS NOT NULL) = 0 
+                        THEN 'fail'
+                    ELSE 'pass'
+                    END                                           AS status
+FROM k8s_core_namespaces;

--- a/plugins/source/k8s/policies_v1/queries/network_hardening/namespace_resource_quota_memory_request.sql
+++ b/plugins/source/k8s/policies_v1/queries/network_hardening/namespace_resource_quota_memory_request.sql
@@ -1,0 +1,20 @@
+INSERT INTO k8s_policy_results (resource_id, execution_time, framework, check_id, title, context, namespace,
+                               resource_name, status)
+select DISTINCT (k8s_core_namespaces.uid)                          AS resource_id,
+                :'execution_time'::timestamp                       AS execution_time,
+                :'framework'                                       AS framework,
+                :'check_id'                                        AS check_id,
+                'Namespace enforces resource quota memory request' AS title,
+                k8s_core_namespaces.context                        AS context,
+                k8s_core_namespaces.name                           AS namespace,
+                k8s_core_namespaces.name                           AS resource_name,
+                CASE
+                    WHEN
+                        (SELECT COUNT(*) FROM k8s_core_resource_quotas
+                            WHERE namespace = k8s_core_namespaces.name
+                            AND context = k8s_core_namespaces.context
+                            AND spec_hard->>'requests.memory' IS NOT NULL) = 0
+                        THEN 'fail'
+                    ELSE 'pass'
+                    END                                            AS status
+FROM k8s_core_namespaces;

--- a/plugins/source/k8s/policies_v1/queries/network_hardening/network_policy_default_deny_egress.sql
+++ b/plugins/source/k8s/policies_v1/queries/network_hardening/network_policy_default_deny_egress.sql
@@ -1,0 +1,23 @@
+INSERT INTO k8s_policy_results (resource_id, execution_time, framework, check_id, title, context, namespace,
+                        resource_name, status)
+select uid                                   AS resource_id,
+:'execution_time'::timestamp         AS execution_time,
+       :'framework'                         AS framework,
+       :'check_id'                          AS check_id,
+       'Network policy default deny egress' AS title,
+       context                              AS context,
+       name                                 AS namespace,
+       name                                 AS resource_name,
+       CASE
+         WHEN
+            (SELECT COUNT(*) FROM k8s_networking_network_policies 
+               WHERE namespace = k8s_core_namespaces.name
+               AND context = k8s_core_namespaces.context
+               AND spec_policy_types @> ARRAY['Egress']
+               AND spec_pod_selector::TEXT = '{}'
+               AND ((spec_egress IS NULL) OR (JSONB_ARRAY_LENGTH(spec_egress) = 0))) = 0
+            THEN 'fail'
+         ELSE 'pass'
+         END                                AS STATUS
+
+FROM k8s_core_namespaces

--- a/plugins/source/k8s/policies_v1/queries/network_hardening/network_policy_default_deny_ingress.sql
+++ b/plugins/source/k8s/policies_v1/queries/network_hardening/network_policy_default_deny_ingress.sql
@@ -1,0 +1,23 @@
+INSERT INTO k8s_policy_results (resource_id, execution_time, framework, check_id, title, context, namespace,
+                        resource_name, status)
+select uid                                   AS resource_id,
+:'execution_time'::timestamp         AS execution_time,
+       :'framework'                         AS framework,
+       :'check_id'                          AS check_id,
+       'Network policy default deny ingress' AS title,
+       context                              AS context,
+       name                                 AS namespace,
+       name                                 AS resource_name,
+       CASE
+         WHEN
+            (SELECT COUNT(*) FROM k8s_networking_network_policies 
+               WHERE namespace = k8s_core_namespaces.name
+               AND context = k8s_core_namespaces.context
+               AND spec_policy_types @> ARRAY['Ingress']
+               AND spec_pod_selector::TEXT = '{}'
+               AND ((spec_ingress IS NULL) OR (JSONB_ARRAY_LENGTH(spec_ingress) = 0))) = 0
+            THEN 'fail'
+         ELSE 'pass'
+         END                                AS STATUS
+
+FROM k8s_core_namespaces

--- a/plugins/source/k8s/policies_v1/queries/network_hardening/replicaset_cpu_limit.sql
+++ b/plugins/source/k8s/policies_v1/queries/network_hardening/replicaset_cpu_limit.sql
@@ -1,0 +1,24 @@
+-- Join every row in the replica_set table with its json array of containers.
+WITH replica_set_containers AS (SELECT uid, value AS container 
+                               FROM k8s_apps_replica_sets
+                               CROSS JOIN jsonb_array_elements(spec_template->'spec'->'containers') AS value)
+
+INSERT INTO k8s_policy_results (resource_id, execution_time, framework, check_id, title, context, namespace,
+                                resource_name, status)
+select uid                              AS resource_id,
+        :'execution_time'::timestamp     AS execution_time,
+        :'framework'                     AS framework,
+        :'check_id'                      AS check_id,
+        'Replicaset enforces cpu limits' AS title,
+        context                          AS context,
+        namespace                        AS namespace,
+        name                             AS resource_name,
+        CASE
+            WHEN
+                  -- Every container needs to have a CPU limit for the check to pass
+                  (SELECT COUNT(*) FROM replica_set_containers WHERE replica_set_containers.uid = k8s_apps_replica_sets.uid AND
+                  replica_set_containers.container->'resources'->'limits'->>'cpu' IS NULL) > 0
+                THEN 'fail'
+                ELSE 'pass'
+            END                          AS status
+FROM k8s_apps_replica_sets

--- a/plugins/source/k8s/policies_v1/queries/network_hardening/replicaset_cpu_request.sql
+++ b/plugins/source/k8s/policies_v1/queries/network_hardening/replicaset_cpu_request.sql
@@ -1,0 +1,24 @@
+-- Join every row in the replica_set table with its json array of containers.
+WITH replica_set_containers AS (SELECT uid, value AS container 
+                               FROM k8s_apps_replica_sets
+                               CROSS JOIN jsonb_array_elements(spec_template->'spec'->'containers') AS value)
+
+INSERT INTO k8s_policy_results (resource_id, execution_time, framework, check_id, title, context, namespace,
+                                resource_name, status)
+select uid                              AS resource_id,
+        :'execution_time'::timestamp     AS execution_time,
+        :'framework'                     AS framework,
+        :'check_id'                      AS check_id,
+        'Replicaset enforces cpu requests' AS title,
+        context                          AS context,
+        namespace                        AS namespace,
+        name                             AS resource_name,
+        CASE
+            WHEN
+                  -- Every container needs to have a CPU request for the check to pass
+                  (SELECT COUNT(*) FROM replica_set_containers WHERE replica_set_containers.uid = k8s_apps_replica_sets.uid AND
+                  replica_set_containers.container->'resources'->'requests'->>'cpu' IS NULL) > 0
+                THEN 'fail'
+                ELSE 'pass'
+            END                          AS status
+FROM k8s_apps_replica_sets

--- a/plugins/source/k8s/policies_v1/queries/network_hardening/replicaset_memory_limit.sql
+++ b/plugins/source/k8s/policies_v1/queries/network_hardening/replicaset_memory_limit.sql
@@ -1,0 +1,24 @@
+-- Join every row in the replica_set table with its json array of containers.
+WITH replica_set_containers AS (SELECT uid, value AS container 
+                               FROM k8s_apps_replica_sets
+                               CROSS JOIN jsonb_array_elements(spec_template->'spec'->'containers') AS value)
+
+INSERT INTO k8s_policy_results (resource_id, execution_time, framework, check_id, title, context, namespace,
+                                resource_name, status)
+select uid                              AS resource_id,
+        :'execution_time'::timestamp     AS execution_time,
+        :'framework'                     AS framework,
+        :'check_id'                      AS check_id,
+        'Replicaset enforces memory limits' AS title,
+        context                          AS context,
+        namespace                        AS namespace,
+        name                             AS resource_name,
+        CASE
+            WHEN
+                  -- Every container needs to have a memory limit for the check to pass
+                  (SELECT COUNT(*) FROM replica_set_containers WHERE replica_set_containers.uid = k8s_apps_replica_sets.uid AND
+                  replica_set_containers.container->'resources'->'limits'->>'memory' IS NULL) > 0
+                THEN 'fail'
+                ELSE 'pass'
+            END                          AS status
+FROM k8s_apps_replica_sets

--- a/plugins/source/k8s/policies_v1/queries/network_hardening/replicaset_memory_request.sql
+++ b/plugins/source/k8s/policies_v1/queries/network_hardening/replicaset_memory_request.sql
@@ -1,0 +1,24 @@
+-- Join every row in the deployment table with its json array of containers.
+With replica_set_containers AS (SELECT uid, value AS container 
+                               FROM k8s_apps_replica_sets
+                               CROSS JOIN jsonb_array_elements(spec_template->'spec'->'containers') AS value)
+
+Insert Into k8s_policy_results (resource_id, execution_time, framework, check_id, title, context, namespace,
+                                resource_name, status)
+select uid                              AS resource_id,
+        :'execution_time'::timestamp     AS execution_time,
+        :'framework'                     AS framework,
+        :'check_id'                      AS check_id,
+        'Replicaset enforces memory requests' AS title,
+        context                          AS context,
+        namespace                        AS namespace,
+        name                             AS resource_name,
+        CASE
+            WHEN
+                  -- Every container needs to have a memory request for the check to pass
+                  (SELECT COUNT(*) FROM replica_set_containers WHERE replica_set_containers.uid = k8s_apps_replica_sets.uid AND
+                  replica_set_containers.container->'resources'->'requests'->>'memory' IS NULL) > 0
+                THEN 'fail'
+                ELSE 'pass'
+            END                          AS status
+FROM k8s_apps_replica_sets

--- a/plugins/source/k8s/policies_v1/queries/pod_security/daemonset_container_privilege_disabled.sql
+++ b/plugins/source/k8s/policies_v1/queries/pod_security/daemonset_container_privilege_disabled.sql
@@ -1,0 +1,21 @@
+WITH daemonset_containers AS (SELECT uid, value AS container 
+                               FROM k8s_apps_daemon_sets
+                               CROSS JOIN jsonb_array_elements(spec_template->'spec'->'containers') AS value)
+
+INSERT INTO k8s_policy_results (resource_id, execution_time, framework, check_id, title, context, namespace,
+                                resource_name, status)
+select uid                              AS resource_id,
+      :'execution_time'::timestamp      AS execution_time,
+      :'framework'                      AS framework,
+      :'check_id'                       AS check_id,
+      'DaemonSet containers privileges disabled' AS title,
+      context                           AS context,
+      namespace                         AS namespace,
+      name                              AS resource_name,
+      CASE WHEN
+          (SELECT COUNT(*) FROM daemonset_containers WHERE daemonset_containers.uid = k8s_apps_daemon_sets.uid AND
+            daemonset_containers.container->'securityContext'->>'privileged' = 'true') > 0
+          THEN 'fail'
+          ELSE 'pass'
+          END                          AS status
+FROM k8s_apps_daemon_sets;

--- a/plugins/source/k8s/policies_v1/queries/pod_security/daemonset_container_privilege_escalation_disabled.sql
+++ b/plugins/source/k8s/policies_v1/queries/pod_security/daemonset_container_privilege_escalation_disabled.sql
@@ -1,0 +1,21 @@
+WITH daemonset_containers AS (SELECT uid, value AS container 
+                               FROM k8s_apps_daemon_sets
+                               CROSS JOIN jsonb_array_elements(spec_template->'spec'->'containers') AS value)
+
+INSERT INTO k8s_policy_results (resource_id, execution_time, framework, check_id, title, context, namespace,
+                                resource_name, status)
+select uid                              AS resource_id,
+      :'execution_time'::timestamp      AS execution_time,
+      :'framework'                      AS framework,
+      :'check_id'                       AS check_id,
+      'DaemonSet containers privilege escalation disabled' AS title,
+      context                           AS context,
+      namespace                         AS namespace,
+      name                              AS resource_name,
+      CASE WHEN
+          (SELECT COUNT(*) FROM daemonset_containers WHERE daemonset_containers.uid = k8s_apps_daemon_sets.uid AND
+            daemonset_containers.container->'securityContext'->>'allowPrivilegeEscalation' = 'true') > 0
+          THEN 'fail'
+          ELSE 'pass'
+          END                          AS status
+FROM k8s_apps_daemon_sets;

--- a/plugins/source/k8s/policies_v1/queries/pod_security/daemonset_host_network_access_disabled.sql
+++ b/plugins/source/k8s/policies_v1/queries/pod_security/daemonset_host_network_access_disabled.sql
@@ -1,0 +1,17 @@
+INSERT INTO k8s_policy_results (resource_id, execution_time, framework, check_id, title, context, namespace,
+                               resource_name, status)
+select uid                                        AS resource_id,
+       :'execution_time'::timestamp               AS execution_time,
+       :'framework'                               AS framework,
+       :'check_id'                                AS check_id,
+       'Deamonset container hostNetwork disabled' AS title,
+       context                                    AS context,
+       namespace                                  AS namespace,
+       name                                       AS resource_name,
+       CASE
+           WHEN
+               spec_template -> 'spec' ->> 'hostNetwork' = 'true'
+               THEN 'fail'
+           ELSE 'pass'
+           END                                    AS status
+FROM k8s_apps_daemon_sets;

--- a/plugins/source/k8s/policies_v1/queries/pod_security/daemonset_hostpid_hostipc_sharing_disabled.sql
+++ b/plugins/source/k8s/policies_v1/queries/pod_security/daemonset_hostpid_hostipc_sharing_disabled.sql
@@ -1,0 +1,18 @@
+INSERT INTO k8s_policy_results (resource_id, execution_time, framework, check_id, title, context, namespace,
+                               resource_name, status)
+select uid                                                         AS resource_id,
+       :'execution_time'::timestamp                                AS execution_time,
+       :'framework'                                                AS framework,
+       :'check_id'                                                 AS check_id,
+       'Deamonset containers HostPID and HostIPC sharing disabled' AS title,
+       context                                                     AS context,
+       namespace                                                   AS namespace,
+       name                                                        AS resource_name,
+       CASE
+           WHEN
+                    spec_template -> 'spec' ->> 'hostPID' = 'true'
+                   OR spec_template -> 'spec' ->> 'hostIPC' = 'true'
+               THEN 'fail'
+           ELSE 'pass'
+           END                                                     AS status
+FROM k8s_apps_daemon_sets;

--- a/plugins/source/k8s/policies_v1/queries/pod_security/daemonset_immutable_container_filesystem.sql
+++ b/plugins/source/k8s/policies_v1/queries/pod_security/daemonset_immutable_container_filesystem.sql
@@ -1,0 +1,22 @@
+WITH daemonset_containers AS (SELECT uid, value AS container 
+                               FROM k8s_apps_daemon_sets
+                               CROSS JOIN jsonb_array_elements(spec_template->'spec'->'containers') AS value)
+
+INSERT INTO k8s_policy_results (resource_id, execution_time, framework, check_id, title, context, namespace,
+                                resource_name, status)
+select uid                              AS resource_id,
+       :'execution_time'::timestamp                         AS execution_time,
+       :'framework'                                         AS framework,
+       :'check_id'                                          AS check_id,
+       'DeamonSet containers root file system is read-only' AS title,
+       context                                              AS context,
+       namespace                                            AS namespace,
+       name                                                 AS resource_name,
+       CASE
+           WHEN
+               (SELECT COUNT(*) FROM daemonset_containers WHERE daemonset_containers.uid = k8s_apps_daemon_sets.uid AND
+                 daemonset_containers.container->'securityContext'->>'readOnlyRootFilesystem' IS DISTINCT FROM 'true') > 0
+               THEN 'fail'
+           ELSE 'pass'
+           END                                              AS status
+FROM k8s_apps_daemon_sets;

--- a/plugins/source/k8s/policies_v1/queries/pod_security/daemonset_non_root_container.sql
+++ b/plugins/source/k8s/policies_v1/queries/pod_security/daemonset_non_root_container.sql
@@ -1,0 +1,21 @@
+WITH daemonset_containers AS (SELECT uid, value AS container 
+                               FROM k8s_apps_daemon_sets
+                               CROSS JOIN jsonb_array_elements(spec_template->'spec'->'containers') AS value)
+
+INSERT INTO k8s_policy_results (resource_id, execution_time, framework, check_id, title, context, namespace,
+                                resource_name, status)
+select uid                              AS resource_id,
+        :'execution_time'::timestamp      AS execution_time,
+        :'framework'                      AS framework,
+        :'check_id'                       AS check_id,
+        'DaemonSet containers to run as non-root' AS title,
+        context                           AS context,
+        namespace                         AS namespace,
+        name                              AS resource_name,
+        CASE WHEN
+            (SELECT COUNT(*) FROM daemonset_containers WHERE daemonset_containers.uid = k8s_apps_daemon_sets.uid AND
+              daemonset_containers.container->'securityContext'->>'runAsNonRoot' IS DISTINCT FROM 'true') > 0
+            THEN 'fail'
+            ELSE 'pass'
+            END                          AS status
+FROM k8s_apps_daemon_sets;

--- a/plugins/source/k8s/policies_v1/queries/pod_security/deployment_container_privilege_disabled.sql
+++ b/plugins/source/k8s/policies_v1/queries/pod_security/deployment_container_privilege_disabled.sql
@@ -1,0 +1,21 @@
+WITH deployment_containers AS (SELECT uid, value AS container 
+                               FROM k8s_apps_deployments
+                               CROSS JOIN jsonb_array_elements(spec_template->'spec'->'containers') AS value)
+
+INSERT INTO k8s_policy_results (resource_id, execution_time, framework, check_id, title, context, namespace,
+                                resource_name, status)
+select uid                              AS resource_id,
+      :'execution_time'::timestamp      AS execution_time,
+      :'framework'                      AS framework,
+      :'check_id'                       AS check_id,
+      'Deployments privileges disabled' AS title,
+      context                           AS context,
+      namespace                         AS namespace,
+      name                              AS resource_name,
+      CASE WHEN
+          (SELECT COUNT(*) FROM deployment_containers WHERE deployment_containers.uid = k8s_apps_deployments.uid AND
+            deployment_containers.container->'securityContext'->>'privileged' = 'true') > 0
+          THEN 'fail'
+          ELSE 'pass'
+          END                          AS status
+FROM k8s_apps_deployments;

--- a/plugins/source/k8s/policies_v1/queries/pod_security/deployment_container_privilege_escalation_disabled.sql
+++ b/plugins/source/k8s/policies_v1/queries/pod_security/deployment_container_privilege_escalation_disabled.sql
@@ -1,0 +1,25 @@
+WITH deployment_containers AS (SELECT uid, value AS container 
+                               FROM k8s_apps_deployments
+                               CROSS JOIN jsonb_array_elements(spec_template->'spec'->'containers') AS value)
+
+INSERT INTO k8s_policy_results (resource_id, execution_time, framework, check_id, title, context, namespace,
+                                resource_name, status)
+select uid                              AS resource_id,
+      :'execution_time'::timestamp      AS execution_time,
+      :'framework'                      AS framework,
+      :'check_id'                       AS check_id,
+      'Deployments privilege escalation disabled' AS title,
+      context                           AS context,
+      namespace                         AS namespace,
+      name                              AS resource_name,
+      CASE WHEN
+          (SELECT COUNT(*) FROM deployment_containers WHERE deployment_containers.uid = k8s_apps_deployments.uid AND
+            deployment_containers.container->'securityContext'->>'allowPrivilegeEscalation' = 'true') > 0
+          THEN 'fail'
+          ELSE 'pass'
+          END                          AS status 
+FROM k8s_apps_deployments;
+
+
+
+

--- a/plugins/source/k8s/policies_v1/queries/pod_security/deployment_host_network_access_disabled.sql
+++ b/plugins/source/k8s/policies_v1/queries/pod_security/deployment_host_network_access_disabled.sql
@@ -1,0 +1,17 @@
+INSERT INTO k8s_policy_results (resource_id, execution_time, framework, check_id, title, context, namespace,
+                               resource_name, status)
+select uid                                          AS resource_id,
+       :'execution_time'::timestamp                 AS execution_time,
+       :'framework'                                 AS framework,
+       :'check_id'                                  AS check_id,
+       'Deployments container hostNetwork disabled' AS title,
+       context                                      AS context,
+       namespace                                    AS namespace,
+       name                                         AS resource_name,
+       CASE
+           WHEN
+               spec_template -> 'spec' ->> 'hostNetwork' = 'true'
+               THEN 'fail'
+           ELSE 'pass'
+           END                                      AS status
+FROM k8s_apps_deployments;

--- a/plugins/source/k8s/policies_v1/queries/pod_security/deployment_hostpid_hostipc_sharing_disabled.sql
+++ b/plugins/source/k8s/policies_v1/queries/pod_security/deployment_hostpid_hostipc_sharing_disabled.sql
@@ -1,0 +1,18 @@
+INSERT INTO k8s_policy_results (resource_id, execution_time, framework, check_id, title, context, namespace,
+                               resource_name, status)
+select uid                                                          AS resource_id,
+       :'execution_time'::timestamp                                 AS execution_time,
+       :'framework'                                                 AS framework,
+       :'check_id'                                                  AS check_id,
+       'Deployment containers HostPID and HostIPC sharing disabled' AS title,
+       context                                                      AS context,
+       namespace                                                    AS namespace,
+       name                                                         AS resource_name,
+       CASE
+           WHEN
+                    spec_template -> 'spec' ->> 'hostPID' = 'true'
+                   OR spec_template -> 'spec' ->> 'hostIPC' = 'true'
+               THEN 'fail'
+           ELSE 'pass'
+           END                                                      AS status
+FROM k8s_apps_deployments;

--- a/plugins/source/k8s/policies_v1/queries/pod_security/deployment_immutable_container_filesystem.sql
+++ b/plugins/source/k8s/policies_v1/queries/pod_security/deployment_immutable_container_filesystem.sql
@@ -1,0 +1,22 @@
+WITH deployment_containers AS (SELECT uid, value AS container 
+                               FROM k8s_apps_deployments
+                               CROSS JOIN jsonb_array_elements(spec_template->'spec'->'containers') AS value)
+
+INSERT INTO k8s_policy_results (resource_id, execution_time, framework, check_id, title, context, namespace,
+                                resource_name, status)
+select uid                              AS resource_id,
+      :'execution_time'::timestamp      AS execution_time,
+      :'framework'                      AS framework,
+      :'check_id'                       AS check_id,
+      'Deployment containers root file system is read-only' AS title,
+      context                           AS context,
+      namespace                         AS namespace,
+      name                              AS resource_name,
+      CASE WHEN
+          (SELECT COUNT(*) FROM deployment_containers WHERE deployment_containers.uid = k8s_apps_deployments.uid AND
+            deployment_containers.container->'securityContext'->>'readOnlyRootFilesystem' IS DISTINCT FROM 'true') > 0
+          THEN 'fail'
+          ELSE 'pass'
+          END                          AS status
+FROM k8s_apps_deployments;
+

--- a/plugins/source/k8s/policies_v1/queries/pod_security/deployment_non_root_container.sql
+++ b/plugins/source/k8s/policies_v1/queries/pod_security/deployment_non_root_container.sql
@@ -1,0 +1,21 @@
+WITH deployment_containers AS (SELECT uid, value AS container 
+                               FROM k8s_apps_deployments
+                               CROSS JOIN jsonb_array_elements(spec_template->'spec'->'containers') AS value)
+
+INSERT INTO k8s_policy_results (resource_id, execution_time, framework, check_id, title, context, namespace,
+                                resource_name, status)
+select uid                              AS resource_id,
+      :'execution_time'::timestamp      AS execution_time,
+      :'framework'                      AS framework,
+      :'check_id'                       AS check_id,
+      'Deployment containers to run as non-root' AS title,
+      context                           AS context,
+      namespace                         AS namespace,
+      name                              AS resource_name,
+      CASE WHEN
+          (SELECT COUNT(*) FROM deployment_containers WHERE deployment_containers.uid = k8s_apps_deployments.uid AND
+            deployment_containers.container->'securityContext'->>'runAsNonRoot' IS DISTINCT FROM 'true') > 0
+          THEN 'fail'
+          ELSE 'pass'
+          END                          AS status
+FROM k8s_apps_deployments;

--- a/plugins/source/k8s/policies_v1/queries/pod_security/job_container_privilege_disabled.sql
+++ b/plugins/source/k8s/policies_v1/queries/pod_security/job_container_privilege_disabled.sql
@@ -1,0 +1,23 @@
+WITH job_containers AS (SELECT uid, value AS container 
+                        FROM k8s_batch_jobs
+                        CROSS JOIN jsonb_array_elements(spec_template->'spec'->'containers') AS value)
+
+INSERT INTO k8s_policy_results (resource_id, execution_time, framework, check_id, title, context, namespace,
+                                resource_name, status)
+select uid                                         AS resource_id,
+       :'execution_time'::timestamp         AS execution_time,
+       :'framework'                         AS framework,
+       :'check_id'                          AS check_id,
+       'Job containers privileges disabled' AS title,
+       context                              AS context,
+       namespace                            AS namespace,
+       name                                 AS resource_name,
+       CASE
+           WHEN
+               (SELECT COUNT(*) FROM job_containers WHERE job_containers.uid = k8s_batch_jobs.uid AND
+              job_containers.container->'securityContext'->>'privileged' = 'true') > 0
+               THEN 'fail'
+           ELSE 'pass'
+           END                              AS status
+FROM k8s_batch_jobs
+

--- a/plugins/source/k8s/policies_v1/queries/pod_security/job_container_privilege_escalation_disabled.sql
+++ b/plugins/source/k8s/policies_v1/queries/pod_security/job_container_privilege_escalation_disabled.sql
@@ -1,0 +1,22 @@
+WITH job_containers AS (SELECT uid, value AS container 
+                        FROM k8s_batch_jobs
+                        CROSS JOIN jsonb_array_elements(spec_template->'spec'->'containers') AS value)
+
+INSERT INTO k8s_policy_results (resource_id, execution_time, framework, check_id, title, context, namespace,
+                                resource_name, status)
+select uid                                         AS resource_id,
+        :'execution_time'::timestamp         AS execution_time,
+        :'framework'                         AS framework,
+        :'check_id'                          AS check_id,
+        'Job containers privilege escalation disabled' AS title,
+        context                              AS context,
+        namespace                            AS namespace,
+        name                                 AS resource_name,
+        CASE
+            WHEN
+                (SELECT COUNT(*) FROM job_containers WHERE job_containers.uid = k8s_batch_jobs.uid AND
+                job_containers.container->'securityContext'->>'allowPrivilegeEscalation' = 'true') > 0
+                THEN 'fail'
+            ELSE 'pass'
+            END                              AS status
+FROM k8s_batch_jobs

--- a/plugins/source/k8s/policies_v1/queries/pod_security/job_host_network_access_disabled.sql
+++ b/plugins/source/k8s/policies_v1/queries/pod_security/job_host_network_access_disabled.sql
@@ -1,0 +1,17 @@
+INSERT INTO k8s_policy_results (resource_id, execution_time, framework, check_id, title, context, namespace,
+                               resource_name, status)
+select uid                                   AS resource_id,
+       :'execution_time'::timestamp          AS execution_time,
+       :'framework'                          AS framework,
+       :'check_id'                           AS check_id,
+       'Jobs container hostNetwork disabled' AS title,
+       context                               AS context,
+       namespace                             AS namespace,
+       name                                  AS resource_name,
+       CASE
+           WHEN
+               spec_template -> 'spec' ->> 'hostNetwork' = 'true'
+               THEN 'fail'
+           ELSE 'pass'
+           END                               AS status
+FROM k8s_batch_jobs;

--- a/plugins/source/k8s/policies_v1/queries/pod_security/job_hostpid_hostipc_sharing_disabled.sql
+++ b/plugins/source/k8s/policies_v1/queries/pod_security/job_hostpid_hostipc_sharing_disabled.sql
@@ -1,0 +1,18 @@
+INSERT INTO k8s_policy_results (resource_id, execution_time, framework, check_id, title, context, namespace,
+                               resource_name, status)
+select uid                                                   AS resource_id,
+       :'execution_time'::timestamp                          AS execution_time,
+       :'framework'                                          AS framework,
+       :'check_id'                                           AS check_id,
+       'Job containers HostPID and HostIPC sharing disabled' AS title,
+       context                                               AS context,
+       namespace                                             AS namespace,
+       name                                                  AS resource_name,
+       CASE
+           WHEN
+                               spec_template -> 'spec' ->> 'hostPID' = 'true'
+                   OR spec_template -> 'spec' ->> 'hostIPC' = 'true'
+               THEN 'fail'
+           ELSE 'pass'
+           END                                               AS status
+FROM k8s_batch_jobs;

--- a/plugins/source/k8s/policies_v1/queries/pod_security/job_immutable_container_filesystem.sql
+++ b/plugins/source/k8s/policies_v1/queries/pod_security/job_immutable_container_filesystem.sql
@@ -1,0 +1,22 @@
+WITH job_containers AS (SELECT uid, value AS container 
+                        FROM k8s_batch_jobs
+                        CROSS JOIN jsonb_array_elements(spec_template->'spec'->'containers') AS value)
+
+INSERT INTO k8s_policy_results (resource_id, execution_time, framework, check_id, title, context, namespace,
+                                resource_name, status)
+select uid                                         AS resource_id,
+        :'execution_time'::timestamp         AS execution_time,
+        :'framework'                         AS framework,
+        :'check_id'                          AS check_id,
+        'Job containers root file system is read-only' AS title,
+        context                              AS context,
+        namespace                            AS namespace,
+        name                                 AS resource_name,
+        CASE
+            WHEN
+                (SELECT COUNT(*) FROM job_containers WHERE job_containers.uid = k8s_batch_jobs.uid AND
+                job_containers.container->'securityContext'->>'readOnlyRootFilesystem' IS DISTINCT FROM 'true') > 0
+                THEN 'fail'
+            ELSE 'pass'
+            END                              AS status
+FROM k8s_batch_jobs

--- a/plugins/source/k8s/policies_v1/queries/pod_security/job_non_root_container.sql
+++ b/plugins/source/k8s/policies_v1/queries/pod_security/job_non_root_container.sql
@@ -1,0 +1,22 @@
+WITH job_containers AS (SELECT uid, value AS container 
+                        FROM k8s_batch_jobs
+                        CROSS JOIN jsonb_array_elements(spec_template->'spec'->'containers') AS value)
+
+INSERT INTO k8s_policy_results (resource_id, execution_time, framework, check_id, title, context, namespace,
+                                resource_name, status)
+select uid                                         AS resource_id,
+        :'execution_time'::timestamp         AS execution_time,
+        :'framework'                         AS framework,
+        :'check_id'                          AS check_id,
+        'Job containers run as non-root' AS title,
+        context                              AS context,
+        namespace                            AS namespace,
+        name                                 AS resource_name,
+        CASE
+            WHEN
+                (SELECT COUNT(*) FROM job_containers WHERE job_containers.uid = k8s_batch_jobs.uid AND
+                job_containers.container->'securityContext'->>'runAsNonRoot' IS DISTINCT FROM 'true') > 0
+                THEN 'fail'
+            ELSE 'pass'
+            END                              AS status
+FROM k8s_batch_jobs

--- a/plugins/source/k8s/policies_v1/queries/pod_security/pod_container_privilege_disabled.sql
+++ b/plugins/source/k8s/policies_v1/queries/pod_security/pod_container_privilege_disabled.sql
@@ -1,0 +1,22 @@
+WITH pod_containers AS (SELECT uid, value AS container 
+                        FROM k8s_core_pods
+                        CROSS JOIN jsonb_array_elements(spec_containers) AS value)
+
+INSERT INTO k8s_policy_results (resource_id, execution_time, framework, check_id, title, context, namespace,
+                                resource_name, status)
+select uid                              AS resource_id,
+        :'execution_time'::timestamp      AS execution_time,
+        :'framework'                      AS framework,
+        :'check_id'                       AS check_id,
+        'Pod container privileged access disabled' AS title,
+        context                           AS context,
+        namespace                         AS namespace,
+        name                              AS resource_name,
+        CASE WHEN
+            (SELECT COUNT(*) FROM pod_containers WHERE pod_containers.uid = k8s_core_pods.uid AND
+              pod_containers.container->'securityContext'->>'privileged' = 'true') > 0
+            THEN 'fail'
+            ELSE 'pass'
+            END                          AS status  
+FROM k8s_core_pods;
+

--- a/plugins/source/k8s/policies_v1/queries/pod_security/pod_container_privilege_escalation_disabled.sql
+++ b/plugins/source/k8s/policies_v1/queries/pod_security/pod_container_privilege_escalation_disabled.sql
@@ -1,0 +1,21 @@
+WITH pod_containers AS (SELECT uid, value AS container 
+                        FROM k8s_core_pods
+                        CROSS JOIN jsonb_array_elements(spec_containers) AS value)
+
+INSERT INTO k8s_policy_results (resource_id, execution_time, framework, check_id, title, context, namespace,
+                                resource_name, status)
+select uid                              AS resource_id,
+        :'execution_time'::timestamp      AS execution_time,
+        :'framework'                      AS framework,
+        :'check_id'                       AS check_id,
+        'Pod container privilege escalation disabled' AS title,
+        context                           AS context,
+        namespace                         AS namespace,
+        name                              AS resource_name,
+        CASE WHEN
+            (SELECT COUNT(*) FROM pod_containers WHERE pod_containers.uid = k8s_core_pods.uid AND
+              pod_containers.container->'securityContext'->>'allowPrivilegeEscalation' = 'true') > 0
+            THEN 'fail'
+            ELSE 'pass'
+            END                          AS status
+FROM k8s_core_pods;

--- a/plugins/source/k8s/policies_v1/queries/pod_security/pod_host_network_access_disabled.sql
+++ b/plugins/source/k8s/policies_v1/queries/pod_security/pod_host_network_access_disabled.sql
@@ -1,0 +1,17 @@
+INSERT INTO k8s_policy_results (resource_id, execution_time, framework, check_id, title, context, namespace,
+                               resource_name, status)
+select uid                                   AS resource_id,
+       :'execution_time'::timestamp          AS execution_time,
+       :'framework'                          AS framework,
+       :'check_id'                           AS check_id,
+       'Pods container hostNetwork disabled' AS title,
+       context                               AS context,
+       namespace                             AS namespace,
+       name                                  AS resource_name,
+       CASE
+           WHEN
+               spec_host_network
+               THEN 'fail'
+           ELSE 'pass'
+           END                               AS status
+FROM k8s_core_pods;

--- a/plugins/source/k8s/policies_v1/queries/pod_security/pod_hostpid_hostipc_sharing_disabled.sql
+++ b/plugins/source/k8s/policies_v1/queries/pod_security/pod_hostpid_hostipc_sharing_disabled.sql
@@ -1,0 +1,17 @@
+INSERT INTO k8s_policy_results (resource_id, execution_time, framework, check_id, title, context, namespace,
+                               resource_name, status)
+select uid                                                   AS resource_id,
+       :'execution_time'::timestamp                          AS execution_time,
+       :'framework'                                          AS framework,
+       :'check_id'                                           AS check_id,
+       'Pod containers HostPID and HostIPC sharing disabled' AS title,
+       context                                               AS context,
+       namespace                                             AS namespace,
+       name                                                  AS resource_name,
+       CASE
+           WHEN
+               spec_host_pid OR spec_host_ipc
+               THEN 'fail'
+           ELSE 'pass'
+           END                                               AS status
+FROM k8s_core_pods;

--- a/plugins/source/k8s/policies_v1/queries/pod_security/pod_immutable_container_filesystem.sql
+++ b/plugins/source/k8s/policies_v1/queries/pod_security/pod_immutable_container_filesystem.sql
@@ -1,0 +1,21 @@
+WITH pod_containers AS (SELECT uid, value AS container 
+                        FROM k8s_core_pods
+                        CROSS JOIN jsonb_array_elements(spec_containers) AS value)
+
+INSERT INTO k8s_policy_results (resource_id, execution_time, framework, check_id, title, context, namespace,
+                                resource_name, status)
+select uid                              AS resource_id,
+        :'execution_time'::timestamp      AS execution_time,
+        :'framework'                      AS framework,
+        :'check_id'                       AS check_id,
+        'Pod container filesystem is read-ony' AS title,
+        context                           AS context,
+        namespace                         AS namespace,
+        name                              AS resource_name,
+        CASE WHEN
+            (SELECT COUNT(*) FROM pod_containers WHERE pod_containers.uid = k8s_core_pods.uid AND
+              pod_containers.container->'securityContext'->>'readOnlyRootFilesystem' IS DISTINCT FROM 'true') > 0
+            THEN 'fail'
+            ELSE 'pass'
+            END                          AS status
+FROM k8s_core_pods;

--- a/plugins/source/k8s/policies_v1/queries/pod_security/pod_non_root_container.sql
+++ b/plugins/source/k8s/policies_v1/queries/pod_security/pod_non_root_container.sql
@@ -1,0 +1,21 @@
+WITH pod_containers AS (SELECT uid, value AS container 
+                        FROM k8s_core_pods
+                        CROSS JOIN jsonb_array_elements(spec_containers) AS value)
+
+INSERT INTO k8s_policy_results (resource_id, execution_time, framework, check_id, title, context, namespace,
+                                resource_name, status)
+select uid                              AS resource_id,
+        :'execution_time'::timestamp      AS execution_time,
+        :'framework'                      AS framework,
+        :'check_id'                       AS check_id,
+        'Pod container runs as non-root' AS title,
+        context                           AS context,
+        namespace                         AS namespace,
+        name                              AS resource_name,
+        CASE WHEN
+            (SELECT COUNT(*) FROM pod_containers WHERE pod_containers.uid = k8s_core_pods.uid AND
+              pod_containers.container->'securityContext'->>'runAsNonRoot' IS DISTINCT FROM 'true') > 0
+            THEN 'fail'
+            ELSE 'pass'
+            END                          AS status
+FROM k8s_core_pods;

--- a/plugins/source/k8s/policies_v1/queries/pod_security/pod_service_account_token_disabled.sql
+++ b/plugins/source/k8s/policies_v1/queries/pod_security/pod_service_account_token_disabled.sql
@@ -1,0 +1,17 @@
+INSERT INTO k8s_policy_results (resource_id, execution_time, framework, check_id, title, context, namespace,
+                               resource_name, status)
+select DISTINCT uid                                   AS resource_id,
+                :'execution_time'::timestamp          AS execution_time,
+                :'framework'                          AS framework,
+                :'check_id'                           AS check_id,
+                'Pod service account tokens disabled' AS title,
+                context                               AS context,
+                namespace                             AS namespace,
+                name                                  AS resource_name,
+                CASE
+                    WHEN
+                        spec_automount_service_account_token
+                        THEN 'fail'
+                    ELSE 'pass'
+                    END                               AS status
+FROM k8s_core_pods

--- a/plugins/source/k8s/policies_v1/queries/pod_security/pod_volume_host_path.sql
+++ b/plugins/source/k8s/policies_v1/queries/pod_security/pod_volume_host_path.sql
@@ -1,0 +1,21 @@
+WITH pod_volumes AS (SELECT uid, value AS volumes
+                     FROM k8s_core_pods
+                     CROSS JOIN jsonb_array_elements(spec_volumes) AS value)
+
+INSERT INTO k8s_policy_results (resource_id, execution_time, framework, check_id, title, context, namespace,
+                                resource_name, status)
+select uid                              AS resource_id,
+            :'execution_time'::timestamp      AS execution_time,
+            :'framework'                      AS framework,
+            :'check_id'                       AS check_id,
+            'Pod volume don''t have a hostPath'            AS title,
+            context                           AS context,
+            namespace                         AS namespace,
+            name                              AS resource_name,
+            CASE WHEN
+               (SELECT COUNT(*) FROM pod_volumes WHERE pod_volumes.uid = k8s_core_pods.uid AND
+                 pod_volumes.volumes->>'hostPath' IS NOT NULL) > 0
+               THEN 'fail'
+               ELSE 'pass'
+               END                          AS status
+FROM k8s_core_pods;

--- a/plugins/source/k8s/policies_v1/queries/pod_security/replicaset_container_privilege_disabled.sql
+++ b/plugins/source/k8s/policies_v1/queries/pod_security/replicaset_container_privilege_disabled.sql
@@ -1,0 +1,22 @@
+WITH replica_set_containers AS (SELECT uid, value AS container 
+                               FROM k8s_apps_replica_sets
+                               CROSS JOIN jsonb_array_elements(spec_template->'spec'->'containers') AS value)
+
+INSERT INTO k8s_policy_results (resource_id, execution_time, framework, check_id, title, context, namespace,
+                                resource_name, status)
+select uid                              AS resource_id,
+        :'execution_time'::timestamp      AS execution_time,
+        :'framework'                      AS framework,
+        :'check_id'                       AS check_id,
+        'Replicaset privileges disabled' AS title,
+        context                           AS context,
+        namespace                         AS namespace,
+        name                              AS resource_name,
+        CASE WHEN
+            (SELECT COUNT(*) FROM replica_set_containers WHERE replica_set_containers.uid = k8s_apps_replica_sets.uid AND
+              replica_set_containers.container->'securityContext'->>'privileged' = 'true') > 0
+            THEN 'fail'
+            ELSE 'pass'
+            END                          AS status
+FROM k8s_apps_replica_sets;
+

--- a/plugins/source/k8s/policies_v1/queries/pod_security/replicaset_container_privilege_escalation_disabled.sql
+++ b/plugins/source/k8s/policies_v1/queries/pod_security/replicaset_container_privilege_escalation_disabled.sql
@@ -1,0 +1,21 @@
+WITH replica_set_containers AS (SELECT uid, value AS container 
+                               FROM k8s_apps_replica_sets
+                               CROSS JOIN jsonb_array_elements(spec_template->'spec'->'containers') AS value)
+
+INSERT INTO k8s_policy_results (resource_id, execution_time, framework, check_id, title, context, namespace,
+                                resource_name, status)
+select uid                              AS resource_id,
+        :'execution_time'::timestamp      AS execution_time,
+        :'framework'                      AS framework,
+        :'check_id'                       AS check_id,
+        'ReplicaSet container privileged escalation disabled' AS title,
+        context                           AS context,
+        namespace                         AS namespace,
+        name                              AS resource_name,
+        CASE WHEN
+            (SELECT COUNT(*) FROM replica_set_containers WHERE replica_set_containers.uid = k8s_apps_replica_sets.uid AND
+              replica_set_containers.container->'securityContext'->>'privileged' = 'true') > 0
+            THEN 'fail'
+            ELSE 'pass'
+            END                          AS status
+FROM k8s_apps_replica_sets;

--- a/plugins/source/k8s/policies_v1/queries/pod_security/replicaset_host_network_access_disabled.sql
+++ b/plugins/source/k8s/policies_v1/queries/pod_security/replicaset_host_network_access_disabled.sql
@@ -1,0 +1,17 @@
+INSERT INTO k8s_policy_results (resource_id, execution_time, framework, check_id, title, context, namespace,
+                               resource_name, status)
+select uid                                         AS resource_id,
+       :'execution_time'::timestamp                AS execution_time,
+       :'framework'                                AS framework,
+       :'check_id'                                 AS check_id,
+       'ReplicaSet container hostNetwork disabled' AS title,
+       context                                     AS context,
+       namespace                                   AS namespace,
+       name                                        AS resource_name,
+       CASE
+           WHEN
+               spec_template -> 'spec' ->> 'hostNetwork' = 'true'
+               THEN 'fail'
+           ELSE 'pass'
+           END                                     AS status
+FROM k8s_apps_replica_sets;

--- a/plugins/source/k8s/policies_v1/queries/pod_security/replicaset_hostpid_hostipc_sharing_disabled.sql
+++ b/plugins/source/k8s/policies_v1/queries/pod_security/replicaset_hostpid_hostipc_sharing_disabled.sql
@@ -1,0 +1,18 @@
+INSERT INTO k8s_policy_results (resource_id, execution_time, framework, check_id, title, context, namespace,
+                               resource_name, status)
+select uid                                                           AS resource_id,
+       :'execution_time'::timestamp                                  AS execution_time,
+       :'framework'                                                  AS framework,
+       :'check_id'                                                   AS check_id,
+       'ReplicaSet containers HostPID and HostIPC sharing disabled' AS title,
+       context                                                       AS context,
+       namespace                                                     AS namespace,
+       name                                                          AS resource_name,
+       CASE
+           WHEN
+                               spec_template -> 'spec' ->> 'hostPID' = 'true'
+                   OR spec_template -> 'spec' ->> 'hostIPC' = 'true'
+               THEN 'fail'
+           ELSE 'pass'
+           END                                                       AS status
+FROM k8s_apps_replica_sets;

--- a/plugins/source/k8s/policies_v1/queries/pod_security/replicaset_immutable_container_filesystem.sql
+++ b/plugins/source/k8s/policies_v1/queries/pod_security/replicaset_immutable_container_filesystem.sql
@@ -1,0 +1,22 @@
+WITH replica_set_containers AS (SELECT uid, value AS container 
+                               FROM k8s_apps_replica_sets
+                               CROSS JOIN jsonb_array_elements(spec_template->'spec'->'containers') AS value)
+
+INSERT INTO k8s_policy_results (resource_id, execution_time, framework, check_id, title, context, namespace,
+                                resource_name, status)
+select uid                              AS resource_id,
+       :'execution_time'::timestamp                          AS execution_time,
+       :'framework'                                          AS framework,
+       :'check_id'                                           AS check_id,
+       'ReplicaSet containers root file system is read-only' AS title,
+       context                                               AS context,
+       namespace                                             AS namespace,
+       name                                                  AS resource_name,
+       CASE
+           WHEN
+               (SELECT COUNT(*) FROM replica_set_containers WHERE replica_set_containers.uid = k8s_apps_replica_sets.uid AND
+                replica_set_containers.container->'securityContext' ->> 'readOnlyRootFilesystem' IS DISTINCT FROM 'true') > 0
+               THEN 'fail'
+           ELSE 'pass'
+           END                                               AS status
+FROM k8s_apps_replica_sets;

--- a/plugins/source/k8s/policies_v1/queries/pod_security/replicaset_non_root_container.sql
+++ b/plugins/source/k8s/policies_v1/queries/pod_security/replicaset_non_root_container.sql
@@ -1,0 +1,22 @@
+WITH replica_set_containers AS (SELECT uid, value AS container 
+                               FROM k8s_apps_replica_sets
+                               CROSS JOIN jsonb_array_elements(spec_template->'spec'->'containers') AS value)
+
+INSERT INTO k8s_policy_results (resource_id, execution_time, framework, check_id, title, context, namespace,
+                                resource_name, status)
+select uid                              AS resource_id,
+        :'execution_time'::timestamp                          AS execution_time,
+        :'framework'                                          AS framework,
+        :'check_id'                                           AS check_id,
+        'ReplicaSet containers must run as non-root' AS title,
+        context                                               AS context,
+        namespace                                             AS namespace,
+        name                                                  AS resource_name,
+        CASE
+            WHEN
+                (SELECT COUNT(*) FROM replica_set_containers WHERE replica_set_containers.uid = k8s_apps_replica_sets.uid AND
+                  replica_set_containers.container->'securityContext' ->> 'runAsNonRoot' IS DISTINCT FROM 'true') > 0
+                THEN 'fail'
+            ELSE 'pass'
+            END                                               AS status
+FROM k8s_apps_replica_sets;

--- a/plugins/source/k8s/policies_v1/queries/pod_security/service_account_token_disabled.sql
+++ b/plugins/source/k8s/policies_v1/queries/pod_security/service_account_token_disabled.sql
@@ -1,0 +1,17 @@
+INSERT INTO k8s_policy_results (resource_id, execution_time, framework, check_id, title, context, namespace,
+                               resource_name, status)
+select DISTINCT uid                                    AS resource_id,
+                :'execution_time'::timestamp           AS execution_time,
+                :'framework'                           AS framework,
+                :'check_id'                            AS check_id,
+                'Pod service account tokens disabled"' AS title,
+                context                                AS context,
+                namespace                              AS namespace,
+                name                                   AS resource_name,
+                CASE
+                    WHEN
+                        spec_automount_service_account_token
+                        THEN 'fail'
+                    ELSE 'pass'
+                    END                                AS status
+FROM k8s_core_service_accounts


### PR DESCRIPTION
[draft for easier reviewing at https://github.com/cloudquery/cloudquery/pull/2466]

- fixed many issues of duplicate rows. Each resources tested must have a single line in the output (but if our SELECT query joins with subtables, each resource may have many rows... ).
- removed endpoint_api_serve_on_secure_port.. The check tested that the k8s-api was served on port 6443 or 443. But obviously the port number has very little to do with security. NSA-Cisa [page 18], of course, doesn't specify that these must be the port numbers. e.g. minikube uses port 8443 instead of 6443. The check also tested the port 'name', but that of course also doesn't necesarrily indicate the actual protocol used...
- fixed `default_deny_ingress` and `default_deny_egress` policies to actually work (they always returned fail until now). Also deleted `default_dont_allow_ingress` and `default_dont_deny_egress`, since they seem to be duplicates of the `deny` policy?

https://media.defense.gov/2022/Aug/29/2003066362/-1/-1/0/CTR_KUBERNETES_HARDENING_GUIDANCE_1.2_20220829.PDF

<!-- 🎉 Thank you for making CloudQuery awesome by submitting a PR 🎉 -->

#### Summary

<!--
Explain what problem this PR addresses
-->

<!--
Use the following steps to ensure your PR is ready to be reviewed

- [ ] Read the [contribution guidelines](../blob/main/CONTRIBUTING.md) 🧑‍🎓
- [ ] Test locally on your own infrastructure
- [ ] Run `go fmt` to format your code 🖊
- [ ] Lint your changes via `golangci-lint run` 🚨 (install golangci-lint [here](https://golangci-lint.run/usage/install/#local-installation))
- [ ] Update or add tests 🧪
- [ ] Ensure the status checks below are successful ✅
--->
