### PR TITLE
feat: Add anonymised analytics

### DIFF
--- a/cli/cmd/analytics.go
+++ b/cli/cmd/analytics.go
@@ -1,0 +1,34 @@
+package cmd
+
+import "github.com/rudderlabs/analytics-go"
+
+const (
+	rudderStackWritekey = "2Fz1JvndsXs5WjHQ03fSYNv4gcp"
+	rudderStackEndpoint = "https://cloudquerypgm.dataplane.rudderstack.com"
+)
+
+type Analytics struct {
+	client analytics.Client
+}
+
+func initAnalytics() *Analytics {
+	c := Analytics{
+		client : analytics.New(rudderStackWritekey, rudderStackEndpoint),
+	}
+	return &c
+}
+
+func (a *Analytics) Enqueue(event analytics.Message) error {
+	if a.client != nil {
+		return a.client.Enqueue(event)
+	}
+	return nil
+}
+
+func (a *Analytics) Close() error {
+	if a.client != nil {
+		return a.client.Close()
+	}
+	return nil
+}
+

--- a/cli/cmd/logging.go
+++ b/cli/cmd/logging.go
@@ -1,0 +1,47 @@
+package cmd
+
+import (
+	"fmt"
+	"io"
+	"os"
+
+	"github.com/cloudquery/cloudquery/cli/internal/enum"
+	"github.com/rs/zerolog"
+	"github.com/rs/zerolog/log"
+)
+
+func initLogging(noLogFile bool, logLevel *enum.Enum, logFormat *enum.Enum, logConsole bool, logFileName string) (*os.File, error) {
+	var logFile *os.File
+	zerologLevel, err := zerolog.ParseLevel(logLevel.String())
+	if err != nil {
+		return nil, err
+	}
+	var writers []io.Writer
+	if !noLogFile {
+		logFile, err = os.OpenFile(logFileName, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0666)
+		if err != nil {
+			return nil, err
+		}
+		if logFormat.String() == "text" {
+			// for file logging we dont need color. we can add it as an option but don't think it is useful
+			writers = append(writers, zerolog.ConsoleWriter{Out: logFile, NoColor: true})
+		} else {
+			writers = append(writers, logFile)
+		}
+	}
+	if logConsole {
+		if err := os.Stdout.Close(); err != nil {
+			return nil, fmt.Errorf("failed to close stdout: %w", err)
+		}
+		if logFormat.String() == "text" {
+			writers = append(writers, zerolog.ConsoleWriter{Out: os.Stderr, NoColor: false})
+		} else {
+			writers = append(writers, os.Stderr)
+		}
+
+	}
+
+	mw := io.MultiWriter(writers...)
+	log.Logger = zerolog.New(mw).Level(zerologLevel).With().Str("module", "cli").Timestamp().Logger()
+	return logFile, nil
+}

--- a/cli/cmd/root.go
+++ b/cli/cmd/root.go
@@ -2,14 +2,12 @@ package cmd
 
 import (
 	"fmt"
-	"io"
 	"os"
 	"strings"
 
 	"github.com/cloudquery/cloudquery/cli/internal/enum"
-	"github.com/getsentry/sentry-go"
-	"github.com/rs/zerolog"
 	"github.com/rs/zerolog/log"
+	"github.com/rudderlabs/analytics-go"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 )
@@ -25,18 +23,32 @@ Open source data integration that works.
 
 Find more information at:
 	https://cloudquery.io`
+	telemetryLevels = []string{"none", "errors", "all"}
+
+	analyticsClient *Analytics
 )
