### PR TITLE
fix: Flush destination plugins when sync finish

### DIFF
--- a/cli/cmd/sync.go
+++ b/cli/cmd/sync.go
@@ -153,6 +153,9 @@ func syncConnection(ctx context.Context, sourceSpec specs.Source, destinationsSp
 			if destFailedWrites, err = destClients[i].Write(gctx, sourceSpec.Name, syncTime, destSubscriptions[i]); err != nil {
 				return fmt.Errorf("failed to write for %s->%s: %w", sourceSpec.Name, destination, err)
 			}
+			if destClients[i].Close(ctx); err != nil {
+				return fmt.Errorf("failed to close destination client for %s->%s: %w", sourceSpec.Name, destination, err)
+			}
 			failedWrites += destFailedWrites
 			return nil
 		})


### PR DESCRIPTION
Seems like this bug was hanging there but now when we started using batch in our postgresql plugin we were hit by this. 