### PR TITLE
fix: Fixed crashes when json field is nil

### DIFF
--- a/plugins/source/aws/client/resolvers.go
+++ b/plugins/source/aws/client/resolvers.go
@@ -139,15 +139,14 @@ func MarshaledJsonResolver(path string) schema.ColumnResolver {
 		var j map[string]interface{}
 		field := funk.Get(r.Item, path, funk.WithAllowZero())
 
+		if field == nil {
+			return nil
+		}
+
 		var val reflect.Value
+		val = reflect.ValueOf(field)
 		if reflect.TypeOf(field).Kind() == reflect.Ptr {
-			s := reflect.ValueOf(field)
-			if s.IsNil() {
-				return nil
-			}
-			val = s.Elem()
-		} else {
-			val = reflect.ValueOf(field)
+			val = val.Elem()
 		}
 		var err error
 		j = make(map[string]interface{})

--- a/plugins/source/aws/client/resolvers.go
+++ b/plugins/source/aws/client/resolvers.go
@@ -148,17 +148,24 @@ func MarshaledJsonResolver(path string) schema.ColumnResolver {
 		if reflect.TypeOf(field).Kind() == reflect.Ptr {
 			val = val.Elem()
 		}
-		var err error
-		j = make(map[string]interface{})
+
+		var b []byte
 		switch val.Kind() {
 		case reflect.String:
-			err = json.Unmarshal([]byte(val.String()), &j)
+			b = []byte(val.String())
 		case reflect.Slice, reflect.Array:
-			err = json.Unmarshal(val.Bytes(), &j)
+			b = val.Bytes()
 		}
+		if len(b) == 0 {
+			return r.Set(c.Name, nil)
+		}
+
+		j = make(map[string]interface{})
+		err := json.Unmarshal(b, &j)
 		if err != nil {
 			return errors.WithStack(err)
 		}
+
 		return r.Set(c.Name, j)
 	}
 }

--- a/plugins/source/aws/client/resolvers.go
+++ b/plugins/source/aws/client/resolvers.go
@@ -140,7 +140,7 @@ func MarshaledJsonResolver(path string) schema.ColumnResolver {
 		field := funk.Get(r.Item, path, funk.WithAllowZero())
 
 		if field == nil {
-			return nil
+			return r.Set(c.Name, nil)
 		}
 
 		var val reflect.Value

--- a/plugins/source/aws/client/resolvers_test.go
+++ b/plugins/source/aws/client/resolvers_test.go
@@ -153,7 +153,7 @@ var jsonBytes = []byte(jsonString)
 func TestResolveStringJson(t *testing.T) {
 	cases := []struct {
 		InputItem    interface{}
-		ExpectedData map[string]interface{}
+		ExpectedData interface{}
 		Path         string
 	}{
 		{
@@ -172,6 +172,13 @@ func TestResolveStringJson(t *testing.T) {
 		},
 		{
 			InputItem: struct {
+				Json *string
+			}{Json: nil},
+			ExpectedData: nil,
+			Path:         "Json",
+		},
+		{
+			InputItem: struct {
 				Json []byte
 			}{Json: jsonBytes},
 			ExpectedData: map[string]interface{}{"k1": "v1"},
@@ -182,6 +189,13 @@ func TestResolveStringJson(t *testing.T) {
 				Json *[]byte
 			}{Json: &jsonBytes},
 			ExpectedData: map[string]interface{}{"k1": "v1"},
+			Path:         "Json",
+		},
+		{
+			InputItem: struct {
+				Json *[]byte
+			}{Json: nil},
+			ExpectedData: nil,
 			Path:         "Json",
 		},
 	}

--- a/plugins/source/aws/client/resolvers_test.go
+++ b/plugins/source/aws/client/resolvers_test.go
@@ -165,6 +165,13 @@ func TestResolveStringJson(t *testing.T) {
 		},
 		{
 			InputItem: struct {
+				Json string
+			}{Json: ""},
+			ExpectedData: nil,
+			Path:         "Json",
+		},
+		{
+			InputItem: struct {
 				Json *string
 			}{Json: &jsonString},
 			ExpectedData: map[string]interface{}{"k1": "v1"},
@@ -195,6 +202,13 @@ func TestResolveStringJson(t *testing.T) {
 			InputItem: struct {
 				Json *[]byte
 			}{Json: nil},
+			ExpectedData: nil,
+			Path:         "Json",
+		},
+		{
+			InputItem: struct {
+				Json []byte
+			}{Json: []byte{}},
 			ExpectedData: nil,
 			Path:         "Json",
 		},

--- a/plugins/source/aws/resources/services/sns/subscriptions_mock_test.go
+++ b/plugins/source/aws/resources/services/sns/subscriptions_mock_test.go
@@ -1,6 +1,7 @@
 package sns
 
 import (
+	"github.com/aws/aws-sdk-go-v2/aws"
 	"testing"
 
 	"github.com/aws/aws-sdk-go-v2/service/sns"
@@ -19,12 +20,25 @@ func buildSnsSubscriptions(t *testing.T, ctrl *gomock.Controller) client.Service
 		t.Fatal(err)
 	}
 
+	subTemp := types.Subscription{}
+	err = faker.FakeData(&subTemp)
+	if err != nil {
+		t.Fatal(err)
+	}
+	emptySub := types.Subscription{
+		SubscriptionArn: aws.String("PendingConfirmation"),
+		Owner:           subTemp.Owner,
+		Protocol:        subTemp.Protocol,
+		TopicArn:        subTemp.TopicArn,
+		Endpoint:        subTemp.Endpoint,
+	}
+
 	m.EXPECT().ListSubscriptions(
 		gomock.Any(),
 		&sns.ListSubscriptionsInput{},
 	).Return(
 		&sns.ListSubscriptionsOutput{
-			Subscriptions: []types.Subscription{sub},
+			Subscriptions: []types.Subscription{sub, emptySub},
 		}, nil)
 
 	m.EXPECT().GetSubscriptionAttributes(


### PR DESCRIPTION
<!-- 🎉 Thank you for making CloudQuery awesome by submitting a PR 🎉 -->

#### Summary

<!--
Explain what problem this PR addresses
-->
 MarshaledJsonResolver  was not able to handle nil fields
<!--
Use the following steps to ensure your PR is ready to be reviewed

- [ ] Read the [contribution guidelines](../blob/main/CONTRIBUTING.md) 🧑‍🎓
- [ ] Test locally on your own infrastructure
- [ ] Run `go fmt` to format your code 🖊
- [ ] Lint your changes via `golangci-lint run` 🚨 (install golangci-lint [here](https://golangci-lint.run/usage/install/#local-installation))
- [ ] Update or add tests 🧪
- [ ] Ensure the status checks below are successful ✅
--->
