### PR TITLE
fix: Use [files and directories] in sync command description

### DIFF
--- a/cli/cmd/sync.go
+++ b/cli/cmd/sync.go
@@ -25,7 +25,7 @@ cloudquery sync ./directory ./aws.yml ./pg.yml
 
 func NewCmdSync() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:     "sync [file or directories...]",
+		Use:     "sync [files or directories]",
 		Short:   fetchShort,
 		Long:    fetchShort,
 		Example: fetchExample,

--- a/website/pages/docs/reference/cli/cloudquery_sync.md
+++ b/website/pages/docs/reference/cli/cloudquery_sync.md
@@ -10,7 +10,7 @@ Sync resources from configured source plugins to destinations
 Sync resources from configured source plugins to destinations
 
 ```
-cloudquery sync [file or directories...] [flags]
+cloudquery sync [files or directories] [flags]
 ```
 
 ### Examples


### PR DESCRIPTION
<!-- 🎉 Thank you for making CloudQuery awesome by submitting a PR 🎉 -->

#### Summary

I think we support a list of files/directories and not only a single file

<!--
Use the following steps to ensure your PR is ready to be reviewed

- [ ] Read the [contribution guidelines](../blob/main/CONTRIBUTING.md) 🧑‍🎓
- [ ] Test locally on your own infrastructure
- [ ] Run `go fmt` to format your code 🖊
- [ ] Lint your changes via `golangci-lint run` 🚨 (install golangci-lint [here](https://golangci-lint.run/usage/install/#local-installation))
- [ ] Update or add tests 🧪
- [ ] Ensure the status checks below are successful ✅
--->
