### PR TITLE
chore(website): Add recipes section

### DIFF
--- a/website/pages/docs/_meta.json
+++ b/website/pages/docs/_meta.json
@@ -4,6 +4,7 @@
   "core-concepts": "Core Concepts",
   "advanced-topics": "Advanced Topics",
   "reference": "Reference",
+  "recipes": "Recipes",
   "deployment": "Deployment",
   "developers": "Developers",
   "cq-vs-others": "CloudQuery vs Others",

--- a/website/pages/docs/recipes/_meta.json
+++ b/website/pages/docs/recipes/_meta.json
@@ -1,0 +1,5 @@
+{
+  "overview": "Overview",
+  "aws-postgresql": "AWS + PostgreSQL",
+  "gcp-postgresql": "GCP + Postgresql"
+}

--- a/website/pages/docs/recipes/_meta.json
+++ b/website/pages/docs/recipes/_meta.json
@@ -1,5 +1,6 @@
 {
   "overview": "Overview",
   "aws-postgresql": "AWS + PostgreSQL",
-  "gcp-postgresql": "GCP + Postgresql"
+  "gcp-postgresql": "GCP + Postgresql",
+  "azure-postgresql": "Azure + PostgreSQL"
 }

--- a/website/pages/docs/recipes/aws-postgresql.md
+++ b/website/pages/docs/recipes/aws-postgresql.md
@@ -1,0 +1,20 @@
+# AWS + PostgreSQL
+
+```yaml
+kind: source
+spec:
+  name: aws
+  path: cloudquery/aws
+  version: v2.1.0 # latest version of aws plugin
+  tables: ["*"]
+  destinations: ["postgresql"]
+---
+kind: destination
+spec:
+  name: postgresql
+  path: cloudquery/postgresql
+  version: v1.1.0 # latest version of postgresql plugin
+  spec:
+    connection_string: ${PG_CONNECTION_STRING}
+```
+

--- a/website/pages/docs/recipes/azure-postgresql.md
+++ b/website/pages/docs/recipes/azure-postgresql.md
@@ -1,0 +1,19 @@
+# Azure + PostgreSQL
+
+```yaml
+kind: source
+spec:
+  name: azure
+  path: cloudquery/azure
+  version: v1.0.1 # latest version of azure plugin
+  tables: ["*"]
+  destinations: ["postgresql"]
+---
+kind: destination
+spec:
+  name: postgresql
+  path: cloudquery/postgresql
+  version: v1.1.0 # latest version of postgresql plugin
+  spec:
+    connection_string: ${PG_CONNECTION_STRING}
+```

--- a/website/pages/docs/recipes/gcp-postgresql.md
+++ b/website/pages/docs/recipes/gcp-postgresql.md
@@ -1,0 +1,19 @@
+# GCP + PostgreSQL
+
+```yaml
+kind: source
+spec:
+  name: gcp
+  path: cloudquery/gcp
+  version: v1.0.1 # latest version of gcp plugin
+  tables: ["*"]
+  destinations: ["postgresql"]
+---
+kind: destination
+spec:
+  name: postgresql
+  path: cloudquery/postgresql
+  version: v1.1.0 # latest version of postgresql plugin
+  spec:
+    connection_string: ${PG_CONNECTION_STRING}
+```

--- a/website/pages/docs/recipes/overview.md
+++ b/website/pages/docs/recipes/overview.md
@@ -1,0 +1,3 @@
+# CloudQuery Recipes
+
+This section provides set of basic examples for cloudquery configuration to sync data from source plugins to destinations plugins.


### PR DESCRIPTION
This adds section of useful configs for most used source/destination plugins that users can just copy paste (with auto-update pinned versions as part of CI).

Closes: https://github.com/cloudquery/cloudquery/issues/2047