+
+
+func strInArray(str string, arr []string) bool {
+	for _, s := range arr {
+		if s == str {
+			return true
+		}
+	}
+	return false
+}
+
 
 func NewCmdRoot() *cobra.Command {
 	logLevel := enum.NewEnum([]string{"trace", "debug", "info", "warn", "error"}, "info")
 	logFormat := enum.NewEnum([]string{"text", "json"}, "text")
-	noColor := false
 	logConsole := false
 	noLogFile := false
 	logFileName := "cloudquery.log"
 	sentryDsn := sentryDsnDefault
 
 	var logFile *os.File
+	var analyticsClient analytics.Client
 	cmd := &cobra.Command{
 		Use:     "cloudquery",
 		Short:   rootShort,
@@ -46,63 +58,33 @@ func NewCmdRoot() *cobra.Command {
 			// Don't print usage on command errors.
 			// PersistentPreRunE runs after argument parsing, so errors during parsing will result in printing the help
 			cmd.SilenceUsage = true
-			zerologLevel, err := zerolog.ParseLevel(logLevel.String())
-			if err != nil {
+			var err error
+			if logFile, err = initLogging(noLogFile, logLevel, logFormat, logConsole, logFileName); err != nil {
 				return err
 			}
-			var writers []io.Writer
-			if !noLogFile {
-				logFile, err = os.OpenFile(logFileName, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0666)
-				if err != nil {
-					return err
-				}
-				if logFormat.String() == "text" {
-					// for file logging we dont need color. we can add it as an option but don't think it is useful
-					writers = append(writers, zerolog.ConsoleWriter{Out: logFile, NoColor: true})
-				} else {
-					writers = append(writers, logFile)
-				}
+
+			telemetryLevel := viper.GetString("telemetry-level")
+			if !strInArray(telemetryLevel, telemetryLevels) {
+				return fmt.Errorf("invalid telemetry level %s. must be one of %v", telemetryLevel, telemetryLevels)
 			}
-			if logConsole {
-				if err := os.Stdout.Close(); err != nil {
-					return fmt.Errorf("failed to close stdout: %w", err)
-				}
-				if logFormat.String() == "text" {
-					writers = append(writers, zerolog.ConsoleWriter{Out: os.Stderr, NoColor: noColor})
-				} else {
-					writers = append(writers, os.Stderr)
+			if telemetryLevel == "all" {
+				analyticsClient = initAnalytics()
+			}
+
+			if sentryDsn != "" && Version != "development" && telemetryLevel != "none" {
+				if err := initSentry(sentryDsn, Version) ; err != nil {
+					// we don't fail on sentry init errors as there might be no connection or sentry can be blocked.
+					log.Err(err).Msg("failed to initialize sentry")
 				}
 			}
 
-			mw := io.MultiWriter(writers...)
-			log.Logger = zerolog.New(mw).Level(zerologLevel).With().Str("module", "cli").Timestamp().Logger()
-			if sentryDsn != "" && Version != "development" {
-				if err := sentry.Init(sentry.ClientOptions{
-					Debug:     false,
-					Dsn:       sentryDsn,
-					Release:   "cloudquery@" + Version,
-					Transport: sentry.NewHTTPSyncTransport(),
-					// https://docs.sentry.io/platforms/go/configuration/options/#removing-default-integrations
-					Integrations: func(integrations []sentry.Integration) []sentry.Integration {
-						var filteredIntegrations []sentry.Integration
-						for _, integration := range integrations {
-							if integration.Name() == "Modules" {
-								continue
-							}
-							filteredIntegrations = append(filteredIntegrations, integration)
-						}
-						return filteredIntegrations
-					},
-				}); err != nil {
-					return err
-				}
-			}
 			return nil
 		},
 		PersistentPostRun: func(cmd *cobra.Command, args []string) {
 			if logFile != nil {
 				logFile.Close()
 			}
+			analyticsClient.Close()
 		},
 	}
 
@@ -118,25 +100,13 @@ func NewCmdRoot() *cobra.Command {
 	cmd.PersistentFlags().StringVar(&logFileName, "log-file-name", "cloudquery.log", "Log filename")
 
 	// Telemtry (analytics) flags
-	cmd.PersistentFlags().Bool("no-telemetry", false, "disable telemetry collection")
+	cmd.PersistentFlags().String("telemetry-level", "all" ,"Telemetry level (none, errors, all)")
 	// we dont need viper support for most flags as all can be used via command line for now (we can add in the future if really necessary)
 	// the only exception is the telemetry as people might want to put in a bash starter script
-	if err := viper.BindPFlag("no-telemetry", cmd.PersistentFlags().Lookup("no-telemetry")); err != nil {
+	if err := viper.BindPFlag("telemetry-level", cmd.PersistentFlags().Lookup("telemetry-level")); err != nil {
 		panic(err)
 	}
-	cmd.PersistentFlags().Bool("telemetry-inspect", false, "enable telemetry inspection")
-	cmd.PersistentFlags().Bool("telemetry-debug", false, "enable telemetry debug logging")
 
-	// Sentry (error reporting) flags
-	cmd.PersistentFlags().StringVar(&sentryDsn, "sentry-dsn", sentryDsnDefault, "sentry DSN")
-
-	hiddenFlags := []string{"telemetry-inspect", "telemetry-debug", "sentry-dsn"}
-	for _, f := range hiddenFlags {
-		err := cmd.PersistentFlags().MarkHidden(f)
-		if err != nil {
-			panic(err)
-		}
-	}
 	initViper()
 	cmd.SetHelpCommand(&cobra.Command{Hidden: true})
 	cmd.AddCommand(NewCmdSync(), newCmdDoc())
@@ -149,4 +119,9 @@ func initViper() {
 	viper.AutomaticEnv()
 	viper.SetEnvPrefix("CQ")
 	viper.SetEnvKeyReplacer(strings.NewReplacer("-", "_"))
+	viper.SetConfigName("config") // name of config file (without extension)
+	viper.SetConfigType("yaml") // REQUIRED if the config file does not have the extension in the name
+	viper.AddConfigPath("/etc/cq/")   // path to look for the config file in
+	viper.AddConfigPath("$HOME/.cq")  // call multiple times to add many search paths
+	viper.AddConfigPath(".")  
 }

--- a/cli/cmd/sentry.go
+++ b/cli/cmd/sentry.go
@@ -1,0 +1,23 @@
+package cmd
+
+import "github.com/getsentry/sentry-go"
+
+func initSentry(sentryDsn string, version string) error {
+	return sentry.Init(sentry.ClientOptions{
+		Debug:     false,
+		Dsn:       sentryDsn,
+		Release:   "cloudquery@" + version,
+		Transport: sentry.NewHTTPSyncTransport(),
+		// https://docs.sentry.io/platforms/go/configuration/options/#removing-default-integrations
+		Integrations: func(integrations []sentry.Integration) []sentry.Integration {
+			var filteredIntegrations []sentry.Integration
+			for _, integration := range integrations {
+				if integration.Name() == "Modules" {
+					continue
+				}
+				filteredIntegrations = append(filteredIntegrations, integration)
+			}
+			return filteredIntegrations
+		},
+	})
+}

--- a/cli/go.mod
+++ b/cli/go.mod
@@ -31,16 +31,22 @@ require (
 	github.com/pelletier/go-toml v1.9.5 // indirect
 	github.com/pelletier/go-toml/v2 v2.0.1 // indirect
 	github.com/rivo/uniseg v0.4.2 // indirect
+	github.com/rudderlabs/analytics-go v3.3.3+incompatible // indirect
 	github.com/russross/blackfriday/v2 v2.1.0 // indirect
+	github.com/segmentio/backo-go v1.0.1 // indirect
 	github.com/spf13/afero v1.8.2 // indirect
 	github.com/spf13/cast v1.5.0 // indirect
 	github.com/spf13/jwalterweatherman v1.1.0 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
 	github.com/subosito/gotenv v1.3.0 // indirect
 	github.com/thoas/go-funk v0.9.2 // indirect
+	github.com/tidwall/gjson v1.14.3 // indirect
+	github.com/tidwall/match v1.1.1 // indirect
+	github.com/tidwall/pretty v1.2.0 // indirect
 	github.com/xeipuuv/gojsonpointer v0.0.0-20190905194746-02993c407bfb // indirect
 	github.com/xeipuuv/gojsonreference v0.0.0-20180127040603-bd5ef7bd5415 // indirect
 	github.com/xeipuuv/gojsonschema v1.2.0 // indirect
+	github.com/xtgo/uuid v0.0.0-20140804021211-a0b114877d4c // indirect
 	golang.org/x/net v0.0.0-20220920203100-d0c6ba3f52d9 // indirect
 	golang.org/x/sys v0.0.0-20220928140112-f11e5e49a4ec // indirect
 	golang.org/x/term v0.0.0-20220919170432-7a66f970e087 // indirect

--- a/cli/go.sum
+++ b/cli/go.sum
@@ -191,10 +191,14 @@ github.com/rogpeppe/go-internal v1.6.1 h1:/FiVV8dS/e+YqF2JvO3yXRFbBLTIuSDkuC7aBO
 github.com/rs/xid v1.4.0/go.mod h1:trrq9SKmegXys3aeAKXMUTdJsYXVwGY3RLcfgqegfbg=
 github.com/rs/zerolog v1.28.0 h1:MirSo27VyNi7RJYP3078AA1+Cyzd2GB66qy3aUHvsWY=
 github.com/rs/zerolog v1.28.0/go.mod h1:NILgTygv/Uej1ra5XxGf82ZFSLk58MFGAUS2o6usyD0=
+github.com/rudderlabs/analytics-go v3.3.3+incompatible h1:OG0XlKoXfr539e2t1dXtTB+Gr89uFW+OUNQBVhHIIBY=
+github.com/rudderlabs/analytics-go v3.3.3+incompatible/go.mod h1:LF8/ty9kUX4PTY3l5c97K3nZZaX5Hwsvt+NBaRL/f30=
 github.com/russross/blackfriday/v2 v2.1.0 h1:JIOH55/0cWyOuilr9/qlrm0BSXldqnqwMsf35Ld67mk=
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/schollz/progressbar/v3 v3.11.0 h1:3nIBUF1Zw/pGUaRHP7PZWmARP7ZQbWQ6vL6hwoQiIvU=
 github.com/schollz/progressbar/v3 v3.11.0/go.mod h1:R2djRgv58sn00AGysc4fN0ip4piOGd3z88K+zVBjczs=
+github.com/segmentio/backo-go v1.0.1 h1:68RQccglxZeyURy93ASB/2kc9QudzgIDexJ927N++y4=
+github.com/segmentio/backo-go v1.0.1/go.mod h1:9/Rh6yILuLysoQnZ2oNooD2g7aBnvM7r/fNVxRNWfBc=
 github.com/spf13/afero v1.8.2 h1:xehSyVa0YnHWsJ49JFljMpg1HX19V6NDZ1fkm1Xznbo=
 github.com/spf13/afero v1.8.2/go.mod h1:CtAatgMJh6bJEIs48Ay/FOnkljP3WeGUG0MC1RfAqwo=
 github.com/spf13/cast v1.5.0 h1:rj3WzYc11XZaIZMPKmwP96zkFEnnAmV8s6XbB2aY32w=
@@ -219,6 +223,12 @@ github.com/subosito/gotenv v1.3.0 h1:mjC+YW8QpAdXibNi+vNWgzmgBH4+5l5dCXv8cNysBLI
 github.com/subosito/gotenv v1.3.0/go.mod h1:YzJjq/33h7nrwdY+iHMhEOEEbW0ovIz0tB6t6PwAXzs=
 github.com/thoas/go-funk v0.9.2 h1:oKlNYv0AY5nyf9g+/GhMgS/UO2ces0QRdPKwkhY3VCk=
 github.com/thoas/go-funk v0.9.2/go.mod h1:+IWnUfUmFO1+WVYQWQtIJHeRRdaIyyYglZN7xzUPe4Q=
+github.com/tidwall/gjson v1.14.3 h1:9jvXn7olKEHU1S9vwoMGliaT8jq1vJ7IH/n9zD9Dnlw=
+github.com/tidwall/gjson v1.14.3/go.mod h1:/wbyibRr2FHMks5tjHJ5F8dMZh3AcwJEMf5vlfC0lxk=
+github.com/tidwall/match v1.1.1 h1:+Ho715JplO36QYgwN9PGYNhgZvoUSc9X2c80KVTi+GA=
+github.com/tidwall/match v1.1.1/go.mod h1:eRSPERbgtNPcGhD8UCthc6PmLEQXEWd3PRB5JTxsfmM=
+github.com/tidwall/pretty v1.2.0 h1:RWIZEg2iJ8/g6fDDYzMpobmaoGh5OLl4AXtGUGPcqCs=
+github.com/tidwall/pretty v1.2.0/go.mod h1:ITEVvHYasfjBbM0u2Pg8T2nJnzm8xPwvNhhsoaGGjNU=
 github.com/xeipuuv/gojsonpointer v0.0.0-20180127040702-4e3ac2762d5f/go.mod h1:N2zxlSyiKSe5eX1tZViRH5QA0qijqEDrYZiPEAiq3wU=
 github.com/xeipuuv/gojsonpointer v0.0.0-20190905194746-02993c407bfb h1:zGWFAtiMcyryUHoUjUJX0/lt1H2+i2Ka2n+D3DImSNo=
 github.com/xeipuuv/gojsonpointer v0.0.0-20190905194746-02993c407bfb/go.mod h1:N2zxlSyiKSe5eX1tZViRH5QA0qijqEDrYZiPEAiq3wU=
@@ -226,6 +236,8 @@ github.com/xeipuuv/gojsonreference v0.0.0-20180127040603-bd5ef7bd5415 h1:EzJWgHo
 github.com/xeipuuv/gojsonreference v0.0.0-20180127040603-bd5ef7bd5415/go.mod h1:GwrjFmJcFw6At/Gs6z4yjiIwzuJ1/+UwLxMQDVQXShQ=
 github.com/xeipuuv/gojsonschema v1.2.0 h1:LhYJRs+L4fBtjZUfuSZIKGeVu0QRy8e5Xi7D17UxZ74=
 github.com/xeipuuv/gojsonschema v1.2.0/go.mod h1:anYRn/JVcOK2ZgGU+IjEV4nwlhoK5sQluxsYJ78Id3Y=
+github.com/xtgo/uuid v0.0.0-20140804021211-a0b114877d4c h1:3lbZUMbMiGUW/LMkfsEABsc5zNT9+b1CvsJx47JzJ8g=
+github.com/xtgo/uuid v0.0.0-20140804021211-a0b114877d4c/go.mod h1:UrdRz5enIKZ63MEE3IF9l2/ebyx59GyGgPi+tICQdmM=
 github.com/yuin/goldmark v1.1.25/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.1.27/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.1.32/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=


### PR DESCRIPTION
<!-- 🎉 Thank you for making CloudQuery awesome by submitting a PR 🎉 -->

#### Summary

This still needs more testing once we fix main.

This introduce anonymised analytics that will help us get a few key metrics:
- Important: source and destination plugins used including versions
- Important: resources/data synced with each plugin
- Semi-Important: Fetch Error, Write Errors, Panics

Few notes:
- We don't need a note on this apart from the documentation because those analytics are fully anonymysed (GDPR compliant, similar to server side analytics). 
- We don't and shouldn't try to identify a user with a cookie or database id because this information is not ours and then we will need also to get a consent. Also, this will still give innacurate information about number of users so it's just best not to collect it in the first place and run in circles of trying to identify a user where in the first place we say it is anonymysed.
- I don't think it will ever become a need unless we introduce our own hub or GitHub will put a limitation on release downloads in which case we might need to introduce login to make sure our egress is not abused.
- We shouldn't turn the analytics into a product of itself and/or turn it into a funnel optimisation thing because we don't really have one as the product is really simple now - it gets data from one place to another.
- Any performance relates things most prob shouldn't go into here as well and in any-case we don't really have performance monitor for CQ, so this should come once we solve this with prometheus or whatever we decide. 

