### PR TITLE
fix: AWS codegen: fix ec2 naming

### DIFF
--- a/plugins/source/aws/codegen/recipes/base.go
+++ b/plugins/source/aws/codegen/recipes/base.go
@@ -4,11 +4,11 @@ import (
 	"bytes"
 	"embed"
 	"fmt"
+	"github.com/cloudquery/plugin-sdk/caser"
 	"go/format"
 	"os"
 	"path"
 	"reflect"
-	"regexp"
 	"runtime"
 	"strings"
 	"text/template"
@@ -57,19 +57,10 @@ var defaultRegionalColumns = []codegen.ColumnDefinition{
 }
 
 func awsNameTransformer(f reflect.StructField) (string, error) {
-	name, err := codegen.DefaultNameTransformer(f)
-	if err != nil {
-		return name, err
-	}
-	// replace occurrences with <underscore-number> with <number>
-
-	// (this is codegen, no need to hyper-optimize by pre-compiling regular expressions)
-	r, err := regexp.Compile(`_(\d+)`)
-	if err != nil {
-		return "", err
-	}
-
-	return r.ReplaceAllString(name, `$1`), nil
+	c := caser.New(caser.WithCustomInitialisms(map[string]bool{
+		"EC2": true,
+	}))
+	return c.ToSnake(f.Name), nil
 }
 
 func (r *Resource) Generate() error {

--- a/plugins/source/aws/codegen/recipes/base.go
+++ b/plugins/source/aws/codegen/recipes/base.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"embed"
 	"fmt"
-	"github.com/cloudquery/plugin-sdk/caser"
 	"go/format"
 	"os"
 	"path"
@@ -13,6 +12,7 @@ import (
 	"strings"
 	"text/template"
 
+	"github.com/cloudquery/plugin-sdk/caser"
 	"github.com/cloudquery/plugin-sdk/codegen"
 	"github.com/cloudquery/plugin-sdk/schema"
 	"github.com/iancoleman/strcase"


### PR DESCRIPTION
Add a special case for EC2 so that it doesn't get converted to `e_c2` by the caser. I re-ran codegen using this and it resulted in no changes (as expected).