### PR TITLE
chore: Redirect getting started links

### DIFF
--- a/website/vercel.json
+++ b/website/vercel.json
@@ -28,6 +28,10 @@
     {
       "source": "/providers",
       "destination": "/docs/plugins/sources"
+    },
+    {
+      "source": "/docs/getting-started/:path*",
+      "destination": "/docs/quickstart"
     }
   ]
 }


### PR DESCRIPTION
<!-- 🎉 Thank you for making CloudQuery awesome by submitting a PR 🎉 -->

#### Summary

If you Google `CloudQuery getting started` the top results are broken. This redirects those links to the quick start guide

<!--
Use the following steps to ensure your PR is ready to be reviewed

- [ ] Read the [contribution guidelines](../blob/main/CONTRIBUTING.md) 🧑‍🎓
- [ ] Test locally on your own infrastructure
- [ ] Run `go fmt` to format your code 🖊
- [ ] Lint your changes via `golangci-lint run` 🚨 (install golangci-lint [here](https://golangci-lint.run/usage/install/#local-installation))
- [ ] Update or add tests 🧪
- [ ] Ensure the status checks below are successful ✅
--->
