### PR TITLE
chore(tests): Use other faker less

### DIFF
--- a/plugins/source/aws/go.mod
+++ b/plugins/source/aws/go.mod
@@ -76,7 +76,6 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/xray v1.13.19
 	github.com/aws/smithy-go v1.13.3
 	github.com/basgys/goxml2json v1.1.0
-	github.com/cloudquery/faker/v3 v3.7.7
 	github.com/cloudquery/plugin-sdk v0.13.6
 	github.com/ettle/strcase v0.1.1
 	github.com/gocarina/gocsv v0.0.0-20220927221512-ad3251f9fa25
@@ -94,6 +93,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/internal/checksum v1.1.18 // indirect
 	github.com/aws/aws-sdk-go-v2/service/ssooidc v1.13.6 // indirect
 	github.com/bitly/go-simplejson v0.5.0 // indirect
+	github.com/cloudquery/faker/v3 v3.7.7 // indirect
 	github.com/getsentry/sentry-go v0.14.0 // indirect
 	github.com/grpc-ecosystem/go-grpc-middleware/providers/zerolog/v2 v2.0.0-rc.2 // indirect
 	github.com/grpc-ecosystem/go-grpc-middleware/v2 v2.0.0-rc.2 // indirect

--- a/plugins/source/aws/resources/services/accessanalyzer/analyzers_mock_test.go
+++ b/plugins/source/aws/resources/services/accessanalyzer/analyzers_mock_test.go
@@ -7,18 +7,18 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/accessanalyzer/types"
 	"github.com/cloudquery/cloudquery/plugins/source/aws/client"
 	"github.com/cloudquery/cloudquery/plugins/source/aws/client/mocks"
-	"github.com/cloudquery/faker/v3"
+	"github.com/cloudquery/plugin-sdk/faker"
 	"github.com/golang/mock/gomock"
 )
 
 func buildAccessAnalyzer(t *testing.T, ctrl *gomock.Controller) client.Services {
 	m := mocks.NewMockAnalyzerClient(ctrl)
 	u := types.AnalyzerSummary{}
-	if err := faker.FakeData(&u); err != nil {
+	if err := faker.FakeObject(&u); err != nil {
 		t.Fatal(err)
 	}
 	f := types.FindingSummary{}
-	if err := faker.FakeData(&f); err != nil {
+	if err := faker.FakeObject(&f); err != nil {
 		t.Fatal(err)
 	}
 
@@ -33,7 +33,7 @@ func buildAccessAnalyzer(t *testing.T, ctrl *gomock.Controller) client.Services 
 		}, nil)
 
 	arch := types.ArchiveRuleSummary{}
-	if err := faker.FakeData(&arch); err != nil {
+	if err := faker.FakeObject(&arch); err != nil {
 		t.Fatal(err)
 	}
 	m.EXPECT().ListArchiveRules(gomock.Any(), gomock.Any(), gomock.Any()).Return(

--- a/plugins/source/aws/resources/services/acm/certificates_mock_test.go
+++ b/plugins/source/aws/resources/services/acm/certificates_mock_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/acm/types"
 	"github.com/cloudquery/cloudquery/plugins/source/aws/client"
 	"github.com/cloudquery/cloudquery/plugins/source/aws/client/mocks"
-	"github.com/cloudquery/faker/v3"
+	"github.com/cloudquery/plugin-sdk/faker"
 	"github.com/golang/mock/gomock"
 )
 
@@ -16,7 +16,7 @@ func buildACMCertificates(t *testing.T, ctrl *gomock.Controller) client.Services
 	mock := mocks.NewMockACMClient(ctrl)
 
 	var cs types.CertificateSummary
-	if err := faker.FakeData(&cs); err != nil {
+	if err := faker.FakeObject(&cs); err != nil {
 		t.Fatal(err)
 	}
 	mock.EXPECT().ListCertificates(
@@ -29,7 +29,7 @@ func buildACMCertificates(t *testing.T, ctrl *gomock.Controller) client.Services
 	)
 
 	var cert types.CertificateDetail
-	if err := faker.FakeData(&cert); err != nil {
+	if err := faker.FakeObject(&cert); err != nil {
 		t.Fatal(err)
 	}
 	cert.CertificateArn = cs.CertificateArn

--- a/plugins/source/aws/resources/services/apigateway/api_keys_mock_test.go
+++ b/plugins/source/aws/resources/services/apigateway/api_keys_mock_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/apigateway/types"
 	"github.com/cloudquery/cloudquery/plugins/source/aws/client"
 	"github.com/cloudquery/cloudquery/plugins/source/aws/client/mocks"
-	"github.com/cloudquery/faker/v3"
+	"github.com/cloudquery/plugin-sdk/faker"
 	"github.com/golang/mock/gomock"
 )
 
@@ -15,7 +15,7 @@ func buildApiKeysMock(t *testing.T, ctrl *gomock.Controller) client.Services {
 	m := mocks.NewMockApigatewayClient(ctrl)
 
 	a := types.ApiKey{}
-	err := faker.FakeData(&a)
+	err := faker.FakeObject(&a)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/plugins/source/aws/resources/services/apigateway/client_certificates_mock_test.go
+++ b/plugins/source/aws/resources/services/apigateway/client_certificates_mock_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/apigateway/types"
 	"github.com/cloudquery/cloudquery/plugins/source/aws/client"
 	"github.com/cloudquery/cloudquery/plugins/source/aws/client/mocks"
-	"github.com/cloudquery/faker/v3"
+	"github.com/cloudquery/plugin-sdk/faker"
 	"github.com/golang/mock/gomock"
 )
 
@@ -15,7 +15,7 @@ func buildApigatewayClientCertificates(t *testing.T, ctrl *gomock.Controller) cl
 	m := mocks.NewMockApigatewayClient(ctrl)
 
 	c := types.ClientCertificate{}
-	err := faker.FakeData(&c)
+	err := faker.FakeObject(&c)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/plugins/source/aws/resources/services/apigateway/domain_names_mock_test.go
+++ b/plugins/source/aws/resources/services/apigateway/domain_names_mock_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/apigateway/types"
 	"github.com/cloudquery/cloudquery/plugins/source/aws/client"
 	"github.com/cloudquery/cloudquery/plugins/source/aws/client/mocks"
-	"github.com/cloudquery/faker/v3"
+	"github.com/cloudquery/plugin-sdk/faker"
 	"github.com/golang/mock/gomock"
 )
 
@@ -15,7 +15,7 @@ func buildApigatewayDomainNames(t *testing.T, ctrl *gomock.Controller) client.Se
 	m := mocks.NewMockApigatewayClient(ctrl)
 
 	dm := types.DomainName{}
-	err := faker.FakeData(&dm)
+	err := faker.FakeObject(&dm)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -25,7 +25,7 @@ func buildApigatewayDomainNames(t *testing.T, ctrl *gomock.Controller) client.Se
 		}, nil)
 
 	bpm := types.BasePathMapping{}
-	err = faker.FakeData(&bpm)
+	err = faker.FakeObject(&bpm)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/plugins/source/aws/resources/services/apigateway/rest_apis_mock_test.go
+++ b/plugins/source/aws/resources/services/apigateway/rest_apis_mock_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/apigateway/types"
 	"github.com/cloudquery/cloudquery/plugins/source/aws/client"
 	"github.com/cloudquery/cloudquery/plugins/source/aws/client/mocks"
-	"github.com/cloudquery/faker/v3"
+	"github.com/cloudquery/plugin-sdk/faker"
 	"github.com/golang/mock/gomock"
 )
 
@@ -15,7 +15,7 @@ func buildApigatewayRestApis(t *testing.T, ctrl *gomock.Controller) client.Servi
 	m := mocks.NewMockApigatewayClient(ctrl)
 
 	r := types.RestApi{}
-	err := faker.FakeData(&r)
+	err := faker.FakeObject(&r)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -25,7 +25,7 @@ func buildApigatewayRestApis(t *testing.T, ctrl *gomock.Controller) client.Servi
 		}, nil)
 
 	a := types.Authorizer{}
-	err = faker.FakeData(&a)
+	err = faker.FakeObject(&a)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -35,7 +35,7 @@ func buildApigatewayRestApis(t *testing.T, ctrl *gomock.Controller) client.Servi
 		}, nil)
 
 	d := types.Deployment{}
-	err = faker.FakeData(&d)
+	err = faker.FakeObject(&d)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -45,7 +45,7 @@ func buildApigatewayRestApis(t *testing.T, ctrl *gomock.Controller) client.Servi
 		}, nil)
 
 	dp := types.DocumentationPart{}
-	err = faker.FakeData(&dp)
+	err = faker.FakeObject(&dp)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -55,7 +55,7 @@ func buildApigatewayRestApis(t *testing.T, ctrl *gomock.Controller) client.Servi
 		}, nil)
 
 	dv := types.DocumentationVersion{}
-	err = faker.FakeData(&dv)
+	err = faker.FakeObject(&dv)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -65,7 +65,7 @@ func buildApigatewayRestApis(t *testing.T, ctrl *gomock.Controller) client.Servi
 		}, nil)
 
 	gr := types.GatewayResponse{}
-	err = faker.FakeData(&gr)
+	err = faker.FakeObject(&gr)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -75,7 +75,7 @@ func buildApigatewayRestApis(t *testing.T, ctrl *gomock.Controller) client.Servi
 		}, nil)
 
 	am := types.Model{}
-	err = faker.FakeData(&am)
+	err = faker.FakeObject(&am)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -85,7 +85,7 @@ func buildApigatewayRestApis(t *testing.T, ctrl *gomock.Controller) client.Servi
 		}, nil)
 
 	mt := apigateway.GetModelTemplateOutput{}
-	err = faker.FakeData(&mt)
+	err = faker.FakeObject(&mt)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -93,7 +93,7 @@ func buildApigatewayRestApis(t *testing.T, ctrl *gomock.Controller) client.Servi
 		&mt, nil)
 
 	rv := types.RequestValidator{}
-	err = faker.FakeData(&rv)
+	err = faker.FakeObject(&rv)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -103,7 +103,7 @@ func buildApigatewayRestApis(t *testing.T, ctrl *gomock.Controller) client.Servi
 		}, nil)
 
 	ar := types.Resource{}
-	err = faker.FakeData(&ar)
+	err = faker.FakeObject(&ar)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -113,7 +113,7 @@ func buildApigatewayRestApis(t *testing.T, ctrl *gomock.Controller) client.Servi
 		}, nil)
 
 	s := types.Stage{}
-	err = faker.FakeData(&s)
+	err = faker.FakeObject(&s)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/plugins/source/aws/resources/services/apigateway/usage_plans_mock_test.go
+++ b/plugins/source/aws/resources/services/apigateway/usage_plans_mock_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/apigateway/types"
 	"github.com/cloudquery/cloudquery/plugins/source/aws/client"
 	"github.com/cloudquery/cloudquery/plugins/source/aws/client/mocks"
-	"github.com/cloudquery/faker/v3"
+	"github.com/cloudquery/plugin-sdk/faker"
 	"github.com/golang/mock/gomock"
 )
 
@@ -15,7 +15,7 @@ func buildApigatewayUsagePlans(t *testing.T, ctrl *gomock.Controller) client.Ser
 	m := mocks.NewMockApigatewayClient(ctrl)
 
 	u := types.UsagePlan{}
-	err := faker.FakeData(&u)
+	err := faker.FakeObject(&u)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -25,7 +25,7 @@ func buildApigatewayUsagePlans(t *testing.T, ctrl *gomock.Controller) client.Ser
 		}, nil)
 
 	uk := types.UsagePlanKey{}
-	err = faker.FakeData(&uk)
+	err = faker.FakeObject(&uk)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/plugins/source/aws/resources/services/apigateway/vpc_links_mock_test.go
+++ b/plugins/source/aws/resources/services/apigateway/vpc_links_mock_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/apigateway/types"
 	"github.com/cloudquery/cloudquery/plugins/source/aws/client"
 	"github.com/cloudquery/cloudquery/plugins/source/aws/client/mocks"
-	"github.com/cloudquery/faker/v3"
+	"github.com/cloudquery/plugin-sdk/faker"
 	"github.com/golang/mock/gomock"
 )
 
@@ -15,7 +15,7 @@ func buildApigatewayVpcLinks(t *testing.T, ctrl *gomock.Controller) client.Servi
 	m := mocks.NewMockApigatewayClient(ctrl)
 
 	l := types.VpcLink{}
-	err := faker.FakeData(&l)
+	err := faker.FakeObject(&l)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/plugins/source/aws/resources/services/apigatewayv2/apis_mock_test.go
+++ b/plugins/source/aws/resources/services/apigatewayv2/apis_mock_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/apigatewayv2/types"
 	"github.com/cloudquery/cloudquery/plugins/source/aws/client"
 	"github.com/cloudquery/cloudquery/plugins/source/aws/client/mocks"
-	"github.com/cloudquery/faker/v3"
+	"github.com/cloudquery/plugin-sdk/faker"
 	"github.com/golang/mock/gomock"
 )
 
@@ -15,7 +15,7 @@ func buildApigatewayv2Apis(t *testing.T, ctrl *gomock.Controller) client.Service
 	m := mocks.NewMockApigatewayv2Client(ctrl)
 
 	a := types.Api{}
-	err := faker.FakeData(&a)
+	err := faker.FakeObject(&a)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -25,7 +25,7 @@ func buildApigatewayv2Apis(t *testing.T, ctrl *gomock.Controller) client.Service
 		}, nil)
 
 	aa := types.Authorizer{}
-	err = faker.FakeData(&aa)
+	err = faker.FakeObject(&aa)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -35,7 +35,7 @@ func buildApigatewayv2Apis(t *testing.T, ctrl *gomock.Controller) client.Service
 		}, nil)
 
 	d := types.Deployment{}
-	err = faker.FakeData(&d)
+	err = faker.FakeObject(&d)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -45,7 +45,7 @@ func buildApigatewayv2Apis(t *testing.T, ctrl *gomock.Controller) client.Service
 		}, nil)
 
 	i := types.Integration{}
-	err = faker.FakeData(&i)
+	err = faker.FakeObject(&i)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -55,7 +55,7 @@ func buildApigatewayv2Apis(t *testing.T, ctrl *gomock.Controller) client.Service
 		}, nil)
 
 	ir := types.IntegrationResponse{}
-	err = faker.FakeData(&ir)
+	err = faker.FakeObject(&ir)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -65,7 +65,7 @@ func buildApigatewayv2Apis(t *testing.T, ctrl *gomock.Controller) client.Service
 		}, nil)
 
 	am := types.Model{}
-	err = faker.FakeData(&am)
+	err = faker.FakeObject(&am)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -75,7 +75,7 @@ func buildApigatewayv2Apis(t *testing.T, ctrl *gomock.Controller) client.Service
 		}, nil)
 
 	mt := apigatewayv2.GetModelTemplateOutput{}
-	err = faker.FakeData(&mt)
+	err = faker.FakeObject(&mt)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -83,7 +83,7 @@ func buildApigatewayv2Apis(t *testing.T, ctrl *gomock.Controller) client.Service
 		&mt, nil)
 
 	r := types.Route{}
-	err = faker.FakeData(&r)
+	err = faker.FakeObject(&r)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -93,7 +93,7 @@ func buildApigatewayv2Apis(t *testing.T, ctrl *gomock.Controller) client.Service
 		}, nil)
 
 	s := types.Stage{}
-	err = faker.FakeData(&s)
+	err = faker.FakeObject(&s)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -103,7 +103,7 @@ func buildApigatewayv2Apis(t *testing.T, ctrl *gomock.Controller) client.Service
 		}, nil)
 
 	rr := types.RouteResponse{}
-	err = faker.FakeData(&rr)
+	err = faker.FakeObject(&rr)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/plugins/source/aws/resources/services/apigatewayv2/domain_names_mock_test.go
+++ b/plugins/source/aws/resources/services/apigatewayv2/domain_names_mock_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/apigatewayv2/types"
 	"github.com/cloudquery/cloudquery/plugins/source/aws/client"
 	"github.com/cloudquery/cloudquery/plugins/source/aws/client/mocks"
-	"github.com/cloudquery/faker/v3"
+	"github.com/cloudquery/plugin-sdk/faker"
 	"github.com/golang/mock/gomock"
 )
 
@@ -15,7 +15,7 @@ func buildApigatewayv2DomainNames(t *testing.T, ctrl *gomock.Controller) client.
 	m := mocks.NewMockApigatewayv2Client(ctrl)
 
 	dn := types.DomainName{}
-	err := faker.FakeData(&dn)
+	err := faker.FakeObject(&dn)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -25,7 +25,7 @@ func buildApigatewayv2DomainNames(t *testing.T, ctrl *gomock.Controller) client.
 		}, nil)
 
 	am := types.ApiMapping{}
-	err = faker.FakeData(&am)
+	err = faker.FakeObject(&am)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/plugins/source/aws/resources/services/apigatewayv2/vpc_links_mock_test.go
+++ b/plugins/source/aws/resources/services/apigatewayv2/vpc_links_mock_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/apigatewayv2/types"
 	"github.com/cloudquery/cloudquery/plugins/source/aws/client"
 	"github.com/cloudquery/cloudquery/plugins/source/aws/client/mocks"
-	"github.com/cloudquery/faker/v3"
+	"github.com/cloudquery/plugin-sdk/faker"
 	"github.com/golang/mock/gomock"
 )
 
@@ -15,7 +15,7 @@ func buildApigatewayv2VpcLinks(t *testing.T, ctrl *gomock.Controller) client.Ser
 	m := mocks.NewMockApigatewayv2Client(ctrl)
 
 	v := types.VpcLink{}
-	err := faker.FakeData(&v)
+	err := faker.FakeObject(&v)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/plugins/source/aws/resources/services/applicationautoscaling/policies_mock_test.go
+++ b/plugins/source/aws/resources/services/applicationautoscaling/policies_mock_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/applicationautoscaling/types"
 	"github.com/cloudquery/cloudquery/plugins/source/aws/client"
 	"github.com/cloudquery/cloudquery/plugins/source/aws/client/mocks"
-	"github.com/cloudquery/faker/v3"
+	"github.com/cloudquery/plugin-sdk/faker"
 	"github.com/golang/mock/gomock"
 )
 
@@ -17,7 +17,7 @@ func buildApplicationAutoscalingPoliciesMock(t *testing.T, ctrl *gomock.Controll
 		ApplicationAutoscaling: m,
 	}
 	c := types.ScalingPolicy{}
-	if err := faker.FakeData(&c); err != nil {
+	if err := faker.FakeObject(&c); err != nil {
 		t.Fatal(err)
 	}
 	output := &applicationautoscaling.DescribeScalingPoliciesOutput{

--- a/plugins/source/aws/resources/services/appsync/graphql_apis_mock_test.go
+++ b/plugins/source/aws/resources/services/appsync/graphql_apis_mock_test.go
@@ -7,14 +7,14 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/appsync/types"
 	"github.com/cloudquery/cloudquery/plugins/source/aws/client"
 	"github.com/cloudquery/cloudquery/plugins/source/aws/client/mocks"
-	"github.com/cloudquery/faker/v3"
+	"github.com/cloudquery/plugin-sdk/faker"
 	"github.com/golang/mock/gomock"
 )
 
 func buildAppsyncGraphqlApisMock(t *testing.T, ctrl *gomock.Controller) client.Services {
 	m := mocks.NewMockAppSyncClient(ctrl)
 	l := types.GraphqlApi{}
-	err := faker.FakeData(&l)
+	err := faker.FakeObject(&l)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/plugins/source/aws/resources/services/athena/data_catalogs_mock_test.go
+++ b/plugins/source/aws/resources/services/athena/data_catalogs_mock_test.go
@@ -6,7 +6,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/athena"
 	"github.com/cloudquery/cloudquery/plugins/source/aws/client"
 	"github.com/cloudquery/cloudquery/plugins/source/aws/client/mocks"
-	"github.com/cloudquery/faker/v3"
+	"github.com/cloudquery/plugin-sdk/faker"
 	"github.com/golang/mock/gomock"
 )
 
@@ -14,7 +14,7 @@ func buildDataCatalogs(t *testing.T, ctrl *gomock.Controller) client.Services {
 	m := mocks.NewMockAthenaClient(ctrl)
 
 	catalogs := athena.ListDataCatalogsOutput{}
-	err := faker.FakeData(&catalogs)
+	err := faker.FakeObject(&catalogs)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -22,7 +22,7 @@ func buildDataCatalogs(t *testing.T, ctrl *gomock.Controller) client.Services {
 	m.EXPECT().ListDataCatalogs(gomock.Any(), gomock.Any(), gomock.Any()).Return(&catalogs, nil)
 
 	catalog := athena.GetDataCatalogOutput{}
-	err = faker.FakeData(&catalog)
+	err = faker.FakeObject(&catalog)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -30,7 +30,7 @@ func buildDataCatalogs(t *testing.T, ctrl *gomock.Controller) client.Services {
 	m.EXPECT().GetDataCatalog(gomock.Any(), gomock.Any(), gomock.Any()).Return(&catalog, nil)
 
 	databases := athena.ListDatabasesOutput{}
-	err = faker.FakeData(&databases)
+	err = faker.FakeObject(&databases)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -38,7 +38,7 @@ func buildDataCatalogs(t *testing.T, ctrl *gomock.Controller) client.Services {
 	m.EXPECT().ListDatabases(gomock.Any(), gomock.Any(), gomock.Any()).Return(&databases, nil)
 
 	tags := athena.ListTagsForResourceOutput{}
-	err = faker.FakeData(&tags)
+	err = faker.FakeObject(&tags)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -46,7 +46,7 @@ func buildDataCatalogs(t *testing.T, ctrl *gomock.Controller) client.Services {
 	m.EXPECT().ListTagsForResource(gomock.Any(), gomock.Any(), gomock.Any()).Return(&tags, nil)
 
 	tables := athena.ListTableMetadataOutput{}
-	err = faker.FakeData(&tables)
+	err = faker.FakeObject(&tables)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/plugins/source/aws/resources/services/athena/work_groups_mock_test.go
+++ b/plugins/source/aws/resources/services/athena/work_groups_mock_test.go
@@ -6,7 +6,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/athena"
 	"github.com/cloudquery/cloudquery/plugins/source/aws/client"
 	"github.com/cloudquery/cloudquery/plugins/source/aws/client/mocks"
-	"github.com/cloudquery/faker/v3"
+	"github.com/cloudquery/plugin-sdk/faker"
 	"github.com/golang/mock/gomock"
 )
 
@@ -14,7 +14,7 @@ func buildWorkGroups(t *testing.T, ctrl *gomock.Controller) client.Services {
 	m := mocks.NewMockAthenaClient(ctrl)
 
 	workGroupsOutput := athena.ListWorkGroupsOutput{}
-	err := faker.FakeData(&workGroupsOutput)
+	err := faker.FakeObject(&workGroupsOutput)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -22,14 +22,14 @@ func buildWorkGroups(t *testing.T, ctrl *gomock.Controller) client.Services {
 	m.EXPECT().ListWorkGroups(gomock.Any(), gomock.Any(), gomock.Any()).Return(&workGroupsOutput, nil)
 
 	workGroup := athena.GetWorkGroupOutput{}
-	err = faker.FakeData(&workGroup)
+	err = faker.FakeObject(&workGroup)
 	if err != nil {
 		t.Fatal(err)
 	}
 	m.EXPECT().GetWorkGroup(gomock.Any(), gomock.Any(), gomock.Any()).Return(&workGroup, nil)
 
 	namedQueriesOutput := athena.ListNamedQueriesOutput{}
-	err = faker.FakeData(&namedQueriesOutput)
+	err = faker.FakeObject(&namedQueriesOutput)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -37,7 +37,7 @@ func buildWorkGroups(t *testing.T, ctrl *gomock.Controller) client.Services {
 	m.EXPECT().ListNamedQueries(gomock.Any(), gomock.Any(), gomock.Any()).Return(&namedQueriesOutput, nil)
 
 	queryExecutionsOutput := athena.ListQueryExecutionsOutput{}
-	err = faker.FakeData(&queryExecutionsOutput)
+	err = faker.FakeObject(&queryExecutionsOutput)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -45,7 +45,7 @@ func buildWorkGroups(t *testing.T, ctrl *gomock.Controller) client.Services {
 	m.EXPECT().ListQueryExecutions(gomock.Any(), gomock.Any(), gomock.Any()).Return(&queryExecutionsOutput, nil)
 
 	preparedStatementsOutput := athena.ListPreparedStatementsOutput{}
-	err = faker.FakeData(&preparedStatementsOutput)
+	err = faker.FakeObject(&preparedStatementsOutput)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -53,7 +53,7 @@ func buildWorkGroups(t *testing.T, ctrl *gomock.Controller) client.Services {
 	m.EXPECT().ListPreparedStatements(gomock.Any(), gomock.Any(), gomock.Any()).Return(&preparedStatementsOutput, nil)
 
 	tags := athena.ListTagsForResourceOutput{}
-	err = faker.FakeData(&tags)
+	err = faker.FakeObject(&tags)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -61,20 +61,20 @@ func buildWorkGroups(t *testing.T, ctrl *gomock.Controller) client.Services {
 	m.EXPECT().ListTagsForResource(gomock.Any(), gomock.Any(), gomock.Any()).Return(&tags, nil)
 
 	preparedStatement := athena.GetPreparedStatementOutput{}
-	err = faker.FakeData(&preparedStatement)
+	err = faker.FakeObject(&preparedStatement)
 	if err != nil {
 		t.Fatal(err)
 	}
 	m.EXPECT().GetPreparedStatement(gomock.Any(), gomock.Any(), gomock.Any()).Return(&preparedStatement, nil)
 
 	namedQuery := athena.GetNamedQueryOutput{}
-	err = faker.FakeData(&namedQuery)
+	err = faker.FakeObject(&namedQuery)
 	if err != nil {
 		t.Fatal(err)
 	}
 	m.EXPECT().GetNamedQuery(gomock.Any(), gomock.Any(), gomock.Any()).Return(&namedQuery, nil)
 	queryExecution := athena.GetQueryExecutionOutput{}
-	err = faker.FakeData(&queryExecution)
+	err = faker.FakeObject(&queryExecution)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/plugins/source/aws/resources/services/autoscaling/groups_mock_test.go
+++ b/plugins/source/aws/resources/services/autoscaling/groups_mock_test.go
@@ -6,7 +6,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/autoscaling"
 	"github.com/cloudquery/cloudquery/plugins/source/aws/client"
 	"github.com/cloudquery/cloudquery/plugins/source/aws/client/mocks"
-	"github.com/cloudquery/faker/v3"
+	"github.com/cloudquery/plugin-sdk/faker"
 	"github.com/golang/mock/gomock"
 )
 
@@ -14,7 +14,7 @@ func buildAutoscalingGroups(t *testing.T, ctrl *gomock.Controller) client.Servic
 	m := mocks.NewMockAutoscalingClient(ctrl)
 
 	groups := autoscaling.DescribeAutoScalingGroupsOutput{}
-	err := faker.FakeData(&groups)
+	err := faker.FakeObject(&groups)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -22,7 +22,7 @@ func buildAutoscalingGroups(t *testing.T, ctrl *gomock.Controller) client.Servic
 	m.EXPECT().DescribeAutoScalingGroups(gomock.Any(), gomock.Any(), gomock.Any()).Return(&groups, nil)
 
 	configurations := autoscaling.DescribeNotificationConfigurationsOutput{}
-	err = faker.FakeData(&configurations)
+	err = faker.FakeObject(&configurations)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -31,7 +31,7 @@ func buildAutoscalingGroups(t *testing.T, ctrl *gomock.Controller) client.Servic
 	m.EXPECT().DescribeNotificationConfigurations(gomock.Any(), gomock.Any(), gomock.Any()).Return(&configurations, nil)
 
 	loadBalancers := autoscaling.DescribeLoadBalancersOutput{}
-	err = faker.FakeData(&loadBalancers)
+	err = faker.FakeObject(&loadBalancers)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -39,7 +39,7 @@ func buildAutoscalingGroups(t *testing.T, ctrl *gomock.Controller) client.Servic
 	m.EXPECT().DescribeLoadBalancers(gomock.Any(), gomock.Any(), gomock.Any()).Return(&loadBalancers, nil)
 
 	loadBalancerTargetGroups := autoscaling.DescribeLoadBalancerTargetGroupsOutput{}
-	err = faker.FakeData(&loadBalancerTargetGroups)
+	err = faker.FakeObject(&loadBalancerTargetGroups)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -47,7 +47,7 @@ func buildAutoscalingGroups(t *testing.T, ctrl *gomock.Controller) client.Servic
 	m.EXPECT().DescribeLoadBalancerTargetGroups(gomock.Any(), gomock.Any(), gomock.Any()).Return(&loadBalancerTargetGroups, nil)
 
 	policies := autoscaling.DescribePoliciesOutput{}
-	err = faker.FakeData(&policies)
+	err = faker.FakeObject(&policies)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -55,7 +55,7 @@ func buildAutoscalingGroups(t *testing.T, ctrl *gomock.Controller) client.Servic
 	m.EXPECT().DescribePolicies(gomock.Any(), gomock.Any(), gomock.Any()).Return(&policies, nil)
 
 	lifecycleHooks := autoscaling.DescribeLifecycleHooksOutput{}
-	err = faker.FakeData(&lifecycleHooks)
+	err = faker.FakeObject(&lifecycleHooks)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/plugins/source/aws/resources/services/autoscaling/launch_configuration_mock_test.go
+++ b/plugins/source/aws/resources/services/autoscaling/launch_configuration_mock_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/autoscaling/types"
 	"github.com/cloudquery/cloudquery/plugins/source/aws/client"
 	"github.com/cloudquery/cloudquery/plugins/source/aws/client/mocks"
-	"github.com/cloudquery/faker/v3"
+	"github.com/cloudquery/plugin-sdk/faker"
 	"github.com/golang/mock/gomock"
 )
 
@@ -17,7 +17,7 @@ func buildAutoscalingLaunchConfigurationsMock(t *testing.T, ctrl *gomock.Control
 		Autoscaling: m,
 	}
 	l := types.LaunchConfiguration{}
-	err := faker.FakeData(&l)
+	err := faker.FakeObject(&l)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/plugins/source/aws/resources/services/autoscaling/scheduled_actions_mock_test.go
+++ b/plugins/source/aws/resources/services/autoscaling/scheduled_actions_mock_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/autoscaling/types"
 	"github.com/cloudquery/cloudquery/plugins/source/aws/client"
 	"github.com/cloudquery/cloudquery/plugins/source/aws/client/mocks"
-	"github.com/cloudquery/faker/v3"
+	"github.com/cloudquery/plugin-sdk/faker"
 	"github.com/golang/mock/gomock"
 )
 
@@ -17,7 +17,7 @@ func buildAutoscalingSheduledActionMock(t *testing.T, ctrl *gomock.Controller) c
 		Autoscaling: m,
 	}
 	l := types.ScheduledUpdateGroupAction{}
-	err := faker.FakeData(&l)
+	err := faker.FakeObject(&l)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/plugins/source/aws/resources/services/backup/global_settings_mock_test.go
+++ b/plugins/source/aws/resources/services/backup/global_settings_mock_test.go
@@ -6,7 +6,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/backup"
 	"github.com/cloudquery/cloudquery/plugins/source/aws/client"
 	"github.com/cloudquery/cloudquery/plugins/source/aws/client/mocks"
-	"github.com/cloudquery/faker/v3"
+	"github.com/cloudquery/plugin-sdk/faker"
 	"github.com/golang/mock/gomock"
 )
 
@@ -14,7 +14,7 @@ func buildBackupGlobalSettingsMock(t *testing.T, ctrl *gomock.Controller) client
 	m := mocks.NewMockBackupClient(ctrl)
 
 	var settings backup.DescribeGlobalSettingsOutput
-	if err := faker.FakeData(&settings); err != nil {
+	if err := faker.FakeObject(&settings); err != nil {
 		t.Fatal(err)
 	}
 	m.EXPECT().DescribeGlobalSettings(

--- a/plugins/source/aws/resources/services/backup/plans_mock_test.go
+++ b/plugins/source/aws/resources/services/backup/plans_mock_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/backup/types"
 	"github.com/cloudquery/cloudquery/plugins/source/aws/client"
 	"github.com/cloudquery/cloudquery/plugins/source/aws/client/mocks"
-	"github.com/cloudquery/faker/v3"
+	"github.com/cloudquery/plugin-sdk/faker"
 	"github.com/golang/mock/gomock"
 )
 
@@ -16,7 +16,7 @@ func buildBackupPlansMock(t *testing.T, ctrl *gomock.Controller) client.Services
 	m := mocks.NewMockBackupClient(ctrl)
 
 	var plan backup.GetBackupPlanOutput
-	if err := faker.FakeData(&plan); err != nil {
+	if err := faker.FakeObject(&plan); err != nil {
 		t.Fatal(err)
 	}
 	m.EXPECT().ListBackupPlans(
@@ -54,7 +54,7 @@ func buildBackupPlansMock(t *testing.T, ctrl *gomock.Controller) client.Services
 	)
 
 	var selection backup.GetBackupSelectionOutput
-	if err := faker.FakeData(&selection); err != nil {
+	if err := faker.FakeObject(&selection); err != nil {
 		t.Fatal(err)
 	}
 	selection.BackupPlanId = plan.BackupPlanId

--- a/plugins/source/aws/resources/services/backup/region_settings_mock_test.go
+++ b/plugins/source/aws/resources/services/backup/region_settings_mock_test.go
@@ -6,7 +6,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/backup"
 	"github.com/cloudquery/cloudquery/plugins/source/aws/client"
 	"github.com/cloudquery/cloudquery/plugins/source/aws/client/mocks"
-	"github.com/cloudquery/faker/v3"
+	"github.com/cloudquery/plugin-sdk/faker"
 	"github.com/golang/mock/gomock"
 )
 
@@ -14,7 +14,7 @@ func buildBackupRegionSettingsMock(t *testing.T, ctrl *gomock.Controller) client
 	m := mocks.NewMockBackupClient(ctrl)
 
 	var settings backup.DescribeRegionSettingsOutput
-	if err := faker.FakeData(&settings); err != nil {
+	if err := faker.FakeObject(&settings); err != nil {
 		t.Fatal(err)
 	}
 	m.EXPECT().DescribeRegionSettings(

--- a/plugins/source/aws/resources/services/backup/vaults_mock_test.go
+++ b/plugins/source/aws/resources/services/backup/vaults_mock_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/backup/types"
 	"github.com/cloudquery/cloudquery/plugins/source/aws/client"
 	"github.com/cloudquery/cloudquery/plugins/source/aws/client/mocks"
-	"github.com/cloudquery/faker/v3"
+	"github.com/cloudquery/plugin-sdk/faker"
 	"github.com/golang/mock/gomock"
 )
 
@@ -16,7 +16,7 @@ func buildBackupVaultsMock(t *testing.T, ctrl *gomock.Controller) client.Service
 	m := mocks.NewMockBackupClient(ctrl)
 
 	var vault types.BackupVaultListMember
-	if err := faker.FakeData(&vault); err != nil {
+	if err := faker.FakeObject(&vault); err != nil {
 		t.Fatal(err)
 	}
 	m.EXPECT().ListBackupVaults(
@@ -64,7 +64,7 @@ func buildBackupVaultsMock(t *testing.T, ctrl *gomock.Controller) client.Service
 	)
 
 	var rp types.RecoveryPointByBackupVault
-	if err := faker.FakeData(&rp); err != nil {
+	if err := faker.FakeObject(&rp); err != nil {
 		t.Fatal(err)
 	}
 	rp.ResourceArn = aws.String("arn:aws:s3:eu-central-1:testAccount:resource/id")

--- a/plugins/source/aws/resources/services/cloudformation/stacks_mock_test.go
+++ b/plugins/source/aws/resources/services/cloudformation/stacks_mock_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/cloudformation/types"
 	"github.com/cloudquery/cloudquery/plugins/source/aws/client"
 	"github.com/cloudquery/cloudquery/plugins/source/aws/client/mocks"
-	"github.com/cloudquery/faker/v3"
+	"github.com/cloudquery/plugin-sdk/faker"
 	"github.com/golang/mock/gomock"
 )
 
@@ -15,7 +15,7 @@ func buildStacks(t *testing.T, ctrl *gomock.Controller) client.Services {
 	mock := mocks.NewMockCloudFormationClient(ctrl)
 
 	var stack types.Stack
-	if err := faker.FakeData(&stack); err != nil {
+	if err := faker.FakeObject(&stack); err != nil {
 		t.Fatal(err)
 	}
 	mock.EXPECT().DescribeStacks(
@@ -28,7 +28,7 @@ func buildStacks(t *testing.T, ctrl *gomock.Controller) client.Services {
 	)
 
 	var resource types.StackResourceSummary
-	if err := faker.FakeData(&resource); err != nil {
+	if err := faker.FakeObject(&resource); err != nil {
 		t.Fatal(err)
 	}
 	mock.EXPECT().ListStackResources(

--- a/plugins/source/aws/resources/services/cloudfront/cache_policies_mock_test.go
+++ b/plugins/source/aws/resources/services/cloudfront/cache_policies_mock_test.go
@@ -7,7 +7,7 @@ import (
 	cloudfrontTypes "github.com/aws/aws-sdk-go-v2/service/cloudfront/types"
 	"github.com/cloudquery/cloudquery/plugins/source/aws/client"
 	"github.com/cloudquery/cloudquery/plugins/source/aws/client/mocks"
-	"github.com/cloudquery/faker/v3"
+	"github.com/cloudquery/plugin-sdk/faker"
 	"github.com/golang/mock/gomock"
 )
 
@@ -17,7 +17,7 @@ func buildCloudfrontCachePoliciesMock(t *testing.T, ctrl *gomock.Controller) cli
 		Cloudfront: m,
 	}
 	cp := cloudfrontTypes.CachePolicySummary{}
-	if err := faker.FakeData(&cp); err != nil {
+	if err := faker.FakeObject(&cp); err != nil {
 		t.Fatal(err)
 	}
 

--- a/plugins/source/aws/resources/services/cloudfront/distributions_mock_test.go
+++ b/plugins/source/aws/resources/services/cloudfront/distributions_mock_test.go
@@ -7,7 +7,7 @@ import (
 	cloudfrontTypes "github.com/aws/aws-sdk-go-v2/service/cloudfront/types"
 	"github.com/cloudquery/cloudquery/plugins/source/aws/client"
 	"github.com/cloudquery/cloudquery/plugins/source/aws/client/mocks"
-	"github.com/cloudquery/faker/v3"
+	"github.com/cloudquery/plugin-sdk/faker"
 	"github.com/golang/mock/gomock"
 )
 
@@ -17,7 +17,7 @@ func buildCloudfrontDistributionsMock(t *testing.T, ctrl *gomock.Controller) cli
 		Cloudfront: m,
 	}
 	ds := cloudfrontTypes.DistributionSummary{}
-	if err := faker.FakeData(&ds); err != nil {
+	if err := faker.FakeObject(&ds); err != nil {
 		t.Fatal(err)
 	}
 	cloudfrontOutput := &cloudfront.ListDistributionsOutput{
@@ -31,7 +31,7 @@ func buildCloudfrontDistributionsMock(t *testing.T, ctrl *gomock.Controller) cli
 	)
 
 	distribution := &cloudfront.GetDistributionOutput{}
-	if err := faker.FakeData(&distribution); err != nil {
+	if err := faker.FakeObject(&distribution); err != nil {
 		t.Fatal(err)
 	}
 	m.EXPECT().GetDistribution(gomock.Any(), gomock.Any(), gomock.Any()).Return(
@@ -40,7 +40,7 @@ func buildCloudfrontDistributionsMock(t *testing.T, ctrl *gomock.Controller) cli
 	)
 
 	tags := &cloudfront.ListTagsForResourceOutput{}
-	if err := faker.FakeData(&tags); err != nil {
+	if err := faker.FakeObject(&tags); err != nil {
 		t.Fatal(err)
 	}
 	m.EXPECT().ListTagsForResource(gomock.Any(), gomock.Any(), gomock.Any()).Return(

--- a/plugins/source/aws/resources/services/cloudhsmv2/backups_mock_test.go
+++ b/plugins/source/aws/resources/services/cloudhsmv2/backups_mock_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/cloudhsmv2/types"
 	"github.com/cloudquery/cloudquery/plugins/source/aws/client"
 	"github.com/cloudquery/cloudquery/plugins/source/aws/client/mocks"
-	"github.com/cloudquery/faker/v3"
+	"github.com/cloudquery/plugin-sdk/faker"
 	"github.com/golang/mock/gomock"
 )
 
@@ -15,7 +15,7 @@ func buildHSMBackups(t *testing.T, ctrl *gomock.Controller) client.Services {
 	mock := mocks.NewMockCloudHSMV2Client(ctrl)
 
 	var backups []types.Backup
-	if err := faker.FakeData(&backups); err != nil {
+	if err := faker.FakeObject(&backups); err != nil {
 		t.Fatal(err)
 	}
 

--- a/plugins/source/aws/resources/services/cloudhsmv2/clusters_mock_test.go
+++ b/plugins/source/aws/resources/services/cloudhsmv2/clusters_mock_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/cloudhsmv2/types"
 	"github.com/cloudquery/cloudquery/plugins/source/aws/client"
 	"github.com/cloudquery/cloudquery/plugins/source/aws/client/mocks"
-	"github.com/cloudquery/faker/v3"
+	"github.com/cloudquery/plugin-sdk/faker"
 	"github.com/golang/mock/gomock"
 )
 
@@ -15,7 +15,7 @@ func buildHSMClusters(t *testing.T, ctrl *gomock.Controller) client.Services {
 	mock := mocks.NewMockCloudHSMV2Client(ctrl)
 
 	var clusters []types.Cluster
-	if err := faker.FakeData(&clusters); err != nil {
+	if err := faker.FakeObject(&clusters); err != nil {
 		t.Fatal(err)
 	}
 

--- a/plugins/source/aws/resources/services/cloudtrail/trails_mock_test.go
+++ b/plugins/source/aws/resources/services/cloudtrail/trails_mock_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/cloudtrail/types"
 	"github.com/cloudquery/cloudquery/plugins/source/aws/client"
 	"github.com/cloudquery/cloudquery/plugins/source/aws/client/mocks"
-	"github.com/cloudquery/faker/v3"
+	"github.com/cloudquery/plugin-sdk/faker"
 	"github.com/golang/mock/gomock"
 )
 
@@ -18,7 +18,7 @@ func buildCloudtrailTrailsMock(t *testing.T, ctrl *gomock.Controller) client.Ser
 		Cloudtrail: m,
 	}
 	trail := types.Trail{}
-	err := faker.FakeData(&trail)
+	err := faker.FakeObject(&trail)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -27,12 +27,12 @@ func buildCloudtrailTrailsMock(t *testing.T, ctrl *gomock.Controller) client.Ser
 	trail.CloudWatchLogsLogGroupArn = aws.String("arn:aws:logs:eu-central-1:123:log-group:test-group:")
 
 	trailStatus := cloudtrail.GetTrailStatusOutput{}
-	err = faker.FakeData(&trailStatus)
+	err = faker.FakeObject(&trailStatus)
 	if err != nil {
 		t.Fatal(err)
 	}
 	eventSelector := types.EventSelector{}
-	err = faker.FakeData(&eventSelector)
+	err = faker.FakeObject(&eventSelector)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -53,7 +53,7 @@ func buildCloudtrailTrailsMock(t *testing.T, ctrl *gomock.Controller) client.Ser
 		nil,
 	)
 	tags := cloudtrail.ListTagsOutput{}
-	err = faker.FakeData(&tags)
+	err = faker.FakeObject(&tags)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/plugins/source/aws/resources/services/cloudwatch/alarms_mock_test.go
+++ b/plugins/source/aws/resources/services/cloudwatch/alarms_mock_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/cloudwatch/types"
 	"github.com/cloudquery/cloudquery/plugins/source/aws/client"
 	"github.com/cloudquery/cloudquery/plugins/source/aws/client/mocks"
-	"github.com/cloudquery/faker/v3"
+	"github.com/cloudquery/plugin-sdk/faker"
 	"github.com/golang/mock/gomock"
 )
 
@@ -17,7 +17,7 @@ func buildCloudWatchAlarmsMock(t *testing.T, ctrl *gomock.Controller) client.Ser
 		Cloudwatch: m,
 	}
 	a := types.MetricAlarm{}
-	err := faker.FakeData(&a)
+	err := faker.FakeObject(&a)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -28,7 +28,7 @@ func buildCloudWatchAlarmsMock(t *testing.T, ctrl *gomock.Controller) client.Ser
 		}, nil)
 
 	tagResponse := cloudwatch.ListTagsForResourceOutput{}
-	err = faker.FakeData(&tagResponse)
+	err = faker.FakeObject(&tagResponse)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/plugins/source/aws/resources/services/codebuild/projects_mock_test.go
+++ b/plugins/source/aws/resources/services/codebuild/projects_mock_test.go
@@ -6,7 +6,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/codebuild"
 	"github.com/cloudquery/cloudquery/plugins/source/aws/client"
 	"github.com/cloudquery/cloudquery/plugins/source/aws/client/mocks"
-	"github.com/cloudquery/faker/v3"
+	"github.com/cloudquery/plugin-sdk/faker"
 	"github.com/golang/mock/gomock"
 )
 
@@ -14,7 +14,7 @@ func buildCodebuildProjects(t *testing.T, ctrl *gomock.Controller) client.Servic
 	m := mocks.NewMockCodebuildClient(ctrl)
 
 	projectsList := codebuild.ListProjectsOutput{}
-	if err := faker.FakeData(&projectsList); err != nil {
+	if err := faker.FakeObject(&projectsList); err != nil {
 		t.Fatal(err)
 	}
 	projectsList.NextToken = nil
@@ -28,7 +28,7 @@ func buildCodebuildProjects(t *testing.T, ctrl *gomock.Controller) client.Servic
 	)
 
 	projects := codebuild.BatchGetProjectsOutput{}
-	if err := faker.FakeData(&projects); err != nil {
+	if err := faker.FakeObject(&projects); err != nil {
 		t.Fatal(err)
 	}
 	m.EXPECT().BatchGetProjects(

--- a/plugins/source/aws/resources/services/codepipeline/pipelines_mock_test.go
+++ b/plugins/source/aws/resources/services/codepipeline/pipelines_mock_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/codepipeline/types"
 	"github.com/cloudquery/cloudquery/plugins/source/aws/client"
 	"github.com/cloudquery/cloudquery/plugins/source/aws/client/mocks"
-	"github.com/cloudquery/faker/v3"
+	"github.com/cloudquery/plugin-sdk/faker"
 	"github.com/golang/mock/gomock"
 )
 
@@ -15,7 +15,7 @@ func buildPipelines(t *testing.T, ctrl *gomock.Controller) client.Services {
 	mock := mocks.NewMockCodePipelineClient(ctrl)
 
 	var pipeSummary types.PipelineSummary
-	if err := faker.FakeData(&pipeSummary); err != nil {
+	if err := faker.FakeObject(&pipeSummary); err != nil {
 		t.Fatal(err)
 	}
 	mock.EXPECT().ListPipelines(
@@ -28,7 +28,7 @@ func buildPipelines(t *testing.T, ctrl *gomock.Controller) client.Services {
 	)
 
 	var resource codepipeline.GetPipelineOutput
-	if err := faker.FakeData(&resource); err != nil {
+	if err := faker.FakeObject(&resource); err != nil {
 		t.Fatal(err)
 	}
 	mock.EXPECT().GetPipeline(
@@ -41,7 +41,7 @@ func buildPipelines(t *testing.T, ctrl *gomock.Controller) client.Services {
 	)
 
 	tags := &codepipeline.ListTagsForResourceOutput{}
-	if err := faker.FakeData(&tags); err != nil {
+	if err := faker.FakeObject(&tags); err != nil {
 		t.Fatal(err)
 	}
 	mock.EXPECT().ListTagsForResource(gomock.Any(), gomock.Any(), gomock.Any()).Return(

--- a/plugins/source/aws/resources/services/codepipeline/webhooks_mock_test.go
+++ b/plugins/source/aws/resources/services/codepipeline/webhooks_mock_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/codepipeline/types"
 	"github.com/cloudquery/cloudquery/plugins/source/aws/client"
 	"github.com/cloudquery/cloudquery/plugins/source/aws/client/mocks"
-	"github.com/cloudquery/faker/v3"
+	"github.com/cloudquery/plugin-sdk/faker"
 	"github.com/golang/mock/gomock"
 )
 
@@ -15,7 +15,7 @@ func buildWebhooks(t *testing.T, ctrl *gomock.Controller) client.Services {
 	mock := mocks.NewMockCodePipelineClient(ctrl)
 
 	var webhook types.ListWebhookItem
-	if err := faker.FakeData(&webhook); err != nil {
+	if err := faker.FakeObject(&webhook); err != nil {
 		t.Fatal(err)
 	}
 	mock.EXPECT().ListWebhooks(

--- a/plugins/source/aws/resources/services/cognito/identity_pools_mock_test.go
+++ b/plugins/source/aws/resources/services/cognito/identity_pools_mock_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/cognitoidentity/types"
 	"github.com/cloudquery/cloudquery/plugins/source/aws/client"
 	"github.com/cloudquery/cloudquery/plugins/source/aws/client/mocks"
-	"github.com/cloudquery/faker/v3"
+	"github.com/cloudquery/plugin-sdk/faker"
 	"github.com/golang/mock/gomock"
 )
 
@@ -15,7 +15,7 @@ func buildCognitoIdentityPools(t *testing.T, ctrl *gomock.Controller) client.Ser
 	m := mocks.NewMockCognitoIdentityPoolsClient(ctrl)
 
 	var desc types.IdentityPoolShortDescription
-	if err := faker.FakeData(&desc); err != nil {
+	if err := faker.FakeObject(&desc); err != nil {
 		t.Fatal(err)
 	}
 	m.EXPECT().ListIdentityPools(
@@ -28,7 +28,7 @@ func buildCognitoIdentityPools(t *testing.T, ctrl *gomock.Controller) client.Ser
 	)
 
 	var ipo cognitoidentity.DescribeIdentityPoolOutput
-	if err := faker.FakeData(&ipo); err != nil {
+	if err := faker.FakeObject(&ipo); err != nil {
 		t.Fatal(err)
 	}
 	ipo.IdentityPoolId = desc.IdentityPoolId

--- a/plugins/source/aws/resources/services/cognito/user_pools_mock_test.go
+++ b/plugins/source/aws/resources/services/cognito/user_pools_mock_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/cognitoidentityprovider/types"
 	"github.com/cloudquery/cloudquery/plugins/source/aws/client"
 	"github.com/cloudquery/cloudquery/plugins/source/aws/client/mocks"
-	"github.com/cloudquery/faker/v3"
+	"github.com/cloudquery/plugin-sdk/faker"
 	"github.com/golang/mock/gomock"
 )
 
@@ -15,7 +15,7 @@ func buildCognitoUserPools(t *testing.T, ctrl *gomock.Controller) client.Service
 	m := mocks.NewMockCognitoUserPoolsClient(ctrl)
 
 	var desc types.UserPoolDescriptionType
-	if err := faker.FakeData(&desc); err != nil {
+	if err := faker.FakeObject(&desc); err != nil {
 		t.Fatal(err)
 	}
 	m.EXPECT().ListUserPools(
@@ -28,7 +28,7 @@ func buildCognitoUserPools(t *testing.T, ctrl *gomock.Controller) client.Service
 	)
 
 	var pool types.UserPoolType
-	if err := faker.FakeData(&pool); err != nil {
+	if err := faker.FakeObject(&pool); err != nil {
 		t.Fatal(err)
 	}
 	pool.Id = desc.Id
@@ -42,7 +42,7 @@ func buildCognitoUserPools(t *testing.T, ctrl *gomock.Controller) client.Service
 	)
 
 	var providerDesc types.ProviderDescription
-	if err := faker.FakeData(&providerDesc); err != nil {
+	if err := faker.FakeObject(&providerDesc); err != nil {
 		t.Fatal(err)
 	}
 	m.EXPECT().ListIdentityProviders(
@@ -55,7 +55,7 @@ func buildCognitoUserPools(t *testing.T, ctrl *gomock.Controller) client.Service
 	)
 
 	var provider types.IdentityProviderType
-	if err := faker.FakeData(&provider); err != nil {
+	if err := faker.FakeObject(&provider); err != nil {
 		t.Fatal(err)
 	}
 	provider.ProviderName = providerDesc.ProviderName

--- a/plugins/source/aws/resources/services/config/configuration_recorders_mock_test.go
+++ b/plugins/source/aws/resources/services/config/configuration_recorders_mock_test.go
@@ -7,18 +7,18 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/configservice/types"
 	"github.com/cloudquery/cloudquery/plugins/source/aws/client"
 	"github.com/cloudquery/cloudquery/plugins/source/aws/client/mocks"
-	"github.com/cloudquery/faker/v3"
+	"github.com/cloudquery/plugin-sdk/faker"
 	"github.com/golang/mock/gomock"
 )
 
 func buildConfigConfigurationRecorders(t *testing.T, ctrl *gomock.Controller) client.Services {
 	m := mocks.NewMockConfigServiceClient(ctrl)
 	l := types.ConfigurationRecorder{}
-	if err := faker.FakeData(&l); err != nil {
+	if err := faker.FakeObject(&l); err != nil {
 		t.Fatal(err)
 	}
 	sl := types.ConfigurationRecorderStatus{}
-	if err := faker.FakeData(&sl); err != nil {
+	if err := faker.FakeObject(&sl); err != nil {
 		t.Fatal(err)
 	}
 	sl.Name = l.Name

--- a/plugins/source/aws/resources/services/config/conformance_pack_mock_test.go
+++ b/plugins/source/aws/resources/services/config/conformance_pack_mock_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/configservice/types"
 	"github.com/cloudquery/cloudquery/plugins/source/aws/client"
 	"github.com/cloudquery/cloudquery/plugins/source/aws/client/mocks"
-	"github.com/cloudquery/faker/v3"
+	"github.com/cloudquery/plugin-sdk/faker"
 	"github.com/golang/mock/gomock"
 )
 
@@ -15,15 +15,15 @@ func buildConfigConformancePack(t *testing.T, ctrl *gomock.Controller) client.Se
 	m := mocks.NewMockConfigServiceClient(ctrl)
 
 	var cpd types.ConformancePackDetail
-	if err := faker.FakeData(&cpd); err != nil {
+	if err := faker.FakeObject(&cpd); err != nil {
 		t.Fatal(err)
 	}
 	var cprc types.ConformancePackRuleCompliance
-	if err := faker.FakeData(&cprc); err != nil {
+	if err := faker.FakeObject(&cprc); err != nil {
 		t.Fatal(err)
 	}
 	var cpre types.ConformancePackEvaluationResult
-	if err := faker.FakeData(&cpre); err != nil {
+	if err := faker.FakeObject(&cpre); err != nil {
 		t.Fatal(err)
 	}
 

--- a/plugins/source/aws/resources/services/dax/clusters_mock_test.go
+++ b/plugins/source/aws/resources/services/dax/clusters_mock_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/dax/types"
 	"github.com/cloudquery/cloudquery/plugins/source/aws/client"
 	"github.com/cloudquery/cloudquery/plugins/source/aws/client/mocks"
-	"github.com/cloudquery/faker/v3"
+	"github.com/cloudquery/plugin-sdk/faker"
 	"github.com/golang/mock/gomock"
 )
 
@@ -17,7 +17,7 @@ func buildDAXClustersMock(t *testing.T, ctrl *gomock.Controller) client.Services
 		DAX: m,
 	}
 	c := types.Cluster{}
-	if err := faker.FakeData(&c); err != nil {
+	if err := faker.FakeObject(&c); err != nil {
 		t.Fatal(err)
 	}
 	daxOutput := &dax.DescribeClustersOutput{
@@ -29,7 +29,7 @@ func buildDAXClustersMock(t *testing.T, ctrl *gomock.Controller) client.Services
 	)
 
 	tags := &dax.ListTagsOutput{}
-	if err := faker.FakeData(&tags); err != nil {
+	if err := faker.FakeObject(&tags); err != nil {
 		t.Fatal(err)
 	}
 	m.EXPECT().ListTags(gomock.Any(), gomock.Any(), gomock.Any()).Return(

--- a/plugins/source/aws/resources/services/directconnect/connections_mock_test.go
+++ b/plugins/source/aws/resources/services/directconnect/connections_mock_test.go
@@ -7,14 +7,14 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/directconnect/types"
 	"github.com/cloudquery/cloudquery/plugins/source/aws/client"
 	"github.com/cloudquery/cloudquery/plugins/source/aws/client/mocks"
-	"github.com/cloudquery/faker/v3"
+	"github.com/cloudquery/plugin-sdk/faker"
 	"github.com/golang/mock/gomock"
 )
 
 func buildDirectconnectConnection(t *testing.T, ctrl *gomock.Controller) client.Services {
 	m := mocks.NewMockDirectconnectClient(ctrl)
 	conn := types.Connection{}
-	err := faker.FakeData(&conn)
+	err := faker.FakeObject(&conn)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/plugins/source/aws/resources/services/directconnect/gateway_mock_test.go
+++ b/plugins/source/aws/resources/services/directconnect/gateway_mock_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/directconnect/types"
 	"github.com/cloudquery/cloudquery/plugins/source/aws/client"
 	"github.com/cloudquery/cloudquery/plugins/source/aws/client/mocks"
-	"github.com/cloudquery/faker/v3"
+	"github.com/cloudquery/plugin-sdk/faker"
 	"github.com/golang/mock/gomock"
 )
 
@@ -16,15 +16,15 @@ func buildDirectconnectGatewaysMock(t *testing.T, ctrl *gomock.Controller) clien
 	l := types.DirectConnectGateway{}
 	association := types.DirectConnectGatewayAssociation{}
 	attachment := types.DirectConnectGatewayAttachment{}
-	err := faker.FakeData(&l)
+	err := faker.FakeObject(&l)
 	if err != nil {
 		t.Fatal(err)
 	}
-	err = faker.FakeData(&association)
+	err = faker.FakeObject(&association)
 	if err != nil {
 		t.Fatal(err)
 	}
-	err = faker.FakeData(&attachment)
+	err = faker.FakeObject(&attachment)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/plugins/source/aws/resources/services/directconnect/lags_mock_test.go
+++ b/plugins/source/aws/resources/services/directconnect/lags_mock_test.go
@@ -7,14 +7,14 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/directconnect/types"
 	"github.com/cloudquery/cloudquery/plugins/source/aws/client"
 	"github.com/cloudquery/cloudquery/plugins/source/aws/client/mocks"
-	"github.com/cloudquery/faker/v3"
+	"github.com/cloudquery/plugin-sdk/faker"
 	"github.com/golang/mock/gomock"
 )
 
 func buildDirectconnectLag(t *testing.T, ctrl *gomock.Controller) client.Services {
 	m := mocks.NewMockDirectconnectClient(ctrl)
 	lag := types.Lag{}
-	err := faker.FakeData(&lag)
+	err := faker.FakeObject(&lag)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/plugins/source/aws/resources/services/directconnect/virtual_gateways_mock_test.go
+++ b/plugins/source/aws/resources/services/directconnect/virtual_gateways_mock_test.go
@@ -7,14 +7,14 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/directconnect/types"
 	"github.com/cloudquery/cloudquery/plugins/source/aws/client"
 	"github.com/cloudquery/cloudquery/plugins/source/aws/client/mocks"
-	"github.com/cloudquery/faker/v3"
+	"github.com/cloudquery/plugin-sdk/faker"
 	"github.com/golang/mock/gomock"
 )
 
 func buildDirectconnectVirtualGatewaysMock(t *testing.T, ctrl *gomock.Controller) client.Services {
 	m := mocks.NewMockDirectconnectClient(ctrl)
 	l := types.VirtualGateway{}
-	err := faker.FakeData(&l)
+	err := faker.FakeObject(&l)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/plugins/source/aws/resources/services/directconnect/virtual_interfaces_mock_test.go
+++ b/plugins/source/aws/resources/services/directconnect/virtual_interfaces_mock_test.go
@@ -7,14 +7,14 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/directconnect/types"
 	"github.com/cloudquery/cloudquery/plugins/source/aws/client"
 	"github.com/cloudquery/cloudquery/plugins/source/aws/client/mocks"
-	"github.com/cloudquery/faker/v3"
+	"github.com/cloudquery/plugin-sdk/faker"
 	"github.com/golang/mock/gomock"
 )
 
 func buildDirectconnectVirtualInterfacesMock(t *testing.T, ctrl *gomock.Controller) client.Services {
 	m := mocks.NewMockDirectconnectClient(ctrl)
 	l := types.VirtualInterface{}
-	err := faker.FakeData(&l)
+	err := faker.FakeObject(&l)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/plugins/source/aws/resources/services/dms/replication_instances_mock_test.go
+++ b/plugins/source/aws/resources/services/dms/replication_instances_mock_test.go
@@ -8,14 +8,14 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/databasemigrationservice/types"
 	"github.com/cloudquery/cloudquery/plugins/source/aws/client"
 	"github.com/cloudquery/cloudquery/plugins/source/aws/client/mocks"
-	"github.com/cloudquery/faker/v3"
+	"github.com/cloudquery/plugin-sdk/faker"
 	"github.com/golang/mock/gomock"
 )
 
 func buildDmsReplicationInstances(t *testing.T, ctrl *gomock.Controller) client.Services {
 	m := mocks.NewMockDatabasemigrationserviceClient(ctrl)
 	l := types.ReplicationInstance{}
-	if err := faker.FakeData(&l); err != nil {
+	if err := faker.FakeObject(&l); err != nil {
 		t.Fatal(err)
 	}
 	l.ReplicationInstancePrivateIpAddress = aws.String("1.2.3.4") //nolint
@@ -27,7 +27,7 @@ func buildDmsReplicationInstances(t *testing.T, ctrl *gomock.Controller) client.
 			ReplicationInstances: []types.ReplicationInstance{l},
 		}, nil)
 	lt := types.Tag{}
-	if err := faker.FakeData(&lt); err != nil {
+	if err := faker.FakeObject(&lt); err != nil {
 		t.Fatal(err)
 	}
 	lt.ResourceArn = l.ReplicationInstanceArn

--- a/plugins/source/aws/resources/services/dynamodb/tables_mock_test.go
+++ b/plugins/source/aws/resources/services/dynamodb/tables_mock_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/dynamodb/types"
 	"github.com/cloudquery/cloudquery/plugins/source/aws/client"
 	"github.com/cloudquery/cloudquery/plugins/source/aws/client/mocks"
-	"github.com/cloudquery/faker/v3"
+	"github.com/cloudquery/plugin-sdk/faker"
 	"github.com/golang/mock/gomock"
 )
 
@@ -17,7 +17,7 @@ func buildDynamodbTablesMock(t *testing.T, ctrl *gomock.Controller) client.Servi
 		DynamoDB: m,
 	}
 	var tableName string
-	if err := faker.FakeData(&tableName); err != nil {
+	if err := faker.FakeObject(&tableName); err != nil {
 		t.Fatal(err)
 	}
 	listOutput := &dynamodb.ListTablesOutput{
@@ -33,7 +33,7 @@ func buildDynamodbTablesMock(t *testing.T, ctrl *gomock.Controller) client.Servi
 			TableName: &tableName,
 		},
 	}
-	if err := faker.FakeData(descOutput.Table); err != nil {
+	if err := faker.FakeObject(descOutput.Table); err != nil {
 		t.Fatal(err)
 	}
 
@@ -48,7 +48,7 @@ func buildDynamodbTablesMock(t *testing.T, ctrl *gomock.Controller) client.Servi
 			TableStatus: types.TableStatusActive,
 		},
 	}
-	if err := faker.FakeData(&repOutput.TableAutoScalingDescription.Replicas); err != nil {
+	if err := faker.FakeObject(&repOutput.TableAutoScalingDescription.Replicas); err != nil {
 		t.Fatal(err)
 	}
 
@@ -60,7 +60,7 @@ func buildDynamodbTablesMock(t *testing.T, ctrl *gomock.Controller) client.Servi
 	cbOutput := &dynamodb.DescribeContinuousBackupsOutput{
 		ContinuousBackupsDescription: &types.ContinuousBackupsDescription{},
 	}
-	if err := faker.FakeData(&cbOutput.ContinuousBackupsDescription); err != nil {
+	if err := faker.FakeObject(&cbOutput.ContinuousBackupsDescription); err != nil {
 		t.Fatal(err)
 	}
 
@@ -70,7 +70,7 @@ func buildDynamodbTablesMock(t *testing.T, ctrl *gomock.Controller) client.Servi
 	)
 
 	tags := &dynamodb.ListTagsOfResourceOutput{}
-	if err := faker.FakeData(&tags); err != nil {
+	if err := faker.FakeObject(&tags); err != nil {
 		t.Fatal(err)
 	}
 	m.EXPECT().ListTagsOfResource(gomock.Any(), gomock.Any(), gomock.Any()).Return(

--- a/plugins/source/aws/resources/services/ec2/byoip_cidrs_mock_test.go
+++ b/plugins/source/aws/resources/services/ec2/byoip_cidrs_mock_test.go
@@ -7,14 +7,14 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/ec2/types"
 	"github.com/cloudquery/cloudquery/plugins/source/aws/client"
 	"github.com/cloudquery/cloudquery/plugins/source/aws/client/mocks"
-	"github.com/cloudquery/faker/v3"
+	"github.com/cloudquery/plugin-sdk/faker"
 	"github.com/golang/mock/gomock"
 )
 
 func buildEc2ByoipCidrsMock(t *testing.T, ctrl *gomock.Controller) client.Services {
 	m := mocks.NewMockEc2Client(ctrl)
 	l := types.ByoipCidr{}
-	err := faker.FakeData(&l)
+	err := faker.FakeObject(&l)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/plugins/source/aws/resources/services/ec2/customer_gateways_mock_test.go
+++ b/plugins/source/aws/resources/services/ec2/customer_gateways_mock_test.go
@@ -7,14 +7,14 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/ec2/types"
 	"github.com/cloudquery/cloudquery/plugins/source/aws/client"
 	"github.com/cloudquery/cloudquery/plugins/source/aws/client/mocks"
-	"github.com/cloudquery/faker/v3"
+	"github.com/cloudquery/plugin-sdk/faker"
 	"github.com/golang/mock/gomock"
 )
 
 func buildEc2CustomerGateways(t *testing.T, ctrl *gomock.Controller) client.Services {
 	m := mocks.NewMockEc2Client(ctrl)
 	l := types.CustomerGateway{}
-	err := faker.FakeData(&l)
+	err := faker.FakeObject(&l)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/plugins/source/aws/resources/services/ec2/ebs_snapshots_mock_test.go
+++ b/plugins/source/aws/resources/services/ec2/ebs_snapshots_mock_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/ec2/types"
 	"github.com/cloudquery/cloudquery/plugins/source/aws/client"
 	"github.com/cloudquery/cloudquery/plugins/source/aws/client/mocks"
-	"github.com/cloudquery/faker/v3"
+	"github.com/cloudquery/plugin-sdk/faker"
 	"github.com/golang/mock/gomock"
 )
 
@@ -19,7 +19,7 @@ func buildEc2EbsSnapshots(t *testing.T, ctrl *gomock.Controller) client.Services
 		Group:  "test",
 		UserId: &userId,
 	}
-	err := faker.FakeData(&s)
+	err := faker.FakeObject(&s)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/plugins/source/aws/resources/services/ec2/ebs_volumes_mock_test.go
+++ b/plugins/source/aws/resources/services/ec2/ebs_volumes_mock_test.go
@@ -6,14 +6,14 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/ec2"
 	"github.com/cloudquery/cloudquery/plugins/source/aws/client"
 	"github.com/cloudquery/cloudquery/plugins/source/aws/client/mocks"
-	"github.com/cloudquery/faker/v3"
+	"github.com/cloudquery/plugin-sdk/faker"
 	"github.com/golang/mock/gomock"
 )
 
 func buildEc2EbsVolumes(t *testing.T, ctrl *gomock.Controller) client.Services {
 	m := mocks.NewMockEc2Client(ctrl)
 	volumesOutput := ec2.DescribeVolumesOutput{}
-	err := faker.FakeData(&volumesOutput)
+	err := faker.FakeObject(&volumesOutput)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/plugins/source/aws/resources/services/ec2/egress_only_internet_gateways_mock_test.go
+++ b/plugins/source/aws/resources/services/ec2/egress_only_internet_gateways_mock_test.go
@@ -6,14 +6,14 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/ec2"
 	"github.com/cloudquery/cloudquery/plugins/source/aws/client"
 	"github.com/cloudquery/cloudquery/plugins/source/aws/client/mocks"
-	"github.com/cloudquery/faker/v3"
+	"github.com/cloudquery/plugin-sdk/faker"
 	"github.com/golang/mock/gomock"
 )
 
 func buildEgressOnlyInternetGateways(t *testing.T, ctrl *gomock.Controller) client.Services {
 	m := mocks.NewMockEc2Client(ctrl)
 	egressOutput := ec2.DescribeEgressOnlyInternetGatewaysOutput{}
-	err := faker.FakeData(&egressOutput)
+	err := faker.FakeObject(&egressOutput)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/plugins/source/aws/resources/services/ec2/eips_mock_test.go
+++ b/plugins/source/aws/resources/services/ec2/eips_mock_test.go
@@ -7,14 +7,14 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/ec2/types"
 	"github.com/cloudquery/cloudquery/plugins/source/aws/client"
 	"github.com/cloudquery/cloudquery/plugins/source/aws/client/mocks"
-	"github.com/cloudquery/faker/v3"
+	"github.com/cloudquery/plugin-sdk/faker"
 	"github.com/golang/mock/gomock"
 )
 
 func buildEc2Eips(t *testing.T, ctrl *gomock.Controller) client.Services {
 	m := mocks.NewMockEc2Client(ctrl)
 	a := types.Address{}
-	err := faker.FakeData(&a)
+	err := faker.FakeObject(&a)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/plugins/source/aws/resources/services/ec2/flow_logs_mock_test.go
+++ b/plugins/source/aws/resources/services/ec2/flow_logs_mock_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/ec2/types"
 	"github.com/cloudquery/cloudquery/plugins/source/aws/client"
 	"github.com/cloudquery/cloudquery/plugins/source/aws/client/mocks"
-	"github.com/cloudquery/faker/v3"
+	"github.com/cloudquery/plugin-sdk/faker"
 	"github.com/golang/mock/gomock"
 )
 
@@ -15,7 +15,7 @@ func buildEc2FlowLogsMock(t *testing.T, ctrl *gomock.Controller) client.Services
 	m := mocks.NewMockEc2Client(ctrl)
 
 	g := types.FlowLog{}
-	err := faker.FakeData(&g)
+	err := faker.FakeObject(&g)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/plugins/source/aws/resources/services/ec2/hosts_mock_test.go
+++ b/plugins/source/aws/resources/services/ec2/hosts_mock_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/ec2/types"
 	"github.com/cloudquery/cloudquery/plugins/source/aws/client"
 	"github.com/cloudquery/cloudquery/plugins/source/aws/client/mocks"
-	"github.com/cloudquery/faker/v3"
+	"github.com/cloudquery/plugin-sdk/faker"
 	"github.com/golang/mock/gomock"
 )
 
@@ -15,7 +15,7 @@ func buildEc2Hosts(t *testing.T, ctrl *gomock.Controller) client.Services {
 	m := mocks.NewMockEc2Client(ctrl)
 
 	g := types.Host{}
-	err := faker.FakeData(&g)
+	err := faker.FakeObject(&g)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/plugins/source/aws/resources/services/ec2/images_mock_test.go
+++ b/plugins/source/aws/resources/services/ec2/images_mock_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/ec2/types"
 	"github.com/cloudquery/cloudquery/plugins/source/aws/client"
 	"github.com/cloudquery/cloudquery/plugins/source/aws/client/mocks"
-	"github.com/cloudquery/faker/v3"
+	"github.com/cloudquery/plugin-sdk/faker"
 	"github.com/golang/mock/gomock"
 )
 
@@ -18,7 +18,7 @@ func buildEc2ImagesMock(t *testing.T, ctrl *gomock.Controller) client.Services {
 		EC2: m,
 	}
 	g := types.Image{}
-	err := faker.FakeData(&g)
+	err := faker.FakeObject(&g)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/plugins/source/aws/resources/services/ec2/instance_statuses_mock_test.go
+++ b/plugins/source/aws/resources/services/ec2/instance_statuses_mock_test.go
@@ -7,14 +7,14 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/ec2/types"
 	"github.com/cloudquery/cloudquery/plugins/source/aws/client"
 	"github.com/cloudquery/cloudquery/plugins/source/aws/client/mocks"
-	"github.com/cloudquery/faker/v3"
+	"github.com/cloudquery/plugin-sdk/faker"
 	"github.com/golang/mock/gomock"
 )
 
 func buildEc2InstanceStatuses(t *testing.T, ctrl *gomock.Controller) client.Services {
 	m := mocks.NewMockEc2Client(ctrl)
 	l := types.InstanceStatus{}
-	err := faker.FakeData(&l)
+	err := faker.FakeObject(&l)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/plugins/source/aws/resources/services/ec2/instance_types_mock_test.go
+++ b/plugins/source/aws/resources/services/ec2/instance_types_mock_test.go
@@ -8,14 +8,14 @@ import (
 	"github.com/aws/smithy-go/middleware"
 	"github.com/cloudquery/cloudquery/plugins/source/aws/client"
 	"github.com/cloudquery/cloudquery/plugins/source/aws/client/mocks"
-	"github.com/cloudquery/faker/v3"
+	"github.com/cloudquery/plugin-sdk/faker"
 	"github.com/golang/mock/gomock"
 )
 
 func buildEc2InstanceTypes(t *testing.T, ctrl *gomock.Controller) client.Services {
 	m := mocks.NewMockEc2Client(ctrl)
 	info := types.InstanceTypeInfo{}
-	err := faker.FakeData(&info)
+	err := faker.FakeObject(&info)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/plugins/source/aws/resources/services/ec2/instances_mock_test.go
+++ b/plugins/source/aws/resources/services/ec2/instances_mock_test.go
@@ -8,14 +8,14 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/ec2/types"
 	"github.com/cloudquery/cloudquery/plugins/source/aws/client"
 	"github.com/cloudquery/cloudquery/plugins/source/aws/client/mocks"
-	"github.com/cloudquery/faker/v3"
+	"github.com/cloudquery/plugin-sdk/faker"
 	"github.com/golang/mock/gomock"
 )
 
 func buildEc2Instances(t *testing.T, ctrl *gomock.Controller) client.Services {
 	m := mocks.NewMockEc2Client(ctrl)
 	l := types.Reservation{}
-	err := faker.FakeData(&l)
+	err := faker.FakeObject(&l)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/plugins/source/aws/resources/services/ec2/internet_gateways_mock_test.go
+++ b/plugins/source/aws/resources/services/ec2/internet_gateways_mock_test.go
@@ -7,14 +7,14 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/ec2/types"
 	"github.com/cloudquery/cloudquery/plugins/source/aws/client"
 	"github.com/cloudquery/cloudquery/plugins/source/aws/client/mocks"
-	"github.com/cloudquery/faker/v3"
+	"github.com/cloudquery/plugin-sdk/faker"
 	"github.com/golang/mock/gomock"
 )
 
 func buildEc2InternetGateways(t *testing.T, ctrl *gomock.Controller) client.Services {
 	m := mocks.NewMockEc2Client(ctrl)
 	l := types.InternetGateway{}
-	err := faker.FakeData(&l)
+	err := faker.FakeObject(&l)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/plugins/source/aws/resources/services/ec2/key_pairs_mock_test.go
+++ b/plugins/source/aws/resources/services/ec2/key_pairs_mock_test.go
@@ -7,14 +7,14 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/ec2/types"
 	"github.com/cloudquery/cloudquery/plugins/source/aws/client"
 	"github.com/cloudquery/cloudquery/plugins/source/aws/client/mocks"
-	"github.com/cloudquery/faker/v3"
+	"github.com/cloudquery/plugin-sdk/faker"
 	"github.com/golang/mock/gomock"
 )
 
 func buildEc2KeyPairs(t *testing.T, ctrl *gomock.Controller) client.Services {
 	m := mocks.NewMockEc2Client(ctrl)
 	l := types.KeyPairInfo{}
-	err := faker.FakeData(&l)
+	err := faker.FakeObject(&l)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/plugins/source/aws/resources/services/ec2/nat_gateways_mock_test.go
+++ b/plugins/source/aws/resources/services/ec2/nat_gateways_mock_test.go
@@ -7,14 +7,14 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/ec2/types"
 	"github.com/cloudquery/cloudquery/plugins/source/aws/client"
 	"github.com/cloudquery/cloudquery/plugins/source/aws/client/mocks"
-	"github.com/cloudquery/faker/v3"
+	"github.com/cloudquery/plugin-sdk/faker"
 	"github.com/golang/mock/gomock"
 )
 
 func buildEc2NatGateways(t *testing.T, ctrl *gomock.Controller) client.Services {
 	m := mocks.NewMockEc2Client(ctrl)
 	l := types.NatGateway{}
-	err := faker.FakeData(&l)
+	err := faker.FakeObject(&l)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/plugins/source/aws/resources/services/ec2/network_acls_mock_test.go
+++ b/plugins/source/aws/resources/services/ec2/network_acls_mock_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/ec2/types"
 	"github.com/cloudquery/cloudquery/plugins/source/aws/client"
 	"github.com/cloudquery/cloudquery/plugins/source/aws/client/mocks"
-	"github.com/cloudquery/faker/v3"
+	"github.com/cloudquery/plugin-sdk/faker"
 	"github.com/golang/mock/gomock"
 )
 
@@ -16,7 +16,7 @@ func buildEc2NetworkAcls(t *testing.T, ctrl *gomock.Controller) client.Services 
 	m := mocks.NewMockEc2Client(ctrl)
 
 	l := types.NetworkAcl{}
-	err := faker.FakeData(&l)
+	err := faker.FakeObject(&l)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/plugins/source/aws/resources/services/ec2/network_interfaces_mock_test.go
+++ b/plugins/source/aws/resources/services/ec2/network_interfaces_mock_test.go
@@ -6,7 +6,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/ec2"
 	"github.com/cloudquery/cloudquery/plugins/source/aws/client"
 	"github.com/cloudquery/cloudquery/plugins/source/aws/client/mocks"
-	"github.com/cloudquery/faker/v3"
+	"github.com/cloudquery/plugin-sdk/faker"
 	"github.com/golang/mock/gomock"
 )
 
@@ -14,7 +14,7 @@ func buildEc2NetworkInterfaces(t *testing.T, ctrl *gomock.Controller) client.Ser
 	m := mocks.NewMockEc2Client(ctrl)
 
 	niOutput := ec2.DescribeNetworkInterfacesOutput{}
-	err := faker.FakeData(&niOutput)
+	err := faker.FakeObject(&niOutput)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/plugins/source/aws/resources/services/ec2/regions_mock_test.go
+++ b/plugins/source/aws/resources/services/ec2/regions_mock_test.go
@@ -8,14 +8,14 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/ec2/types"
 	"github.com/cloudquery/cloudquery/plugins/source/aws/client"
 	"github.com/cloudquery/cloudquery/plugins/source/aws/client/mocks"
-	"github.com/cloudquery/faker/v3"
+	"github.com/cloudquery/plugin-sdk/faker"
 	"github.com/golang/mock/gomock"
 )
 
 func buildRegionsMock(t *testing.T, ctrl *gomock.Controller) client.Services {
 	m := mocks.NewMockEc2Client(ctrl)
 	r := types.Region{}
-	if err := faker.FakeData(&r); err != nil {
+	if err := faker.FakeObject(&r); err != nil {
 		t.Fatal(err)
 	}
 	r.OptInStatus = aws.String("opted-in")

--- a/plugins/source/aws/resources/services/ec2/reserved_instances_mock_test.go
+++ b/plugins/source/aws/resources/services/ec2/reserved_instances_mock_test.go
@@ -7,14 +7,14 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/ec2/types"
 	"github.com/cloudquery/cloudquery/plugins/source/aws/client"
 	"github.com/cloudquery/cloudquery/plugins/source/aws/client/mocks"
-	"github.com/cloudquery/faker/v3"
+	"github.com/cloudquery/plugin-sdk/faker"
 	"github.com/golang/mock/gomock"
 )
 
 func buildReservedEc2Instances(t *testing.T, ctrl *gomock.Controller) client.Services {
 	m := mocks.NewMockEc2Client(ctrl)
 	l := types.ReservedInstances{}
-	err := faker.FakeData(&l)
+	err := faker.FakeObject(&l)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/plugins/source/aws/resources/services/ec2/route_tables_mock_test.go
+++ b/plugins/source/aws/resources/services/ec2/route_tables_mock_test.go
@@ -7,14 +7,14 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/ec2/types"
 	"github.com/cloudquery/cloudquery/plugins/source/aws/client"
 	"github.com/cloudquery/cloudquery/plugins/source/aws/client/mocks"
-	"github.com/cloudquery/faker/v3"
+	"github.com/cloudquery/plugin-sdk/faker"
 	"github.com/golang/mock/gomock"
 )
 
 func buildEc2RouteTables(t *testing.T, ctrl *gomock.Controller) client.Services {
 	m := mocks.NewMockEc2Client(ctrl)
 	l := types.RouteTable{}
-	err := faker.FakeData(&l)
+	err := faker.FakeObject(&l)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/plugins/source/aws/resources/services/ec2/security_groups_mock_test.go
+++ b/plugins/source/aws/resources/services/ec2/security_groups_mock_test.go
@@ -7,14 +7,14 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/ec2/types"
 	"github.com/cloudquery/cloudquery/plugins/source/aws/client"
 	"github.com/cloudquery/cloudquery/plugins/source/aws/client/mocks"
-	"github.com/cloudquery/faker/v3"
+	"github.com/cloudquery/plugin-sdk/faker"
 	"github.com/golang/mock/gomock"
 )
 
 func buildEc2SecurityGroups(t *testing.T, ctrl *gomock.Controller) client.Services {
 	m := mocks.NewMockEc2Client(ctrl)
 	l := types.SecurityGroup{}
-	err := faker.FakeData(&l)
+	err := faker.FakeObject(&l)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/plugins/source/aws/resources/services/ec2/subnets_mock_test.go
+++ b/plugins/source/aws/resources/services/ec2/subnets_mock_test.go
@@ -7,14 +7,14 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/ec2/types"
 	"github.com/cloudquery/cloudquery/plugins/source/aws/client"
 	"github.com/cloudquery/cloudquery/plugins/source/aws/client/mocks"
-	"github.com/cloudquery/faker/v3"
+	"github.com/cloudquery/plugin-sdk/faker"
 	"github.com/golang/mock/gomock"
 )
 
 func buildEc2Subnets(t *testing.T, ctrl *gomock.Controller) client.Services {
 	m := mocks.NewMockEc2Client(ctrl)
 	l := types.Subnet{}
-	err := faker.FakeData(&l)
+	err := faker.FakeObject(&l)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/plugins/source/aws/resources/services/ec2/transit_gateways_mock_test.go
+++ b/plugins/source/aws/resources/services/ec2/transit_gateways_mock_test.go
@@ -7,44 +7,44 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/ec2/types"
 	"github.com/cloudquery/cloudquery/plugins/source/aws/client"
 	"github.com/cloudquery/cloudquery/plugins/source/aws/client/mocks"
-	"github.com/cloudquery/faker/v3"
+	"github.com/cloudquery/plugin-sdk/faker"
 	"github.com/golang/mock/gomock"
 )
 
 func buildEc2TransitGateways(t *testing.T, ctrl *gomock.Controller) client.Services {
 	m := mocks.NewMockEc2Client(ctrl)
 	tgw := types.TransitGateway{}
-	err := faker.FakeData(&tgw)
+	err := faker.FakeObject(&tgw)
 	if err != nil {
 		t.Fatal(err)
 	}
 
 	tgwvpca := types.TransitGatewayVpcAttachment{}
-	err = faker.FakeData(&tgwvpca)
+	err = faker.FakeObject(&tgwvpca)
 	if err != nil {
 		t.Fatal(err)
 	}
 
 	tgwpeera := types.TransitGatewayPeeringAttachment{}
-	err = faker.FakeData(&tgwpeera)
+	err = faker.FakeObject(&tgwpeera)
 	if err != nil {
 		t.Fatal(err)
 	}
 
 	tgwrt := types.TransitGatewayRouteTable{}
-	err = faker.FakeData(&tgwrt)
+	err = faker.FakeObject(&tgwrt)
 	if err != nil {
 		t.Fatal(err)
 	}
 
 	tgwmcd := types.TransitGatewayMulticastDomain{}
-	err = faker.FakeData(&tgwmcd)
+	err = faker.FakeObject(&tgwmcd)
 	if err != nil {
 		t.Fatal(err)
 	}
 
 	tgwa := types.TransitGatewayAttachment{}
-	err = faker.FakeData(&tgwa)
+	err = faker.FakeObject(&tgwa)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/plugins/source/aws/resources/services/ec2/vpc_endpoint_service_configurations_mock_test.go
+++ b/plugins/source/aws/resources/services/ec2/vpc_endpoint_service_configurations_mock_test.go
@@ -7,14 +7,14 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/ec2/types"
 	"github.com/cloudquery/cloudquery/plugins/source/aws/client"
 	"github.com/cloudquery/cloudquery/plugins/source/aws/client/mocks"
-	"github.com/cloudquery/faker/v3"
+	"github.com/cloudquery/plugin-sdk/faker"
 	"github.com/golang/mock/gomock"
 )
 
 func buildEc2VpcEndpointServiceConfigurations(t *testing.T, ctrl *gomock.Controller) client.Services {
 	m := mocks.NewMockEc2Client(ctrl)
 	sc := types.ServiceConfiguration{}
-	if err := faker.FakeData(&sc); err != nil {
+	if err := faker.FakeObject(&sc); err != nil {
 		t.Fatal(err)
 	}
 	m.EXPECT().DescribeVpcEndpointServiceConfigurations(gomock.Any(), gomock.Any(), gomock.Any()).Return(

--- a/plugins/source/aws/resources/services/ec2/vpc_endpoint_services_mock_test.go
+++ b/plugins/source/aws/resources/services/ec2/vpc_endpoint_services_mock_test.go
@@ -7,14 +7,14 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/ec2/types"
 	"github.com/cloudquery/cloudquery/plugins/source/aws/client"
 	"github.com/cloudquery/cloudquery/plugins/source/aws/client/mocks"
-	"github.com/cloudquery/faker/v3"
+	"github.com/cloudquery/plugin-sdk/faker"
 	"github.com/golang/mock/gomock"
 )
 
 func buildEc2VpcEndpointServices(t *testing.T, ctrl *gomock.Controller) client.Services {
 	m := mocks.NewMockEc2Client(ctrl)
 	sd := types.ServiceDetail{}
-	if err := faker.FakeData(&sd); err != nil {
+	if err := faker.FakeObject(&sd); err != nil {
 		t.Fatal(err)
 	}
 	m.EXPECT().DescribeVpcEndpointServices(gomock.Any(), gomock.Any(), gomock.Any()).Return(

--- a/plugins/source/aws/resources/services/ec2/vpc_endpoints_mock_test.go
+++ b/plugins/source/aws/resources/services/ec2/vpc_endpoints_mock_test.go
@@ -7,14 +7,14 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/ec2/types"
 	"github.com/cloudquery/cloudquery/plugins/source/aws/client"
 	"github.com/cloudquery/cloudquery/plugins/source/aws/client/mocks"
-	"github.com/cloudquery/faker/v3"
+	"github.com/cloudquery/plugin-sdk/faker"
 	"github.com/golang/mock/gomock"
 )
 
 func buildEc2VpcEndpoints(t *testing.T, ctrl *gomock.Controller) client.Services {
 	m := mocks.NewMockEc2Client(ctrl)
 	e := types.VpcEndpoint{}
-	if err := faker.FakeData(&e); err != nil {
+	if err := faker.FakeObject(&e); err != nil {
 		t.Fatal(err)
 	}
 	m.EXPECT().DescribeVpcEndpoints(gomock.Any(), gomock.Any(), gomock.Any()).Return(

--- a/plugins/source/aws/resources/services/ec2/vpcs_mock_test.go
+++ b/plugins/source/aws/resources/services/ec2/vpcs_mock_test.go
@@ -7,14 +7,14 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/ec2/types"
 	"github.com/cloudquery/cloudquery/plugins/source/aws/client"
 	"github.com/cloudquery/cloudquery/plugins/source/aws/client/mocks"
-	"github.com/cloudquery/faker/v3"
+	"github.com/cloudquery/plugin-sdk/faker"
 	"github.com/golang/mock/gomock"
 )
 
 func buildEc2Vpcs(t *testing.T, ctrl *gomock.Controller) client.Services {
 	m := mocks.NewMockEc2Client(ctrl)
 	l := types.Vpc{}
-	err := faker.FakeData(&l)
+	err := faker.FakeObject(&l)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/plugins/source/aws/resources/services/ec2/vpcs_peering_connections_mock_test.go
+++ b/plugins/source/aws/resources/services/ec2/vpcs_peering_connections_mock_test.go
@@ -7,14 +7,14 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/ec2/types"
 	"github.com/cloudquery/cloudquery/plugins/source/aws/client"
 	"github.com/cloudquery/cloudquery/plugins/source/aws/client/mocks"
-	"github.com/cloudquery/faker/v3"
+	"github.com/cloudquery/plugin-sdk/faker"
 	"github.com/golang/mock/gomock"
 )
 
 func buildEc2VpcsPeeringConnections(t *testing.T, ctrl *gomock.Controller) client.Services {
 	m := mocks.NewMockEc2Client(ctrl)
 	l := types.VpcPeeringConnection{}
-	err := faker.FakeData(&l)
+	err := faker.FakeObject(&l)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/plugins/source/aws/resources/services/ec2/vpn_gateways_mock_test.go
+++ b/plugins/source/aws/resources/services/ec2/vpn_gateways_mock_test.go
@@ -7,14 +7,14 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/ec2/types"
 	"github.com/cloudquery/cloudquery/plugins/source/aws/client"
 	"github.com/cloudquery/cloudquery/plugins/source/aws/client/mocks"
-	"github.com/cloudquery/faker/v3"
+	"github.com/cloudquery/plugin-sdk/faker"
 	"github.com/golang/mock/gomock"
 )
 
 func buildEc2VpnGateways(t *testing.T, ctrl *gomock.Controller) client.Services {
 	m := mocks.NewMockEc2Client(ctrl)
 	l := types.VpnGateway{}
-	err := faker.FakeData(&l)
+	err := faker.FakeObject(&l)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/plugins/source/aws/resources/services/ecr/registries_mock_test.go
+++ b/plugins/source/aws/resources/services/ecr/registries_mock_test.go
@@ -8,19 +8,19 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/ecr/types"
 	"github.com/cloudquery/cloudquery/plugins/source/aws/client"
 	"github.com/cloudquery/cloudquery/plugins/source/aws/client/mocks"
-	"github.com/cloudquery/faker/v3"
+	"github.com/cloudquery/plugin-sdk/faker"
 	"github.com/golang/mock/gomock"
 )
 
 func buildEcrRegistriesMock(t *testing.T, ctrl *gomock.Controller) client.Services {
 	m := mocks.NewMockEcrClient(ctrl)
 	var registryId string
-	err := faker.FakeData(&registryId)
+	err := faker.FakeObject(&registryId)
 	if err != nil {
 		t.Fatal(err)
 	}
 	rcs := types.ReplicationConfiguration{}
-	err = faker.FakeData(&rcs)
+	err = faker.FakeObject(&rcs)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/plugins/source/aws/resources/services/ecr/registry_policies_mock_test.go
+++ b/plugins/source/aws/resources/services/ecr/registry_policies_mock_test.go
@@ -7,14 +7,14 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/ecr"
 	"github.com/cloudquery/cloudquery/plugins/source/aws/client"
 	"github.com/cloudquery/cloudquery/plugins/source/aws/client/mocks"
-	"github.com/cloudquery/faker/v3"
+	"github.com/cloudquery/plugin-sdk/faker"
 	"github.com/golang/mock/gomock"
 )
 
 func buildEcrRegistryPoliciesMock(t *testing.T, ctrl *gomock.Controller) client.Services {
 	m := mocks.NewMockEcrClient(ctrl)
 	var registryId string
-	err := faker.FakeData(&registryId)
+	err := faker.FakeObject(&registryId)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/plugins/source/aws/resources/services/ecr/repositories_mock_test.go
+++ b/plugins/source/aws/resources/services/ecr/repositories_mock_test.go
@@ -7,19 +7,19 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/ecr/types"
 	"github.com/cloudquery/cloudquery/plugins/source/aws/client"
 	"github.com/cloudquery/cloudquery/plugins/source/aws/client/mocks"
-	"github.com/cloudquery/faker/v3"
+	"github.com/cloudquery/plugin-sdk/faker"
 	"github.com/golang/mock/gomock"
 )
 
 func buildEcrRepositoriesMock(t *testing.T, ctrl *gomock.Controller) client.Services {
 	m := mocks.NewMockEcrClient(ctrl)
 	l := types.Repository{}
-	err := faker.FakeData(&l)
+	err := faker.FakeObject(&l)
 	if err != nil {
 		t.Fatal(err)
 	}
 	i := types.ImageDetail{}
-	err = faker.FakeData(&i)
+	err = faker.FakeObject(&i)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -35,7 +35,7 @@ func buildEcrRepositoriesMock(t *testing.T, ctrl *gomock.Controller) client.Serv
 		}, nil)
 
 	tagResponse := ecr.ListTagsForResourceOutput{}
-	err = faker.FakeData(&tagResponse)
+	err = faker.FakeObject(&tagResponse)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/plugins/source/aws/resources/services/ecrpublic/repositories_mock_test.go
+++ b/plugins/source/aws/resources/services/ecrpublic/repositories_mock_test.go
@@ -7,19 +7,19 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/ecrpublic/types"
 	"github.com/cloudquery/cloudquery/plugins/source/aws/client"
 	"github.com/cloudquery/cloudquery/plugins/source/aws/client/mocks"
-	"github.com/cloudquery/faker/v3"
+	"github.com/cloudquery/plugin-sdk/faker"
 	"github.com/golang/mock/gomock"
 )
 
 func buildEcrPublicRepositoriesMock(t *testing.T, ctrl *gomock.Controller) client.Services {
 	m := mocks.NewMockEcrPublicClient(ctrl)
 	l := types.Repository{}
-	err := faker.FakeData(&l)
+	err := faker.FakeObject(&l)
 	if err != nil {
 		t.Fatal(err)
 	}
 	i := types.ImageDetail{}
-	err = faker.FakeData(&i)
+	err = faker.FakeObject(&i)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -35,7 +35,7 @@ func buildEcrPublicRepositoriesMock(t *testing.T, ctrl *gomock.Controller) clien
 		}, nil)
 
 	tagResponse := ecrpublic.ListTagsForResourceOutput{}
-	err = faker.FakeData(&tagResponse)
+	err = faker.FakeObject(&tagResponse)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/plugins/source/aws/resources/services/ecs/cluster_mock_test.go
+++ b/plugins/source/aws/resources/services/ecs/cluster_mock_test.go
@@ -49,14 +49,14 @@ func buildEcsClusterMock(t *testing.T, ctrl *gomock.Controller) client.Services 
 	m.EXPECT().ListContainerInstances(gomock.Any(), gomock.Any(), gomock.Any()).Return(&instancesList, nil)
 
 	instances := ecs.DescribeContainerInstancesOutput{}
-	err = faker.FakeObject(&instances)
+	err = faker.FakeData(&instances)
 	if err != nil {
 		t.Fatal(err)
 	}
 	m.EXPECT().DescribeContainerInstances(gomock.Any(), gomock.Any(), gomock.Any()).Return(&instances, nil)
 
 	listTasks := ecs.ListTasksOutput{}
-	err = faker.FakeObject(&listTasks)
+	err = faker.FakeData(&listTasks)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -64,7 +64,7 @@ func buildEcsClusterMock(t *testing.T, ctrl *gomock.Controller) client.Services 
 	m.EXPECT().ListTasks(gomock.Any(), gomock.Any(), gomock.Any()).Return(&listTasks, nil)
 
 	tasks := ecs.DescribeTasksOutput{}
-	err = faker.FakeObject(&tasks)
+	err = faker.FakeData(&tasks)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/plugins/source/aws/resources/services/ecs/cluster_mock_test.go
+++ b/plugins/source/aws/resources/services/ecs/cluster_mock_test.go
@@ -7,7 +7,7 @@ import (
 	ecsTypes "github.com/aws/aws-sdk-go-v2/service/ecs/types"
 	"github.com/cloudquery/cloudquery/plugins/source/aws/client"
 	"github.com/cloudquery/cloudquery/plugins/source/aws/client/mocks"
-	faker "github.com/cloudquery/faker/v3"
+	"github.com/cloudquery/plugin-sdk/faker"
 	"github.com/golang/mock/gomock"
 )
 
@@ -16,9 +16,8 @@ func buildEcsClusterMock(t *testing.T, ctrl *gomock.Controller) client.Services 
 	services := client.Services{
 		ECS: m,
 	}
-	faker.SetIgnoreInterface(true)
 	c := ecsTypes.Cluster{}
-	err := faker.FakeData(&c)
+	err := faker.FakeObject(&c)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -37,7 +36,7 @@ func buildEcsClusterMock(t *testing.T, ctrl *gomock.Controller) client.Services 
 	m.EXPECT().ListServices(gomock.Any(), gomock.Any(), gomock.Any()).Return(&servicesList, nil)
 
 	svcs := ecs.DescribeServicesOutput{}
-	err = faker.FakeData(&svcs)
+	err = faker.FakeObject(&svcs)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -49,14 +48,14 @@ func buildEcsClusterMock(t *testing.T, ctrl *gomock.Controller) client.Services 
 	m.EXPECT().ListContainerInstances(gomock.Any(), gomock.Any(), gomock.Any()).Return(&instancesList, nil)
 
 	instances := ecs.DescribeContainerInstancesOutput{}
-	err = faker.FakeData(&instances)
+	err = faker.FakeObject(&instances)
 	if err != nil {
 		t.Fatal(err)
 	}
 	m.EXPECT().DescribeContainerInstances(gomock.Any(), gomock.Any(), gomock.Any()).Return(&instances, nil)
 
 	listTasks := ecs.ListTasksOutput{}
-	err = faker.FakeData(&listTasks)
+	err = faker.FakeObject(&listTasks)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -64,7 +63,7 @@ func buildEcsClusterMock(t *testing.T, ctrl *gomock.Controller) client.Services 
 	m.EXPECT().ListTasks(gomock.Any(), gomock.Any(), gomock.Any()).Return(&listTasks, nil)
 
 	tasks := ecs.DescribeTasksOutput{}
-	err = faker.FakeData(&tasks)
+	err = faker.FakeObject(&tasks)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/plugins/source/aws/resources/services/ecs/cluster_mock_test.go
+++ b/plugins/source/aws/resources/services/ecs/cluster_mock_test.go
@@ -7,7 +7,7 @@ import (
 	ecsTypes "github.com/aws/aws-sdk-go-v2/service/ecs/types"
 	"github.com/cloudquery/cloudquery/plugins/source/aws/client"
 	"github.com/cloudquery/cloudquery/plugins/source/aws/client/mocks"
-	"github.com/cloudquery/faker/v3"
+	"github.com/cloudquery/plugin-sdk/faker"
 	"github.com/golang/mock/gomock"
 )
 
@@ -18,7 +18,7 @@ func buildEcsClusterMock(t *testing.T, ctrl *gomock.Controller) client.Services 
 	}
 	faker.SetIgnoreInterface(true)
 	c := ecsTypes.Cluster{}
-	err := faker.FakeData(&c)
+	err := faker.FakeObject(&c)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -37,7 +37,7 @@ func buildEcsClusterMock(t *testing.T, ctrl *gomock.Controller) client.Services 
 	m.EXPECT().ListServices(gomock.Any(), gomock.Any(), gomock.Any()).Return(&servicesList, nil)
 
 	svcs := ecs.DescribeServicesOutput{}
-	err = faker.FakeData(&svcs)
+	err = faker.FakeObject(&svcs)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -49,14 +49,14 @@ func buildEcsClusterMock(t *testing.T, ctrl *gomock.Controller) client.Services 
 	m.EXPECT().ListContainerInstances(gomock.Any(), gomock.Any(), gomock.Any()).Return(&instancesList, nil)
 
 	instances := ecs.DescribeContainerInstancesOutput{}
-	err = faker.FakeData(&instances)
+	err = faker.FakeObject(&instances)
 	if err != nil {
 		t.Fatal(err)
 	}
 	m.EXPECT().DescribeContainerInstances(gomock.Any(), gomock.Any(), gomock.Any()).Return(&instances, nil)
 
 	listTasks := ecs.ListTasksOutput{}
-	err = faker.FakeData(&listTasks)
+	err = faker.FakeObject(&listTasks)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -64,7 +64,7 @@ func buildEcsClusterMock(t *testing.T, ctrl *gomock.Controller) client.Services 
 	m.EXPECT().ListTasks(gomock.Any(), gomock.Any(), gomock.Any()).Return(&listTasks, nil)
 
 	tasks := ecs.DescribeTasksOutput{}
-	err = faker.FakeData(&tasks)
+	err = faker.FakeObject(&tasks)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/plugins/source/aws/resources/services/ecs/cluster_mock_test.go
+++ b/plugins/source/aws/resources/services/ecs/cluster_mock_test.go
@@ -7,7 +7,7 @@ import (
 	ecsTypes "github.com/aws/aws-sdk-go-v2/service/ecs/types"
 	"github.com/cloudquery/cloudquery/plugins/source/aws/client"
 	"github.com/cloudquery/cloudquery/plugins/source/aws/client/mocks"
-	"github.com/cloudquery/plugin-sdk/faker"
+	faker "github.com/cloudquery/faker/v3"
 	"github.com/golang/mock/gomock"
 )
 
@@ -18,7 +18,7 @@ func buildEcsClusterMock(t *testing.T, ctrl *gomock.Controller) client.Services 
 	}
 	faker.SetIgnoreInterface(true)
 	c := ecsTypes.Cluster{}
-	err := faker.FakeObject(&c)
+	err := faker.FakeData(&c)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -37,7 +37,7 @@ func buildEcsClusterMock(t *testing.T, ctrl *gomock.Controller) client.Services 
 	m.EXPECT().ListServices(gomock.Any(), gomock.Any(), gomock.Any()).Return(&servicesList, nil)
 
 	svcs := ecs.DescribeServicesOutput{}
-	err = faker.FakeObject(&svcs)
+	err = faker.FakeData(&svcs)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/plugins/source/aws/resources/services/ecs/task_definitions_mock_test.go
+++ b/plugins/source/aws/resources/services/ecs/task_definitions_mock_test.go
@@ -6,7 +6,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/ecs"
 	"github.com/cloudquery/cloudquery/plugins/source/aws/client"
 	"github.com/cloudquery/cloudquery/plugins/source/aws/client/mocks"
-	"github.com/cloudquery/faker/v3"
+	"github.com/cloudquery/plugin-sdk/faker"
 	"github.com/golang/mock/gomock"
 )
 
@@ -15,7 +15,7 @@ func buildEcsTaskDefinitions(t *testing.T, ctrl *gomock.Controller) client.Servi
 
 	faker.SetIgnoreInterface(true)
 	listTaskDefinitionsOutput := ecs.ListTaskDefinitionsOutput{}
-	err := faker.FakeData(&listTaskDefinitionsOutput)
+	err := faker.FakeObject(&listTaskDefinitionsOutput)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -23,7 +23,7 @@ func buildEcsTaskDefinitions(t *testing.T, ctrl *gomock.Controller) client.Servi
 	m.EXPECT().ListTaskDefinitions(gomock.Any(), gomock.Any(), gomock.Any()).Return(&listTaskDefinitionsOutput, nil)
 
 	taskDefinition := &ecs.DescribeTaskDefinitionOutput{}
-	err = faker.FakeData(&taskDefinition)
+	err = faker.FakeObject(&taskDefinition)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/plugins/source/aws/resources/services/ecs/task_definitions_mock_test.go
+++ b/plugins/source/aws/resources/services/ecs/task_definitions_mock_test.go
@@ -6,7 +6,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/ecs"
 	"github.com/cloudquery/cloudquery/plugins/source/aws/client"
 	"github.com/cloudquery/cloudquery/plugins/source/aws/client/mocks"
-	"github.com/cloudquery/plugin-sdk/faker"
+	faker "github.com/cloudquery/faker/v3"
 	"github.com/golang/mock/gomock"
 )
 
@@ -15,7 +15,7 @@ func buildEcsTaskDefinitions(t *testing.T, ctrl *gomock.Controller) client.Servi
 
 	faker.SetIgnoreInterface(true)
 	listTaskDefinitionsOutput := ecs.ListTaskDefinitionsOutput{}
-	err := faker.FakeObject(&listTaskDefinitionsOutput)
+	err := faker.FakeData(&listTaskDefinitionsOutput)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -23,7 +23,7 @@ func buildEcsTaskDefinitions(t *testing.T, ctrl *gomock.Controller) client.Servi
 	m.EXPECT().ListTaskDefinitions(gomock.Any(), gomock.Any(), gomock.Any()).Return(&listTaskDefinitionsOutput, nil)
 
 	taskDefinition := &ecs.DescribeTaskDefinitionOutput{}
-	err = faker.FakeObject(&taskDefinition)
+	err = faker.FakeData(&taskDefinition)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/plugins/source/aws/resources/services/ecs/task_definitions_mock_test.go
+++ b/plugins/source/aws/resources/services/ecs/task_definitions_mock_test.go
@@ -6,16 +6,15 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/ecs"
 	"github.com/cloudquery/cloudquery/plugins/source/aws/client"
 	"github.com/cloudquery/cloudquery/plugins/source/aws/client/mocks"
-	faker "github.com/cloudquery/faker/v3"
+	"github.com/cloudquery/plugin-sdk/faker"
 	"github.com/golang/mock/gomock"
 )
 
 func buildEcsTaskDefinitions(t *testing.T, ctrl *gomock.Controller) client.Services {
 	m := mocks.NewMockEcsClient(ctrl)
 
-	faker.SetIgnoreInterface(true)
 	listTaskDefinitionsOutput := ecs.ListTaskDefinitionsOutput{}
-	err := faker.FakeData(&listTaskDefinitionsOutput)
+	err := faker.FakeObject(&listTaskDefinitionsOutput)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -23,7 +22,7 @@ func buildEcsTaskDefinitions(t *testing.T, ctrl *gomock.Controller) client.Servi
 	m.EXPECT().ListTaskDefinitions(gomock.Any(), gomock.Any(), gomock.Any()).Return(&listTaskDefinitionsOutput, nil)
 
 	taskDefinition := &ecs.DescribeTaskDefinitionOutput{}
-	err = faker.FakeData(&taskDefinition)
+	err = faker.FakeObject(&taskDefinition)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/plugins/source/aws/resources/services/efs/filesystems_mock_test.go
+++ b/plugins/source/aws/resources/services/efs/filesystems_mock_test.go
@@ -7,14 +7,14 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/efs/types"
 	"github.com/cloudquery/cloudquery/plugins/source/aws/client"
 	"github.com/cloudquery/cloudquery/plugins/source/aws/client/mocks"
-	"github.com/cloudquery/faker/v3"
+	"github.com/cloudquery/plugin-sdk/faker"
 	"github.com/golang/mock/gomock"
 )
 
 func buildEfsFilesystemsMock(t *testing.T, ctrl *gomock.Controller) client.Services {
 	m := mocks.NewMockEfsClient(ctrl)
 	l := types.FileSystemDescription{}
-	err := faker.FakeData(&l)
+	err := faker.FakeObject(&l)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -24,7 +24,7 @@ func buildEfsFilesystemsMock(t *testing.T, ctrl *gomock.Controller) client.Servi
 		}, nil)
 
 	b := efs.DescribeBackupPolicyOutput{}
-	err = faker.FakeData(&b)
+	err = faker.FakeObject(&b)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/plugins/source/aws/resources/services/elasticache/clusters_mock_test.go
+++ b/plugins/source/aws/resources/services/elasticache/clusters_mock_test.go
@@ -6,14 +6,14 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/elasticache"
 	"github.com/cloudquery/cloudquery/plugins/source/aws/client"
 	"github.com/cloudquery/cloudquery/plugins/source/aws/client/mocks"
-	"github.com/cloudquery/faker/v3"
+	"github.com/cloudquery/plugin-sdk/faker"
 	"github.com/golang/mock/gomock"
 )
 
 func buildElasticacheClusters(t *testing.T, ctrl *gomock.Controller) client.Services {
 	mockElasticache := mocks.NewMockElastiCache(ctrl)
 	output := elasticache.DescribeCacheClustersOutput{}
-	err := faker.FakeData(&output)
+	err := faker.FakeObject(&output)
 	output.Marker = nil
 	if err != nil {
 		t.Fatal(err)

--- a/plugins/source/aws/resources/services/elasticache/engine_versions_mock_test.go
+++ b/plugins/source/aws/resources/services/elasticache/engine_versions_mock_test.go
@@ -6,14 +6,14 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/elasticache"
 	"github.com/cloudquery/cloudquery/plugins/source/aws/client"
 	"github.com/cloudquery/cloudquery/plugins/source/aws/client/mocks"
-	"github.com/cloudquery/faker/v3"
+	"github.com/cloudquery/plugin-sdk/faker"
 	"github.com/golang/mock/gomock"
 )
 
 func buildElasticacheEngineVersions(t *testing.T, ctrl *gomock.Controller) client.Services {
 	mockElasticache := mocks.NewMockElastiCache(ctrl)
 	output := elasticache.DescribeCacheEngineVersionsOutput{}
-	err := faker.FakeData(&output)
+	err := faker.FakeObject(&output)
 	output.Marker = nil
 	if err != nil {
 		t.Fatal(err)

--- a/plugins/source/aws/resources/services/elasticache/global_replication_groups_mock_test.go
+++ b/plugins/source/aws/resources/services/elasticache/global_replication_groups_mock_test.go
@@ -6,14 +6,14 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/elasticache"
 	"github.com/cloudquery/cloudquery/plugins/source/aws/client"
 	"github.com/cloudquery/cloudquery/plugins/source/aws/client/mocks"
-	"github.com/cloudquery/faker/v3"
+	"github.com/cloudquery/plugin-sdk/faker"
 	"github.com/golang/mock/gomock"
 )
 
 func buildElasticacheGlobalReplicationGroup(t *testing.T, ctrl *gomock.Controller) client.Services {
 	mockElasticache := mocks.NewMockElastiCache(ctrl)
 	output := elasticache.DescribeGlobalReplicationGroupsOutput{}
-	err := faker.FakeData(&output)
+	err := faker.FakeObject(&output)
 	output.Marker = nil
 	if err != nil {
 		t.Fatal(err)

--- a/plugins/source/aws/resources/services/elasticache/parameter_groups_mock_test.go
+++ b/plugins/source/aws/resources/services/elasticache/parameter_groups_mock_test.go
@@ -6,21 +6,21 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/elasticache"
 	"github.com/cloudquery/cloudquery/plugins/source/aws/client"
 	"github.com/cloudquery/cloudquery/plugins/source/aws/client/mocks"
-	"github.com/cloudquery/faker/v3"
+	"github.com/cloudquery/plugin-sdk/faker"
 	"github.com/golang/mock/gomock"
 )
 
 func buildElasticacheParameterGroups(t *testing.T, ctrl *gomock.Controller) client.Services {
 	mockElasticache := mocks.NewMockElastiCache(ctrl)
 	parameterGroupsOutput := elasticache.DescribeCacheParameterGroupsOutput{}
-	err := faker.FakeData(&parameterGroupsOutput)
+	err := faker.FakeObject(&parameterGroupsOutput)
 	parameterGroupsOutput.Marker = nil
 	if err != nil {
 		t.Fatal(err)
 	}
 
 	parametersOutput := elasticache.DescribeCacheParametersOutput{}
-	err = faker.FakeData(&parametersOutput)
+	err = faker.FakeObject(&parametersOutput)
 	parametersOutput.Marker = nil
 	if err != nil {
 		t.Fatal(err)

--- a/plugins/source/aws/resources/services/elasticache/replication_groups_mock_test.go
+++ b/plugins/source/aws/resources/services/elasticache/replication_groups_mock_test.go
@@ -6,14 +6,14 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/elasticache"
 	"github.com/cloudquery/cloudquery/plugins/source/aws/client"
 	"github.com/cloudquery/cloudquery/plugins/source/aws/client/mocks"
-	"github.com/cloudquery/faker/v3"
+	"github.com/cloudquery/plugin-sdk/faker"
 	"github.com/golang/mock/gomock"
 )
 
 func buildElasticacheReplicationGroups(t *testing.T, ctrl *gomock.Controller) client.Services {
 	mockElasticache := mocks.NewMockElastiCache(ctrl)
 	output := elasticache.DescribeReplicationGroupsOutput{}
-	err := faker.FakeData(&output)
+	err := faker.FakeObject(&output)
 	output.Marker = nil
 	if err != nil {
 		t.Fatal(err)

--- a/plugins/source/aws/resources/services/elasticache/reserved_cache_nodes_mock_test.go
+++ b/plugins/source/aws/resources/services/elasticache/reserved_cache_nodes_mock_test.go
@@ -6,14 +6,14 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/elasticache"
 	"github.com/cloudquery/cloudquery/plugins/source/aws/client"
 	"github.com/cloudquery/cloudquery/plugins/source/aws/client/mocks"
-	"github.com/cloudquery/faker/v3"
+	"github.com/cloudquery/plugin-sdk/faker"
 	"github.com/golang/mock/gomock"
 )
 
 func buildElasticacheReservedCacheNodes(t *testing.T, ctrl *gomock.Controller) client.Services {
 	mockElasticache := mocks.NewMockElastiCache(ctrl)
 	output := elasticache.DescribeReservedCacheNodesOutput{}
-	err := faker.FakeData(&output)
+	err := faker.FakeObject(&output)
 	output.Marker = nil
 	if err != nil {
 		t.Fatal(err)

--- a/plugins/source/aws/resources/services/elasticache/reserved_cache_nodes_offerings_mock_test.go
+++ b/plugins/source/aws/resources/services/elasticache/reserved_cache_nodes_offerings_mock_test.go
@@ -6,14 +6,14 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/elasticache"
 	"github.com/cloudquery/cloudquery/plugins/source/aws/client"
 	"github.com/cloudquery/cloudquery/plugins/source/aws/client/mocks"
-	"github.com/cloudquery/faker/v3"
+	"github.com/cloudquery/plugin-sdk/faker"
 	"github.com/golang/mock/gomock"
 )
 
 func buildElasticacheReservedCacheNodesOfferings(t *testing.T, ctrl *gomock.Controller) client.Services {
 	mockElasticache := mocks.NewMockElastiCache(ctrl)
 	output := elasticache.DescribeReservedCacheNodesOfferingsOutput{}
-	err := faker.FakeData(&output)
+	err := faker.FakeObject(&output)
 	output.Marker = nil
 	if err != nil {
 		t.Fatal(err)

--- a/plugins/source/aws/resources/services/elasticache/service_updates_mock_test.go
+++ b/plugins/source/aws/resources/services/elasticache/service_updates_mock_test.go
@@ -6,14 +6,14 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/elasticache"
 	"github.com/cloudquery/cloudquery/plugins/source/aws/client"
 	"github.com/cloudquery/cloudquery/plugins/source/aws/client/mocks"
-	"github.com/cloudquery/faker/v3"
+	"github.com/cloudquery/plugin-sdk/faker"
 	"github.com/golang/mock/gomock"
 )
 
 func buildElasticacheServiceUpdates(t *testing.T, ctrl *gomock.Controller) client.Services {
 	mockElasticache := mocks.NewMockElastiCache(ctrl)
 	output := elasticache.DescribeServiceUpdatesOutput{}
-	err := faker.FakeData(&output)
+	err := faker.FakeObject(&output)
 	output.Marker = nil
 	if err != nil {
 		t.Fatal(err)

--- a/plugins/source/aws/resources/services/elasticache/snapshots_mock_test.go
+++ b/plugins/source/aws/resources/services/elasticache/snapshots_mock_test.go
@@ -6,14 +6,14 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/elasticache"
 	"github.com/cloudquery/cloudquery/plugins/source/aws/client"
 	"github.com/cloudquery/cloudquery/plugins/source/aws/client/mocks"
-	"github.com/cloudquery/faker/v3"
+	"github.com/cloudquery/plugin-sdk/faker"
 	"github.com/golang/mock/gomock"
 )
 
 func buildElasticacheSnapshots(t *testing.T, ctrl *gomock.Controller) client.Services {
 	mockElasticache := mocks.NewMockElastiCache(ctrl)
 	output := elasticache.DescribeSnapshotsOutput{}
-	err := faker.FakeData(&output)
+	err := faker.FakeObject(&output)
 	output.Marker = nil
 	if err != nil {
 		t.Fatal(err)

--- a/plugins/source/aws/resources/services/elasticache/subnet_groups_mock_test.go
+++ b/plugins/source/aws/resources/services/elasticache/subnet_groups_mock_test.go
@@ -6,14 +6,14 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/elasticache"
 	"github.com/cloudquery/cloudquery/plugins/source/aws/client"
 	"github.com/cloudquery/cloudquery/plugins/source/aws/client/mocks"
-	"github.com/cloudquery/faker/v3"
+	"github.com/cloudquery/plugin-sdk/faker"
 	"github.com/golang/mock/gomock"
 )
 
 func buildElasticacheSubnetGroups(t *testing.T, ctrl *gomock.Controller) client.Services {
 	mockElasticache := mocks.NewMockElastiCache(ctrl)
 	output := elasticache.DescribeCacheSubnetGroupsOutput{}
-	err := faker.FakeData(&output)
+	err := faker.FakeObject(&output)
 	output.Marker = nil
 	if err != nil {
 		t.Fatal(err)

--- a/plugins/source/aws/resources/services/elasticache/user_groups_mock_test.go
+++ b/plugins/source/aws/resources/services/elasticache/user_groups_mock_test.go
@@ -6,14 +6,14 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/elasticache"
 	"github.com/cloudquery/cloudquery/plugins/source/aws/client"
 	"github.com/cloudquery/cloudquery/plugins/source/aws/client/mocks"
-	"github.com/cloudquery/faker/v3"
+	"github.com/cloudquery/plugin-sdk/faker"
 	"github.com/golang/mock/gomock"
 )
 
 func buildElasticacheUserGroups(t *testing.T, ctrl *gomock.Controller) client.Services {
 	mockElasticache := mocks.NewMockElastiCache(ctrl)
 	output := elasticache.DescribeUserGroupsOutput{}
-	err := faker.FakeData(&output)
+	err := faker.FakeObject(&output)
 	output.Marker = nil
 	if err != nil {
 		t.Fatal(err)

--- a/plugins/source/aws/resources/services/elasticache/users_mock_test.go
+++ b/plugins/source/aws/resources/services/elasticache/users_mock_test.go
@@ -6,14 +6,14 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/elasticache"
 	"github.com/cloudquery/cloudquery/plugins/source/aws/client"
 	"github.com/cloudquery/cloudquery/plugins/source/aws/client/mocks"
-	"github.com/cloudquery/faker/v3"
+	"github.com/cloudquery/plugin-sdk/faker"
 	"github.com/golang/mock/gomock"
 )
 
 func buildElasticacheUsers(t *testing.T, ctrl *gomock.Controller) client.Services {
 	mockElasticache := mocks.NewMockElastiCache(ctrl)
 	output := elasticache.DescribeUsersOutput{}
-	err := faker.FakeData(&output)
+	err := faker.FakeObject(&output)
 	output.Marker = nil
 	if err != nil {
 		t.Fatal(err)

--- a/plugins/source/aws/resources/services/elasticbeanstalk/application_versions_mock_test.go
+++ b/plugins/source/aws/resources/services/elasticbeanstalk/application_versions_mock_test.go
@@ -7,7 +7,7 @@ import (
 	elasticbeanstalkTypes "github.com/aws/aws-sdk-go-v2/service/elasticbeanstalk/types"
 	"github.com/cloudquery/cloudquery/plugins/source/aws/client"
 	"github.com/cloudquery/cloudquery/plugins/source/aws/client/mocks"
-	"github.com/cloudquery/faker/v3"
+	"github.com/cloudquery/plugin-sdk/faker"
 	"github.com/golang/mock/gomock"
 )
 
@@ -15,7 +15,7 @@ func buildElasticbeanstalkApplicationVersions(t *testing.T, ctrl *gomock.Control
 	m := mocks.NewMockElasticbeanstalkClient(ctrl)
 
 	la := elasticbeanstalkTypes.ApplicationVersionDescription{}
-	err := faker.FakeData(&la)
+	err := faker.FakeObject(&la)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/plugins/source/aws/resources/services/elasticbeanstalk/applications_mock_test.go
+++ b/plugins/source/aws/resources/services/elasticbeanstalk/applications_mock_test.go
@@ -7,7 +7,7 @@ import (
 	elasticbeanstalkTypes "github.com/aws/aws-sdk-go-v2/service/elasticbeanstalk/types"
 	"github.com/cloudquery/cloudquery/plugins/source/aws/client"
 	"github.com/cloudquery/cloudquery/plugins/source/aws/client/mocks"
-	"github.com/cloudquery/faker/v3"
+	"github.com/cloudquery/plugin-sdk/faker"
 	"github.com/golang/mock/gomock"
 )
 
@@ -15,7 +15,7 @@ func buildElasticbeanstalkApplications(t *testing.T, ctrl *gomock.Controller) cl
 	m := mocks.NewMockElasticbeanstalkClient(ctrl)
 
 	la := elasticbeanstalkTypes.ApplicationDescription{}
-	err := faker.FakeData(&la)
+	err := faker.FakeObject(&la)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/plugins/source/aws/resources/services/elasticbeanstalk/envrionments_mock_test.go
+++ b/plugins/source/aws/resources/services/elasticbeanstalk/envrionments_mock_test.go
@@ -7,7 +7,7 @@ import (
 	elasticbeanstalkTypes "github.com/aws/aws-sdk-go-v2/service/elasticbeanstalk/types"
 	"github.com/cloudquery/cloudquery/plugins/source/aws/client"
 	"github.com/cloudquery/cloudquery/plugins/source/aws/client/mocks"
-	"github.com/cloudquery/faker/v3"
+	"github.com/cloudquery/plugin-sdk/faker"
 	"github.com/golang/mock/gomock"
 )
 
@@ -15,7 +15,7 @@ func buildElasticbeanstalkEnvironments(t *testing.T, ctrl *gomock.Controller) cl
 	m := mocks.NewMockElasticbeanstalkClient(ctrl)
 
 	la := elasticbeanstalkTypes.ApplicationDescription{}
-	err := faker.FakeData(&la)
+	err := faker.FakeObject(&la)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -23,7 +23,7 @@ func buildElasticbeanstalkEnvironments(t *testing.T, ctrl *gomock.Controller) cl
 	l := elasticbeanstalkTypes.EnvironmentDescription{
 		ApplicationName: la.ApplicationName,
 	}
-	err = faker.FakeData(&l)
+	err = faker.FakeObject(&l)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -34,7 +34,7 @@ func buildElasticbeanstalkEnvironments(t *testing.T, ctrl *gomock.Controller) cl
 		}, nil)
 
 	tags := elasticbeanstalk.ListTagsForResourceOutput{}
-	err = faker.FakeData(&tags)
+	err = faker.FakeObject(&tags)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -43,14 +43,14 @@ func buildElasticbeanstalkEnvironments(t *testing.T, ctrl *gomock.Controller) cl
 		&tags, nil)
 
 	configSettingsOutput := elasticbeanstalk.DescribeConfigurationSettingsOutput{}
-	err = faker.FakeData(&configSettingsOutput)
+	err = faker.FakeObject(&configSettingsOutput)
 	if err != nil {
 		t.Fatal(err)
 	}
 	m.EXPECT().DescribeConfigurationSettings(gomock.Any(), gomock.Any(), gomock.Any()).Return(&configSettingsOutput, nil)
 
 	configOptsOutput := elasticbeanstalk.DescribeConfigurationOptionsOutput{}
-	err = faker.FakeData(&configOptsOutput)
+	err = faker.FakeObject(&configOptsOutput)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/plugins/source/aws/resources/services/elasticsearch/domains_mock_test.go
+++ b/plugins/source/aws/resources/services/elasticsearch/domains_mock_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/elasticsearchservice/types"
 	"github.com/cloudquery/cloudquery/plugins/source/aws/client"
 	"github.com/cloudquery/cloudquery/plugins/source/aws/client/mocks"
-	"github.com/cloudquery/faker/v3"
+	"github.com/cloudquery/plugin-sdk/faker"
 	"github.com/golang/mock/gomock"
 )
 
@@ -15,14 +15,14 @@ func buildElasticSearchDomains(t *testing.T, ctrl *gomock.Controller) client.Ser
 	m := mocks.NewMockElasticSearch(ctrl)
 
 	var di types.DomainInfo
-	if err := faker.FakeData(&di); err != nil {
+	if err := faker.FakeObject(&di); err != nil {
 		t.Fatal(err)
 	}
 	m.EXPECT().ListDomainNames(gomock.Any(), &elasticsearchservice.ListDomainNamesInput{}, gomock.Any()).Return(
 		&elasticsearchservice.ListDomainNamesOutput{DomainNames: []types.DomainInfo{di}}, nil)
 
 	var ds types.ElasticsearchDomainStatus
-	if err := faker.FakeData(&ds); err != nil {
+	if err := faker.FakeObject(&ds); err != nil {
 		t.Fatal(err)
 	}
 	m.EXPECT().DescribeElasticsearchDomain(
@@ -32,7 +32,7 @@ func buildElasticSearchDomains(t *testing.T, ctrl *gomock.Controller) client.Ser
 	).Return(&elasticsearchservice.DescribeElasticsearchDomainOutput{DomainStatus: &ds}, nil)
 
 	var tags elasticsearchservice.ListTagsOutput
-	if err := faker.FakeData(&tags); err != nil {
+	if err := faker.FakeObject(&tags); err != nil {
 		t.Fatal(err)
 	}
 	m.EXPECT().ListTags(gomock.Any(), gomock.Any(), gomock.Any()).Return(&tags, nil)

--- a/plugins/source/aws/resources/services/elbv1/load_balancers_mock_test.go
+++ b/plugins/source/aws/resources/services/elbv1/load_balancers_mock_test.go
@@ -7,14 +7,14 @@ import (
 	elbv1Types "github.com/aws/aws-sdk-go-v2/service/elasticloadbalancing/types"
 	"github.com/cloudquery/cloudquery/plugins/source/aws/client"
 	"github.com/cloudquery/cloudquery/plugins/source/aws/client/mocks"
-	"github.com/cloudquery/faker/v3"
+	"github.com/cloudquery/plugin-sdk/faker"
 	"github.com/golang/mock/gomock"
 )
 
 func buildElbv1LoadBalancers(t *testing.T, ctrl *gomock.Controller) client.Services {
 	m := mocks.NewMockElbV1Client(ctrl)
 	l := elbv1Types.LoadBalancerDescription{}
-	err := faker.FakeData(&l)
+	err := faker.FakeObject(&l)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -25,7 +25,7 @@ func buildElbv1LoadBalancers(t *testing.T, ctrl *gomock.Controller) client.Servi
 		}, nil)
 
 	tag := elbv1Types.Tag{}
-	err = faker.FakeData(&tag)
+	err = faker.FakeObject(&tag)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -40,7 +40,7 @@ func buildElbv1LoadBalancers(t *testing.T, ctrl *gomock.Controller) client.Servi
 		}, nil)
 
 	a := elbv1Types.LoadBalancerAttributes{}
-	err = faker.FakeData(&a)
+	err = faker.FakeObject(&a)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -50,7 +50,7 @@ func buildElbv1LoadBalancers(t *testing.T, ctrl *gomock.Controller) client.Servi
 		}, nil)
 
 	p := elbv1Types.PolicyDescription{}
-	err = faker.FakeData(&p)
+	err = faker.FakeObject(&p)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/plugins/source/aws/resources/services/elbv2/load_balancers_mock_test.go
+++ b/plugins/source/aws/resources/services/elbv2/load_balancers_mock_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/wafv2/types"
 	"github.com/cloudquery/cloudquery/plugins/source/aws/client"
 	"github.com/cloudquery/cloudquery/plugins/source/aws/client/mocks"
-	"github.com/cloudquery/faker/v3"
+	"github.com/cloudquery/plugin-sdk/faker"
 	"github.com/golang/mock/gomock"
 )
 
@@ -17,7 +17,7 @@ func buildElbv2LoadBalancers(t *testing.T, ctrl *gomock.Controller) client.Servi
 	m := mocks.NewMockElbV2Client(ctrl)
 	w := mocks.NewMockWafV2Client(ctrl)
 	l := elbv2Types.LoadBalancer{}
-	err := faker.FakeData(&l)
+	err := faker.FakeObject(&l)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -35,11 +35,7 @@ func buildElbv2LoadBalancers(t *testing.T, ctrl *gomock.Controller) client.Servi
 	).Return(fakeLoadBalancerAttributes(), nil)
 
 	webAcl := types.WebACL{}
-	err = faker.FakeDataSkipFields(&webAcl, []string{
-		"PostProcessFirewallManagerRuleGroups",
-		"PreProcessFirewallManagerRuleGroups",
-		"Rules",
-	})
+	err = faker.FakeObject(&webAcl)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -48,14 +44,14 @@ func buildElbv2LoadBalancers(t *testing.T, ctrl *gomock.Controller) client.Servi
 		&wafv2.GetWebACLForResourceOutput{WebACL: &webAcl}, nil).AnyTimes()
 
 	tags := elasticloadbalancingv2.DescribeTagsOutput{}
-	err = faker.FakeData(&tags)
+	err = faker.FakeObject(&tags)
 	if err != nil {
 		t.Fatal(err)
 	}
 	m.EXPECT().DescribeTags(gomock.Any(), gomock.Any(), gomock.Any()).Times(2).Return(&tags, nil)
 
 	lis := elbv2Types.Listener{}
-	if err := faker.FakeData(&lis); err != nil {
+	if err := faker.FakeObject(&lis); err != nil {
 		t.Fatal(err)
 	}
 
@@ -65,7 +61,7 @@ func buildElbv2LoadBalancers(t *testing.T, ctrl *gomock.Controller) client.Servi
 		}, nil)
 
 	c := elbv2Types.Certificate{}
-	if err := faker.FakeData(&c); err != nil {
+	if err := faker.FakeObject(&c); err != nil {
 		t.Fatal(err)
 	}
 	m.EXPECT().DescribeListenerCertificates(

--- a/plugins/source/aws/resources/services/elbv2/target_groups_mock_test.go
+++ b/plugins/source/aws/resources/services/elbv2/target_groups_mock_test.go
@@ -7,14 +7,14 @@ import (
 	elbv2Types "github.com/aws/aws-sdk-go-v2/service/elasticloadbalancingv2/types"
 	"github.com/cloudquery/cloudquery/plugins/source/aws/client"
 	"github.com/cloudquery/cloudquery/plugins/source/aws/client/mocks"
-	"github.com/cloudquery/faker/v3"
+	"github.com/cloudquery/plugin-sdk/faker"
 	"github.com/golang/mock/gomock"
 )
 
 func buildElbv2TargetGroups(t *testing.T, ctrl *gomock.Controller) client.Services {
 	m := mocks.NewMockElbV2Client(ctrl)
 	l := elbv2Types.TargetGroup{}
-	err := faker.FakeData(&l)
+	err := faker.FakeObject(&l)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -25,14 +25,14 @@ func buildElbv2TargetGroups(t *testing.T, ctrl *gomock.Controller) client.Servic
 		}, nil)
 
 	tags := elasticloadbalancingv2.DescribeTagsOutput{}
-	err = faker.FakeData(&tags)
+	err = faker.FakeObject(&tags)
 	if err != nil {
 		t.Fatal(err)
 	}
 	m.EXPECT().DescribeTags(gomock.Any(), gomock.Any(), gomock.Any()).Return(&tags, nil)
 
 	th := elasticloadbalancingv2.DescribeTargetHealthOutput{}
-	err = faker.FakeData(&th)
+	err = faker.FakeObject(&th)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/plugins/source/aws/resources/services/emr/clusters_mock_test.go
+++ b/plugins/source/aws/resources/services/emr/clusters_mock_test.go
@@ -7,14 +7,14 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/emr/types"
 	"github.com/cloudquery/cloudquery/plugins/source/aws/client"
 	"github.com/cloudquery/cloudquery/plugins/source/aws/client/mocks"
-	"github.com/cloudquery/faker/v3"
+	"github.com/cloudquery/plugin-sdk/faker"
 	"github.com/golang/mock/gomock"
 )
 
 func buildEMRClusters(t *testing.T, ctrl *gomock.Controller) client.Services {
 	mock := mocks.NewMockEmrClient(ctrl)
 	var summary types.ClusterSummary
-	if err := faker.FakeData(&summary); err != nil {
+	if err := faker.FakeObject(&summary); err != nil {
 		t.Fatal(err)
 	}
 	mock.EXPECT().ListClusters(gomock.Any(), &emr.ListClustersInput{}, gomock.Any()).Return(
@@ -23,15 +23,14 @@ func buildEMRClusters(t *testing.T, ctrl *gomock.Controller) client.Services {
 	)
 
 	var cluster types.Cluster
-	skipFields := []string{"Configurations", "InstanceCollectionType", "RepoUpgradeOnBoot", "ScaleDownBehavior"}
-	if err := faker.FakeDataSkipFields(&cluster, skipFields); err != nil {
+	if err := faker.FakeObject(&cluster); err != nil {
 		t.Fatal(err)
 	}
 	cluster.InstanceCollectionType = types.InstanceCollectionTypeInstanceFleet
 	cluster.RepoUpgradeOnBoot = types.RepoUpgradeOnBootNone
 	cluster.ScaleDownBehavior = types.ScaleDownBehaviorTerminateAtInstanceHour
 	var config types.Configuration
-	if err := faker.FakeDataSkipFields(&config, []string{"Configurations"}); err != nil {
+	if err := faker.FakeObject(&config); err != nil {
 		t.Fatal(err)
 	}
 	config.Configurations = []types.Configuration{}

--- a/plugins/source/aws/resources/services/eventbridge/event_buses_mock_test.go
+++ b/plugins/source/aws/resources/services/eventbridge/event_buses_mock_test.go
@@ -7,26 +7,26 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/eventbridge/types"
 	"github.com/cloudquery/cloudquery/plugins/source/aws/client"
 	"github.com/cloudquery/cloudquery/plugins/source/aws/client/mocks"
-	"github.com/cloudquery/faker/v3"
+	"github.com/cloudquery/plugin-sdk/faker"
 	"github.com/golang/mock/gomock"
 )
 
 func buildEventBridgeEventBusesMock(t *testing.T, ctrl *gomock.Controller) client.Services {
 	m := mocks.NewMockEventBridgeClient(ctrl)
 	bus := types.EventBus{}
-	err := faker.FakeData(&bus)
+	err := faker.FakeObject(&bus)
 	if err != nil {
 		t.Fatal(err)
 	}
 
 	rule := types.Rule{}
-	err = faker.FakeData(&rule)
+	err = faker.FakeObject(&rule)
 	if err != nil {
 		t.Fatal(err)
 	}
 
 	tags := eventbridge.ListTagsForResourceOutput{}
-	err = faker.FakeData(&tags)
+	err = faker.FakeObject(&tags)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/plugins/source/aws/resources/services/fsx/data_repository_associations_test.go
+++ b/plugins/source/aws/resources/services/fsx/data_repository_associations_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/fsx/types"
 	"github.com/cloudquery/cloudquery/plugins/source/aws/client"
 	"github.com/cloudquery/cloudquery/plugins/source/aws/client/mocks"
-	"github.com/cloudquery/faker/v3"
+	"github.com/cloudquery/plugin-sdk/faker"
 	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/require"
 )
@@ -17,7 +17,7 @@ func buildDataRepoAssociationsMock(t *testing.T, ctrl *gomock.Controller) client
 	m := mocks.NewMockFsxClient(ctrl)
 
 	var a types.DataRepositoryAssociation
-	require.NoError(t, faker.FakeData(&a))
+	require.NoError(t, faker.FakeObject(&a))
 	m.EXPECT().DescribeDataRepositoryAssociations(
 		gomock.Any(),
 		&fsx.DescribeDataRepositoryAssociationsInput{MaxResults: aws.Int32(25)},

--- a/plugins/source/aws/resources/services/fsx/data_repository_tasks_test.go
+++ b/plugins/source/aws/resources/services/fsx/data_repository_tasks_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/fsx/types"
 	"github.com/cloudquery/cloudquery/plugins/source/aws/client"
 	"github.com/cloudquery/cloudquery/plugins/source/aws/client/mocks"
-	"github.com/cloudquery/faker/v3"
+	"github.com/cloudquery/plugin-sdk/faker"
 	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/require"
 )
@@ -17,7 +17,7 @@ func buildDataRepoTasksMock(t *testing.T, ctrl *gomock.Controller) client.Servic
 	m := mocks.NewMockFsxClient(ctrl)
 
 	var task types.DataRepositoryTask
-	require.NoError(t, faker.FakeData(&task))
+	require.NoError(t, faker.FakeObject(&task))
 	m.EXPECT().DescribeDataRepositoryTasks(
 		gomock.Any(),
 		&fsx.DescribeDataRepositoryTasksInput{MaxResults: aws.Int32(1000)},

--- a/plugins/source/aws/resources/services/fsx/storage_vms_test.go
+++ b/plugins/source/aws/resources/services/fsx/storage_vms_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/fsx/types"
 	"github.com/cloudquery/cloudquery/plugins/source/aws/client"
 	"github.com/cloudquery/cloudquery/plugins/source/aws/client/mocks"
-	"github.com/cloudquery/faker/v3"
+	"github.com/cloudquery/plugin-sdk/faker"
 	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/require"
 )
@@ -17,7 +17,7 @@ func buildStorageVmsMock(t *testing.T, ctrl *gomock.Controller) client.Services 
 	m := mocks.NewMockFsxClient(ctrl)
 
 	var vm types.StorageVirtualMachine
-	require.NoError(t, faker.FakeData(&vm))
+	require.NoError(t, faker.FakeObject(&vm))
 	m.EXPECT().DescribeStorageVirtualMachines(
 		gomock.Any(),
 		&fsx.DescribeStorageVirtualMachinesInput{MaxResults: aws.Int32(1000)},

--- a/plugins/source/aws/resources/services/glue/classifiers_test.go
+++ b/plugins/source/aws/resources/services/glue/classifiers_test.go
@@ -6,7 +6,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/glue"
 	"github.com/cloudquery/cloudquery/plugins/source/aws/client"
 	"github.com/cloudquery/cloudquery/plugins/source/aws/client/mocks"
-	"github.com/cloudquery/faker/v3"
+	"github.com/cloudquery/plugin-sdk/faker"
 	"github.com/golang/mock/gomock"
 )
 
@@ -14,7 +14,7 @@ func buildClassifiers(t *testing.T, ctrl *gomock.Controller) client.Services {
 	m := mocks.NewMockGlueClient(ctrl)
 
 	var c glue.GetClassifiersOutput
-	if err := faker.FakeData(&c); err != nil {
+	if err := faker.FakeObject(&c); err != nil {
 		t.Fatal(err)
 	}
 	c.NextToken = nil

--- a/plugins/source/aws/resources/services/glue/connections_test.go
+++ b/plugins/source/aws/resources/services/glue/connections_test.go
@@ -6,7 +6,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/glue"
 	"github.com/cloudquery/cloudquery/plugins/source/aws/client"
 	"github.com/cloudquery/cloudquery/plugins/source/aws/client/mocks"
-	"github.com/cloudquery/faker/v3"
+	"github.com/cloudquery/plugin-sdk/faker"
 	"github.com/golang/mock/gomock"
 )
 
@@ -14,7 +14,7 @@ func buildConnections(t *testing.T, ctrl *gomock.Controller) client.Services {
 	m := mocks.NewMockGlueClient(ctrl)
 
 	var connecions glue.GetConnectionsOutput
-	if err := faker.FakeData(&connecions); err != nil {
+	if err := faker.FakeObject(&connecions); err != nil {
 		t.Fatal(err)
 	}
 	connecions.NextToken = nil

--- a/plugins/source/aws/resources/services/glue/crawlers_test.go
+++ b/plugins/source/aws/resources/services/glue/crawlers_test.go
@@ -6,7 +6,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/glue"
 	"github.com/cloudquery/cloudquery/plugins/source/aws/client"
 	"github.com/cloudquery/cloudquery/plugins/source/aws/client/mocks"
-	"github.com/cloudquery/faker/v3"
+	"github.com/cloudquery/plugin-sdk/faker"
 	"github.com/golang/mock/gomock"
 )
 
@@ -14,14 +14,14 @@ func buildCrawlers(t *testing.T, ctrl *gomock.Controller) client.Services {
 	m := mocks.NewMockGlueClient(ctrl)
 
 	var crawler glue.GetCrawlersOutput
-	if err := faker.FakeData(&crawler); err != nil {
+	if err := faker.FakeObject(&crawler); err != nil {
 		t.Fatal(err)
 	}
 	crawler.NextToken = nil
 	m.EXPECT().GetCrawlers(gomock.Any(), gomock.Any(), gomock.Any()).Return(&crawler, nil)
 
 	var tags glue.GetTagsOutput
-	if err := faker.FakeData(&tags); err != nil {
+	if err := faker.FakeObject(&tags); err != nil {
 		t.Fatal(err)
 	}
 	m.EXPECT().GetTags(gomock.Any(), gomock.Any(), gomock.Any()).Return(&tags, nil)

--- a/plugins/source/aws/resources/services/glue/databases_mock_test.go
+++ b/plugins/source/aws/resources/services/glue/databases_mock_test.go
@@ -6,7 +6,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/glue"
 	"github.com/cloudquery/cloudquery/plugins/source/aws/client"
 	"github.com/cloudquery/cloudquery/plugins/source/aws/client/mocks"
-	"github.com/cloudquery/faker/v3"
+	"github.com/cloudquery/plugin-sdk/faker"
 	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/require"
 )
@@ -15,22 +15,22 @@ func buildDatabasesMock(t *testing.T, ctrl *gomock.Controller) client.Services {
 	m := mocks.NewMockGlueClient(ctrl)
 
 	db := glue.GetDatabasesOutput{}
-	require.NoError(t, faker.FakeData(&db))
+	require.NoError(t, faker.FakeObject(&db))
 	db.NextToken = nil
 	m.EXPECT().GetDatabases(gomock.Any(), gomock.Any()).Return(&db, nil)
 
 	tb := glue.GetTablesOutput{}
-	require.NoError(t, faker.FakeData(&tb))
+	require.NoError(t, faker.FakeObject(&tb))
 	tb.NextToken = nil
 	m.EXPECT().GetTables(gomock.Any(), gomock.Any()).Return(&tb, nil)
 
 	i := glue.GetPartitionIndexesOutput{}
-	require.NoError(t, faker.FakeData(&i))
+	require.NoError(t, faker.FakeObject(&i))
 	i.NextToken = nil
 	m.EXPECT().GetPartitionIndexes(gomock.Any(), gomock.Any()).Return(&i, nil)
 
 	tags := glue.GetTagsOutput{}
-	require.NoError(t, faker.FakeData(&tags))
+	require.NoError(t, faker.FakeObject(&tags))
 	m.EXPECT().GetTags(gomock.Any(), gomock.Any()).Return(&tags, nil)
 
 	return client.Services{

--- a/plugins/source/aws/resources/services/glue/datacatalog_encryption_settings_test.go
+++ b/plugins/source/aws/resources/services/glue/datacatalog_encryption_settings_test.go
@@ -6,7 +6,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/glue"
 	"github.com/cloudquery/cloudquery/plugins/source/aws/client"
 	"github.com/cloudquery/cloudquery/plugins/source/aws/client/mocks"
-	"github.com/cloudquery/faker/v3"
+	"github.com/cloudquery/plugin-sdk/faker"
 	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/require"
 )
@@ -15,7 +15,7 @@ func buildDatacatalogEncryptionSettingsMock(t *testing.T, ctrl *gomock.Controlle
 	m := mocks.NewMockGlueClient(ctrl)
 
 	var s glue.GetDataCatalogEncryptionSettingsOutput
-	require.NoError(t, faker.FakeData(&s))
+	require.NoError(t, faker.FakeObject(&s))
 	m.EXPECT().GetDataCatalogEncryptionSettings(
 		gomock.Any(),
 		gomock.Any(),

--- a/plugins/source/aws/resources/services/glue/dev_endpoints_test.go
+++ b/plugins/source/aws/resources/services/glue/dev_endpoints_test.go
@@ -6,7 +6,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/glue"
 	"github.com/cloudquery/cloudquery/plugins/source/aws/client"
 	"github.com/cloudquery/cloudquery/plugins/source/aws/client/mocks"
-	"github.com/cloudquery/faker/v3"
+	"github.com/cloudquery/plugin-sdk/faker"
 	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/require"
 )
@@ -15,7 +15,7 @@ func buildDevEndpointsMock(t *testing.T, ctrl *gomock.Controller) client.Service
 	m := mocks.NewMockGlueClient(ctrl)
 
 	var devEndpoint glue.GetDevEndpointsOutput
-	require.NoError(t, faker.FakeData(&devEndpoint))
+	require.NoError(t, faker.FakeObject(&devEndpoint))
 	devEndpoint.NextToken = nil
 	m.EXPECT().GetDevEndpoints(
 		gomock.Any(),

--- a/plugins/source/aws/resources/services/glue/jobs_test.go
+++ b/plugins/source/aws/resources/services/glue/jobs_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/glue/types"
 	"github.com/cloudquery/cloudquery/plugins/source/aws/client"
 	"github.com/cloudquery/cloudquery/plugins/source/aws/client/mocks"
-	"github.com/cloudquery/faker/v3"
+	"github.com/cloudquery/plugin-sdk/faker"
 	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/require"
 )
@@ -17,16 +17,16 @@ func buildJobsMock(t *testing.T, ctrl *gomock.Controller) client.Services {
 
 	node := types.CodeGenConfigurationNode{}
 
-	require.NoError(t, faker.FakeDataSkipFields(&node, []string{"ApplyMapping", "JDBCConnectorSource"}))
+	require.NoError(t, faker.FakeObject(&node))
 	job := types.Job{
 		CodeGenConfigurationNodes: map[string]types.CodeGenConfigurationNode{"test": node},
 		ExecutionClass:            types.ExecutionClassFlex,
 	}
-	require.NoError(t, faker.FakeDataSkipFields(&job, []string{"WorkerType", "CodeGenConfigurationNodes", "ExecutionClass"}))
+	require.NoError(t, faker.FakeObject(&job))
 	m.EXPECT().GetJobs(gomock.Any(), gomock.Any()).Return(&glue.GetJobsOutput{Jobs: []types.Job{job}}, nil)
 
 	var jobRuns glue.GetJobRunsOutput
-	require.NoError(t, faker.FakeData(&jobRuns))
+	require.NoError(t, faker.FakeObject(&jobRuns))
 	jobRuns.NextToken = nil
 	m.EXPECT().GetJobRuns(gomock.Any(), gomock.Any()).Return(&jobRuns, nil)
 

--- a/plugins/source/aws/resources/services/glue/ml_transforms_test.go
+++ b/plugins/source/aws/resources/services/glue/ml_transforms_test.go
@@ -6,7 +6,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/glue"
 	"github.com/cloudquery/cloudquery/plugins/source/aws/client"
 	"github.com/cloudquery/cloudquery/plugins/source/aws/client/mocks"
-	"github.com/cloudquery/faker/v3"
+	"github.com/cloudquery/plugin-sdk/faker"
 	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/require"
 )
@@ -15,7 +15,7 @@ func buildMlTransformsMock(t *testing.T, ctrl *gomock.Controller) client.Service
 	m := mocks.NewMockGlueClient(ctrl)
 
 	var transforms glue.GetMLTransformsOutput
-	require.NoError(t, faker.FakeData(&transforms))
+	require.NoError(t, faker.FakeObject(&transforms))
 	transforms.NextToken = nil
 	m.EXPECT().GetMLTransforms(
 		gomock.Any(),
@@ -23,7 +23,7 @@ func buildMlTransformsMock(t *testing.T, ctrl *gomock.Controller) client.Service
 	).Return(&transforms, nil)
 
 	var runs glue.GetMLTaskRunsOutput
-	require.NoError(t, faker.FakeData(&runs))
+	require.NoError(t, faker.FakeObject(&runs))
 	runs.NextToken = nil
 	m.EXPECT().GetMLTaskRuns(
 		gomock.Any(),

--- a/plugins/source/aws/resources/services/glue/registries_test.go
+++ b/plugins/source/aws/resources/services/glue/registries_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/glue/types"
 	"github.com/cloudquery/cloudquery/plugins/source/aws/client"
 	"github.com/cloudquery/cloudquery/plugins/source/aws/client/mocks"
-	"github.com/cloudquery/faker/v3"
+	"github.com/cloudquery/plugin-sdk/faker"
 	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/require"
 )
@@ -17,7 +17,7 @@ func buildRegistriesMock(t *testing.T, ctrl *gomock.Controller) client.Services 
 	m := mocks.NewMockGlueClient(ctrl)
 
 	var r types.RegistryListItem
-	require.NoError(t, faker.FakeData(&r))
+	require.NoError(t, faker.FakeObject(&r))
 	m.EXPECT().ListRegistries(
 		gomock.Any(),
 		&glue.ListRegistriesInput{MaxResults: aws.Int32(100)},
@@ -35,7 +35,7 @@ func buildRegistriesMock(t *testing.T, ctrl *gomock.Controller) client.Services 
 	)
 
 	var s glue.GetSchemaOutput
-	require.NoError(t, faker.FakeData(&s))
+	require.NoError(t, faker.FakeObject(&s))
 	m.EXPECT().ListSchemas(
 		gomock.Any(),
 		&glue.ListSchemasInput{
@@ -61,7 +61,7 @@ func buildRegistriesMock(t *testing.T, ctrl *gomock.Controller) client.Services 
 	)
 
 	var lsv glue.ListSchemaVersionsOutput
-	require.NoError(t, faker.FakeData(&lsv))
+	require.NoError(t, faker.FakeObject(&lsv))
 	lsv.NextToken = nil
 	m.EXPECT().ListSchemaVersions(
 		gomock.Any(),
@@ -69,14 +69,14 @@ func buildRegistriesMock(t *testing.T, ctrl *gomock.Controller) client.Services 
 	).Return(&lsv, nil)
 
 	var sv glue.GetSchemaVersionOutput
-	require.NoError(t, faker.FakeData(&sv))
+	require.NoError(t, faker.FakeObject(&sv))
 	m.EXPECT().GetSchemaVersion(
 		gomock.Any(),
 		gomock.Any(),
 	).Return(&sv, nil)
 
 	var sm glue.QuerySchemaVersionMetadataOutput
-	require.NoError(t, faker.FakeData(&sm))
+	require.NoError(t, faker.FakeObject(&sm))
 	sm.NextToken = nil
 	m.EXPECT().QuerySchemaVersionMetadata(
 		gomock.Any(),

--- a/plugins/source/aws/resources/services/glue/security_configurations_test.go
+++ b/plugins/source/aws/resources/services/glue/security_configurations_test.go
@@ -6,7 +6,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/glue"
 	"github.com/cloudquery/cloudquery/plugins/source/aws/client"
 	"github.com/cloudquery/cloudquery/plugins/source/aws/client/mocks"
-	"github.com/cloudquery/faker/v3"
+	"github.com/cloudquery/plugin-sdk/faker"
 	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/require"
 )
@@ -15,7 +15,7 @@ func buildSecurityConfigurationsMock(t *testing.T, ctrl *gomock.Controller) clie
 	m := mocks.NewMockGlueClient(ctrl)
 
 	var s glue.GetSecurityConfigurationsOutput
-	require.NoError(t, faker.FakeData(&s))
+	require.NoError(t, faker.FakeObject(&s))
 	s.NextToken = nil
 	m.EXPECT().GetSecurityConfigurations(
 		gomock.Any(),

--- a/plugins/source/aws/resources/services/glue/triggers_test.go
+++ b/plugins/source/aws/resources/services/glue/triggers_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/glue/types"
 	"github.com/cloudquery/cloudquery/plugins/source/aws/client"
 	"github.com/cloudquery/cloudquery/plugins/source/aws/client/mocks"
-	"github.com/cloudquery/faker/v3"
+	"github.com/cloudquery/plugin-sdk/faker"
 	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/require"
 )
@@ -17,7 +17,7 @@ func buildTriggersMock(t *testing.T, ctrl *gomock.Controller) client.Services {
 	m := mocks.NewMockGlueClient(ctrl)
 
 	var name string
-	require.NoError(t, faker.FakeData(&name))
+	require.NoError(t, faker.FakeObject(&name))
 	m.EXPECT().ListTriggers(
 		gomock.Any(),
 		&glue.ListTriggersInput{MaxResults: aws.Int32(200)},
@@ -27,7 +27,7 @@ func buildTriggersMock(t *testing.T, ctrl *gomock.Controller) client.Services {
 	)
 
 	var tr types.Trigger
-	require.NoError(t, faker.FakeData(&tr))
+	require.NoError(t, faker.FakeObject(&tr))
 	tr.Name = &name
 	m.EXPECT().GetTrigger(
 		gomock.Any(),

--- a/plugins/source/aws/resources/services/glue/workflows_test.go
+++ b/plugins/source/aws/resources/services/glue/workflows_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/glue/types"
 	"github.com/cloudquery/cloudquery/plugins/source/aws/client"
 	"github.com/cloudquery/cloudquery/plugins/source/aws/client/mocks"
-	"github.com/cloudquery/faker/v3"
+	"github.com/cloudquery/plugin-sdk/faker"
 	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/require"
 )
@@ -17,7 +17,7 @@ func buildWorkflowsMock(t *testing.T, ctrl *gomock.Controller) client.Services {
 	m := mocks.NewMockGlueClient(ctrl)
 
 	var name string
-	require.NoError(t, faker.FakeData(&name))
+	require.NoError(t, faker.FakeObject(&name))
 	m.EXPECT().ListWorkflows(
 		gomock.Any(),
 		&glue.ListWorkflowsInput{MaxResults: aws.Int32(25)},
@@ -27,7 +27,7 @@ func buildWorkflowsMock(t *testing.T, ctrl *gomock.Controller) client.Services {
 	)
 
 	var w types.Workflow
-	require.NoError(t, faker.FakeData(&w))
+	require.NoError(t, faker.FakeObject(&w))
 	w.Name = &name
 	m.EXPECT().GetWorkflow(
 		gomock.Any(),

--- a/plugins/source/aws/resources/services/guardduty/detectors_mock_test.go
+++ b/plugins/source/aws/resources/services/guardduty/detectors_mock_test.go
@@ -9,7 +9,7 @@ import (
 	gdTypes "github.com/aws/aws-sdk-go-v2/service/guardduty/types"
 	"github.com/cloudquery/cloudquery/plugins/source/aws/client"
 	"github.com/cloudquery/cloudquery/plugins/source/aws/client/mocks"
-	"github.com/cloudquery/faker/v3"
+	"github.com/cloudquery/plugin-sdk/faker"
 	"github.com/golang/mock/gomock"
 )
 
@@ -17,7 +17,7 @@ func buildGuardDutyDetectors(t *testing.T, ctrl *gomock.Controller) client.Servi
 	m := mocks.NewMockGuardDutyClient(ctrl)
 
 	var d guardduty.GetDetectorOutput
-	if err := faker.FakeData(&d); err != nil {
+	if err := faker.FakeObject(&d); err != nil {
 		t.Fatal(err)
 	}
 	d.CreatedAt = aws.String(time.Now().Format(time.RFC3339))
@@ -31,7 +31,7 @@ func buildGuardDutyDetectors(t *testing.T, ctrl *gomock.Controller) client.Servi
 	m.EXPECT().GetDetector(gomock.Any(), gomock.Any(), gomock.Any()).Return(&d, nil)
 
 	var member gdTypes.Member
-	if err := faker.FakeData(&member); err != nil {
+	if err := faker.FakeObject(&member); err != nil {
 		t.Fatal(err)
 	}
 	member.UpdatedAt = aws.String(time.Now().Format(time.RFC3339))

--- a/plugins/source/aws/resources/services/iam/accounts_mock_test.go
+++ b/plugins/source/aws/resources/services/iam/accounts_mock_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/iam"
 	"github.com/cloudquery/cloudquery/plugins/source/aws/client"
 	"github.com/cloudquery/cloudquery/plugins/source/aws/client/mocks"
-	"github.com/cloudquery/faker/v3"
+	"github.com/cloudquery/plugin-sdk/faker"
 	"github.com/golang/mock/gomock"
 )
 
@@ -43,7 +43,7 @@ func buildAccount(t *testing.T, ctrl *gomock.Controller) client.Services {
 		GlobalEndpointTokenVersion        int32 `json:"global_endpoint_token_version,omitempty"`
 	}{}
 
-	if err := faker.FakeData(&acc); err != nil {
+	if err := faker.FakeObject(&acc); err != nil {
 		t.Fatal(err)
 	}
 	data, err := json.Marshal(acc)

--- a/plugins/source/aws/resources/services/iam/groups_mock_test.go
+++ b/plugins/source/aws/resources/services/iam/groups_mock_test.go
@@ -7,20 +7,20 @@ import (
 	iamTypes "github.com/aws/aws-sdk-go-v2/service/iam/types"
 	"github.com/cloudquery/cloudquery/plugins/source/aws/client"
 	"github.com/cloudquery/cloudquery/plugins/source/aws/client/mocks"
-	"github.com/cloudquery/faker/v3"
+	"github.com/cloudquery/plugin-sdk/faker"
 	"github.com/golang/mock/gomock"
 )
 
 func buildIamGroups(t *testing.T, ctrl *gomock.Controller) client.Services {
 	m := mocks.NewMockIamClient(ctrl)
 	g := iamTypes.Group{}
-	err := faker.FakeData(&g)
+	err := faker.FakeObject(&g)
 	if err != nil {
 		t.Fatal(err)
 	}
 
 	p := iamTypes.AttachedPolicy{}
-	err = faker.FakeData(&p)
+	err = faker.FakeObject(&p)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -36,7 +36,7 @@ func buildIamGroups(t *testing.T, ctrl *gomock.Controller) client.Services {
 
 	//list policies
 	var l []string
-	err = faker.FakeData(&l)
+	err = faker.FakeObject(&l)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -47,7 +47,7 @@ func buildIamGroups(t *testing.T, ctrl *gomock.Controller) client.Services {
 
 	//get policy
 	gp := iam.GetGroupPolicyOutput{}
-	err = faker.FakeData(&gp)
+	err = faker.FakeObject(&gp)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/plugins/source/aws/resources/services/iam/openid_connect_identity_providers_mock_test.go
+++ b/plugins/source/aws/resources/services/iam/openid_connect_identity_providers_mock_test.go
@@ -7,14 +7,14 @@ import (
 	iamTypes "github.com/aws/aws-sdk-go-v2/service/iam/types"
 	"github.com/cloudquery/cloudquery/plugins/source/aws/client"
 	"github.com/cloudquery/cloudquery/plugins/source/aws/client/mocks"
-	"github.com/cloudquery/faker/v3"
+	"github.com/cloudquery/plugin-sdk/faker"
 	"github.com/golang/mock/gomock"
 )
 
 func buildIamOpenIDConnectProviders(t *testing.T, ctrl *gomock.Controller) client.Services {
 	m := mocks.NewMockIamClient(ctrl)
 	l := iamTypes.OpenIDConnectProviderListEntry{}
-	err := faker.FakeData(&l)
+	err := faker.FakeObject(&l)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -24,7 +24,7 @@ func buildIamOpenIDConnectProviders(t *testing.T, ctrl *gomock.Controller) clien
 		}, nil)
 
 	p := iam.GetOpenIDConnectProviderOutput{}
-	err = faker.FakeData(&p)
+	err = faker.FakeObject(&p)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/plugins/source/aws/resources/services/iam/password_policies_mock_test.go
+++ b/plugins/source/aws/resources/services/iam/password_policies_mock_test.go
@@ -7,14 +7,14 @@ import (
 	iamTypes "github.com/aws/aws-sdk-go-v2/service/iam/types"
 	"github.com/cloudquery/cloudquery/plugins/source/aws/client"
 	"github.com/cloudquery/cloudquery/plugins/source/aws/client/mocks"
-	"github.com/cloudquery/faker/v3"
+	"github.com/cloudquery/plugin-sdk/faker"
 	"github.com/golang/mock/gomock"
 )
 
 func buildIamPasswordPolicies(t *testing.T, ctrl *gomock.Controller) client.Services {
 	m := mocks.NewMockIamClient(ctrl)
 	g := iamTypes.PasswordPolicy{}
-	err := faker.FakeData(&g)
+	err := faker.FakeObject(&g)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/plugins/source/aws/resources/services/iam/policies_mock_test.go
+++ b/plugins/source/aws/resources/services/iam/policies_mock_test.go
@@ -7,14 +7,14 @@ import (
 	iamTypes "github.com/aws/aws-sdk-go-v2/service/iam/types"
 	"github.com/cloudquery/cloudquery/plugins/source/aws/client"
 	"github.com/cloudquery/cloudquery/plugins/source/aws/client/mocks"
-	"github.com/cloudquery/faker/v3"
+	"github.com/cloudquery/plugin-sdk/faker"
 	"github.com/golang/mock/gomock"
 )
 
 func buildIamPolicies(t *testing.T, ctrl *gomock.Controller) client.Services {
 	m := mocks.NewMockIamClient(ctrl)
 	g := iamTypes.ManagedPolicyDetail{}
-	err := faker.FakeData(&g)
+	err := faker.FakeObject(&g)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -31,7 +31,7 @@ func buildIamPolicies(t *testing.T, ctrl *gomock.Controller) client.Services {
 
 	//get tags
 	tag := iamTypes.Tag{}
-	err = faker.FakeData(&tag)
+	err = faker.FakeObject(&tag)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/plugins/source/aws/resources/services/iam/roles_mock_test.go
+++ b/plugins/source/aws/resources/services/iam/roles_mock_test.go
@@ -7,20 +7,20 @@ import (
 	iamTypes "github.com/aws/aws-sdk-go-v2/service/iam/types"
 	"github.com/cloudquery/cloudquery/plugins/source/aws/client"
 	"github.com/cloudquery/cloudquery/plugins/source/aws/client/mocks"
-	"github.com/cloudquery/faker/v3"
+	"github.com/cloudquery/plugin-sdk/faker"
 	"github.com/golang/mock/gomock"
 )
 
 func buildRoles(t *testing.T, ctrl *gomock.Controller) client.Services {
 	m := mocks.NewMockIamClient(ctrl)
 	r := iamTypes.Role{}
-	err := faker.FakeData(&r)
+	err := faker.FakeObject(&r)
 	if err != nil {
 		t.Fatal(err)
 	}
 
 	p := iamTypes.AttachedPolicy{}
-	err = faker.FakeData(&p)
+	err = faker.FakeObject(&p)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -45,7 +45,7 @@ func buildRoles(t *testing.T, ctrl *gomock.Controller) client.Services {
 
 	// list policies by role
 	var l []string
-	err = faker.FakeData(&l)
+	err = faker.FakeObject(&l)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -56,7 +56,7 @@ func buildRoles(t *testing.T, ctrl *gomock.Controller) client.Services {
 
 	//get policy
 	pd := iam.GetRolePolicyOutput{}
-	err = faker.FakeData(&pd)
+	err = faker.FakeObject(&pd)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -66,7 +66,7 @@ func buildRoles(t *testing.T, ctrl *gomock.Controller) client.Services {
 
 	//get tags
 	tag := iamTypes.Tag{}
-	err = faker.FakeData(&tag)
+	err = faker.FakeObject(&tag)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/plugins/source/aws/resources/services/iam/saml_identity_providers_mock_test.go
+++ b/plugins/source/aws/resources/services/iam/saml_identity_providers_mock_test.go
@@ -7,14 +7,14 @@ import (
 	iamTypes "github.com/aws/aws-sdk-go-v2/service/iam/types"
 	"github.com/cloudquery/cloudquery/plugins/source/aws/client"
 	"github.com/cloudquery/cloudquery/plugins/source/aws/client/mocks"
-	"github.com/cloudquery/faker/v3"
+	"github.com/cloudquery/plugin-sdk/faker"
 	"github.com/golang/mock/gomock"
 )
 
 func buildIamSAMLProviders(t *testing.T, ctrl *gomock.Controller) client.Services {
 	m := mocks.NewMockIamClient(ctrl)
 	l := iamTypes.SAMLProviderListEntry{}
-	err := faker.FakeData(&l)
+	err := faker.FakeObject(&l)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -24,7 +24,7 @@ func buildIamSAMLProviders(t *testing.T, ctrl *gomock.Controller) client.Service
 		}, nil)
 
 	p := iam.GetSAMLProviderOutput{}
-	err = faker.FakeData(&p)
+	err = faker.FakeObject(&p)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/plugins/source/aws/resources/services/iam/server_certificates_mock_test.go
+++ b/plugins/source/aws/resources/services/iam/server_certificates_mock_test.go
@@ -7,14 +7,14 @@ import (
 	iamTypes "github.com/aws/aws-sdk-go-v2/service/iam/types"
 	"github.com/cloudquery/cloudquery/plugins/source/aws/client"
 	"github.com/cloudquery/cloudquery/plugins/source/aws/client/mocks"
-	"github.com/cloudquery/faker/v3"
+	"github.com/cloudquery/plugin-sdk/faker"
 	"github.com/golang/mock/gomock"
 )
 
 func buildIamServerCerts(t *testing.T, ctrl *gomock.Controller) client.Services {
 	m := mocks.NewMockIamClient(ctrl)
 	u := iamTypes.ServerCertificateMetadata{}
-	err := faker.FakeData(&u)
+	err := faker.FakeObject(&u)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/plugins/source/aws/resources/services/iam/users_mock_test.go
+++ b/plugins/source/aws/resources/services/iam/users_mock_test.go
@@ -7,40 +7,40 @@ import (
 	iamTypes "github.com/aws/aws-sdk-go-v2/service/iam/types"
 	"github.com/cloudquery/cloudquery/plugins/source/aws/client"
 	"github.com/cloudquery/cloudquery/plugins/source/aws/client/mocks"
-	"github.com/cloudquery/faker/v3"
+	"github.com/cloudquery/plugin-sdk/faker"
 	"github.com/golang/mock/gomock"
 )
 
 func buildIamUsers(t *testing.T, ctrl *gomock.Controller) client.Services {
 	m := mocks.NewMockIamClient(ctrl)
 	u := iamTypes.User{}
-	err := faker.FakeData(&u)
+	err := faker.FakeObject(&u)
 	if err != nil {
 		t.Fatal(err)
 	}
 	g := iamTypes.Group{}
-	err = faker.FakeData(&g)
+	err = faker.FakeObject(&g)
 	if err != nil {
 		t.Fatal(err)
 	}
 	km := iamTypes.AccessKeyMetadata{}
-	err = faker.FakeData(&km)
+	err = faker.FakeObject(&km)
 	if err != nil {
 		t.Fatal(err)
 	}
 	aup := iamTypes.AttachedPolicy{}
-	err = faker.FakeData(&aup)
+	err = faker.FakeObject(&aup)
 	if err != nil {
 		t.Fatal(err)
 	}
 	akl := iam.GetAccessKeyLastUsedOutput{}
-	err = faker.FakeData(&akl)
+	err = faker.FakeObject(&akl)
 	if err != nil {
 		t.Fatal(err)
 	}
 
 	var tags []iamTypes.Tag
-	err = faker.FakeData(&tags)
+	err = faker.FakeObject(&tags)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -70,7 +70,7 @@ func buildIamUsers(t *testing.T, ctrl *gomock.Controller) client.Services {
 
 	//list user inline policies
 	var l []string
-	err = faker.FakeData(&l)
+	err = faker.FakeObject(&l)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -81,7 +81,7 @@ func buildIamUsers(t *testing.T, ctrl *gomock.Controller) client.Services {
 
 	//get policy
 	p := iam.GetUserPolicyOutput{}
-	err = faker.FakeData(&p)
+	err = faker.FakeObject(&p)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/plugins/source/aws/resources/services/iam/virtual_mfa_devices_mock_test.go
+++ b/plugins/source/aws/resources/services/iam/virtual_mfa_devices_mock_test.go
@@ -7,14 +7,14 @@ import (
 	iamTypes "github.com/aws/aws-sdk-go-v2/service/iam/types"
 	"github.com/cloudquery/cloudquery/plugins/source/aws/client"
 	"github.com/cloudquery/cloudquery/plugins/source/aws/client/mocks"
-	"github.com/cloudquery/faker/v3"
+	"github.com/cloudquery/plugin-sdk/faker"
 	"github.com/golang/mock/gomock"
 )
 
 func buildIamVirtualMfaDevices(t *testing.T, ctrl *gomock.Controller) client.Services {
 	m := mocks.NewMockIamClient(ctrl)
 	g := iamTypes.VirtualMFADevice{}
-	err := faker.FakeData(&g)
+	err := faker.FakeObject(&g)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/plugins/source/aws/resources/services/inspector/findings_mock_test.go
+++ b/plugins/source/aws/resources/services/inspector/findings_mock_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/inspector/types"
 	"github.com/cloudquery/cloudquery/plugins/source/aws/client"
 	"github.com/cloudquery/cloudquery/plugins/source/aws/client/mocks"
-	"github.com/cloudquery/faker/v3"
+	"github.com/cloudquery/plugin-sdk/faker"
 	"github.com/golang/mock/gomock"
 )
 
@@ -16,7 +16,7 @@ func buildInspectorFindings(t *testing.T, ctrl *gomock.Controller) client.Servic
 	inspectorClient := mocks.NewMockInspectorClient(ctrl)
 
 	finding := types.Finding{}
-	err := faker.FakeData(&finding)
+	err := faker.FakeObject(&finding)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/plugins/source/aws/resources/services/inspector2/findings_mock_test.go
+++ b/plugins/source/aws/resources/services/inspector2/findings_mock_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/inspector2/types"
 	"github.com/cloudquery/cloudquery/plugins/source/aws/client"
 	"github.com/cloudquery/cloudquery/plugins/source/aws/client/mocks"
-	"github.com/cloudquery/faker/v3"
+	"github.com/cloudquery/plugin-sdk/faker"
 	"github.com/golang/mock/gomock"
 )
 
@@ -15,7 +15,7 @@ func buildInspectorV2Findings(t *testing.T, ctrl *gomock.Controller) client.Serv
 	inspectorClient := mocks.NewMockInspectorV2Client(ctrl)
 
 	finding := types.Finding{}
-	err := faker.FakeData(&finding)
+	err := faker.FakeObject(&finding)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/plugins/source/aws/resources/services/iot/iot_billing_groups_mock_test.go
+++ b/plugins/source/aws/resources/services/iot/iot_billing_groups_mock_test.go
@@ -6,7 +6,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/iot"
 	"github.com/cloudquery/cloudquery/plugins/source/aws/client"
 	"github.com/cloudquery/cloudquery/plugins/source/aws/client/mocks"
-	"github.com/cloudquery/faker/v3"
+	"github.com/cloudquery/plugin-sdk/faker"
 	"github.com/golang/mock/gomock"
 )
 
@@ -14,7 +14,7 @@ func buildIotBillingGroupsMock(t *testing.T, ctrl *gomock.Controller) client.Ser
 	m := mocks.NewMockIOTClient(ctrl)
 
 	groupsOutput := iot.ListBillingGroupsOutput{}
-	err := faker.FakeData(&groupsOutput)
+	err := faker.FakeObject(&groupsOutput)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -23,7 +23,7 @@ func buildIotBillingGroupsMock(t *testing.T, ctrl *gomock.Controller) client.Ser
 		&groupsOutput, nil)
 
 	groupOutput := iot.DescribeBillingGroupOutput{}
-	err = faker.FakeData(&groupOutput)
+	err = faker.FakeObject(&groupOutput)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -31,7 +31,7 @@ func buildIotBillingGroupsMock(t *testing.T, ctrl *gomock.Controller) client.Ser
 		&groupOutput, nil)
 
 	thingsInBillingGroupOutput := iot.ListThingsInBillingGroupOutput{}
-	err = faker.FakeData(&thingsInBillingGroupOutput)
+	err = faker.FakeObject(&thingsInBillingGroupOutput)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -40,7 +40,7 @@ func buildIotBillingGroupsMock(t *testing.T, ctrl *gomock.Controller) client.Ser
 		&thingsInBillingGroupOutput, nil)
 
 	tags := iot.ListTagsForResourceOutput{}
-	err = faker.FakeData(&tags)
+	err = faker.FakeObject(&tags)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/plugins/source/aws/resources/services/iot/iot_ca_certificates_mock_test.go
+++ b/plugins/source/aws/resources/services/iot/iot_ca_certificates_mock_test.go
@@ -6,7 +6,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/iot"
 	"github.com/cloudquery/cloudquery/plugins/source/aws/client"
 	"github.com/cloudquery/cloudquery/plugins/source/aws/client/mocks"
-	"github.com/cloudquery/faker/v3"
+	"github.com/cloudquery/plugin-sdk/faker"
 	"github.com/golang/mock/gomock"
 )
 
@@ -14,7 +14,7 @@ func buildIotCaCertificatesMock(t *testing.T, ctrl *gomock.Controller) client.Se
 	m := mocks.NewMockIOTClient(ctrl)
 
 	ca := iot.ListCACertificatesOutput{}
-	err := faker.FakeData(&ca)
+	err := faker.FakeObject(&ca)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -23,7 +23,7 @@ func buildIotCaCertificatesMock(t *testing.T, ctrl *gomock.Controller) client.Se
 		&ca, nil)
 
 	cd := iot.DescribeCACertificateOutput{}
-	err = faker.FakeData(&cd)
+	err = faker.FakeObject(&cd)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -31,7 +31,7 @@ func buildIotCaCertificatesMock(t *testing.T, ctrl *gomock.Controller) client.Se
 		&cd, nil)
 
 	ct := iot.ListCertificatesByCAOutput{}
-	err = faker.FakeData(&ct)
+	err = faker.FakeObject(&ct)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/plugins/source/aws/resources/services/iot/iot_certificates_mock_test.go
+++ b/plugins/source/aws/resources/services/iot/iot_certificates_mock_test.go
@@ -6,7 +6,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/iot"
 	"github.com/cloudquery/cloudquery/plugins/source/aws/client"
 	"github.com/cloudquery/cloudquery/plugins/source/aws/client/mocks"
-	"github.com/cloudquery/faker/v3"
+	"github.com/cloudquery/plugin-sdk/faker"
 	"github.com/golang/mock/gomock"
 )
 
@@ -14,7 +14,7 @@ func buildIotCertificatesMock(t *testing.T, ctrl *gomock.Controller) client.Serv
 	m := mocks.NewMockIOTClient(ctrl)
 
 	certs := iot.ListCertificatesOutput{}
-	err := faker.FakeData(&certs)
+	err := faker.FakeObject(&certs)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -23,7 +23,7 @@ func buildIotCertificatesMock(t *testing.T, ctrl *gomock.Controller) client.Serv
 		&certs, nil)
 
 	cd := iot.DescribeCertificateOutput{}
-	err = faker.FakeData(&cd)
+	err = faker.FakeObject(&cd)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -31,7 +31,7 @@ func buildIotCertificatesMock(t *testing.T, ctrl *gomock.Controller) client.Serv
 		&cd, nil)
 
 	p := iot.ListAttachedPoliciesOutput{}
-	err = faker.FakeData(&p)
+	err = faker.FakeObject(&p)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/plugins/source/aws/resources/services/iot/iot_jobs_mock_test.go
+++ b/plugins/source/aws/resources/services/iot/iot_jobs_mock_test.go
@@ -6,7 +6,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/iot"
 	"github.com/cloudquery/cloudquery/plugins/source/aws/client"
 	"github.com/cloudquery/cloudquery/plugins/source/aws/client/mocks"
-	"github.com/cloudquery/faker/v3"
+	"github.com/cloudquery/plugin-sdk/faker"
 	"github.com/golang/mock/gomock"
 )
 
@@ -14,7 +14,7 @@ func buildIotJobs(t *testing.T, ctrl *gomock.Controller) client.Services {
 	m := mocks.NewMockIOTClient(ctrl)
 
 	lp := iot.ListJobsOutput{}
-	err := faker.FakeData(&lp)
+	err := faker.FakeObject(&lp)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -23,7 +23,7 @@ func buildIotJobs(t *testing.T, ctrl *gomock.Controller) client.Services {
 		&lp, nil)
 
 	p := iot.DescribeJobOutput{}
-	err = faker.FakeData(&p)
+	err = faker.FakeObject(&p)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -31,7 +31,7 @@ func buildIotJobs(t *testing.T, ctrl *gomock.Controller) client.Services {
 		&p, nil)
 
 	tags := iot.ListTagsForResourceOutput{}
-	err = faker.FakeData(&tags)
+	err = faker.FakeObject(&tags)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/plugins/source/aws/resources/services/iot/iot_policies_mock_test.go
+++ b/plugins/source/aws/resources/services/iot/iot_policies_mock_test.go
@@ -6,7 +6,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/iot"
 	"github.com/cloudquery/cloudquery/plugins/source/aws/client"
 	"github.com/cloudquery/cloudquery/plugins/source/aws/client/mocks"
-	"github.com/cloudquery/faker/v3"
+	"github.com/cloudquery/plugin-sdk/faker"
 	"github.com/golang/mock/gomock"
 )
 
@@ -14,7 +14,7 @@ func buildIotPolicies(t *testing.T, ctrl *gomock.Controller) client.Services {
 	m := mocks.NewMockIOTClient(ctrl)
 
 	lp := iot.ListPoliciesOutput{}
-	err := faker.FakeData(&lp)
+	err := faker.FakeObject(&lp)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -23,7 +23,7 @@ func buildIotPolicies(t *testing.T, ctrl *gomock.Controller) client.Services {
 		&lp, nil)
 
 	p := iot.GetPolicyOutput{}
-	err = faker.FakeData(&p)
+	err = faker.FakeObject(&p)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -31,7 +31,7 @@ func buildIotPolicies(t *testing.T, ctrl *gomock.Controller) client.Services {
 		&p, nil)
 
 	tags := iot.ListTagsForResourceOutput{}
-	err = faker.FakeData(&tags)
+	err = faker.FakeObject(&tags)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/plugins/source/aws/resources/services/iot/iot_security_profiles_mock_test.go
+++ b/plugins/source/aws/resources/services/iot/iot_security_profiles_mock_test.go
@@ -6,7 +6,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/iot"
 	"github.com/cloudquery/cloudquery/plugins/source/aws/client"
 	"github.com/cloudquery/cloudquery/plugins/source/aws/client/mocks"
-	"github.com/cloudquery/faker/v3"
+	"github.com/cloudquery/plugin-sdk/faker"
 	"github.com/golang/mock/gomock"
 )
 
@@ -14,7 +14,7 @@ func buildIotSecurityProfilesMock(t *testing.T, ctrl *gomock.Controller) client.
 	m := mocks.NewMockIOTClient(ctrl)
 
 	sp := iot.ListSecurityProfilesOutput{}
-	err := faker.FakeData(&sp)
+	err := faker.FakeObject(&sp)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -23,7 +23,7 @@ func buildIotSecurityProfilesMock(t *testing.T, ctrl *gomock.Controller) client.
 		&sp, nil)
 
 	profileOutput := iot.DescribeSecurityProfileOutput{}
-	err = faker.FakeData(&profileOutput)
+	err = faker.FakeObject(&profileOutput)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -31,7 +31,7 @@ func buildIotSecurityProfilesMock(t *testing.T, ctrl *gomock.Controller) client.
 		&profileOutput, nil)
 
 	targets := iot.ListTargetsForSecurityProfileOutput{}
-	err = faker.FakeData(&targets)
+	err = faker.FakeObject(&targets)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -41,7 +41,7 @@ func buildIotSecurityProfilesMock(t *testing.T, ctrl *gomock.Controller) client.
 		&targets, nil)
 
 	tags := iot.ListTagsForResourceOutput{}
-	err = faker.FakeData(&tags)
+	err = faker.FakeObject(&tags)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/plugins/source/aws/resources/services/iot/iot_streams_mock_test.go
+++ b/plugins/source/aws/resources/services/iot/iot_streams_mock_test.go
@@ -6,7 +6,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/iot"
 	"github.com/cloudquery/cloudquery/plugins/source/aws/client"
 	"github.com/cloudquery/cloudquery/plugins/source/aws/client/mocks"
-	"github.com/cloudquery/faker/v3"
+	"github.com/cloudquery/plugin-sdk/faker"
 	"github.com/golang/mock/gomock"
 )
 
@@ -14,7 +14,7 @@ func buildIotStreamsMock(t *testing.T, ctrl *gomock.Controller) client.Services 
 	m := mocks.NewMockIOTClient(ctrl)
 
 	streams := iot.ListStreamsOutput{}
-	err := faker.FakeData(&streams)
+	err := faker.FakeObject(&streams)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -23,7 +23,7 @@ func buildIotStreamsMock(t *testing.T, ctrl *gomock.Controller) client.Services 
 		&streams, nil)
 
 	streamOutput := iot.DescribeStreamOutput{}
-	err = faker.FakeData(&streamOutput)
+	err = faker.FakeObject(&streamOutput)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/plugins/source/aws/resources/services/iot/iot_thing_groups_mock_test.go
+++ b/plugins/source/aws/resources/services/iot/iot_thing_groups_mock_test.go
@@ -6,7 +6,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/iot"
 	"github.com/cloudquery/cloudquery/plugins/source/aws/client"
 	"github.com/cloudquery/cloudquery/plugins/source/aws/client/mocks"
-	"github.com/cloudquery/faker/v3"
+	"github.com/cloudquery/plugin-sdk/faker"
 	"github.com/golang/mock/gomock"
 )
 
@@ -14,7 +14,7 @@ func buildIotThingGroupsMock(t *testing.T, ctrl *gomock.Controller) client.Servi
 	m := mocks.NewMockIOTClient(ctrl)
 
 	groupsOutput := iot.ListThingGroupsOutput{}
-	err := faker.FakeData(&groupsOutput)
+	err := faker.FakeObject(&groupsOutput)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -23,7 +23,7 @@ func buildIotThingGroupsMock(t *testing.T, ctrl *gomock.Controller) client.Servi
 		&groupsOutput, nil)
 
 	groupOutput := iot.DescribeThingGroupOutput{}
-	err = faker.FakeData(&groupOutput)
+	err = faker.FakeObject(&groupOutput)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -31,7 +31,7 @@ func buildIotThingGroupsMock(t *testing.T, ctrl *gomock.Controller) client.Servi
 		&groupOutput, nil)
 
 	thingsInThingGroupOutput := iot.ListThingsInThingGroupOutput{}
-	err = faker.FakeData(&thingsInThingGroupOutput)
+	err = faker.FakeObject(&thingsInThingGroupOutput)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -40,7 +40,7 @@ func buildIotThingGroupsMock(t *testing.T, ctrl *gomock.Controller) client.Servi
 		&thingsInThingGroupOutput, nil)
 
 	p := iot.ListAttachedPoliciesOutput{}
-	err = faker.FakeData(&p)
+	err = faker.FakeObject(&p)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -49,7 +49,7 @@ func buildIotThingGroupsMock(t *testing.T, ctrl *gomock.Controller) client.Servi
 		&p, nil)
 
 	tags := iot.ListTagsForResourceOutput{}
-	err = faker.FakeData(&tags)
+	err = faker.FakeObject(&tags)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/plugins/source/aws/resources/services/iot/iot_thing_types_mock_test.go
+++ b/plugins/source/aws/resources/services/iot/iot_thing_types_mock_test.go
@@ -6,7 +6,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/iot"
 	"github.com/cloudquery/cloudquery/plugins/source/aws/client"
 	"github.com/cloudquery/cloudquery/plugins/source/aws/client/mocks"
-	"github.com/cloudquery/faker/v3"
+	"github.com/cloudquery/plugin-sdk/faker"
 	"github.com/golang/mock/gomock"
 )
 
@@ -14,7 +14,7 @@ func buildIotThingTypesMock(t *testing.T, ctrl *gomock.Controller) client.Servic
 	m := mocks.NewMockIOTClient(ctrl)
 
 	groupsOutput := iot.ListThingTypesOutput{}
-	err := faker.FakeData(&groupsOutput)
+	err := faker.FakeObject(&groupsOutput)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -23,7 +23,7 @@ func buildIotThingTypesMock(t *testing.T, ctrl *gomock.Controller) client.Servic
 		&groupsOutput, nil)
 
 	tags := iot.ListTagsForResourceOutput{}
-	err = faker.FakeData(&tags)
+	err = faker.FakeObject(&tags)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/plugins/source/aws/resources/services/iot/iot_things_mock_test.go
+++ b/plugins/source/aws/resources/services/iot/iot_things_mock_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/iot/types"
 	"github.com/cloudquery/cloudquery/plugins/source/aws/client"
 	"github.com/cloudquery/cloudquery/plugins/source/aws/client/mocks"
-	"github.com/cloudquery/faker/v3"
+	"github.com/cloudquery/plugin-sdk/faker"
 	"github.com/golang/mock/gomock"
 )
 
@@ -15,7 +15,7 @@ func buildIotThingsMock(t *testing.T, ctrl *gomock.Controller) client.Services {
 	m := mocks.NewMockIOTClient(ctrl)
 
 	thing := types.ThingAttribute{}
-	err := faker.FakeData(&thing)
+	err := faker.FakeObject(&thing)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -23,7 +23,7 @@ func buildIotThingsMock(t *testing.T, ctrl *gomock.Controller) client.Services {
 		&iot.ListThingsOutput{Things: []types.ThingAttribute{thing}}, nil)
 
 	lp := iot.ListThingPrincipalsOutput{}
-	err = faker.FakeData(&lp)
+	err = faker.FakeObject(&lp)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/plugins/source/aws/resources/services/iot/iot_topic_rules_mock_test.go
+++ b/plugins/source/aws/resources/services/iot/iot_topic_rules_mock_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/iot/types"
 	"github.com/cloudquery/cloudquery/plugins/source/aws/client"
 	"github.com/cloudquery/cloudquery/plugins/source/aws/client/mocks"
-	"github.com/cloudquery/faker/v3"
+	faker "github.com/cloudquery/faker/v3"
 	"github.com/golang/mock/gomock"
 )
 

--- a/plugins/source/aws/resources/services/iot/iot_topic_rules_mock_test.go
+++ b/plugins/source/aws/resources/services/iot/iot_topic_rules_mock_test.go
@@ -3,22 +3,19 @@ package iot
 import (
 	"testing"
 
-	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/iot"
 	"github.com/aws/aws-sdk-go-v2/service/iot/types"
 	"github.com/cloudquery/cloudquery/plugins/source/aws/client"
 	"github.com/cloudquery/cloudquery/plugins/source/aws/client/mocks"
-	faker "github.com/cloudquery/faker/v3"
+	"github.com/cloudquery/plugin-sdk/faker"
 	"github.com/golang/mock/gomock"
 )
 
 func buildIotTopicRules(t *testing.T, ctrl *gomock.Controller) client.Services {
 	m := mocks.NewMockIOTClient(ctrl)
 
-	faker.SetIgnoreInterface(true)
 	lp := iot.ListTopicRulesOutput{}
-	err := faker.FakeData(&lp)
-	if err != nil {
+	if err := faker.FakeObject(&lp); err != nil {
 		t.Fatal(err)
 	}
 	lp.NextToken = nil
@@ -33,8 +30,7 @@ func buildIotTopicRules(t *testing.T, ctrl *gomock.Controller) client.Services {
 		p, nil)
 
 	tags := iot.ListTagsForResourceOutput{}
-	err = faker.FakeData(&tags)
-	if err != nil {
+	if err := faker.FakeObject(&tags); err != nil {
 		t.Fatal(err)
 	}
 	tags.NextToken = nil
@@ -48,27 +44,23 @@ func buildIotTopicRules(t *testing.T, ctrl *gomock.Controller) client.Services {
 
 func buildRule() (*iot.GetTopicRuleOutput, error) {
 	p := types.TopicRule{}
-	err := faker.FakeDataSkipFields(&p, []string{"Actions", "ErrorAction", "noSmithyDocumentSerde"})
-	if err != nil {
+	if err := faker.FakeObject(&p); err != nil {
 		return nil, err
 	}
 	a := types.Action{}
-	err = faker.FakeDataSkipFields(&a, []string{"IotSiteWise", "noSmithyDocumentSerde"})
-	if err != nil {
+	if err := faker.FakeObject(&a); err != nil {
 		return nil, err
-	}
-	a.IotSiteWise = &types.IotSiteWiseAction{
-		RoleArn: aws.String(faker.Word()),
 	}
 	p.Actions = []types.Action{
 		a,
 	}
 	p.ErrorAction = &a
-
-	return &iot.GetTopicRuleOutput{
-		Rule:    &p,
-		RuleArn: aws.String(faker.Word()),
-	}, nil
+	o := iot.GetTopicRuleOutput{}
+	if err := faker.FakeObject(&o); err != nil {
+		return nil, err
+	}
+	o.Rule = &p
+	return &o, nil
 }
 
 func TestIotTopicRules(t *testing.T) {

--- a/plugins/source/aws/resources/services/kms/aliases_mock_test.go
+++ b/plugins/source/aws/resources/services/kms/aliases_mock_test.go
@@ -6,7 +6,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/kms"
 	"github.com/cloudquery/cloudquery/plugins/source/aws/client"
 	"github.com/cloudquery/cloudquery/plugins/source/aws/client/mocks"
-	"github.com/cloudquery/faker/v3"
+	"github.com/cloudquery/plugin-sdk/faker"
 	"github.com/golang/mock/gomock"
 )
 
@@ -14,7 +14,7 @@ func buildKmsAliases(t *testing.T, ctrl *gomock.Controller) client.Services {
 	m := mocks.NewMockKmsClient(ctrl)
 
 	aliases := kms.ListAliasesOutput{}
-	err := faker.FakeData(&aliases)
+	err := faker.FakeObject(&aliases)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/plugins/source/aws/resources/services/kms/keys_mock_test.go
+++ b/plugins/source/aws/resources/services/kms/keys_mock_test.go
@@ -6,7 +6,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/kms"
 	"github.com/cloudquery/cloudquery/plugins/source/aws/client"
 	"github.com/cloudquery/cloudquery/plugins/source/aws/client/mocks"
-	"github.com/cloudquery/faker/v3"
+	"github.com/cloudquery/plugin-sdk/faker"
 	"github.com/golang/mock/gomock"
 )
 
@@ -14,7 +14,7 @@ func buildKmsKeys(t *testing.T, ctrl *gomock.Controller) client.Services {
 	m := mocks.NewMockKmsClient(ctrl)
 
 	keys := kms.ListKeysOutput{}
-	err := faker.FakeData(&keys)
+	err := faker.FakeObject(&keys)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -23,7 +23,7 @@ func buildKmsKeys(t *testing.T, ctrl *gomock.Controller) client.Services {
 		&keys, nil)
 
 	tags := kms.ListResourceTagsOutput{}
-	err = faker.FakeData(&tags)
+	err = faker.FakeObject(&tags)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -32,7 +32,7 @@ func buildKmsKeys(t *testing.T, ctrl *gomock.Controller) client.Services {
 		&tags, nil)
 
 	key := kms.DescribeKeyOutput{}
-	err = faker.FakeData(&key)
+	err = faker.FakeObject(&key)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -40,7 +40,7 @@ func buildKmsKeys(t *testing.T, ctrl *gomock.Controller) client.Services {
 		&key, nil)
 
 	rotation := kms.GetKeyRotationStatusOutput{}
-	err = faker.FakeData(&rotation)
+	err = faker.FakeObject(&rotation)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/plugins/source/aws/resources/services/lambda/functions_mock_test.go
+++ b/plugins/source/aws/resources/services/lambda/functions_mock_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/lambda/types"
 	"github.com/cloudquery/cloudquery/plugins/source/aws/client"
 	"github.com/cloudquery/cloudquery/plugins/source/aws/client/mocks"
-	"github.com/cloudquery/faker/v3"
+	"github.com/cloudquery/plugin-sdk/faker"
 	"github.com/golang/mock/gomock"
 )
 
@@ -18,7 +18,7 @@ func buildLambdaFunctionsMock(t *testing.T, ctrl *gomock.Controller) client.Serv
 	lastModified := "1994-11-05T08:15:30.000+0500"
 
 	f := lambda.GetFunctionOutput{}
-	err := faker.FakeData(&f)
+	err := faker.FakeObject(&f)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -27,7 +27,7 @@ func buildLambdaFunctionsMock(t *testing.T, ctrl *gomock.Controller) client.Serv
 		&f, nil)
 
 	fc := types.FunctionConfiguration{}
-	err = faker.FakeData(&fc)
+	err = faker.FakeObject(&fc)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -37,7 +37,7 @@ func buildLambdaFunctionsMock(t *testing.T, ctrl *gomock.Controller) client.Serv
 		}, nil)
 
 	a := types.AliasConfiguration{}
-	err = faker.FakeData(&a)
+	err = faker.FakeObject(&a)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -47,7 +47,7 @@ func buildLambdaFunctionsMock(t *testing.T, ctrl *gomock.Controller) client.Serv
 		}, nil)
 
 	i := types.FunctionEventInvokeConfig{}
-	err = faker.FakeData(&i)
+	err = faker.FakeObject(&i)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -57,7 +57,7 @@ func buildLambdaFunctionsMock(t *testing.T, ctrl *gomock.Controller) client.Serv
 		}, nil)
 
 	cc := types.ProvisionedConcurrencyConfigListItem{}
-	err = faker.FakeData(&cc)
+	err = faker.FakeObject(&cc)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -68,7 +68,7 @@ func buildLambdaFunctionsMock(t *testing.T, ctrl *gomock.Controller) client.Serv
 		}, nil)
 
 	esm := types.EventSourceMappingConfiguration{}
-	err = faker.FakeData(&esm)
+	err = faker.FakeObject(&esm)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -78,7 +78,7 @@ func buildLambdaFunctionsMock(t *testing.T, ctrl *gomock.Controller) client.Serv
 		}, nil)
 
 	fp := lambda.GetPolicyOutput{}
-	err = faker.FakeData(&fp)
+	err = faker.FakeObject(&fp)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -88,7 +88,7 @@ func buildLambdaFunctionsMock(t *testing.T, ctrl *gomock.Controller) client.Serv
 		&fp, nil)
 
 	csco := lambda.GetFunctionCodeSigningConfigOutput{}
-	err = faker.FakeData(&csco)
+	err = faker.FakeObject(&csco)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -96,7 +96,7 @@ func buildLambdaFunctionsMock(t *testing.T, ctrl *gomock.Controller) client.Serv
 		&csco, nil)
 
 	csc := types.CodeSigningConfig{}
-	err = faker.FakeData(&csc)
+	err = faker.FakeObject(&csc)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -113,7 +113,7 @@ func buildLambdaFunctionsMock(t *testing.T, ctrl *gomock.Controller) client.Serv
 		}, nil)
 
 	urlConfig := lambda.GetFunctionUrlConfigOutput{}
-	err = faker.FakeData(&urlConfig)
+	err = faker.FakeObject(&urlConfig)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/plugins/source/aws/resources/services/lambda/layers_mock_test.go
+++ b/plugins/source/aws/resources/services/lambda/layers_mock_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/lambda/types"
 	"github.com/cloudquery/cloudquery/plugins/source/aws/client"
 	"github.com/cloudquery/cloudquery/plugins/source/aws/client/mocks"
-	"github.com/cloudquery/faker/v3"
+	"github.com/cloudquery/plugin-sdk/faker"
 	"github.com/golang/mock/gomock"
 )
 
@@ -17,7 +17,7 @@ func buildLambdaLayersMock(t *testing.T, ctrl *gomock.Controller) client.Service
 	creationDate := "1994-11-05T08:15:30.000+0500"
 
 	l := types.LayersListItem{}
-	err := faker.FakeData(&l)
+	err := faker.FakeObject(&l)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -28,7 +28,7 @@ func buildLambdaLayersMock(t *testing.T, ctrl *gomock.Controller) client.Service
 		}, nil)
 
 	lv := types.LayerVersionsListItem{}
-	err = faker.FakeData(&lv)
+	err = faker.FakeObject(&lv)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -41,7 +41,7 @@ func buildLambdaLayersMock(t *testing.T, ctrl *gomock.Controller) client.Service
 		}, nil)
 
 	lvp := lambda.GetLayerVersionPolicyOutput{}
-	err = faker.FakeData(&lvp)
+	err = faker.FakeObject(&lvp)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/plugins/source/aws/resources/services/lightsail/alarms_mock_test.go
+++ b/plugins/source/aws/resources/services/lightsail/alarms_mock_test.go
@@ -6,7 +6,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/lightsail"
 	"github.com/cloudquery/cloudquery/plugins/source/aws/client"
 	"github.com/cloudquery/cloudquery/plugins/source/aws/client/mocks"
-	"github.com/cloudquery/faker/v3"
+	"github.com/cloudquery/plugin-sdk/faker"
 	"github.com/golang/mock/gomock"
 )
 
@@ -14,7 +14,7 @@ func buildAlarmsMock(t *testing.T, ctrl *gomock.Controller) client.Services {
 	m := mocks.NewMockLightsailClient(ctrl)
 
 	b := lightsail.GetAlarmsOutput{}
-	err := faker.FakeData(&b)
+	err := faker.FakeObject(&b)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/plugins/source/aws/resources/services/lightsail/buckets_mock_test.go
+++ b/plugins/source/aws/resources/services/lightsail/buckets_mock_test.go
@@ -6,7 +6,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/lightsail"
 	"github.com/cloudquery/cloudquery/plugins/source/aws/client"
 	"github.com/cloudquery/cloudquery/plugins/source/aws/client/mocks"
-	"github.com/cloudquery/faker/v3"
+	"github.com/cloudquery/plugin-sdk/faker"
 	"github.com/golang/mock/gomock"
 )
 
@@ -14,7 +14,7 @@ func buildBucketsMock(t *testing.T, ctrl *gomock.Controller) client.Services {
 	m := mocks.NewMockLightsailClient(ctrl)
 
 	b := lightsail.GetBucketsOutput{}
-	err := faker.FakeData(&b)
+	err := faker.FakeObject(&b)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -23,7 +23,7 @@ func buildBucketsMock(t *testing.T, ctrl *gomock.Controller) client.Services {
 		&b, nil)
 
 	ac := lightsail.GetBucketAccessKeysOutput{}
-	err = faker.FakeData(&ac)
+	err = faker.FakeObject(&ac)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/plugins/source/aws/resources/services/lightsail/certificates_mock_test.go
+++ b/plugins/source/aws/resources/services/lightsail/certificates_mock_test.go
@@ -6,7 +6,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/lightsail"
 	"github.com/cloudquery/cloudquery/plugins/source/aws/client"
 	"github.com/cloudquery/cloudquery/plugins/source/aws/client/mocks"
-	"github.com/cloudquery/faker/v3"
+	"github.com/cloudquery/plugin-sdk/faker"
 	"github.com/golang/mock/gomock"
 )
 
@@ -14,7 +14,7 @@ func buildCertificatesMock(t *testing.T, ctrl *gomock.Controller) client.Service
 	m := mocks.NewMockLightsailClient(ctrl)
 
 	b := lightsail.GetCertificatesOutput{}
-	err := faker.FakeData(&b)
+	err := faker.FakeObject(&b)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/plugins/source/aws/resources/services/lightsail/container_services_mock_test.go
+++ b/plugins/source/aws/resources/services/lightsail/container_services_mock_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/lightsail/types"
 	"github.com/cloudquery/cloudquery/plugins/source/aws/client"
 	"github.com/cloudquery/cloudquery/plugins/source/aws/client/mocks"
-	"github.com/cloudquery/faker/v3"
+	"github.com/cloudquery/plugin-sdk/faker"
 	"github.com/golang/mock/gomock"
 )
 
@@ -16,12 +16,12 @@ func buildContainerServicesMock(t *testing.T, ctrl *gomock.Controller) client.Se
 	m := mocks.NewMockLightsailClient(ctrl)
 
 	dep := types.ContainerServiceDeployment{State: "test", Containers: map[string]types.Container{"test": {Image: aws.String("test")}}}
-	err := faker.FakeDataSkipFields(&dep, []string{"Containers", "State"})
+	err := faker.FakeObject(&dep)
 	if err != nil {
 		t.Fatal(err)
 	}
 	service := types.ContainerService{CurrentDeployment: &dep, NextDeployment: &dep, Power: "test", ResourceType: "test", State: "test"}
-	err = faker.FakeDataSkipFields(&service, []string{"CurrentDeployment", "NextDeployment", "Power", "ResourceType", "State"})
+	err = faker.FakeObject(&service)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -32,7 +32,7 @@ func buildContainerServicesMock(t *testing.T, ctrl *gomock.Controller) client.Se
 		&lightsail.GetContainerServiceDeploymentsOutput{Deployments: []types.ContainerServiceDeployment{dep}}, nil)
 
 	i := lightsail.GetContainerImagesOutput{}
-	err = faker.FakeData(&i)
+	err = faker.FakeObject(&i)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/plugins/source/aws/resources/services/lightsail/database_snapshots_mock_test.go
+++ b/plugins/source/aws/resources/services/lightsail/database_snapshots_mock_test.go
@@ -6,7 +6,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/lightsail"
 	"github.com/cloudquery/cloudquery/plugins/source/aws/client"
 	"github.com/cloudquery/cloudquery/plugins/source/aws/client/mocks"
-	"github.com/cloudquery/faker/v3"
+	"github.com/cloudquery/plugin-sdk/faker"
 	"github.com/golang/mock/gomock"
 )
 
@@ -14,7 +14,7 @@ func buildDatabaseSnapshotsMock(t *testing.T, ctrl *gomock.Controller) client.Se
 	m := mocks.NewMockLightsailClient(ctrl)
 
 	s := lightsail.GetRelationalDatabaseSnapshotsOutput{}
-	err := faker.FakeData(&s)
+	err := faker.FakeObject(&s)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/plugins/source/aws/resources/services/lightsail/databases_mock_test.go
+++ b/plugins/source/aws/resources/services/lightsail/databases_mock_test.go
@@ -6,7 +6,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/lightsail"
 	"github.com/cloudquery/cloudquery/plugins/source/aws/client"
 	"github.com/cloudquery/cloudquery/plugins/source/aws/client/mocks"
-	"github.com/cloudquery/faker/v3"
+	"github.com/cloudquery/plugin-sdk/faker"
 	"github.com/golang/mock/gomock"
 )
 
@@ -14,7 +14,7 @@ func buildDatabasesMock(t *testing.T, ctrl *gomock.Controller) client.Services {
 	m := mocks.NewMockLightsailClient(ctrl)
 
 	b := lightsail.GetRelationalDatabasesOutput{}
-	err := faker.FakeData(&b)
+	err := faker.FakeObject(&b)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -23,7 +23,7 @@ func buildDatabasesMock(t *testing.T, ctrl *gomock.Controller) client.Services {
 		&b, nil)
 
 	ac := lightsail.GetRelationalDatabaseParametersOutput{}
-	err = faker.FakeData(&ac)
+	err = faker.FakeObject(&ac)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -33,7 +33,7 @@ func buildDatabasesMock(t *testing.T, ctrl *gomock.Controller) client.Services {
 		&ac, nil)
 
 	e := lightsail.GetRelationalDatabaseEventsOutput{}
-	err = faker.FakeData(&e)
+	err = faker.FakeObject(&e)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -42,7 +42,7 @@ func buildDatabasesMock(t *testing.T, ctrl *gomock.Controller) client.Services {
 	m.EXPECT().GetRelationalDatabaseEvents(gomock.Any(), gomock.Any(), gomock.Any()).Return(
 		&e, nil)
 	ls := lightsail.GetRelationalDatabaseLogStreamsOutput{}
-	err = faker.FakeData(&ls)
+	err = faker.FakeObject(&ls)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -50,7 +50,7 @@ func buildDatabasesMock(t *testing.T, ctrl *gomock.Controller) client.Services {
 		&ls, nil)
 
 	le := lightsail.GetRelationalDatabaseLogEventsOutput{}
-	err = faker.FakeData(&le)
+	err = faker.FakeObject(&le)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/plugins/source/aws/resources/services/lightsail/disks_mock_test.go
+++ b/plugins/source/aws/resources/services/lightsail/disks_mock_test.go
@@ -6,7 +6,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/lightsail"
 	"github.com/cloudquery/cloudquery/plugins/source/aws/client"
 	"github.com/cloudquery/cloudquery/plugins/source/aws/client/mocks"
-	"github.com/cloudquery/faker/v3"
+	"github.com/cloudquery/plugin-sdk/faker"
 	"github.com/golang/mock/gomock"
 )
 
@@ -14,7 +14,7 @@ func buildDisks(t *testing.T, ctrl *gomock.Controller) client.Services {
 	mock := mocks.NewMockLightsailClient(ctrl)
 
 	var disks lightsail.GetDisksOutput
-	if err := faker.FakeData(&disks); err != nil {
+	if err := faker.FakeObject(&disks); err != nil {
 		t.Fatal(err)
 	}
 	disks.NextPageToken = nil
@@ -28,7 +28,7 @@ func buildDisks(t *testing.T, ctrl *gomock.Controller) client.Services {
 	)
 
 	var diskSnapshots lightsail.GetDiskSnapshotsOutput
-	if err := faker.FakeData(&diskSnapshots); err != nil {
+	if err := faker.FakeObject(&diskSnapshots); err != nil {
 		t.Fatal(err)
 	}
 	diskSnapshots.NextPageToken = nil

--- a/plugins/source/aws/resources/services/lightsail/distributions_mock_test.go
+++ b/plugins/source/aws/resources/services/lightsail/distributions_mock_test.go
@@ -6,7 +6,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/lightsail"
 	"github.com/cloudquery/cloudquery/plugins/source/aws/client"
 	"github.com/cloudquery/cloudquery/plugins/source/aws/client/mocks"
-	"github.com/cloudquery/faker/v3"
+	"github.com/cloudquery/plugin-sdk/faker"
 	"github.com/golang/mock/gomock"
 )
 
@@ -14,7 +14,7 @@ func buildDistributions(t *testing.T, ctrl *gomock.Controller) client.Services {
 	mock := mocks.NewMockLightsailClient(ctrl)
 
 	var d lightsail.GetDistributionsOutput
-	if err := faker.FakeData(&d); err != nil {
+	if err := faker.FakeObject(&d); err != nil {
 		t.Fatal(err)
 	}
 	d.NextPageToken = nil
@@ -25,7 +25,7 @@ func buildDistributions(t *testing.T, ctrl *gomock.Controller) client.Services {
 	).Return(&d, nil)
 
 	var r lightsail.GetDistributionLatestCacheResetOutput
-	if err := faker.FakeData(&r); err != nil {
+	if err := faker.FakeObject(&r); err != nil {
 		t.Fatal(err)
 	}
 	mock.EXPECT().GetDistributionLatestCacheReset(

--- a/plugins/source/aws/resources/services/lightsail/instance_snapshots_mock_test.go
+++ b/plugins/source/aws/resources/services/lightsail/instance_snapshots_mock_test.go
@@ -6,7 +6,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/lightsail"
 	"github.com/cloudquery/cloudquery/plugins/source/aws/client"
 	"github.com/cloudquery/cloudquery/plugins/source/aws/client/mocks"
-	"github.com/cloudquery/faker/v3"
+	"github.com/cloudquery/plugin-sdk/faker"
 	"github.com/golang/mock/gomock"
 )
 
@@ -14,7 +14,7 @@ func buildInstanceSnapshots(t *testing.T, ctrl *gomock.Controller) client.Servic
 	mock := mocks.NewMockLightsailClient(ctrl)
 
 	var is lightsail.GetInstanceSnapshotsOutput
-	if err := faker.FakeData(&is); err != nil {
+	if err := faker.FakeObject(&is); err != nil {
 		t.Fatal(err)
 	}
 	is.NextPageToken = nil

--- a/plugins/source/aws/resources/services/lightsail/instances_mock_test.go
+++ b/plugins/source/aws/resources/services/lightsail/instances_mock_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/lightsail/types"
 	"github.com/cloudquery/cloudquery/plugins/source/aws/client"
 	"github.com/cloudquery/cloudquery/plugins/source/aws/client/mocks"
-	"github.com/cloudquery/faker/v3"
+	"github.com/cloudquery/plugin-sdk/faker"
 	"github.com/golang/mock/gomock"
 )
 
@@ -15,7 +15,7 @@ func buildInstances(t *testing.T, ctrl *gomock.Controller) client.Services {
 	mock := mocks.NewMockLightsailClient(ctrl)
 
 	var instances []types.Instance
-	if err := faker.FakeData(&instances); err != nil {
+	if err := faker.FakeObject(&instances); err != nil {
 		t.Fatal(err)
 	}
 
@@ -31,7 +31,7 @@ func buildInstances(t *testing.T, ctrl *gomock.Controller) client.Services {
 	)
 
 	var p lightsail.GetInstancePortStatesOutput
-	if err := faker.FakeData(&p); err != nil {
+	if err := faker.FakeObject(&p); err != nil {
 		t.Fatal(err)
 	}
 	mock.EXPECT().GetInstancePortStates(
@@ -41,7 +41,7 @@ func buildInstances(t *testing.T, ctrl *gomock.Controller) client.Services {
 	).Return(&p, nil)
 
 	var a lightsail.GetInstanceAccessDetailsOutput
-	if err := faker.FakeData(&a); err != nil {
+	if err := faker.FakeObject(&a); err != nil {
 		t.Fatal(err)
 	}
 	mock.EXPECT().GetInstanceAccessDetails(

--- a/plugins/source/aws/resources/services/lightsail/load_balancers_mock_test.go
+++ b/plugins/source/aws/resources/services/lightsail/load_balancers_mock_test.go
@@ -6,7 +6,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/lightsail"
 	"github.com/cloudquery/cloudquery/plugins/source/aws/client"
 	"github.com/cloudquery/cloudquery/plugins/source/aws/client/mocks"
-	"github.com/cloudquery/faker/v3"
+	"github.com/cloudquery/plugin-sdk/faker"
 	"github.com/golang/mock/gomock"
 )
 
@@ -14,7 +14,7 @@ func buildLoadBalancers(t *testing.T, ctrl *gomock.Controller) client.Services {
 	mock := mocks.NewMockLightsailClient(ctrl)
 
 	var lb lightsail.GetLoadBalancersOutput
-	if err := faker.FakeData(&lb); err != nil {
+	if err := faker.FakeObject(&lb); err != nil {
 		t.Fatal(err)
 	}
 	lb.NextPageToken = nil
@@ -26,7 +26,7 @@ func buildLoadBalancers(t *testing.T, ctrl *gomock.Controller) client.Services {
 	).Return(&lb, nil)
 
 	var lbc lightsail.GetLoadBalancerTlsCertificatesOutput
-	if err := faker.FakeData(&lbc); err != nil {
+	if err := faker.FakeObject(&lbc); err != nil {
 		t.Fatal(err)
 	}
 

--- a/plugins/source/aws/resources/services/lightsail/static_ips_mock_test.go
+++ b/plugins/source/aws/resources/services/lightsail/static_ips_mock_test.go
@@ -6,7 +6,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/lightsail"
 	"github.com/cloudquery/cloudquery/plugins/source/aws/client"
 	"github.com/cloudquery/cloudquery/plugins/source/aws/client/mocks"
-	"github.com/cloudquery/faker/v3"
+	"github.com/cloudquery/plugin-sdk/faker"
 	"github.com/golang/mock/gomock"
 )
 
@@ -14,7 +14,7 @@ func buildStaticIps(t *testing.T, ctrl *gomock.Controller) client.Services {
 	mock := mocks.NewMockLightsailClient(ctrl)
 
 	var ips lightsail.GetStaticIpsOutput
-	if err := faker.FakeData(&ips); err != nil {
+	if err := faker.FakeObject(&ips); err != nil {
 		t.Fatal(err)
 	}
 	ips.NextPageToken = nil

--- a/plugins/source/aws/resources/services/mq/brokers_mock_test.go
+++ b/plugins/source/aws/resources/services/mq/brokers_mock_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/mq/types"
 	"github.com/cloudquery/cloudquery/plugins/source/aws/client"
 	"github.com/cloudquery/cloudquery/plugins/source/aws/client/mocks"
-	"github.com/cloudquery/faker/v3"
+	"github.com/cloudquery/plugin-sdk/faker"
 	"github.com/golang/mock/gomock"
 )
 
@@ -16,7 +16,7 @@ func buildMqBrokers(t *testing.T, ctrl *gomock.Controller) client.Services {
 	m := mocks.NewMockMQClient(ctrl)
 
 	bs := types.BrokerSummary{}
-	if err := faker.FakeData(&bs); err != nil {
+	if err := faker.FakeObject(&bs); err != nil {
 		t.Fatal(err)
 	}
 	m.EXPECT().ListBrokers(gomock.Any(), gomock.Any(), gomock.Any()).Return(
@@ -25,14 +25,14 @@ func buildMqBrokers(t *testing.T, ctrl *gomock.Controller) client.Services {
 		}, nil)
 
 	bo := mq.DescribeBrokerOutput{}
-	if err := faker.FakeData(&bo); err != nil {
+	if err := faker.FakeObject(&bo); err != nil {
 		t.Fatal(err)
 	}
 	bo.BrokerId = bs.BrokerId
 	username := "test_username"
 	bo.Users = []types.UserSummary{{Username: &username}}
 	var cfgID types.ConfigurationId
-	if err := faker.FakeData(&cfgID); err != nil {
+	if err := faker.FakeObject(&cfgID); err != nil {
 		t.Fatal(err)
 	}
 	bo.Configurations.Current = &cfgID
@@ -40,7 +40,7 @@ func buildMqBrokers(t *testing.T, ctrl *gomock.Controller) client.Services {
 	m.EXPECT().DescribeBroker(gomock.Any(), &mq.DescribeBrokerInput{BrokerId: bs.BrokerId}, gomock.Any()).Return(&bo, nil)
 
 	uo := mq.DescribeUserOutput{}
-	if err := faker.FakeData(&uo); err != nil {
+	if err := faker.FakeObject(&uo); err != nil {
 		t.Fatal(err)
 	}
 	uo.Username = &username
@@ -48,14 +48,14 @@ func buildMqBrokers(t *testing.T, ctrl *gomock.Controller) client.Services {
 	m.EXPECT().DescribeUser(gomock.Any(), &mq.DescribeUserInput{BrokerId: bo.BrokerId, Username: &username}, gomock.Any()).Return(&uo, nil)
 
 	var co mq.DescribeConfigurationOutput
-	if err := faker.FakeData(&co); err != nil {
+	if err := faker.FakeObject(&co); err != nil {
 		t.Fatal(err)
 	}
 	co.Id = cfgID.Id
 	m.EXPECT().DescribeConfiguration(gomock.Any(), &mq.DescribeConfigurationInput{ConfigurationId: cfgID.Id}, gomock.Any()).Return(&co, nil)
 
 	revisions := mq.ListConfigurationRevisionsOutput{}
-	if err := faker.FakeData(&revisions); err != nil {
+	if err := faker.FakeObject(&revisions); err != nil {
 		t.Fatal(err)
 	}
 	revisions.NextToken = nil
@@ -63,7 +63,7 @@ func buildMqBrokers(t *testing.T, ctrl *gomock.Controller) client.Services {
 		&revisions, nil)
 
 	revision := mq.DescribeConfigurationRevisionOutput{}
-	if err := faker.FakeData(&revision); err != nil {
+	if err := faker.FakeObject(&revision); err != nil {
 		t.Fatal(err)
 	}
 	revision.Data = aws.String("PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0iVVRGLTgiPz48aGVsbG8+d29ybGQ8L2hlbGxvPg==")

--- a/plugins/source/aws/resources/services/organizations/accounts_mock_test.go
+++ b/plugins/source/aws/resources/services/organizations/accounts_mock_test.go
@@ -7,14 +7,14 @@ import (
 	organizationsTypes "github.com/aws/aws-sdk-go-v2/service/organizations/types"
 	"github.com/cloudquery/cloudquery/plugins/source/aws/client"
 	"github.com/cloudquery/cloudquery/plugins/source/aws/client/mocks"
-	"github.com/cloudquery/faker/v3"
+	"github.com/cloudquery/plugin-sdk/faker"
 	"github.com/golang/mock/gomock"
 )
 
 func buildOrganizationsAccounts(t *testing.T, ctrl *gomock.Controller) client.Services {
 	m := mocks.NewMockOrganizationsClient(ctrl)
 	g := organizationsTypes.Account{}
-	err := faker.FakeData(&g)
+	err := faker.FakeObject(&g)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -25,7 +25,7 @@ func buildOrganizationsAccounts(t *testing.T, ctrl *gomock.Controller) client.Se
 		}, nil)
 
 	tt := make([]organizationsTypes.Tag, 3)
-	if err := faker.FakeData(&tt); err != nil {
+	if err := faker.FakeObject(&tt); err != nil {
 		t.Fatal(err)
 	}
 

--- a/plugins/source/aws/resources/services/qldb/ledgers_mock_test.go
+++ b/plugins/source/aws/resources/services/qldb/ledgers_mock_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/qldb/types"
 	"github.com/cloudquery/cloudquery/plugins/source/aws/client"
 	"github.com/cloudquery/cloudquery/plugins/source/aws/client/mocks"
-	"github.com/cloudquery/faker/v3"
+	"github.com/cloudquery/plugin-sdk/faker"
 	"github.com/golang/mock/gomock"
 )
 
@@ -15,14 +15,14 @@ func buildLedgersMock(t *testing.T, ctrl *gomock.Controller) client.Services {
 	m := mocks.NewMockQLDBClient(ctrl)
 
 	ledger := types.LedgerSummary{}
-	if err := faker.FakeData(&ledger); err != nil {
+	if err := faker.FakeObject(&ledger); err != nil {
 		t.Fatal(err)
 	}
 	m.EXPECT().ListLedgers(gomock.Any(), &qldb.ListLedgersInput{}, gomock.Any()).Return(
 		&qldb.ListLedgersOutput{Ledgers: []types.LedgerSummary{ledger}}, nil)
 
 	var resource qldb.DescribeLedgerOutput
-	if err := faker.FakeData(&resource); err != nil {
+	if err := faker.FakeObject(&resource); err != nil {
 		t.Fatal(err)
 	}
 	m.EXPECT().DescribeLedger(
@@ -35,7 +35,7 @@ func buildLedgersMock(t *testing.T, ctrl *gomock.Controller) client.Services {
 	)
 
 	tags := &qldb.ListTagsForResourceOutput{}
-	if err := faker.FakeData(&tags); err != nil {
+	if err := faker.FakeObject(&tags); err != nil {
 		t.Fatal(err)
 	}
 	m.EXPECT().ListTagsForResource(gomock.Any(), gomock.Any(), gomock.Any()).Return(
@@ -44,7 +44,7 @@ func buildLedgersMock(t *testing.T, ctrl *gomock.Controller) client.Services {
 	)
 
 	s3 := types.JournalS3ExportDescription{}
-	if err := faker.FakeData(&s3); err != nil {
+	if err := faker.FakeObject(&s3); err != nil {
 		t.Fatal(err)
 	}
 	m.EXPECT().ListJournalS3ExportsForLedger(gomock.Any(), gomock.Any(), gomock.Any()).
@@ -53,7 +53,7 @@ func buildLedgersMock(t *testing.T, ctrl *gomock.Controller) client.Services {
 		}, nil)
 
 	ke := types.JournalKinesisStreamDescription{}
-	if err := faker.FakeData(&ke); err != nil {
+	if err := faker.FakeObject(&ke); err != nil {
 		t.Fatal(err)
 	}
 	m.EXPECT().ListJournalKinesisStreamsForLedger(gomock.Any(), gomock.Any(), gomock.Any()).

--- a/plugins/source/aws/resources/services/rds/cluster_parameter_groups_mock_test.go
+++ b/plugins/source/aws/resources/services/rds/cluster_parameter_groups_mock_test.go
@@ -8,14 +8,14 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/rds/types"
 	"github.com/cloudquery/cloudquery/plugins/source/aws/client"
 	"github.com/cloudquery/cloudquery/plugins/source/aws/client/mocks"
-	"github.com/cloudquery/faker/v3"
+	"github.com/cloudquery/plugin-sdk/faker"
 	"github.com/golang/mock/gomock"
 )
 
 func buildRdsClusterParameterGroups(t *testing.T, ctrl *gomock.Controller) client.Services {
 	mock := mocks.NewMockRdsClient(ctrl)
 	var g types.DBClusterParameterGroup
-	if err := faker.FakeData(&g); err != nil {
+	if err := faker.FakeObject(&g); err != nil {
 		t.Fatal(err)
 	}
 	mock.EXPECT().DescribeDBClusterParameterGroups(
@@ -39,7 +39,7 @@ func buildRdsClusterParameterGroups(t *testing.T, ctrl *gomock.Controller) clien
 	)
 
 	var p types.Parameter
-	if err := faker.FakeData(&p); err != nil {
+	if err := faker.FakeObject(&p); err != nil {
 		t.Fatal(err)
 	}
 	mock.EXPECT().DescribeDBClusterParameters(

--- a/plugins/source/aws/resources/services/rds/cluster_snapshots_mock_test.go
+++ b/plugins/source/aws/resources/services/rds/cluster_snapshots_mock_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/rds/types"
 	"github.com/cloudquery/cloudquery/plugins/source/aws/client"
 	"github.com/cloudquery/cloudquery/plugins/source/aws/client/mocks"
-	"github.com/cloudquery/faker/v3"
+	"github.com/cloudquery/plugin-sdk/faker"
 	"github.com/golang/mock/gomock"
 )
 
@@ -15,7 +15,7 @@ func buildRDSClientForClusterSnapshots(t *testing.T, ctrl *gomock.Controller) cl
 	mock := mocks.NewMockRdsClient(ctrl)
 
 	var s types.DBClusterSnapshot
-	if err := faker.FakeData(&s); err != nil {
+	if err := faker.FakeObject(&s); err != nil {
 		t.Fatal(err)
 	}
 	mock.EXPECT().DescribeDBClusterSnapshots(
@@ -28,7 +28,7 @@ func buildRDSClientForClusterSnapshots(t *testing.T, ctrl *gomock.Controller) cl
 	)
 
 	var attrs []types.DBClusterSnapshotAttribute
-	if err := faker.FakeData(&attrs); err != nil {
+	if err := faker.FakeObject(&attrs); err != nil {
 		t.Fatal(err)
 	}
 	mock.EXPECT().DescribeDBClusterSnapshotAttributes(

--- a/plugins/source/aws/resources/services/rds/db_parameter_groups_mock_test.go
+++ b/plugins/source/aws/resources/services/rds/db_parameter_groups_mock_test.go
@@ -8,14 +8,14 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/rds/types"
 	"github.com/cloudquery/cloudquery/plugins/source/aws/client"
 	"github.com/cloudquery/cloudquery/plugins/source/aws/client/mocks"
-	"github.com/cloudquery/faker/v3"
+	"github.com/cloudquery/plugin-sdk/faker"
 	"github.com/golang/mock/gomock"
 )
 
 func buildRDSDBParameterGroups(t *testing.T, ctrl *gomock.Controller) client.Services {
 	mock := mocks.NewMockRdsClient(ctrl)
 	var g types.DBParameterGroup
-	if err := faker.FakeData(&g); err != nil {
+	if err := faker.FakeObject(&g); err != nil {
 		t.Fatal(err)
 	}
 	mock.EXPECT().DescribeDBParameterGroups(
@@ -39,7 +39,7 @@ func buildRDSDBParameterGroups(t *testing.T, ctrl *gomock.Controller) client.Ser
 	)
 
 	var p types.Parameter
-	if err := faker.FakeData(&p); err != nil {
+	if err := faker.FakeObject(&p); err != nil {
 		t.Fatal(err)
 	}
 	mock.EXPECT().DescribeDBParameters(

--- a/plugins/source/aws/resources/services/rds/db_security_groups_mock_test.go
+++ b/plugins/source/aws/resources/services/rds/db_security_groups_mock_test.go
@@ -8,14 +8,14 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/rds/types"
 	"github.com/cloudquery/cloudquery/plugins/source/aws/client"
 	"github.com/cloudquery/cloudquery/plugins/source/aws/client/mocks"
-	"github.com/cloudquery/faker/v3"
+	"github.com/cloudquery/plugin-sdk/faker"
 	"github.com/golang/mock/gomock"
 )
 
 func buildRdsDbSecurityGroups(t *testing.T, ctrl *gomock.Controller) client.Services {
 	mock := mocks.NewMockRdsClient(ctrl)
 	var g types.DBSecurityGroup
-	if err := faker.FakeData(&g); err != nil {
+	if err := faker.FakeObject(&g); err != nil {
 		t.Fatal(err)
 	}
 	mock.EXPECT().DescribeDBSecurityGroups(

--- a/plugins/source/aws/resources/services/rds/db_snapshots_mock_test.go
+++ b/plugins/source/aws/resources/services/rds/db_snapshots_mock_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/rds/types"
 	"github.com/cloudquery/cloudquery/plugins/source/aws/client"
 	"github.com/cloudquery/cloudquery/plugins/source/aws/client/mocks"
-	"github.com/cloudquery/faker/v3"
+	"github.com/cloudquery/plugin-sdk/faker"
 	"github.com/golang/mock/gomock"
 )
 
@@ -15,7 +15,7 @@ func buildRDSClient(t *testing.T, ctrl *gomock.Controller) client.Services {
 	mock := mocks.NewMockRdsClient(ctrl)
 
 	var s types.DBSnapshot
-	if err := faker.FakeData(&s); err != nil {
+	if err := faker.FakeObject(&s); err != nil {
 		t.Fatal(err)
 	}
 	mock.EXPECT().DescribeDBSnapshots(
@@ -28,7 +28,7 @@ func buildRDSClient(t *testing.T, ctrl *gomock.Controller) client.Services {
 	)
 
 	var attrs []types.DBSnapshotAttribute
-	if err := faker.FakeData(&attrs); err != nil {
+	if err := faker.FakeObject(&attrs); err != nil {
 		t.Fatal(err)
 	}
 	mock.EXPECT().DescribeDBSnapshotAttributes(

--- a/plugins/source/aws/resources/services/rds/event_subscriptions_mock_test.go
+++ b/plugins/source/aws/resources/services/rds/event_subscriptions_mock_test.go
@@ -8,14 +8,14 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/rds/types"
 	"github.com/cloudquery/cloudquery/plugins/source/aws/client"
 	"github.com/cloudquery/cloudquery/plugins/source/aws/client/mocks"
-	"github.com/cloudquery/faker/v3"
+	"github.com/cloudquery/plugin-sdk/faker"
 	"github.com/golang/mock/gomock"
 )
 
 func buildRDSEventSubscriptions(t *testing.T, ctrl *gomock.Controller) client.Services {
 	mock := mocks.NewMockRdsClient(ctrl)
 	var s types.EventSubscription
-	if err := faker.FakeData(&s); err != nil {
+	if err := faker.FakeObject(&s); err != nil {
 		t.Fatal(err)
 	}
 	mock.EXPECT().DescribeEventSubscriptions(gomock.Any(), &rds.DescribeEventSubscriptionsInput{}, gomock.Any()).Return(

--- a/plugins/source/aws/resources/services/rds/mock_test.go
+++ b/plugins/source/aws/resources/services/rds/mock_test.go
@@ -7,14 +7,14 @@ import (
 	rdsTypes "github.com/aws/aws-sdk-go-v2/service/rds/types"
 	"github.com/cloudquery/cloudquery/plugins/source/aws/client"
 	"github.com/cloudquery/cloudquery/plugins/source/aws/client/mocks"
-	"github.com/cloudquery/faker/v3"
+	"github.com/cloudquery/plugin-sdk/faker"
 	"github.com/golang/mock/gomock"
 )
 
 func buildRdsCertificates(t *testing.T, ctrl *gomock.Controller) client.Services {
 	m := mocks.NewMockRdsClient(ctrl)
 	l := rdsTypes.Certificate{}
-	err := faker.FakeData(&l)
+	err := faker.FakeObject(&l)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -31,7 +31,7 @@ func buildRdsCertificates(t *testing.T, ctrl *gomock.Controller) client.Services
 func buildRdsDBClusters(t *testing.T, ctrl *gomock.Controller) client.Services {
 	m := mocks.NewMockRdsClient(ctrl)
 	l := rdsTypes.DBCluster{}
-	err := faker.FakeData(&l)
+	err := faker.FakeObject(&l)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -48,7 +48,7 @@ func buildRdsDBClusters(t *testing.T, ctrl *gomock.Controller) client.Services {
 func buildRdsDBInstances(t *testing.T, ctrl *gomock.Controller) client.Services {
 	m := mocks.NewMockRdsClient(ctrl)
 	l := rdsTypes.DBInstance{}
-	err := faker.FakeData(&l)
+	err := faker.FakeObject(&l)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -65,7 +65,7 @@ func buildRdsDBInstances(t *testing.T, ctrl *gomock.Controller) client.Services 
 func buildRdsDBSubnetGroups(t *testing.T, ctrl *gomock.Controller) client.Services {
 	m := mocks.NewMockRdsClient(ctrl)
 	l := rdsTypes.DBSubnetGroup{}
-	err := faker.FakeData(&l)
+	err := faker.FakeObject(&l)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/plugins/source/aws/resources/services/redshift/clusters_mock_test.go
+++ b/plugins/source/aws/resources/services/redshift/clusters_mock_test.go
@@ -8,24 +8,24 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/redshift/types"
 	"github.com/cloudquery/cloudquery/plugins/source/aws/client"
 	"github.com/cloudquery/cloudquery/plugins/source/aws/client/mocks"
-	"github.com/cloudquery/faker/v3"
+	"github.com/cloudquery/plugin-sdk/faker"
 	"github.com/golang/mock/gomock"
 )
 
 func buildRedshiftClustersMock(t *testing.T, ctrl *gomock.Controller) client.Services {
 	m := mocks.NewMockRedshiftClient(ctrl)
 	g := types.Cluster{}
-	err := faker.FakeData(&g)
+	err := faker.FakeObject(&g)
 	if err != nil {
 		t.Fatal(err)
 	}
 	p := types.Parameter{}
-	err = faker.FakeData(&p)
+	err = faker.FakeObject(&p)
 	if err != nil {
 		t.Fatal(err)
 	}
 	logging := redshift.DescribeLoggingStatusOutput{}
-	err = faker.FakeData(&logging)
+	err = faker.FakeObject(&logging)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -42,7 +42,7 @@ func buildRedshiftClustersMock(t *testing.T, ctrl *gomock.Controller) client.Ser
 		&logging, nil)
 
 	var snap types.Snapshot
-	if err := faker.FakeData(&snap); err != nil {
+	if err := faker.FakeObject(&snap); err != nil {
 		t.Fatal(err)
 	}
 	snap.ClusterIdentifier = g.ClusterIdentifier
@@ -69,7 +69,7 @@ func buildRedshiftSubnetGroupsMock(t *testing.T, ctrl *gomock.Controller) client
 	m := mocks.NewMockRedshiftClient(ctrl)
 
 	g := types.ClusterSubnetGroup{}
-	err := faker.FakeData(&g)
+	err := faker.FakeObject(&g)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/plugins/source/aws/resources/services/redshift/event_subscriptions_mock_test.go
+++ b/plugins/source/aws/resources/services/redshift/event_subscriptions_mock_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/redshift/types"
 	"github.com/cloudquery/cloudquery/plugins/source/aws/client"
 	"github.com/cloudquery/cloudquery/plugins/source/aws/client/mocks"
-	"github.com/cloudquery/faker/v3"
+	"github.com/cloudquery/plugin-sdk/faker"
 	"github.com/golang/mock/gomock"
 )
 
@@ -16,7 +16,7 @@ func buildRedshiftEventSubscriptionsMock(t *testing.T, ctrl *gomock.Controller) 
 	m := mocks.NewMockRedshiftClient(ctrl)
 
 	var s types.EventSubscription
-	if err := faker.FakeData(&s); err != nil {
+	if err := faker.FakeObject(&s); err != nil {
 		t.Fatal(err)
 	}
 	m.EXPECT().DescribeEventSubscriptions(

--- a/plugins/source/aws/resources/services/resourcegroups/resource_groups_mock_test.go
+++ b/plugins/source/aws/resources/services/resourcegroups/resource_groups_mock_test.go
@@ -7,32 +7,32 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/resourcegroups/types"
 	"github.com/cloudquery/cloudquery/plugins/source/aws/client"
 	"github.com/cloudquery/cloudquery/plugins/source/aws/client/mocks"
-	"github.com/cloudquery/faker/v3"
+	"github.com/cloudquery/plugin-sdk/faker"
 	"github.com/golang/mock/gomock"
 )
 
 func buildResourceGroupsMock(t *testing.T, ctrl *gomock.Controller) client.Services {
 	m := mocks.NewMockResourceGroupsClient(ctrl)
 	gId := types.GroupIdentifier{}
-	err := faker.FakeData(&gId)
+	err := faker.FakeObject(&gId)
 	if err != nil {
 		t.Fatal(err)
 	}
 
 	groupResponse := types.Group{}
-	err = faker.FakeData(&groupResponse)
+	err = faker.FakeObject(&groupResponse)
 	if err != nil {
 		t.Fatal(err)
 	}
 
 	tagsResponse := resourcegroups.GetTagsOutput{}
-	err = faker.FakeData(&tagsResponse)
+	err = faker.FakeObject(&tagsResponse)
 	if err != nil {
 		t.Fatal(err)
 	}
 
 	query := types.GroupQuery{}
-	err = faker.FakeData(&query)
+	err = faker.FakeObject(&query)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/plugins/source/aws/resources/services/route53/delegations_sets_mock_test.go
+++ b/plugins/source/aws/resources/services/route53/delegations_sets_mock_test.go
@@ -7,14 +7,14 @@ import (
 	route53Types "github.com/aws/aws-sdk-go-v2/service/route53/types"
 	"github.com/cloudquery/cloudquery/plugins/source/aws/client"
 	"github.com/cloudquery/cloudquery/plugins/source/aws/client/mocks"
-	"github.com/cloudquery/faker/v3"
+	"github.com/cloudquery/plugin-sdk/faker"
 	"github.com/golang/mock/gomock"
 )
 
 func buildRoute53DelegationSetsMock(t *testing.T, ctrl *gomock.Controller) client.Services {
 	m := mocks.NewMockRoute53Client(ctrl)
 	ds := route53Types.DelegationSet{}
-	if err := faker.FakeData(&ds); err != nil {
+	if err := faker.FakeObject(&ds); err != nil {
 		t.Fatal(err)
 	}
 	m.EXPECT().ListReusableDelegationSets(gomock.Any(), gomock.Any(), gomock.Any()).Return(

--- a/plugins/source/aws/resources/services/route53/domains_mock_test.go
+++ b/plugins/source/aws/resources/services/route53/domains_mock_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/route53domains/types"
 	"github.com/cloudquery/cloudquery/plugins/source/aws/client"
 	"github.com/cloudquery/cloudquery/plugins/source/aws/client/mocks"
-	"github.com/cloudquery/faker/v3"
+	"github.com/cloudquery/plugin-sdk/faker"
 	"github.com/golang/mock/gomock"
 )
 
@@ -15,7 +15,7 @@ func buildRoute53Domains(t *testing.T, ctrl *gomock.Controller) client.Services 
 	mock := mocks.NewMockRoute53DomainsClient(ctrl)
 
 	var ds types.DomainSummary
-	if err := faker.FakeData(&ds.DomainName); err != nil {
+	if err := faker.FakeObject(&ds.DomainName); err != nil {
 		t.Fatal(err)
 	}
 	mock.EXPECT().ListDomains(gomock.Any(), &route53domains.ListDomainsInput{}, gomock.Any()).Return(
@@ -24,7 +24,7 @@ func buildRoute53Domains(t *testing.T, ctrl *gomock.Controller) client.Services 
 	)
 
 	var detail route53domains.GetDomainDetailOutput
-	if err := faker.FakeData(&detail); err != nil {
+	if err := faker.FakeObject(&detail); err != nil {
 		t.Fatal(err)
 	}
 	detail.DomainName = ds.DomainName
@@ -33,7 +33,7 @@ func buildRoute53Domains(t *testing.T, ctrl *gomock.Controller) client.Services 
 	)
 
 	var tagsOut route53domains.ListTagsForDomainOutput
-	if err := faker.FakeData(&tagsOut); err != nil {
+	if err := faker.FakeObject(&tagsOut); err != nil {
 		t.Fatal(err)
 	}
 	mock.EXPECT().ListTagsForDomain(gomock.Any(), &route53domains.ListTagsForDomainInput{DomainName: ds.DomainName}, gomock.Any()).Return(

--- a/plugins/source/aws/resources/services/route53/health_check_mock_test.go
+++ b/plugins/source/aws/resources/services/route53/health_check_mock_test.go
@@ -7,14 +7,14 @@ import (
 	route53Types "github.com/aws/aws-sdk-go-v2/service/route53/types"
 	"github.com/cloudquery/cloudquery/plugins/source/aws/client"
 	"github.com/cloudquery/cloudquery/plugins/source/aws/client/mocks"
-	"github.com/cloudquery/faker/v3"
+	"github.com/cloudquery/plugin-sdk/faker"
 	"github.com/golang/mock/gomock"
 )
 
 func buildRoute53HealthChecksMock(t *testing.T, ctrl *gomock.Controller) client.Services {
 	m := mocks.NewMockRoute53Client(ctrl)
 	hc := route53Types.HealthCheck{}
-	if err := faker.FakeData(&hc); err != nil {
+	if err := faker.FakeObject(&hc); err != nil {
 		t.Fatal(err)
 	}
 	m.EXPECT().ListHealthChecks(gomock.Any(), gomock.Any(), gomock.Any()).Return(
@@ -22,7 +22,7 @@ func buildRoute53HealthChecksMock(t *testing.T, ctrl *gomock.Controller) client.
 			HealthChecks: []route53Types.HealthCheck{hc},
 		}, nil)
 	tag := route53Types.Tag{}
-	if err := faker.FakeData(&tag); err != nil {
+	if err := faker.FakeObject(&tag); err != nil {
 		t.Fatal(err)
 	}
 	//m.EXPECT().ListTagsForResource(gomock.Any(), gomock.Any(), gomock.Any()).Return(

--- a/plugins/source/aws/resources/services/route53/hosted_zones_mock_test.go
+++ b/plugins/source/aws/resources/services/route53/hosted_zones_mock_test.go
@@ -8,14 +8,14 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/route53/types"
 	"github.com/cloudquery/cloudquery/plugins/source/aws/client"
 	"github.com/cloudquery/cloudquery/plugins/source/aws/client/mocks"
-	"github.com/cloudquery/faker/v3"
+	"github.com/cloudquery/plugin-sdk/faker"
 	"github.com/golang/mock/gomock"
 )
 
 func buildRoute53HostedZonesMock(t *testing.T, ctrl *gomock.Controller) client.Services {
 	m := mocks.NewMockRoute53Client(ctrl)
 	h := types.HostedZone{}
-	if err := faker.FakeData(&h); err != nil {
+	if err := faker.FakeObject(&h); err != nil {
 		t.Fatal(err)
 	}
 	m.EXPECT().ListHostedZones(gomock.Any(), gomock.Any(), gomock.Any()).Return(
@@ -23,7 +23,7 @@ func buildRoute53HostedZonesMock(t *testing.T, ctrl *gomock.Controller) client.S
 			HostedZones: []types.HostedZone{h},
 		}, nil)
 	tag := types.Tag{}
-	if err := faker.FakeData(&tag); err != nil {
+	if err := faker.FakeObject(&tag); err != nil {
 		t.Fatal(err)
 	}
 	//create id that is usually returned by aws
@@ -40,7 +40,7 @@ func buildRoute53HostedZonesMock(t *testing.T, ctrl *gomock.Controller) client.S
 			},
 		}, nil)
 	qlc := types.QueryLoggingConfig{}
-	if err := faker.FakeData(&qlc); err != nil {
+	if err := faker.FakeObject(&qlc); err != nil {
 		t.Fatal(err)
 	}
 	m.EXPECT().ListQueryLoggingConfigs(gomock.Any(), gomock.Any(), gomock.Any()).Return(
@@ -48,7 +48,7 @@ func buildRoute53HostedZonesMock(t *testing.T, ctrl *gomock.Controller) client.S
 			QueryLoggingConfigs: []types.QueryLoggingConfig{qlc},
 		}, nil)
 	rrs := types.ResourceRecordSet{}
-	if err := faker.FakeData(&rrs); err != nil {
+	if err := faker.FakeObject(&rrs); err != nil {
 		t.Fatal(err)
 	}
 	m.EXPECT().ListResourceRecordSets(gomock.Any(), gomock.Any(), gomock.Any()).Return(
@@ -56,7 +56,7 @@ func buildRoute53HostedZonesMock(t *testing.T, ctrl *gomock.Controller) client.S
 			ResourceRecordSets: []types.ResourceRecordSet{rrs},
 		}, nil)
 	tpi := types.TrafficPolicyInstance{}
-	if err := faker.FakeData(&tpi); err != nil {
+	if err := faker.FakeObject(&tpi); err != nil {
 		t.Fatal(err)
 	}
 	m.EXPECT().ListTrafficPolicyInstancesByHostedZone(gomock.Any(), gomock.Any(), gomock.Any()).Return(
@@ -64,11 +64,11 @@ func buildRoute53HostedZonesMock(t *testing.T, ctrl *gomock.Controller) client.S
 			TrafficPolicyInstances: []types.TrafficPolicyInstance{tpi},
 		}, nil)
 	vpc := types.VPC{}
-	if err := faker.FakeData(&vpc); err != nil {
+	if err := faker.FakeObject(&vpc); err != nil {
 		t.Fatal(err)
 	}
 	ds := types.DelegationSet{}
-	if err := faker.FakeData(&ds); err != nil {
+	if err := faker.FakeObject(&ds); err != nil {
 		t.Fatal(err)
 	}
 

--- a/plugins/source/aws/resources/services/route53/traffic_policies_mock_test.go
+++ b/plugins/source/aws/resources/services/route53/traffic_policies_mock_test.go
@@ -7,14 +7,14 @@ import (
 	route53Types "github.com/aws/aws-sdk-go-v2/service/route53/types"
 	"github.com/cloudquery/cloudquery/plugins/source/aws/client"
 	"github.com/cloudquery/cloudquery/plugins/source/aws/client/mocks"
-	"github.com/cloudquery/faker/v3"
+	"github.com/cloudquery/plugin-sdk/faker"
 	"github.com/golang/mock/gomock"
 )
 
 func buildRoute53TrafficPoliciesMock(t *testing.T, ctrl *gomock.Controller) client.Services {
 	m := mocks.NewMockRoute53Client(ctrl)
 	tps := route53Types.TrafficPolicySummary{}
-	if err := faker.FakeData(&tps); err != nil {
+	if err := faker.FakeObject(&tps); err != nil {
 		t.Fatal(err)
 	}
 	m.EXPECT().ListTrafficPolicies(gomock.Any(), gomock.Any(), gomock.Any()).Return(
@@ -22,7 +22,7 @@ func buildRoute53TrafficPoliciesMock(t *testing.T, ctrl *gomock.Controller) clie
 			TrafficPolicySummaries: []route53Types.TrafficPolicySummary{tps},
 		}, nil)
 	tp := route53Types.TrafficPolicy{}
-	if err := faker.FakeData(&tp); err != nil {
+	if err := faker.FakeObject(&tp); err != nil {
 		t.Fatal(err)
 	}
 	tp.Id = tps.Id

--- a/plugins/source/aws/resources/services/s3/buckets_mock_test.go
+++ b/plugins/source/aws/resources/services/s3/buckets_mock_test.go
@@ -10,7 +10,7 @@ import (
 	s3Types "github.com/aws/aws-sdk-go-v2/service/s3/types"
 	"github.com/cloudquery/cloudquery/plugins/source/aws/client"
 	"github.com/cloudquery/cloudquery/plugins/source/aws/client/mocks"
-	"github.com/cloudquery/faker/v3"
+	"github.com/cloudquery/plugin-sdk/faker"
 	"github.com/golang/mock/gomock"
 )
 
@@ -18,60 +18,60 @@ func buildS3Buckets(t *testing.T, ctrl *gomock.Controller) client.Services {
 	mgr := mocks.NewMockS3ManagerClient(ctrl)
 	m := mocks.NewMockS3Client(ctrl)
 	b := s3Types.Bucket{}
-	err := faker.FakeData(&b)
+	err := faker.FakeObject(&b)
 	if err != nil {
 		t.Fatal(err)
 	}
 	bloc := s3.GetBucketLocationOutput{}
-	err = faker.FakeData(&bloc)
+	err = faker.FakeObject(&bloc)
 	if err != nil {
 		t.Fatal(err)
 	}
 	blog := s3.GetBucketLoggingOutput{}
-	err = faker.FakeData(&blog)
+	err = faker.FakeObject(&blog)
 	if err != nil {
 		t.Fatal(err)
 	}
 	bpol := s3.GetBucketPolicyOutput{}
-	err = faker.FakeData(&bpol)
+	err = faker.FakeObject(&bpol)
 	if err != nil {
 		t.Fatal(err)
 	}
 	jsonDoc := `{"stuff": 3}`
 	bpol.Policy = &jsonDoc
 	bver := s3.GetBucketVersioningOutput{}
-	err = faker.FakeData(&bver)
+	err = faker.FakeObject(&bver)
 	if err != nil {
 		t.Fatal(err)
 	}
 	bgrant := s3Types.Grant{}
-	err = faker.FakeData(&bgrant)
+	err = faker.FakeObject(&bgrant)
 	if err != nil {
 		t.Fatal(err)
 	}
 	bcors := s3Types.CORSRule{}
-	err = faker.FakeData(&bcors)
+	err = faker.FakeObject(&bcors)
 	if err != nil {
 		t.Fatal(err)
 	}
 	bencryption := s3.GetBucketEncryptionOutput{}
-	err = faker.FakeData(&bencryption)
+	err = faker.FakeObject(&bencryption)
 	if err != nil {
 		t.Fatal(err)
 	}
 
 	bpba := s3.GetPublicAccessBlockOutput{}
-	err = faker.FakeData(&bpba)
+	err = faker.FakeObject(&bpba)
 	if err != nil {
 		t.Fatal(err)
 	}
 	btag := s3.GetBucketTaggingOutput{}
-	err = faker.FakeData(&btag)
+	err = faker.FakeObject(&btag)
 	if err != nil {
 		t.Fatal(err)
 	}
 	bownershipcontrols := s3.GetBucketOwnershipControlsOutput{}
-	err = faker.FakeData(&bownershipcontrols)
+	err = faker.FakeObject(&bownershipcontrols)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -103,11 +103,11 @@ func buildS3Buckets(t *testing.T, ctrl *gomock.Controller) client.Services {
 
 	// bucket replication struct has interfaces and faker doesn't work well with it so we will build it manually
 	sourceSelectionCriteria := s3Types.SourceSelectionCriteria{}
-	if err := faker.FakeData(&sourceSelectionCriteria); err != nil {
+	if err := faker.FakeObject(&sourceSelectionCriteria); err != nil {
 		t.Fatal(err)
 	}
 	replicationDest := s3Types.Destination{}
-	if err := faker.FakeData(&replicationDest); err != nil {
+	if err := faker.FakeObject(&replicationDest); err != nil {
 		t.Fatal(err)
 	}
 	m.EXPECT().GetBucketReplication(gomock.Any(), gomock.Any(), gomock.Any()).Return(

--- a/plugins/source/aws/resources/services/s3/buckets_mock_test.go
+++ b/plugins/source/aws/resources/services/s3/buckets_mock_test.go
@@ -1,16 +1,13 @@
 package s3
 
 import (
-	"math/rand"
 	"testing"
-	"time"
 
-	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/s3"
 	s3Types "github.com/aws/aws-sdk-go-v2/service/s3/types"
 	"github.com/cloudquery/cloudquery/plugins/source/aws/client"
 	"github.com/cloudquery/cloudquery/plugins/source/aws/client/mocks"
-	faker "github.com/cloudquery/faker/v3"
+	"github.com/cloudquery/plugin-sdk/faker"
 	"github.com/golang/mock/gomock"
 )
 
@@ -18,60 +15,60 @@ func buildS3Buckets(t *testing.T, ctrl *gomock.Controller) client.Services {
 	mgr := mocks.NewMockS3ManagerClient(ctrl)
 	m := mocks.NewMockS3Client(ctrl)
 	b := s3Types.Bucket{}
-	err := faker.FakeData(&b)
+	err := faker.FakeObject(&b)
 	if err != nil {
 		t.Fatal(err)
 	}
 	bloc := s3.GetBucketLocationOutput{}
-	err = faker.FakeData(&bloc)
+	err = faker.FakeObject(&bloc)
 	if err != nil {
 		t.Fatal(err)
 	}
 	blog := s3.GetBucketLoggingOutput{}
-	err = faker.FakeData(&blog)
+	err = faker.FakeObject(&blog)
 	if err != nil {
 		t.Fatal(err)
 	}
 	bpol := s3.GetBucketPolicyOutput{}
-	err = faker.FakeData(&bpol)
+	err = faker.FakeObject(&bpol)
 	if err != nil {
 		t.Fatal(err)
 	}
 	jsonDoc := `{"stuff": 3}`
 	bpol.Policy = &jsonDoc
 	bver := s3.GetBucketVersioningOutput{}
-	err = faker.FakeData(&bver)
+	err = faker.FakeObject(&bver)
 	if err != nil {
 		t.Fatal(err)
 	}
 	bgrant := s3Types.Grant{}
-	err = faker.FakeData(&bgrant)
+	err = faker.FakeObject(&bgrant)
 	if err != nil {
 		t.Fatal(err)
 	}
 	bcors := s3Types.CORSRule{}
-	err = faker.FakeData(&bcors)
+	err = faker.FakeObject(&bcors)
 	if err != nil {
 		t.Fatal(err)
 	}
 	bencryption := s3.GetBucketEncryptionOutput{}
-	err = faker.FakeData(&bencryption)
+	err = faker.FakeObject(&bencryption)
 	if err != nil {
 		t.Fatal(err)
 	}
 
 	bpba := s3.GetPublicAccessBlockOutput{}
-	err = faker.FakeData(&bpba)
+	err = faker.FakeObject(&bpba)
 	if err != nil {
 		t.Fatal(err)
 	}
 	btag := s3.GetBucketTaggingOutput{}
-	err = faker.FakeData(&btag)
+	err = faker.FakeObject(&btag)
 	if err != nil {
 		t.Fatal(err)
 	}
 	bownershipcontrols := s3.GetBucketOwnershipControlsOutput{}
-	err = faker.FakeData(&bownershipcontrols)
+	err = faker.FakeObject(&bownershipcontrols)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -101,50 +98,24 @@ func buildS3Buckets(t *testing.T, ctrl *gomock.Controller) client.Services {
 		&bpba, nil)
 	m.EXPECT().GetBucketOwnershipControls(gomock.Any(), gomock.Any(), gomock.Any()).Return(&bownershipcontrols, nil)
 
-	// bucket replication struct has interfaces and faker doesn't work well with it so we will build it manually
-	sourceSelectionCriteria := s3Types.SourceSelectionCriteria{}
-	if err := faker.FakeData(&sourceSelectionCriteria); err != nil {
+	ro := s3.GetBucketReplicationOutput{}
+	if err := faker.FakeObject(&ro); err != nil {
 		t.Fatal(err)
 	}
-	replicationDest := s3Types.Destination{}
-	if err := faker.FakeData(&replicationDest); err != nil {
-		t.Fatal(err)
-	}
-	m.EXPECT().GetBucketReplication(gomock.Any(), gomock.Any(), gomock.Any()).Return(
-		&s3.GetBucketReplicationOutput{
-			ReplicationConfiguration: &s3Types.ReplicationConfiguration{
-				Role: aws.String(faker.Name()),
-				Rules: []s3Types.ReplicationRule{{
-					Destination:               &replicationDest,
-					Status:                    s3Types.ReplicationRuleStatusDisabled,
-					DeleteMarkerReplication:   &s3Types.DeleteMarkerReplication{Status: s3Types.DeleteMarkerReplicationStatusEnabled},
-					ExistingObjectReplication: &s3Types.ExistingObjectReplication{Status: s3Types.ExistingObjectReplicationStatusEnabled},
-					Filter:                    &s3Types.ReplicationRuleFilterMemberPrefix{Value: "blabla"},
-					ID:                        aws.String(faker.Name()),
-					Prefix:                    aws.String(faker.Name()),
-					Priority:                  5,
-					SourceSelectionCriteria:   &sourceSelectionCriteria,
-				}},
-			}}, nil)
+
+	m.EXPECT().GetBucketReplication(gomock.Any(), gomock.Any(), gomock.Any()).Return(&ro, nil)
 	m.EXPECT().GetBucketTagging(gomock.Any(), gomock.Any(), gomock.Any()).Return(
 		&btag, nil)
-	randomTime, _ := time.Parse(time.RFC3339, faker.Timestamp())
-	m.EXPECT().GetBucketLifecycleConfiguration(gomock.Any(), gomock.Any(), gomock.Any()).Return(
-		&s3.GetBucketLifecycleConfigurationOutput{Rules: []s3Types.LifecycleRule{{
-			Status:                         s3Types.ExpirationStatusEnabled,
-			AbortIncompleteMultipartUpload: &s3Types.AbortIncompleteMultipartUpload{DaysAfterInitiation: rand.Int31()},
-			Expiration:                     &s3Types.LifecycleExpiration{Date: &randomTime, Days: 3, ExpiredObjectDeleteMarker: false},
-			Filter:                         &s3Types.LifecycleRuleFilterMemberPrefix{Value: "blabla"},
-			ID:                             aws.String(faker.Name()),
-			NoncurrentVersionExpiration:    &s3Types.NoncurrentVersionExpiration{NoncurrentDays: 33},
-			NoncurrentVersionTransitions:   []s3Types.NoncurrentVersionTransition{{NoncurrentDays: 5, StorageClass: s3Types.TransitionStorageClassDeepArchive}},
-			Prefix:                         aws.String(faker.Name()),
-			Transitions: []s3Types.Transition{{
-				Date:         &randomTime,
-				Days:         15,
-				StorageClass: s3Types.TransitionStorageClassOnezoneIa,
-			}},
-		}}}, nil)
+	tt := s3Types.Transition{}
+	if err := faker.FakeObject(&tt); err != nil {
+		t.Fatal(err)
+	}
+	glco := s3.GetBucketLifecycleConfigurationOutput{}
+	if err := faker.FakeObject(&glco); err != nil {
+		t.Fatal(err)
+	}
+
+	m.EXPECT().GetBucketLifecycleConfiguration(gomock.Any(), gomock.Any(), gomock.Any()).Return(&glco, nil)
 	mgr.EXPECT().GetBucketRegion(gomock.Any(), gomock.Any(), gomock.Any()).Return(
 		"us-east-1", nil)
 	return client.Services{

--- a/plugins/source/aws/resources/services/s3/buckets_mock_test.go
+++ b/plugins/source/aws/resources/services/s3/buckets_mock_test.go
@@ -10,7 +10,7 @@ import (
 	s3Types "github.com/aws/aws-sdk-go-v2/service/s3/types"
 	"github.com/cloudquery/cloudquery/plugins/source/aws/client"
 	"github.com/cloudquery/cloudquery/plugins/source/aws/client/mocks"
-	"github.com/cloudquery/plugin-sdk/faker"
+	faker "github.com/cloudquery/faker/v3"
 	"github.com/golang/mock/gomock"
 )
 
@@ -18,60 +18,60 @@ func buildS3Buckets(t *testing.T, ctrl *gomock.Controller) client.Services {
 	mgr := mocks.NewMockS3ManagerClient(ctrl)
 	m := mocks.NewMockS3Client(ctrl)
 	b := s3Types.Bucket{}
-	err := faker.FakeObject(&b)
+	err := faker.FakeData(&b)
 	if err != nil {
 		t.Fatal(err)
 	}
 	bloc := s3.GetBucketLocationOutput{}
-	err = faker.FakeObject(&bloc)
+	err = faker.FakeData(&bloc)
 	if err != nil {
 		t.Fatal(err)
 	}
 	blog := s3.GetBucketLoggingOutput{}
-	err = faker.FakeObject(&blog)
+	err = faker.FakeData(&blog)
 	if err != nil {
 		t.Fatal(err)
 	}
 	bpol := s3.GetBucketPolicyOutput{}
-	err = faker.FakeObject(&bpol)
+	err = faker.FakeData(&bpol)
 	if err != nil {
 		t.Fatal(err)
 	}
 	jsonDoc := `{"stuff": 3}`
 	bpol.Policy = &jsonDoc
 	bver := s3.GetBucketVersioningOutput{}
-	err = faker.FakeObject(&bver)
+	err = faker.FakeData(&bver)
 	if err != nil {
 		t.Fatal(err)
 	}
 	bgrant := s3Types.Grant{}
-	err = faker.FakeObject(&bgrant)
+	err = faker.FakeData(&bgrant)
 	if err != nil {
 		t.Fatal(err)
 	}
 	bcors := s3Types.CORSRule{}
-	err = faker.FakeObject(&bcors)
+	err = faker.FakeData(&bcors)
 	if err != nil {
 		t.Fatal(err)
 	}
 	bencryption := s3.GetBucketEncryptionOutput{}
-	err = faker.FakeObject(&bencryption)
+	err = faker.FakeData(&bencryption)
 	if err != nil {
 		t.Fatal(err)
 	}
 
 	bpba := s3.GetPublicAccessBlockOutput{}
-	err = faker.FakeObject(&bpba)
+	err = faker.FakeData(&bpba)
 	if err != nil {
 		t.Fatal(err)
 	}
 	btag := s3.GetBucketTaggingOutput{}
-	err = faker.FakeObject(&btag)
+	err = faker.FakeData(&btag)
 	if err != nil {
 		t.Fatal(err)
 	}
 	bownershipcontrols := s3.GetBucketOwnershipControlsOutput{}
-	err = faker.FakeObject(&bownershipcontrols)
+	err = faker.FakeData(&bownershipcontrols)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -103,11 +103,11 @@ func buildS3Buckets(t *testing.T, ctrl *gomock.Controller) client.Services {
 
 	// bucket replication struct has interfaces and faker doesn't work well with it so we will build it manually
 	sourceSelectionCriteria := s3Types.SourceSelectionCriteria{}
-	if err := faker.FakeObject(&sourceSelectionCriteria); err != nil {
+	if err := faker.FakeData(&sourceSelectionCriteria); err != nil {
 		t.Fatal(err)
 	}
 	replicationDest := s3Types.Destination{}
-	if err := faker.FakeObject(&replicationDest); err != nil {
+	if err := faker.FakeData(&replicationDest); err != nil {
 		t.Fatal(err)
 	}
 	m.EXPECT().GetBucketReplication(gomock.Any(), gomock.Any(), gomock.Any()).Return(

--- a/plugins/source/aws/resources/services/sagemaker/endpoint_configurations_mock_test.go
+++ b/plugins/source/aws/resources/services/sagemaker/endpoint_configurations_mock_test.go
@@ -7,7 +7,7 @@ import (
 	types "github.com/aws/aws-sdk-go-v2/service/sagemaker/types"
 	"github.com/cloudquery/cloudquery/plugins/source/aws/client"
 	"github.com/cloudquery/cloudquery/plugins/source/aws/client/mocks"
-	"github.com/cloudquery/faker/v3"
+	"github.com/cloudquery/plugin-sdk/faker"
 	"github.com/golang/mock/gomock"
 )
 
@@ -15,7 +15,7 @@ func buildSageMakerEndpointConfigs(t *testing.T, ctrl *gomock.Controller) client
 	m := mocks.NewMockSageMakerClient(ctrl)
 
 	summ := types.EndpointConfigSummary{}
-	if err := faker.FakeData(&summ); err != nil {
+	if err := faker.FakeObject(&summ); err != nil {
 		t.Fatal(err)
 	}
 
@@ -25,7 +25,7 @@ func buildSageMakerEndpointConfigs(t *testing.T, ctrl *gomock.Controller) client
 	)
 
 	endpointConfig := sagemaker.DescribeEndpointConfigOutput{}
-	if err := faker.FakeData(&endpointConfig); err != nil {
+	if err := faker.FakeObject(&endpointConfig); err != nil {
 		t.Fatal(err)
 	}
 
@@ -35,7 +35,7 @@ func buildSageMakerEndpointConfigs(t *testing.T, ctrl *gomock.Controller) client
 	)
 
 	var tagsOut sagemaker.ListTagsOutput
-	if err := faker.FakeData(&tagsOut); err != nil {
+	if err := faker.FakeObject(&tagsOut); err != nil {
 		t.Fatal(err)
 	}
 	m.EXPECT().ListTags(gomock.Any(), gomock.Any(), gomock.Any()).Return(

--- a/plugins/source/aws/resources/services/sagemaker/models_mock_test.go
+++ b/plugins/source/aws/resources/services/sagemaker/models_mock_test.go
@@ -7,7 +7,7 @@ import (
 	types "github.com/aws/aws-sdk-go-v2/service/sagemaker/types"
 	"github.com/cloudquery/cloudquery/plugins/source/aws/client"
 	"github.com/cloudquery/cloudquery/plugins/source/aws/client/mocks"
-	"github.com/cloudquery/faker/v3"
+	"github.com/cloudquery/plugin-sdk/faker"
 	"github.com/golang/mock/gomock"
 )
 
@@ -15,7 +15,7 @@ func buildSageMakerModels(t *testing.T, ctrl *gomock.Controller) client.Services
 	m := mocks.NewMockSageMakerClient(ctrl)
 
 	summ := types.ModelSummary{}
-	if err := faker.FakeData(&summ); err != nil {
+	if err := faker.FakeObject(&summ); err != nil {
 		t.Fatal(err)
 	}
 
@@ -25,7 +25,7 @@ func buildSageMakerModels(t *testing.T, ctrl *gomock.Controller) client.Services
 	)
 
 	model := sagemaker.DescribeModelOutput{}
-	if err := faker.FakeData(&model); err != nil {
+	if err := faker.FakeObject(&model); err != nil {
 		t.Fatal(err)
 	}
 
@@ -35,7 +35,7 @@ func buildSageMakerModels(t *testing.T, ctrl *gomock.Controller) client.Services
 	)
 
 	var tagsOut sagemaker.ListTagsOutput
-	if err := faker.FakeData(&tagsOut); err != nil {
+	if err := faker.FakeObject(&tagsOut); err != nil {
 		t.Fatal(err)
 	}
 	m.EXPECT().ListTags(gomock.Any(), gomock.Any(), gomock.Any()).Return(

--- a/plugins/source/aws/resources/services/sagemaker/notebook_instances_mock_test.go
+++ b/plugins/source/aws/resources/services/sagemaker/notebook_instances_mock_test.go
@@ -7,7 +7,7 @@ import (
 	types "github.com/aws/aws-sdk-go-v2/service/sagemaker/types"
 	"github.com/cloudquery/cloudquery/plugins/source/aws/client"
 	"github.com/cloudquery/cloudquery/plugins/source/aws/client/mocks"
-	"github.com/cloudquery/faker/v3"
+	"github.com/cloudquery/plugin-sdk/faker"
 	"github.com/golang/mock/gomock"
 )
 
@@ -15,7 +15,7 @@ func buildSageMakerNotebookInstances(t *testing.T, ctrl *gomock.Controller) clie
 	m := mocks.NewMockSageMakerClient(ctrl)
 
 	summ := types.NotebookInstanceSummary{}
-	if err := faker.FakeData(&summ); err != nil {
+	if err := faker.FakeObject(&summ); err != nil {
 		t.Fatal(err)
 	}
 
@@ -25,7 +25,7 @@ func buildSageMakerNotebookInstances(t *testing.T, ctrl *gomock.Controller) clie
 	)
 
 	note := sagemaker.DescribeNotebookInstanceOutput{}
-	if err := faker.FakeData(&note); err != nil {
+	if err := faker.FakeObject(&note); err != nil {
 		t.Fatal(err)
 	}
 
@@ -35,7 +35,7 @@ func buildSageMakerNotebookInstances(t *testing.T, ctrl *gomock.Controller) clie
 	)
 
 	var tagsOut sagemaker.ListTagsOutput
-	if err := faker.FakeData(&tagsOut); err != nil {
+	if err := faker.FakeObject(&tagsOut); err != nil {
 		t.Fatal(err)
 	}
 	m.EXPECT().ListTags(gomock.Any(), gomock.Any(), gomock.Any()).Return(

--- a/plugins/source/aws/resources/services/sagemaker/training_jobs_mock_test.go
+++ b/plugins/source/aws/resources/services/sagemaker/training_jobs_mock_test.go
@@ -7,7 +7,7 @@ import (
 	types "github.com/aws/aws-sdk-go-v2/service/sagemaker/types"
 	"github.com/cloudquery/cloudquery/plugins/source/aws/client"
 	"github.com/cloudquery/cloudquery/plugins/source/aws/client/mocks"
-	"github.com/cloudquery/faker/v3"
+	"github.com/cloudquery/plugin-sdk/faker"
 	"github.com/golang/mock/gomock"
 )
 
@@ -15,7 +15,7 @@ func buildSageMakerTrainingJobs(t *testing.T, ctrl *gomock.Controller) client.Se
 	m := mocks.NewMockSageMakerClient(ctrl)
 
 	summ := types.TrainingJobSummary{}
-	if err := faker.FakeData(&summ); err != nil {
+	if err := faker.FakeObject(&summ); err != nil {
 		t.Fatal(err)
 	}
 
@@ -25,7 +25,7 @@ func buildSageMakerTrainingJobs(t *testing.T, ctrl *gomock.Controller) client.Se
 	)
 
 	note := sagemaker.DescribeTrainingJobOutput{}
-	if err := faker.FakeData(&note); err != nil {
+	if err := faker.FakeObject(&note); err != nil {
 		t.Fatal(err)
 	}
 
@@ -35,7 +35,7 @@ func buildSageMakerTrainingJobs(t *testing.T, ctrl *gomock.Controller) client.Se
 	)
 
 	var tagsOut sagemaker.ListTagsOutput
-	if err := faker.FakeData(&tagsOut); err != nil {
+	if err := faker.FakeObject(&tagsOut); err != nil {
 		t.Fatal(err)
 	}
 	m.EXPECT().ListTags(gomock.Any(), gomock.Any(), gomock.Any()).Return(

--- a/plugins/source/aws/resources/services/secretsmanager/secrets_mock_test.go
+++ b/plugins/source/aws/resources/services/secretsmanager/secrets_mock_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/secretsmanager/types"
 	"github.com/cloudquery/cloudquery/plugins/source/aws/client"
 	"github.com/cloudquery/cloudquery/plugins/source/aws/client/mocks"
-	"github.com/cloudquery/faker/v3"
+	"github.com/cloudquery/plugin-sdk/faker"
 	"github.com/golang/mock/gomock"
 )
 
@@ -15,7 +15,7 @@ func buildSecretsmanagerModels(t *testing.T, ctrl *gomock.Controller) client.Ser
 	m := mocks.NewMockSecretsManagerClient(ctrl)
 
 	secret := types.SecretListEntry{}
-	if err := faker.FakeData(&secret); err != nil {
+	if err := faker.FakeObject(&secret); err != nil {
 		t.Fatal(err)
 	}
 
@@ -25,7 +25,7 @@ func buildSecretsmanagerModels(t *testing.T, ctrl *gomock.Controller) client.Ser
 	)
 
 	dsecret := secretsmanager.DescribeSecretOutput{}
-	if err := faker.FakeData(&dsecret); err != nil {
+	if err := faker.FakeObject(&dsecret); err != nil {
 		t.Fatal(err)
 	}
 
@@ -35,7 +35,7 @@ func buildSecretsmanagerModels(t *testing.T, ctrl *gomock.Controller) client.Ser
 	)
 
 	var policy secretsmanager.GetResourcePolicyOutput
-	if err := faker.FakeData(&policy); err != nil {
+	if err := faker.FakeObject(&policy); err != nil {
 		t.Fatal(err)
 	}
 	p := `{"key":"value"}`

--- a/plugins/source/aws/resources/services/ses/templates_mock_test.go
+++ b/plugins/source/aws/resources/services/ses/templates_mock_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/sesv2/types"
 	"github.com/cloudquery/cloudquery/plugins/source/aws/client"
 	"github.com/cloudquery/cloudquery/plugins/source/aws/client/mocks"
-	"github.com/cloudquery/faker/v3"
+	"github.com/cloudquery/plugin-sdk/faker"
 	"github.com/golang/mock/gomock"
 )
 
@@ -15,13 +15,13 @@ func buildSESTemplates(t *testing.T, ctrl *gomock.Controller) client.Services {
 	sesClient := mocks.NewMockSESClient(ctrl)
 
 	tplMeta := types.EmailTemplateMetadata{}
-	err := faker.FakeData(&tplMeta)
+	err := faker.FakeObject(&tplMeta)
 	if err != nil {
 		t.Fatal(err)
 	}
 
 	tpl := new(types.EmailTemplateContent)
-	err = faker.FakeData(tpl)
+	err = faker.FakeObject(tpl)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/plugins/source/aws/resources/services/shield/attacks_mock_test.go
+++ b/plugins/source/aws/resources/services/shield/attacks_mock_test.go
@@ -6,14 +6,14 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/shield"
 	"github.com/cloudquery/cloudquery/plugins/source/aws/client"
 	"github.com/cloudquery/cloudquery/plugins/source/aws/client/mocks"
-	"github.com/cloudquery/faker/v3"
+	"github.com/cloudquery/plugin-sdk/faker"
 	"github.com/golang/mock/gomock"
 )
 
 func buildAttacks(t *testing.T, ctrl *gomock.Controller) client.Services {
 	m := mocks.NewMockShieldClient(ctrl)
 	protection := shield.ListAttacksOutput{}
-	err := faker.FakeData(&protection)
+	err := faker.FakeObject(&protection)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -21,7 +21,7 @@ func buildAttacks(t *testing.T, ctrl *gomock.Controller) client.Services {
 	m.EXPECT().ListAttacks(gomock.Any(), gomock.Any(), gomock.Any()).Return(&protection, nil)
 
 	tags := shield.DescribeAttackOutput{}
-	err = faker.FakeData(&tags)
+	err = faker.FakeObject(&tags)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/plugins/source/aws/resources/services/shield/protection_groups_mock_test.go
+++ b/plugins/source/aws/resources/services/shield/protection_groups_mock_test.go
@@ -6,14 +6,14 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/shield"
 	"github.com/cloudquery/cloudquery/plugins/source/aws/client"
 	"github.com/cloudquery/cloudquery/plugins/source/aws/client/mocks"
-	"github.com/cloudquery/faker/v3"
+	"github.com/cloudquery/plugin-sdk/faker"
 	"github.com/golang/mock/gomock"
 )
 
 func buildProtectionGroups(t *testing.T, ctrl *gomock.Controller) client.Services {
 	m := mocks.NewMockShieldClient(ctrl)
 	pp := shield.ListProtectionGroupsOutput{}
-	err := faker.FakeData(&pp)
+	err := faker.FakeObject(&pp)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -21,7 +21,7 @@ func buildProtectionGroups(t *testing.T, ctrl *gomock.Controller) client.Service
 	m.EXPECT().ListProtectionGroups(gomock.Any(), gomock.Any(), gomock.Any()).Return(&pp, nil)
 
 	tags := shield.ListTagsForResourceOutput{}
-	err = faker.FakeData(&tags)
+	err = faker.FakeObject(&tags)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/plugins/source/aws/resources/services/shield/protections_mock_test.go
+++ b/plugins/source/aws/resources/services/shield/protections_mock_test.go
@@ -6,14 +6,14 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/shield"
 	"github.com/cloudquery/cloudquery/plugins/source/aws/client"
 	"github.com/cloudquery/cloudquery/plugins/source/aws/client/mocks"
-	"github.com/cloudquery/faker/v3"
+	"github.com/cloudquery/plugin-sdk/faker"
 	"github.com/golang/mock/gomock"
 )
 
 func buildProtections(t *testing.T, ctrl *gomock.Controller) client.Services {
 	m := mocks.NewMockShieldClient(ctrl)
 	protection := shield.ListProtectionsOutput{}
-	err := faker.FakeData(&protection)
+	err := faker.FakeObject(&protection)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -21,7 +21,7 @@ func buildProtections(t *testing.T, ctrl *gomock.Controller) client.Services {
 	m.EXPECT().ListProtections(gomock.Any(), gomock.Any(), gomock.Any()).Return(&protection, nil)
 
 	tags := shield.ListTagsForResourceOutput{}
-	err = faker.FakeData(&tags)
+	err = faker.FakeObject(&tags)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/plugins/source/aws/resources/services/shield/subscriptions_mock_test.go
+++ b/plugins/source/aws/resources/services/shield/subscriptions_mock_test.go
@@ -6,14 +6,14 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/shield"
 	"github.com/cloudquery/cloudquery/plugins/source/aws/client"
 	"github.com/cloudquery/cloudquery/plugins/source/aws/client/mocks"
-	"github.com/cloudquery/faker/v3"
+	"github.com/cloudquery/plugin-sdk/faker"
 	"github.com/golang/mock/gomock"
 )
 
 func buildSubscriptions(t *testing.T, ctrl *gomock.Controller) client.Services {
 	m := mocks.NewMockShieldClient(ctrl)
 	subscription := shield.DescribeSubscriptionOutput{}
-	err := faker.FakeData(&subscription)
+	err := faker.FakeObject(&subscription)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/plugins/source/aws/resources/services/sns/subscriptions_mock_test.go
+++ b/plugins/source/aws/resources/services/sns/subscriptions_mock_test.go
@@ -1,27 +1,28 @@
 package sns
 
 import (
-	"github.com/aws/aws-sdk-go-v2/aws"
 	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
 
 	"github.com/aws/aws-sdk-go-v2/service/sns"
 	"github.com/aws/aws-sdk-go-v2/service/sns/types"
 	"github.com/cloudquery/cloudquery/plugins/source/aws/client"
 	"github.com/cloudquery/cloudquery/plugins/source/aws/client/mocks"
-	"github.com/cloudquery/faker/v3"
+	"github.com/cloudquery/plugin-sdk/faker"
 	"github.com/golang/mock/gomock"
 )
 
 func buildSnsSubscriptions(t *testing.T, ctrl *gomock.Controller) client.Services {
 	m := mocks.NewMockSnsClient(ctrl)
 	sub := types.Subscription{}
-	err := faker.FakeData(&sub)
+	err := faker.FakeObject(&sub)
 	if err != nil {
 		t.Fatal(err)
 	}
 
 	subTemp := types.Subscription{}
-	err = faker.FakeData(&subTemp)
+	err = faker.FakeObject(&subTemp)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/plugins/source/aws/resources/services/sns/topics_mock_test.go
+++ b/plugins/source/aws/resources/services/sns/topics_mock_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/sns/types"
 	"github.com/cloudquery/cloudquery/plugins/source/aws/client"
 	"github.com/cloudquery/cloudquery/plugins/source/aws/client/mocks"
-	"github.com/cloudquery/faker/v3"
+	"github.com/cloudquery/plugin-sdk/faker"
 	"github.com/golang/mock/gomock"
 )
 
@@ -15,11 +15,11 @@ func buildSnsTopics(t *testing.T, ctrl *gomock.Controller) client.Services {
 	m := mocks.NewMockSnsClient(ctrl)
 	topic := types.Topic{}
 	tag := types.Tag{}
-	err := faker.FakeData(&topic)
+	err := faker.FakeObject(&topic)
 	if err != nil {
 		t.Fatal(err)
 	}
-	tagerr := faker.FakeData(&tag)
+	tagerr := faker.FakeObject(&tag)
 	if tagerr != nil {
 		t.Fatal(tagerr)
 	}

--- a/plugins/source/aws/resources/services/ssm/documents_mock_test.go
+++ b/plugins/source/aws/resources/services/ssm/documents_mock_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/ssm/types"
 	"github.com/cloudquery/cloudquery/plugins/source/aws/client"
 	"github.com/cloudquery/cloudquery/plugins/source/aws/client/mocks"
-	"github.com/cloudquery/faker/v3"
+	"github.com/cloudquery/plugin-sdk/faker"
 	"github.com/golang/mock/gomock"
 )
 
@@ -26,7 +26,7 @@ func buildSSMDocuments(t *testing.T, ctrl *gomock.Controller) client.Services {
 	)
 
 	var d types.DocumentDescription
-	if err := faker.FakeData(&d); err != nil {
+	if err := faker.FakeObject(&d); err != nil {
 		t.Fatal(err)
 	}
 	d.Name = &docName

--- a/plugins/source/aws/resources/services/ssm/instances_mock_test.go
+++ b/plugins/source/aws/resources/services/ssm/instances_mock_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/ssm/types"
 	"github.com/cloudquery/cloudquery/plugins/source/aws/client"
 	"github.com/cloudquery/cloudquery/plugins/source/aws/client/mocks"
-	"github.com/cloudquery/faker/v3"
+	"github.com/cloudquery/plugin-sdk/faker"
 	"github.com/golang/mock/gomock"
 )
 
@@ -16,7 +16,7 @@ func buildSSMInstances(t *testing.T, ctrl *gomock.Controller) client.Services {
 	mock := mocks.NewMockSSMClient(ctrl)
 
 	var i types.InstanceInformation
-	if err := faker.FakeData(&i); err != nil {
+	if err := faker.FakeObject(&i); err != nil {
 		t.Fatal(err)
 	}
 	i.IPAddress = aws.String("192.168.1.1")
@@ -30,7 +30,7 @@ func buildSSMInstances(t *testing.T, ctrl *gomock.Controller) client.Services {
 	)
 
 	var c types.ComplianceItem
-	if err := faker.FakeData(&c); err != nil {
+	if err := faker.FakeObject(&c); err != nil {
 		t.Fatal(err)
 	}
 	mock.EXPECT().ListComplianceItems(gomock.Any(),

--- a/plugins/source/aws/resources/services/ssm/parameters_mock_test.go
+++ b/plugins/source/aws/resources/services/ssm/parameters_mock_test.go
@@ -7,14 +7,14 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/ssm/types"
 	"github.com/cloudquery/cloudquery/plugins/source/aws/client"
 	"github.com/cloudquery/cloudquery/plugins/source/aws/client/mocks"
-	"github.com/cloudquery/faker/v3"
+	"github.com/cloudquery/plugin-sdk/faker"
 	"github.com/golang/mock/gomock"
 )
 
 func buildParameters(t *testing.T, ctrl *gomock.Controller) client.Services {
 	mock := mocks.NewMockSSMClient(ctrl)
 	var pm types.ParameterMetadata
-	if err := faker.FakeData(&pm); err != nil {
+	if err := faker.FakeObject(&pm); err != nil {
 		t.Fatal(err)
 	}
 	mock.EXPECT().DescribeParameters(

--- a/plugins/source/aws/resources/services/transfer/servers_test.go
+++ b/plugins/source/aws/resources/services/transfer/servers_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/transfer/types"
 	"github.com/cloudquery/cloudquery/plugins/source/aws/client"
 	"github.com/cloudquery/cloudquery/plugins/source/aws/client/mocks"
-	"github.com/cloudquery/faker/v3"
+	"github.com/cloudquery/plugin-sdk/faker"
 	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/require"
 )
@@ -17,7 +17,7 @@ func buildServersMock(t *testing.T, ctrl *gomock.Controller) client.Services {
 	m := mocks.NewMockTransferClient(ctrl)
 
 	var ls types.ListedServer
-	require.NoError(t, faker.FakeData(&ls))
+	require.NoError(t, faker.FakeObject(&ls))
 	m.EXPECT().ListServers(
 		gomock.Any(),
 		&transfer.ListServersInput{MaxResults: aws.Int32(1000)},
@@ -27,7 +27,7 @@ func buildServersMock(t *testing.T, ctrl *gomock.Controller) client.Services {
 	)
 
 	var ds types.DescribedServer
-	require.NoError(t, faker.FakeData(&ds))
+	require.NoError(t, faker.FakeObject(&ds))
 	ds.ServerId = ls.ServerId
 	ds.Arn = ls.Arn
 	m.EXPECT().DescribeServer(

--- a/plugins/source/aws/resources/services/waf/rule_groups_mock_test.go
+++ b/plugins/source/aws/resources/services/waf/rule_groups_mock_test.go
@@ -7,26 +7,26 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/waf/types"
 	"github.com/cloudquery/cloudquery/plugins/source/aws/client"
 	"github.com/cloudquery/cloudquery/plugins/source/aws/client/mocks"
-	"github.com/cloudquery/faker/v3"
+	"github.com/cloudquery/plugin-sdk/faker"
 	"github.com/golang/mock/gomock"
 )
 
 func buildWAFRuleGroupsMock(t *testing.T, ctrl *gomock.Controller) client.Services {
 	m := mocks.NewMockWafClient(ctrl)
 	tempRuleGroupSum := types.RuleGroupSummary{}
-	if err := faker.FakeData(&tempRuleGroupSum); err != nil {
+	if err := faker.FakeObject(&tempRuleGroupSum); err != nil {
 		t.Fatal(err)
 	}
 	tempRuleGroup := types.RuleGroup{}
-	if err := faker.FakeData(&tempRuleGroup); err != nil {
+	if err := faker.FakeObject(&tempRuleGroup); err != nil {
 		t.Fatal(err)
 	}
 	tempRule := types.ActivatedRule{}
-	if err := faker.FakeData(&tempRule); err != nil {
+	if err := faker.FakeObject(&tempRule); err != nil {
 		t.Fatal(err)
 	}
 	var tempTags []types.Tag
-	if err := faker.FakeData(&tempTags); err != nil {
+	if err := faker.FakeObject(&tempTags); err != nil {
 		t.Fatal(err)
 	}
 	m.EXPECT().ListRuleGroups(gomock.Any(), gomock.Any(), gomock.Any()).Return(&waf.ListRuleGroupsOutput{

--- a/plugins/source/aws/resources/services/waf/rules_mock_test.go
+++ b/plugins/source/aws/resources/services/waf/rules_mock_test.go
@@ -7,22 +7,22 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/waf/types"
 	"github.com/cloudquery/cloudquery/plugins/source/aws/client"
 	"github.com/cloudquery/cloudquery/plugins/source/aws/client/mocks"
-	"github.com/cloudquery/faker/v3"
+	"github.com/cloudquery/plugin-sdk/faker"
 	"github.com/golang/mock/gomock"
 )
 
 func buildWAFRulesMock(t *testing.T, ctrl *gomock.Controller) client.Services {
 	m := mocks.NewMockWafClient(ctrl)
 	tempRuleSum := types.RuleSummary{}
-	if err := faker.FakeData(&tempRuleSum); err != nil {
+	if err := faker.FakeObject(&tempRuleSum); err != nil {
 		t.Fatal(err)
 	}
 	tempRule := types.Rule{}
-	if err := faker.FakeData(&tempRule); err != nil {
+	if err := faker.FakeObject(&tempRule); err != nil {
 		t.Fatal(err)
 	}
 	var tempTags []types.Tag
-	if err := faker.FakeData(&tempTags); err != nil {
+	if err := faker.FakeObject(&tempTags); err != nil {
 		t.Fatal(err)
 	}
 	m.EXPECT().ListRules(gomock.Any(), gomock.Any(), gomock.Any()).Return(&waf.ListRulesOutput{

--- a/plugins/source/aws/resources/services/waf/subscribed_rule_groups_mock_test.go
+++ b/plugins/source/aws/resources/services/waf/subscribed_rule_groups_mock_test.go
@@ -7,14 +7,14 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/waf/types"
 	"github.com/cloudquery/cloudquery/plugins/source/aws/client"
 	"github.com/cloudquery/cloudquery/plugins/source/aws/client/mocks"
-	"github.com/cloudquery/faker/v3"
+	"github.com/cloudquery/plugin-sdk/faker"
 	"github.com/golang/mock/gomock"
 )
 
 func buildWAFSubscribedRuleGroupsMock(t *testing.T, ctrl *gomock.Controller) client.Services {
 	m := mocks.NewMockWafClient(ctrl)
 	tempSubscrRuleGroupSum := types.SubscribedRuleGroupSummary{}
-	if err := faker.FakeData(&tempSubscrRuleGroupSum); err != nil {
+	if err := faker.FakeObject(&tempSubscrRuleGroupSum); err != nil {
 		t.Fatal(err)
 	}
 	m.EXPECT().ListSubscribedRuleGroups(gomock.Any(), gomock.Any(), gomock.Any()).Return(&waf.ListSubscribedRuleGroupsOutput{

--- a/plugins/source/aws/resources/services/waf/web_acls_mock_test.go
+++ b/plugins/source/aws/resources/services/waf/web_acls_mock_test.go
@@ -7,26 +7,26 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/waf/types"
 	"github.com/cloudquery/cloudquery/plugins/source/aws/client"
 	"github.com/cloudquery/cloudquery/plugins/source/aws/client/mocks"
-	"github.com/cloudquery/faker/v3"
+	"github.com/cloudquery/plugin-sdk/faker"
 	"github.com/golang/mock/gomock"
 )
 
 func buildWAFWebACLMock(t *testing.T, ctrl *gomock.Controller) client.Services {
 	m := mocks.NewMockWafClient(ctrl)
 	tempWebACLSum := types.WebACLSummary{}
-	if err := faker.FakeData(&tempWebACLSum); err != nil {
+	if err := faker.FakeObject(&tempWebACLSum); err != nil {
 		t.Fatal(err)
 	}
 	tempWebACL := types.WebACL{}
-	if err := faker.FakeData(&tempWebACL); err != nil {
+	if err := faker.FakeObject(&tempWebACL); err != nil {
 		t.Fatal(err)
 	}
 	var tempTags []types.Tag
-	if err := faker.FakeData(&tempTags); err != nil {
+	if err := faker.FakeObject(&tempTags); err != nil {
 		t.Fatal(err)
 	}
 	var loggingConfiguration types.LoggingConfiguration
-	if err := faker.FakeData(&loggingConfiguration); err != nil {
+	if err := faker.FakeObject(&loggingConfiguration); err != nil {
 		t.Fatal(err)
 	}
 	m.EXPECT().ListWebACLs(gomock.Any(), gomock.Any(), gomock.Any()).Return(&waf.ListWebACLsOutput{

--- a/plugins/source/aws/resources/services/wafregional/rate_based_rules_mock_test.go
+++ b/plugins/source/aws/resources/services/wafregional/rate_based_rules_mock_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/wafregional/types"
 	"github.com/cloudquery/cloudquery/plugins/source/aws/client"
 	"github.com/cloudquery/cloudquery/plugins/source/aws/client/mocks"
-	"github.com/cloudquery/faker/v3"
+	"github.com/cloudquery/plugin-sdk/faker"
 	"github.com/golang/mock/gomock"
 )
 
@@ -17,7 +17,7 @@ func buildRateBasedRulesMock(t *testing.T, ctrl *gomock.Controller) client.Servi
 	m := mocks.NewMockWafRegionalClient(ctrl)
 
 	var rule types.RateBasedRule
-	if err := faker.FakeData(&rule); err != nil {
+	if err := faker.FakeObject(&rule); err != nil {
 		t.Fatal(err)
 	}
 	m.EXPECT().ListRateBasedRules(

--- a/plugins/source/aws/resources/services/wafregional/rule_groups_mock_test.go
+++ b/plugins/source/aws/resources/services/wafregional/rule_groups_mock_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/wafregional/types"
 	"github.com/cloudquery/cloudquery/plugins/source/aws/client"
 	"github.com/cloudquery/cloudquery/plugins/source/aws/client/mocks"
-	"github.com/cloudquery/faker/v3"
+	"github.com/cloudquery/plugin-sdk/faker"
 	"github.com/golang/mock/gomock"
 )
 
@@ -17,7 +17,7 @@ func buildRuleGroupsMock(t *testing.T, ctrl *gomock.Controller) client.Services 
 	m := mocks.NewMockWafRegionalClient(ctrl)
 
 	var g types.RuleGroup
-	if err := faker.FakeData(&g); err != nil {
+	if err := faker.FakeObject(&g); err != nil {
 		t.Fatal(err)
 	}
 	m.EXPECT().ListRuleGroups(

--- a/plugins/source/aws/resources/services/wafregional/rules_mock_test.go
+++ b/plugins/source/aws/resources/services/wafregional/rules_mock_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/wafregional/types"
 	"github.com/cloudquery/cloudquery/plugins/source/aws/client"
 	"github.com/cloudquery/cloudquery/plugins/source/aws/client/mocks"
-	"github.com/cloudquery/faker/v3"
+	"github.com/cloudquery/plugin-sdk/faker"
 	"github.com/golang/mock/gomock"
 )
 
@@ -17,7 +17,7 @@ func buildRulesMock(t *testing.T, ctrl *gomock.Controller) client.Services {
 	m := mocks.NewMockWafRegionalClient(ctrl)
 
 	var r types.Rule
-	if err := faker.FakeData(&r); err != nil {
+	if err := faker.FakeObject(&r); err != nil {
 		t.Fatal(err)
 	}
 	m.EXPECT().ListRules(

--- a/plugins/source/aws/resources/services/wafregional/web_acls_mock_test.go
+++ b/plugins/source/aws/resources/services/wafregional/web_acls_mock_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/wafregional/types"
 	"github.com/cloudquery/cloudquery/plugins/source/aws/client"
 	"github.com/cloudquery/cloudquery/plugins/source/aws/client/mocks"
-	"github.com/cloudquery/faker/v3"
+	"github.com/cloudquery/plugin-sdk/faker"
 	"github.com/golang/mock/gomock"
 )
 
@@ -15,7 +15,7 @@ func buildWebACLsMock(t *testing.T, ctrl *gomock.Controller) client.Services {
 	m := mocks.NewMockWafRegionalClient(ctrl)
 
 	var acl types.WebACL
-	if err := faker.FakeData(&acl); err != nil {
+	if err := faker.FakeObject(&acl); err != nil {
 		t.Fatal(err)
 	}
 	m.EXPECT().ListWebACLs(

--- a/plugins/source/aws/resources/services/wafv2/ipsets_mock_test.go
+++ b/plugins/source/aws/resources/services/wafv2/ipsets_mock_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/wafv2/types"
 	"github.com/cloudquery/cloudquery/plugins/source/aws/client"
 	"github.com/cloudquery/cloudquery/plugins/source/aws/client/mocks"
-	"github.com/cloudquery/faker/v3"
+	"github.com/cloudquery/plugin-sdk/faker"
 	"github.com/golang/mock/gomock"
 )
 
@@ -17,7 +17,7 @@ func buildIpsetsMock(t *testing.T, ctrl *gomock.Controller) client.Services {
 
 	for _, scope := range []types.Scope{types.ScopeCloudfront, types.ScopeRegional} {
 		var s types.IPSet
-		if err := faker.FakeData(&s); err != nil {
+		if err := faker.FakeObject(&s); err != nil {
 			t.Fatal(err)
 		}
 		s.Addresses = []string{"192.0.2.0/24", "2001:db8::/32"}

--- a/plugins/source/aws/resources/services/wafv2/managed_rule_groups_mock_test.go
+++ b/plugins/source/aws/resources/services/wafv2/managed_rule_groups_mock_test.go
@@ -7,19 +7,19 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/wafv2/types"
 	"github.com/cloudquery/cloudquery/plugins/source/aws/client"
 	"github.com/cloudquery/cloudquery/plugins/source/aws/client/mocks"
-	"github.com/cloudquery/faker/v3"
+	"github.com/cloudquery/plugin-sdk/faker"
 	"github.com/golang/mock/gomock"
 )
 
 func buildWAFV2ManagedRuleGroupsMock(t *testing.T, ctrl *gomock.Controller) client.Services {
 	m := mocks.NewMockWafV2Client(ctrl)
 	var tempDescribeManagedRuleGroup wafv2.DescribeManagedRuleGroupOutput
-	if err := faker.FakeData(&tempDescribeManagedRuleGroup); err != nil {
+	if err := faker.FakeObject(&tempDescribeManagedRuleGroup); err != nil {
 		t.Fatal(err)
 	}
 	for _, scope := range []types.Scope{types.ScopeCloudfront, types.ScopeRegional} {
 		tempManagedRuleGroupSum := types.ManagedRuleGroupSummary{}
-		if err := faker.FakeData(&tempManagedRuleGroupSum); err != nil {
+		if err := faker.FakeObject(&tempManagedRuleGroupSum); err != nil {
 			t.Fatal(err)
 		}
 		m.EXPECT().ListAvailableManagedRuleGroups(gomock.Any(), &wafv2.ListAvailableManagedRuleGroupsInput{

--- a/plugins/source/aws/resources/services/wafv2/regex_pattern_sets_mock_test.go
+++ b/plugins/source/aws/resources/services/wafv2/regex_pattern_sets_mock_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/wafv2/types"
 	"github.com/cloudquery/cloudquery/plugins/source/aws/client"
 	"github.com/cloudquery/cloudquery/plugins/source/aws/client/mocks"
-	"github.com/cloudquery/faker/v3"
+	"github.com/cloudquery/plugin-sdk/faker"
 	"github.com/golang/mock/gomock"
 )
 
@@ -17,7 +17,7 @@ func buildRegexPatternSetsMock(t *testing.T, ctrl *gomock.Controller) client.Ser
 
 	for _, scope := range []types.Scope{types.ScopeCloudfront, types.ScopeRegional} {
 		var s types.RegexPatternSet
-		if err := faker.FakeData(&s); err != nil {
+		if err := faker.FakeObject(&s); err != nil {
 			t.Fatal(err)
 		}
 		m.EXPECT().ListRegexPatternSets(

--- a/plugins/source/aws/resources/services/wafv2/rule_groups_mock_test.go
+++ b/plugins/source/aws/resources/services/wafv2/rule_groups_mock_test.go
@@ -9,34 +9,34 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/wafv2/types"
 	"github.com/cloudquery/cloudquery/plugins/source/aws/client"
 	"github.com/cloudquery/cloudquery/plugins/source/aws/client/mocks"
-	"github.com/cloudquery/plugin-sdk/faker"
+	faker "github.com/cloudquery/faker/v3"
 	"github.com/golang/mock/gomock"
 )
 
 func buildWAFV2RuleGroupsMock(t *testing.T, ctrl *gomock.Controller) client.Services {
 	m := mocks.NewMockWafV2Client(ctrl)
 	visibilityConfig := types.VisibilityConfig{}
-	if err := faker.FakeObject(&visibilityConfig); err != nil {
+	if err := faker.FakeData(&visibilityConfig); err != nil {
 		t.Fatal(err)
 	}
 	customRespBody := map[string]types.CustomResponseBody{}
-	if err := faker.FakeObject(&customRespBody); err != nil {
+	if err := faker.FakeData(&customRespBody); err != nil {
 		t.Fatal(err)
 	}
 	var labelSummaries []types.LabelSummary
-	if err := faker.FakeObject(&labelSummaries); err != nil {
+	if err := faker.FakeData(&labelSummaries); err != nil {
 		t.Fatal(err)
 	}
 	overrideAction := types.OverrideAction{}
-	if err := faker.FakeObject(&overrideAction); err != nil {
+	if err := faker.FakeData(&overrideAction); err != nil {
 		t.Fatal(err)
 	}
 	action := types.RuleAction{}
-	if err := faker.FakeObject(&action); err != nil {
+	if err := faker.FakeData(&action); err != nil {
 		t.Fatal(err)
 	}
 	var labels []types.Label
-	if err := faker.FakeObject(&labelSummaries); err != nil {
+	if err := faker.FakeData(&labelSummaries); err != nil {
 		t.Fatal(err)
 	}
 	rule := types.Rule{
@@ -49,17 +49,17 @@ func buildWAFV2RuleGroupsMock(t *testing.T, ctrl *gomock.Controller) client.Serv
 		RuleLabels:       labels,
 	}
 	var tempPolicyOutput wafv2.GetPermissionPolicyOutput
-	if err := faker.FakeObject(&tempPolicyOutput); err != nil {
+	if err := faker.FakeData(&tempPolicyOutput); err != nil {
 		t.Fatal(err)
 	}
 	tempPolicyOutput.Policy = aws.String(`{"test": 1}`)
 	var tempTags []types.Tag
-	if err := faker.FakeObject(&tempTags); err != nil {
+	if err := faker.FakeData(&tempTags); err != nil {
 		t.Fatal(err)
 	}
 	for _, scope := range []types.Scope{types.ScopeCloudfront, types.ScopeRegional} {
 		tempRuleGroupSum := types.RuleGroupSummary{}
-		if err := faker.FakeObject(&tempRuleGroupSum); err != nil {
+		if err := faker.FakeData(&tempRuleGroupSum); err != nil {
 			t.Fatal(err)
 		}
 		m.EXPECT().ListRuleGroups(gomock.Any(), &wafv2.ListRuleGroupsInput{Scope: scope}, gomock.Any()).Return(&wafv2.ListRuleGroupsOutput{

--- a/plugins/source/aws/resources/services/wafv2/rule_groups_mock_test.go
+++ b/plugins/source/aws/resources/services/wafv2/rule_groups_mock_test.go
@@ -9,34 +9,34 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/wafv2/types"
 	"github.com/cloudquery/cloudquery/plugins/source/aws/client"
 	"github.com/cloudquery/cloudquery/plugins/source/aws/client/mocks"
-	"github.com/cloudquery/faker/v3"
+	"github.com/cloudquery/plugin-sdk/faker"
 	"github.com/golang/mock/gomock"
 )
 
 func buildWAFV2RuleGroupsMock(t *testing.T, ctrl *gomock.Controller) client.Services {
 	m := mocks.NewMockWafV2Client(ctrl)
 	visibilityConfig := types.VisibilityConfig{}
-	if err := faker.FakeData(&visibilityConfig); err != nil {
+	if err := faker.FakeObject(&visibilityConfig); err != nil {
 		t.Fatal(err)
 	}
 	customRespBody := map[string]types.CustomResponseBody{}
-	if err := faker.FakeData(&customRespBody); err != nil {
+	if err := faker.FakeObject(&customRespBody); err != nil {
 		t.Fatal(err)
 	}
 	var labelSummaries []types.LabelSummary
-	if err := faker.FakeData(&labelSummaries); err != nil {
+	if err := faker.FakeObject(&labelSummaries); err != nil {
 		t.Fatal(err)
 	}
 	overrideAction := types.OverrideAction{}
-	if err := faker.FakeData(&overrideAction); err != nil {
+	if err := faker.FakeObject(&overrideAction); err != nil {
 		t.Fatal(err)
 	}
 	action := types.RuleAction{}
-	if err := faker.FakeData(&action); err != nil {
+	if err := faker.FakeObject(&action); err != nil {
 		t.Fatal(err)
 	}
 	var labels []types.Label
-	if err := faker.FakeData(&labelSummaries); err != nil {
+	if err := faker.FakeObject(&labelSummaries); err != nil {
 		t.Fatal(err)
 	}
 	rule := types.Rule{
@@ -49,17 +49,17 @@ func buildWAFV2RuleGroupsMock(t *testing.T, ctrl *gomock.Controller) client.Serv
 		RuleLabels:       labels,
 	}
 	var tempPolicyOutput wafv2.GetPermissionPolicyOutput
-	if err := faker.FakeData(&tempPolicyOutput); err != nil {
+	if err := faker.FakeObject(&tempPolicyOutput); err != nil {
 		t.Fatal(err)
 	}
 	tempPolicyOutput.Policy = aws.String(`{"test": 1}`)
 	var tempTags []types.Tag
-	if err := faker.FakeData(&tempTags); err != nil {
+	if err := faker.FakeObject(&tempTags); err != nil {
 		t.Fatal(err)
 	}
 	for _, scope := range []types.Scope{types.ScopeCloudfront, types.ScopeRegional} {
 		tempRuleGroupSum := types.RuleGroupSummary{}
-		if err := faker.FakeData(&tempRuleGroupSum); err != nil {
+		if err := faker.FakeObject(&tempRuleGroupSum); err != nil {
 			t.Fatal(err)
 		}
 		m.EXPECT().ListRuleGroups(gomock.Any(), &wafv2.ListRuleGroupsInput{Scope: scope}, gomock.Any()).Return(&wafv2.ListRuleGroupsOutput{

--- a/plugins/source/aws/resources/services/wafv2/rule_groups_mock_test.go
+++ b/plugins/source/aws/resources/services/wafv2/rule_groups_mock_test.go
@@ -1,7 +1,6 @@
 package wafv2
 
 import (
-	"math/rand"
 	"testing"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
@@ -9,74 +8,65 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/wafv2/types"
 	"github.com/cloudquery/cloudquery/plugins/source/aws/client"
 	"github.com/cloudquery/cloudquery/plugins/source/aws/client/mocks"
-	faker "github.com/cloudquery/faker/v3"
+	"github.com/cloudquery/plugin-sdk/faker"
 	"github.com/golang/mock/gomock"
 )
 
 func buildWAFV2RuleGroupsMock(t *testing.T, ctrl *gomock.Controller) client.Services {
 	m := mocks.NewMockWafV2Client(ctrl)
 	visibilityConfig := types.VisibilityConfig{}
-	if err := faker.FakeData(&visibilityConfig); err != nil {
+	if err := faker.FakeObject(&visibilityConfig); err != nil {
 		t.Fatal(err)
 	}
 	customRespBody := map[string]types.CustomResponseBody{}
-	if err := faker.FakeData(&customRespBody); err != nil {
+	if err := faker.FakeObject(&customRespBody); err != nil {
 		t.Fatal(err)
 	}
 	var labelSummaries []types.LabelSummary
-	if err := faker.FakeData(&labelSummaries); err != nil {
+	if err := faker.FakeObject(&labelSummaries); err != nil {
 		t.Fatal(err)
 	}
 	overrideAction := types.OverrideAction{}
-	if err := faker.FakeData(&overrideAction); err != nil {
+	if err := faker.FakeObject(&overrideAction); err != nil {
 		t.Fatal(err)
 	}
 	action := types.RuleAction{}
-	if err := faker.FakeData(&action); err != nil {
+	if err := faker.FakeObject(&action); err != nil {
 		t.Fatal(err)
 	}
 	var labels []types.Label
-	if err := faker.FakeData(&labelSummaries); err != nil {
+	if err := faker.FakeObject(&labelSummaries); err != nil {
 		t.Fatal(err)
 	}
-	rule := types.Rule{
-		Name:             aws.String(faker.Name()),
-		Priority:         rand.Int31(),
-		Statement:        &types.Statement{AndStatement: &types.AndStatement{}},
-		VisibilityConfig: &visibilityConfig,
-		Action:           &action,
-		OverrideAction:   &overrideAction,
-		RuleLabels:       labels,
+	rule := types.Rule{}
+	if err := faker.FakeObject(&rule); err != nil {
+		t.Fatal(err)
 	}
+	rule.VisibilityConfig = &visibilityConfig
+	rule.Action = &action
+	rule.OverrideAction = &overrideAction
+	rule.RuleLabels = labels
 	var tempPolicyOutput wafv2.GetPermissionPolicyOutput
-	if err := faker.FakeData(&tempPolicyOutput); err != nil {
+	if err := faker.FakeObject(&tempPolicyOutput); err != nil {
 		t.Fatal(err)
 	}
 	tempPolicyOutput.Policy = aws.String(`{"test": 1}`)
 	var tempTags []types.Tag
-	if err := faker.FakeData(&tempTags); err != nil {
+	if err := faker.FakeObject(&tempTags); err != nil {
 		t.Fatal(err)
 	}
 	for _, scope := range []types.Scope{types.ScopeCloudfront, types.ScopeRegional} {
 		tempRuleGroupSum := types.RuleGroupSummary{}
-		if err := faker.FakeData(&tempRuleGroupSum); err != nil {
+		if err := faker.FakeObject(&tempRuleGroupSum); err != nil {
 			t.Fatal(err)
 		}
 		m.EXPECT().ListRuleGroups(gomock.Any(), &wafv2.ListRuleGroupsInput{Scope: scope}, gomock.Any()).Return(&wafv2.ListRuleGroupsOutput{
 			RuleGroups: []types.RuleGroupSummary{tempRuleGroupSum},
 		}, nil)
-		tempRuleGroup := types.RuleGroup{
-			ARN:                  aws.String(faker.Word()),
-			Capacity:             faker.RandomUnixTime(),
-			Id:                   aws.String(faker.Word()),
-			Name:                 aws.String(faker.Word()),
-			VisibilityConfig:     &visibilityConfig,
-			AvailableLabels:      labelSummaries,
-			ConsumedLabels:       labelSummaries,
-			CustomResponseBodies: customRespBody,
-			Description:          aws.String(faker.Word()),
-			LabelNamespace:       aws.String(faker.Word()),
-			Rules:                []types.Rule{rule},
+
+		tempRuleGroup := types.RuleGroup{}
+		if err := faker.FakeObject(&tempRuleGroup); err != nil {
+			t.Fatal(err)
 		}
 		m.EXPECT().GetRuleGroup(gomock.Any(), gomock.Any(), gomock.Any()).Return(&wafv2.GetRuleGroupOutput{
 			RuleGroup: &tempRuleGroup,

--- a/plugins/source/aws/resources/services/wafv2/web_acls_mock_test.go
+++ b/plugins/source/aws/resources/services/wafv2/web_acls_mock_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/wafv2/types"
 	"github.com/cloudquery/cloudquery/plugins/source/aws/client"
 	"github.com/cloudquery/cloudquery/plugins/source/aws/client/mocks"
-	"github.com/cloudquery/plugin-sdk/faker"
+	faker "github.com/cloudquery/faker/v3"
 	"github.com/golang/mock/gomock"
 )
 
@@ -20,25 +20,25 @@ func buildWAFV2WebACLMock(t *testing.T, ctrl *gomock.Controller) client.Services
 	cfm := mocks.NewMockCloudfrontClient(ctrl)
 
 	tempWebACLSum := types.WebACLSummary{}
-	if err := faker.FakeObject(&tempWebACLSum); err != nil {
+	if err := faker.FakeData(&tempWebACLSum); err != nil {
 		t.Fatal(err)
 	}
 	// Faker can't handle recursive nested structs so we have to build some
 	// parts from scratch.
 	defaultAction := types.DefaultAction{}
-	if err := faker.FakeObject(&defaultAction); err != nil {
+	if err := faker.FakeData(&defaultAction); err != nil {
 		t.Fatal(err)
 	}
 	visibilityConfig := types.VisibilityConfig{}
-	if err := faker.FakeObject(&visibilityConfig); err != nil {
+	if err := faker.FakeData(&visibilityConfig); err != nil {
 		t.Fatal(err)
 	}
 	customRespBody := map[string]types.CustomResponseBody{}
-	if err := faker.FakeObject(&customRespBody); err != nil {
+	if err := faker.FakeData(&customRespBody); err != nil {
 		t.Fatal(err)
 	}
 	overrideAction := types.OverrideAction{}
-	if err := faker.FakeObject(&overrideAction); err != nil {
+	if err := faker.FakeData(&overrideAction); err != nil {
 		t.Fatal(err)
 	}
 	processRuleGroups := types.FirewallManagerRuleGroup{
@@ -49,23 +49,23 @@ func buildWAFV2WebACLMock(t *testing.T, ctrl *gomock.Controller) client.Services
 		VisibilityConfig:         &visibilityConfig,
 	}
 	action := types.RuleAction{}
-	if err := faker.FakeObject(&action); err != nil {
+	if err := faker.FakeData(&action); err != nil {
 		t.Fatal(err)
 	}
 	labels := make([]types.Label, 0)
-	if err := faker.FakeObject(&labels); err != nil {
+	if err := faker.FakeData(&labels); err != nil {
 		t.Fatal(err)
 	}
 	var tempResourceArns []string
-	if err := faker.FakeObject(&tempResourceArns); err != nil {
+	if err := faker.FakeData(&tempResourceArns); err != nil {
 		t.Fatal(err)
 	}
 	var tempTags []types.Tag
-	if err := faker.FakeObject(&tempTags); err != nil {
+	if err := faker.FakeData(&tempTags); err != nil {
 		t.Fatal(err)
 	}
 	var loggingConfiguration types.LoggingConfiguration
-	if err := faker.FakeObject(&loggingConfiguration); err != nil {
+	if err := faker.FakeData(&loggingConfiguration); err != nil {
 		t.Fatal(err)
 	}
 	rule := types.Rule{
@@ -122,7 +122,7 @@ func buildWAFV2WebACLMock(t *testing.T, ctrl *gomock.Controller) client.Services
 	}, nil)
 
 	distributionList := cftypes.DistributionList{}
-	if err := faker.FakeObject(&distributionList); err != nil {
+	if err := faker.FakeData(&distributionList); err != nil {
 		t.Fatal(err)
 	}
 	distributionList.NextMarker = nil

--- a/plugins/source/aws/resources/services/wafv2/web_acls_mock_test.go
+++ b/plugins/source/aws/resources/services/wafv2/web_acls_mock_test.go
@@ -1,7 +1,6 @@
 package wafv2
 
 import (
-	"math/rand"
 	"testing"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
@@ -11,7 +10,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/wafv2/types"
 	"github.com/cloudquery/cloudquery/plugins/source/aws/client"
 	"github.com/cloudquery/cloudquery/plugins/source/aws/client/mocks"
-	faker "github.com/cloudquery/faker/v3"
+	"github.com/cloudquery/plugin-sdk/faker"
 	"github.com/golang/mock/gomock"
 )
 
@@ -20,82 +19,30 @@ func buildWAFV2WebACLMock(t *testing.T, ctrl *gomock.Controller) client.Services
 	cfm := mocks.NewMockCloudfrontClient(ctrl)
 
 	tempWebACLSum := types.WebACLSummary{}
-	if err := faker.FakeData(&tempWebACLSum); err != nil {
-		t.Fatal(err)
-	}
-	// Faker can't handle recursive nested structs so we have to build some
-	// parts from scratch.
-	defaultAction := types.DefaultAction{}
-	if err := faker.FakeData(&defaultAction); err != nil {
-		t.Fatal(err)
-	}
-	visibilityConfig := types.VisibilityConfig{}
-	if err := faker.FakeData(&visibilityConfig); err != nil {
-		t.Fatal(err)
-	}
-	customRespBody := map[string]types.CustomResponseBody{}
-	if err := faker.FakeData(&customRespBody); err != nil {
-		t.Fatal(err)
-	}
-	overrideAction := types.OverrideAction{}
-	if err := faker.FakeData(&overrideAction); err != nil {
-		t.Fatal(err)
-	}
-	processRuleGroups := types.FirewallManagerRuleGroup{
-		FirewallManagerStatement: &types.FirewallManagerStatement{},
-		Name:                     aws.String(faker.Word()),
-		OverrideAction:           &overrideAction,
-		Priority:                 rand.Int31(),
-		VisibilityConfig:         &visibilityConfig,
-	}
-	action := types.RuleAction{}
-	if err := faker.FakeData(&action); err != nil {
-		t.Fatal(err)
-	}
-	labels := make([]types.Label, 0)
-	if err := faker.FakeData(&labels); err != nil {
+	if err := faker.FakeObject(&tempWebACLSum); err != nil {
 		t.Fatal(err)
 	}
 	var tempResourceArns []string
-	if err := faker.FakeData(&tempResourceArns); err != nil {
+	if err := faker.FakeObject(&tempResourceArns); err != nil {
 		t.Fatal(err)
 	}
 	var tempTags []types.Tag
-	if err := faker.FakeData(&tempTags); err != nil {
+	if err := faker.FakeObject(&tempTags); err != nil {
 		t.Fatal(err)
 	}
 	var loggingConfiguration types.LoggingConfiguration
-	if err := faker.FakeData(&loggingConfiguration); err != nil {
+	if err := faker.FakeObject(&loggingConfiguration); err != nil {
 		t.Fatal(err)
 	}
-	rule := types.Rule{
-		Name:             aws.String(faker.Name()),
-		Priority:         rand.Int31(),
-		Statement:        &types.Statement{AndStatement: &types.AndStatement{}},
-		VisibilityConfig: &visibilityConfig,
-		Action:           &action,
-		OverrideAction:   &overrideAction,
-		RuleLabels:       labels,
+	rule := types.Rule{}
+	if err := faker.FakeObject(&rule); err != nil {
+		t.Fatal(err)
 	}
+
 	for _, scope := range []types.Scope{types.ScopeCloudfront, types.ScopeRegional} {
-		immunityTime := int64(300)
-		tempWebACL := types.WebACL{
-			ARN:                                  aws.String(faker.UUIDHyphenated()),
-			DefaultAction:                        &defaultAction,
-			Id:                                   aws.String(faker.UUIDDigit()),
-			Name:                                 aws.String(faker.Word()),
-			VisibilityConfig:                     &visibilityConfig,
-			Capacity:                             rand.Int63(),
-			CustomResponseBodies:                 customRespBody,
-			Description:                          aws.String(faker.Word()),
-			LabelNamespace:                       aws.String(faker.Word()),
-			ManagedByFirewallManager:             true,
-			PostProcessFirewallManagerRuleGroups: []types.FirewallManagerRuleGroup{processRuleGroups},
-			PreProcessFirewallManagerRuleGroups:  []types.FirewallManagerRuleGroup{processRuleGroups},
-			Rules:                                []types.Rule{rule},
-			CaptchaConfig: &types.CaptchaConfig{ImmunityTimeProperty: &types.ImmunityTimeProperty{
-				ImmunityTime: &immunityTime,
-			}},
+		tempWebACL := types.WebACL{}
+		if err := faker.FakeObject(&tempWebACL); err != nil {
+			t.Fatal(err)
 		}
 		m.EXPECT().ListWebACLs(gomock.Any(), &wafv2.ListWebACLsInput{
 			Scope: scope,
@@ -122,7 +69,7 @@ func buildWAFV2WebACLMock(t *testing.T, ctrl *gomock.Controller) client.Services
 	}, nil)
 
 	distributionList := cftypes.DistributionList{}
-	if err := faker.FakeData(&distributionList); err != nil {
+	if err := faker.FakeObject(&distributionList); err != nil {
 		t.Fatal(err)
 	}
 	distributionList.NextMarker = nil

--- a/plugins/source/aws/resources/services/wafv2/web_acls_mock_test.go
+++ b/plugins/source/aws/resources/services/wafv2/web_acls_mock_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/wafv2/types"
 	"github.com/cloudquery/cloudquery/plugins/source/aws/client"
 	"github.com/cloudquery/cloudquery/plugins/source/aws/client/mocks"
-	"github.com/cloudquery/faker/v3"
+	"github.com/cloudquery/plugin-sdk/faker"
 	"github.com/golang/mock/gomock"
 )
 
@@ -20,25 +20,25 @@ func buildWAFV2WebACLMock(t *testing.T, ctrl *gomock.Controller) client.Services
 	cfm := mocks.NewMockCloudfrontClient(ctrl)
 
 	tempWebACLSum := types.WebACLSummary{}
-	if err := faker.FakeData(&tempWebACLSum); err != nil {
+	if err := faker.FakeObject(&tempWebACLSum); err != nil {
 		t.Fatal(err)
 	}
 	// Faker can't handle recursive nested structs so we have to build some
 	// parts from scratch.
 	defaultAction := types.DefaultAction{}
-	if err := faker.FakeData(&defaultAction); err != nil {
+	if err := faker.FakeObject(&defaultAction); err != nil {
 		t.Fatal(err)
 	}
 	visibilityConfig := types.VisibilityConfig{}
-	if err := faker.FakeData(&visibilityConfig); err != nil {
+	if err := faker.FakeObject(&visibilityConfig); err != nil {
 		t.Fatal(err)
 	}
 	customRespBody := map[string]types.CustomResponseBody{}
-	if err := faker.FakeData(&customRespBody); err != nil {
+	if err := faker.FakeObject(&customRespBody); err != nil {
 		t.Fatal(err)
 	}
 	overrideAction := types.OverrideAction{}
-	if err := faker.FakeData(&overrideAction); err != nil {
+	if err := faker.FakeObject(&overrideAction); err != nil {
 		t.Fatal(err)
 	}
 	processRuleGroups := types.FirewallManagerRuleGroup{
@@ -49,23 +49,23 @@ func buildWAFV2WebACLMock(t *testing.T, ctrl *gomock.Controller) client.Services
 		VisibilityConfig:         &visibilityConfig,
 	}
 	action := types.RuleAction{}
-	if err := faker.FakeData(&action); err != nil {
+	if err := faker.FakeObject(&action); err != nil {
 		t.Fatal(err)
 	}
 	labels := make([]types.Label, 0)
-	if err := faker.FakeData(&labels); err != nil {
+	if err := faker.FakeObject(&labels); err != nil {
 		t.Fatal(err)
 	}
 	var tempResourceArns []string
-	if err := faker.FakeData(&tempResourceArns); err != nil {
+	if err := faker.FakeObject(&tempResourceArns); err != nil {
 		t.Fatal(err)
 	}
 	var tempTags []types.Tag
-	if err := faker.FakeData(&tempTags); err != nil {
+	if err := faker.FakeObject(&tempTags); err != nil {
 		t.Fatal(err)
 	}
 	var loggingConfiguration types.LoggingConfiguration
-	if err := faker.FakeData(&loggingConfiguration); err != nil {
+	if err := faker.FakeObject(&loggingConfiguration); err != nil {
 		t.Fatal(err)
 	}
 	rule := types.Rule{
@@ -122,7 +122,7 @@ func buildWAFV2WebACLMock(t *testing.T, ctrl *gomock.Controller) client.Services
 	}, nil)
 
 	distributionList := cftypes.DistributionList{}
-	if err := faker.FakeData(&distributionList); err != nil {
+	if err := faker.FakeObject(&distributionList); err != nil {
 		t.Fatal(err)
 	}
 	distributionList.NextMarker = nil

--- a/plugins/source/aws/resources/services/workspaces/directories_mock_test.go
+++ b/plugins/source/aws/resources/services/workspaces/directories_mock_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/workspaces/types"
 	"github.com/cloudquery/cloudquery/plugins/source/aws/client"
 	"github.com/cloudquery/cloudquery/plugins/source/aws/client/mocks"
-	"github.com/cloudquery/faker/v3"
+	"github.com/cloudquery/plugin-sdk/faker"
 	"github.com/golang/mock/gomock"
 )
 
@@ -15,7 +15,7 @@ func buildDirectories(t *testing.T, ctrl *gomock.Controller) client.Services {
 	mock := mocks.NewMockWorkspacesClient(ctrl)
 
 	var directory types.WorkspaceDirectory
-	if err := faker.FakeData(&directory); err != nil {
+	if err := faker.FakeObject(&directory); err != nil {
 		t.Fatal(err)
 	}
 

--- a/plugins/source/aws/resources/services/workspaces/workspaces_mock_test.go
+++ b/plugins/source/aws/resources/services/workspaces/workspaces_mock_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/workspaces/types"
 	"github.com/cloudquery/cloudquery/plugins/source/aws/client"
 	"github.com/cloudquery/cloudquery/plugins/source/aws/client/mocks"
-	"github.com/cloudquery/faker/v3"
+	"github.com/cloudquery/plugin-sdk/faker"
 	"github.com/golang/mock/gomock"
 )
 
@@ -15,7 +15,7 @@ func buildWorkspaces(t *testing.T, ctrl *gomock.Controller) client.Services {
 	mock := mocks.NewMockWorkspacesClient(ctrl)
 
 	var workspace types.Workspace
-	if err := faker.FakeData(&workspace); err != nil {
+	if err := faker.FakeObject(&workspace); err != nil {
 		t.Fatal(err)
 	}
 

--- a/plugins/source/aws/resources/services/xray/encryption_config_mock_test.go
+++ b/plugins/source/aws/resources/services/xray/encryption_config_mock_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/xray/types"
 	"github.com/cloudquery/cloudquery/plugins/source/aws/client"
 	"github.com/cloudquery/cloudquery/plugins/source/aws/client/mocks"
-	"github.com/cloudquery/faker/v3"
+	"github.com/cloudquery/plugin-sdk/faker"
 	"github.com/golang/mock/gomock"
 )
 
@@ -15,7 +15,7 @@ func buildEncryptionConfig(t *testing.T, ctrl *gomock.Controller) client.Service
 	mock := mocks.NewMockXrayClient(ctrl)
 
 	var config types.EncryptionConfig
-	if err := faker.FakeData(&config); err != nil {
+	if err := faker.FakeObject(&config); err != nil {
 		t.Fatal(err)
 	}
 

--- a/plugins/source/aws/resources/services/xray/groups_mock_test.go
+++ b/plugins/source/aws/resources/services/xray/groups_mock_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/xray/types"
 	"github.com/cloudquery/cloudquery/plugins/source/aws/client"
 	"github.com/cloudquery/cloudquery/plugins/source/aws/client/mocks"
-	"github.com/cloudquery/faker/v3"
+	"github.com/cloudquery/plugin-sdk/faker"
 	"github.com/golang/mock/gomock"
 )
 
@@ -17,7 +17,7 @@ func buildGroups(t *testing.T, ctrl *gomock.Controller) client.Services {
 	test := "test"
 
 	var group types.GroupSummary
-	if err := faker.FakeData(&group); err != nil {
+	if err := faker.FakeObject(&group); err != nil {
 		t.Fatal(err)
 	}
 

--- a/plugins/source/aws/resources/services/xray/sampling_rules_mock_test.go
+++ b/plugins/source/aws/resources/services/xray/sampling_rules_mock_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/xray/types"
 	"github.com/cloudquery/cloudquery/plugins/source/aws/client"
 	"github.com/cloudquery/cloudquery/plugins/source/aws/client/mocks"
-	"github.com/cloudquery/faker/v3"
+	"github.com/cloudquery/plugin-sdk/faker"
 	"github.com/golang/mock/gomock"
 )
 
@@ -17,7 +17,7 @@ func buildSamplingRules(t *testing.T, ctrl *gomock.Controller) client.Services {
 	test := "test"
 
 	var rule types.SamplingRuleRecord
-	if err := faker.FakeData(&rule); err != nil {
+	if err := faker.FakeObject(&rule); err != nil {
 		t.Fatal(err)
 	}
 

--- a/plugins/source/azure/resources/services/subscriptions/locations_mock_test.go
+++ b/plugins/source/azure/resources/services/subscriptions/locations_mock_test.go
@@ -13,7 +13,6 @@ import (
 	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/require"
 
-	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resources/armsubscriptions"
 )
 

--- a/plugins/source/azure/resources/services/subscriptions/locations_mock_test.go
+++ b/plugins/source/azure/resources/services/subscriptions/locations_mock_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/require"
 
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resources/armsubscriptions"
 )
 

--- a/plugins/source/azure/resources/services/subscriptions/subscriptions_mock_test.go
+++ b/plugins/source/azure/resources/services/subscriptions/subscriptions_mock_test.go
@@ -13,7 +13,6 @@ import (
 	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/require"
 
-	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resources/armsubscriptions"
 )
 

--- a/plugins/source/azure/resources/services/subscriptions/subscriptions_mock_test.go
+++ b/plugins/source/azure/resources/services/subscriptions/subscriptions_mock_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/require"
 
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resources/armsubscriptions"
 )
 

--- a/plugins/source/azure/resources/services/subscriptions/tenants_mock_test.go
+++ b/plugins/source/azure/resources/services/subscriptions/tenants_mock_test.go
@@ -13,7 +13,6 @@ import (
 	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/require"
 
-	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resources/armsubscriptions"
 )
 

--- a/plugins/source/azure/resources/services/subscriptions/tenants_mock_test.go
+++ b/plugins/source/azure/resources/services/subscriptions/tenants_mock_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/require"
 
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resources/armsubscriptions"
 )
 

--- a/plugins/source/cloudflare/go.mod
+++ b/plugins/source/cloudflare/go.mod
@@ -4,7 +4,6 @@ go 1.19
 
 require (
 	github.com/cloudflare/cloudflare-go v0.46.0
-	github.com/cloudquery/faker/v3 v3.7.7
 	github.com/cloudquery/plugin-sdk v0.13.6
 	github.com/golang/mock v1.6.0
 	github.com/rs/zerolog v1.28.0
@@ -44,6 +43,7 @@ require (
 	github.com/charithe/durationcheck v0.0.9 // indirect
 	github.com/chavacava/garif v0.0.0-20220316182200-5cad0b5181d4 // indirect
 	github.com/client9/misspell v0.3.4 // indirect
+	github.com/cloudquery/faker/v3 v3.7.7 // indirect
 	github.com/daixiang0/gci v0.5.0 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/denis-tingaikin/go-header v0.4.3 // indirect

--- a/plugins/source/cloudflare/resources/services/access_groups/access_groups_mock_test.go
+++ b/plugins/source/cloudflare/resources/services/access_groups/access_groups_mock_test.go
@@ -6,19 +6,20 @@ import (
 	"github.com/cloudflare/cloudflare-go"
 	"github.com/cloudquery/cloudquery/plugins/source/cloudflare/client"
 	"github.com/cloudquery/cloudquery/plugins/source/cloudflare/client/mocks"
-	faker "github.com/cloudquery/faker/v3"
+	"github.com/cloudquery/plugin-sdk/faker"
 	"github.com/golang/mock/gomock"
 )
 
 func buildAccessGroups(t *testing.T, ctrl *gomock.Controller) client.Clients {
 	mock := mocks.NewMockApi(ctrl)
 
-	faker.SetIgnoreInterface(true)
-
 	var accessGroup cloudflare.AccessGroup
-	if err := faker.FakeData(&accessGroup); err != nil {
+	if err := faker.FakeObject(&accessGroup); err != nil {
 		t.Fatal(err)
 	}
+	accessGroup.Include = []interface{}{"a"}
+	accessGroup.Exclude = []interface{}{"b"}
+	accessGroup.Require = []interface{}{"c"}
 	mock.EXPECT().ZoneLevelAccessGroups(
 		gomock.Any(),
 		client.TestZoneID,

--- a/plugins/source/cloudflare/resources/services/access_groups/access_groups_mock_test.go
+++ b/plugins/source/cloudflare/resources/services/access_groups/access_groups_mock_test.go
@@ -6,7 +6,7 @@ import (
 	"github.com/cloudflare/cloudflare-go"
 	"github.com/cloudquery/cloudquery/plugins/source/cloudflare/client"
 	"github.com/cloudquery/cloudquery/plugins/source/cloudflare/client/mocks"
-	"github.com/cloudquery/faker/v3"
+	"github.com/cloudquery/plugin-sdk/faker"
 	"github.com/golang/mock/gomock"
 )
 
@@ -16,7 +16,7 @@ func buildAccessGroups(t *testing.T, ctrl *gomock.Controller) client.Clients {
 	faker.SetIgnoreInterface(true)
 
 	var accessGroup cloudflare.AccessGroup
-	if err := faker.FakeData(&accessGroup); err != nil {
+	if err := faker.FakeObject(&accessGroup); err != nil {
 		t.Fatal(err)
 	}
 	mock.EXPECT().ZoneLevelAccessGroups(

--- a/plugins/source/cloudflare/resources/services/access_groups/access_groups_mock_test.go
+++ b/plugins/source/cloudflare/resources/services/access_groups/access_groups_mock_test.go
@@ -6,7 +6,7 @@ import (
 	"github.com/cloudflare/cloudflare-go"
 	"github.com/cloudquery/cloudquery/plugins/source/cloudflare/client"
 	"github.com/cloudquery/cloudquery/plugins/source/cloudflare/client/mocks"
-	"github.com/cloudquery/plugin-sdk/faker"
+	faker "github.com/cloudquery/faker/v3"
 	"github.com/golang/mock/gomock"
 )
 
@@ -16,7 +16,7 @@ func buildAccessGroups(t *testing.T, ctrl *gomock.Controller) client.Clients {
 	faker.SetIgnoreInterface(true)
 
 	var accessGroup cloudflare.AccessGroup
-	if err := faker.FakeObject(&accessGroup); err != nil {
+	if err := faker.FakeData(&accessGroup); err != nil {
 		t.Fatal(err)
 	}
 	mock.EXPECT().ZoneLevelAccessGroups(

--- a/plugins/source/cloudflare/resources/services/accounts/accounts_mock_test.go
+++ b/plugins/source/cloudflare/resources/services/accounts/accounts_mock_test.go
@@ -6,7 +6,7 @@ import (
 	"github.com/cloudflare/cloudflare-go"
 	"github.com/cloudquery/cloudquery/plugins/source/cloudflare/client"
 	"github.com/cloudquery/cloudquery/plugins/source/cloudflare/client/mocks"
-	"github.com/cloudquery/faker/v3"
+	"github.com/cloudquery/plugin-sdk/faker"
 	"github.com/golang/mock/gomock"
 )
 
@@ -14,7 +14,7 @@ func buildAccounts(t *testing.T, ctrl *gomock.Controller) client.Clients {
 	mock := mocks.NewMockApi(ctrl)
 
 	var acc cloudflare.Account
-	if err := faker.FakeData(&acc); err != nil {
+	if err := faker.FakeObject(&acc); err != nil {
 		t.Fatal(err)
 	}
 	mock.EXPECT().Accounts(
@@ -30,7 +30,7 @@ func buildAccounts(t *testing.T, ctrl *gomock.Controller) client.Clients {
 	)
 
 	var accMem cloudflare.AccountMember
-	if err := faker.FakeData(&accMem); err != nil {
+	if err := faker.FakeObject(&accMem); err != nil {
 		t.Fatal(err)
 	}
 	mock.EXPECT().AccountMembers(

--- a/plugins/source/cloudflare/resources/services/certificate_packs/certificate_packs_mock_test.go
+++ b/plugins/source/cloudflare/resources/services/certificate_packs/certificate_packs_mock_test.go
@@ -6,7 +6,7 @@ import (
 	"github.com/cloudflare/cloudflare-go"
 	"github.com/cloudquery/cloudquery/plugins/source/cloudflare/client"
 	"github.com/cloudquery/cloudquery/plugins/source/cloudflare/client/mocks"
-	"github.com/cloudquery/faker/v3"
+	"github.com/cloudquery/plugin-sdk/faker"
 	"github.com/golang/mock/gomock"
 )
 
@@ -14,7 +14,7 @@ func buildCertificatePacks(t *testing.T, ctrl *gomock.Controller) client.Clients
 	mock := mocks.NewMockApi(ctrl)
 
 	var certPack cloudflare.CertificatePack
-	if err := faker.FakeData(&certPack); err != nil {
+	if err := faker.FakeObject(&certPack); err != nil {
 		t.Fatal(err)
 	}
 	mock.EXPECT().ListCertificatePacks(

--- a/plugins/source/cloudflare/resources/services/dns_records/dns_records_mock_test.go
+++ b/plugins/source/cloudflare/resources/services/dns_records/dns_records_mock_test.go
@@ -6,7 +6,7 @@ import (
 	"github.com/cloudflare/cloudflare-go"
 	"github.com/cloudquery/cloudquery/plugins/source/cloudflare/client"
 	"github.com/cloudquery/cloudquery/plugins/source/cloudflare/client/mocks"
-	"github.com/cloudquery/faker/v3"
+	"github.com/cloudquery/plugin-sdk/faker"
 	"github.com/golang/mock/gomock"
 )
 
@@ -14,8 +14,7 @@ func buildDNSRecords(t *testing.T, ctrl *gomock.Controller) client.Clients {
 	mock := mocks.NewMockApi(ctrl)
 
 	var record cloudflare.DNSRecord
-	skipFields := []string{"Meta", "Data"}
-	if err := faker.FakeDataSkipFields(&record, skipFields); err != nil {
+	if err := faker.FakeObject(&record); err != nil {
 		t.Fatal(err)
 	}
 

--- a/plugins/source/cloudflare/resources/services/images/images_mock_test.go
+++ b/plugins/source/cloudflare/resources/services/images/images_mock_test.go
@@ -6,7 +6,7 @@ import (
 	"github.com/cloudflare/cloudflare-go"
 	"github.com/cloudquery/cloudquery/plugins/source/cloudflare/client"
 	"github.com/cloudquery/cloudquery/plugins/source/cloudflare/client/mocks"
-	"github.com/cloudquery/faker/v3"
+	"github.com/cloudquery/plugin-sdk/faker"
 	"github.com/golang/mock/gomock"
 )
 
@@ -16,7 +16,7 @@ func buildImages(t *testing.T, ctrl *gomock.Controller) client.Clients {
 	faker.SetIgnoreInterface(true)
 
 	var image cloudflare.Image
-	if err := faker.FakeData(&image); err != nil {
+	if err := faker.FakeObject(&image); err != nil {
 		t.Fatal(err)
 	}
 	mock.EXPECT().ListImages(

--- a/plugins/source/cloudflare/resources/services/images/images_mock_test.go
+++ b/plugins/source/cloudflare/resources/services/images/images_mock_test.go
@@ -6,7 +6,7 @@ import (
 	"github.com/cloudflare/cloudflare-go"
 	"github.com/cloudquery/cloudquery/plugins/source/cloudflare/client"
 	"github.com/cloudquery/cloudquery/plugins/source/cloudflare/client/mocks"
-	"github.com/cloudquery/plugin-sdk/faker"
+	faker "github.com/cloudquery/faker/v3"
 	"github.com/golang/mock/gomock"
 )
 
@@ -16,7 +16,7 @@ func buildImages(t *testing.T, ctrl *gomock.Controller) client.Clients {
 	faker.SetIgnoreInterface(true)
 
 	var image cloudflare.Image
-	if err := faker.FakeObject(&image); err != nil {
+	if err := faker.FakeData(&image); err != nil {
 		t.Fatal(err)
 	}
 	mock.EXPECT().ListImages(

--- a/plugins/source/cloudflare/resources/services/images/images_mock_test.go
+++ b/plugins/source/cloudflare/resources/services/images/images_mock_test.go
@@ -6,19 +6,19 @@ import (
 	"github.com/cloudflare/cloudflare-go"
 	"github.com/cloudquery/cloudquery/plugins/source/cloudflare/client"
 	"github.com/cloudquery/cloudquery/plugins/source/cloudflare/client/mocks"
-	faker "github.com/cloudquery/faker/v3"
+	"github.com/cloudquery/plugin-sdk/faker"
 	"github.com/golang/mock/gomock"
 )
 
 func buildImages(t *testing.T, ctrl *gomock.Controller) client.Clients {
 	mock := mocks.NewMockApi(ctrl)
 
-	faker.SetIgnoreInterface(true)
-
 	var image cloudflare.Image
-	if err := faker.FakeData(&image); err != nil {
+	if err := faker.FakeObject(&image); err != nil {
 		t.Fatal(err)
 	}
+	image.Metadata = map[string]interface{}{"a": "b"}
+
 	mock.EXPECT().ListImages(
 		gomock.Any(),
 		client.TestAccountID,

--- a/plugins/source/cloudflare/resources/services/waf_overrides/waf_overrides_mock_test.go
+++ b/plugins/source/cloudflare/resources/services/waf_overrides/waf_overrides_mock_test.go
@@ -6,7 +6,7 @@ import (
 	"github.com/cloudflare/cloudflare-go"
 	"github.com/cloudquery/cloudquery/plugins/source/cloudflare/client"
 	"github.com/cloudquery/cloudquery/plugins/source/cloudflare/client/mocks"
-	"github.com/cloudquery/faker/v3"
+	"github.com/cloudquery/plugin-sdk/faker"
 	"github.com/golang/mock/gomock"
 )
 
@@ -14,7 +14,7 @@ func buildWAFOverrides(t *testing.T, ctrl *gomock.Controller) client.Clients {
 	mock := mocks.NewMockApi(ctrl)
 
 	var wafOverride cloudflare.WAFOverride
-	if err := faker.FakeData(&wafOverride); err != nil {
+	if err := faker.FakeObject(&wafOverride); err != nil {
 		t.Fatal(err)
 	}
 	mock.EXPECT().ListWAFOverrides(

--- a/plugins/source/cloudflare/resources/services/waf_packages/waf_packages_mock_test.go
+++ b/plugins/source/cloudflare/resources/services/waf_packages/waf_packages_mock_test.go
@@ -6,7 +6,7 @@ import (
 	"github.com/cloudflare/cloudflare-go"
 	"github.com/cloudquery/cloudquery/plugins/source/cloudflare/client"
 	"github.com/cloudquery/cloudquery/plugins/source/cloudflare/client/mocks"
-	"github.com/cloudquery/faker/v3"
+	"github.com/cloudquery/plugin-sdk/faker"
 	"github.com/golang/mock/gomock"
 )
 
@@ -14,7 +14,7 @@ func buildWAFPackages(t *testing.T, ctrl *gomock.Controller) client.Clients {
 	mock := mocks.NewMockApi(ctrl)
 
 	var wafPackage cloudflare.WAFPackage
-	if err := faker.FakeData(&wafPackage); err != nil {
+	if err := faker.FakeObject(&wafPackage); err != nil {
 		t.Fatal(err)
 	}
 	mock.EXPECT().ListWAFPackages(
@@ -26,7 +26,7 @@ func buildWAFPackages(t *testing.T, ctrl *gomock.Controller) client.Clients {
 	)
 
 	var wafGroup cloudflare.WAFGroup
-	if err := faker.FakeData(&wafGroup); err != nil {
+	if err := faker.FakeObject(&wafGroup); err != nil {
 		t.Fatal(err)
 	}
 	mock.EXPECT().ListWAFGroups(
@@ -39,8 +39,7 @@ func buildWAFPackages(t *testing.T, ctrl *gomock.Controller) client.Clients {
 	)
 
 	var wafRule cloudflare.WAFRule
-	skipFields := []string{"group"}
-	if err := faker.FakeDataSkipFields(&wafRule, skipFields); err != nil {
+	if err := faker.FakeObject(&wafRule); err != nil {
 		t.Fatal(err)
 	}
 

--- a/plugins/source/cloudflare/resources/services/worker_meta_data/workers_scripts_mock_test.go
+++ b/plugins/source/cloudflare/resources/services/worker_meta_data/workers_scripts_mock_test.go
@@ -6,7 +6,7 @@ import (
 	"github.com/cloudflare/cloudflare-go"
 	"github.com/cloudquery/cloudquery/plugins/source/cloudflare/client"
 	"github.com/cloudquery/cloudquery/plugins/source/cloudflare/client/mocks"
-	"github.com/cloudquery/faker/v3"
+	"github.com/cloudquery/plugin-sdk/faker"
 	"github.com/golang/mock/gomock"
 )
 
@@ -14,7 +14,7 @@ func buildWorkerMetaData(t *testing.T, ctrl *gomock.Controller) client.Clients {
 	mock := mocks.NewMockApi(ctrl)
 
 	var workerScript cloudflare.WorkerMetaData
-	if err := faker.FakeData(&workerScript); err != nil {
+	if err := faker.FakeObject(&workerScript); err != nil {
 		t.Fatal(err)
 	}
 	mock.EXPECT().ListWorkerScripts(
@@ -27,7 +27,7 @@ func buildWorkerMetaData(t *testing.T, ctrl *gomock.Controller) client.Clients {
 	)
 
 	var workerCronTrigger cloudflare.WorkerCronTrigger
-	if err := faker.FakeData(&workerCronTrigger); err != nil {
+	if err := faker.FakeObject(&workerCronTrigger); err != nil {
 		t.Fatal(err)
 	}
 	mock.EXPECT().ListWorkerCronTriggers(
@@ -40,7 +40,7 @@ func buildWorkerMetaData(t *testing.T, ctrl *gomock.Controller) client.Clients {
 	)
 
 	var workerSecret cloudflare.WorkersSecret
-	if err := faker.FakeData(&workerSecret); err != nil {
+	if err := faker.FakeObject(&workerSecret); err != nil {
 		t.Fatal(err)
 	}
 	mock.EXPECT().ListWorkersSecrets(

--- a/plugins/source/cloudflare/resources/services/worker_routes/worker_routes_mock_test.go
+++ b/plugins/source/cloudflare/resources/services/worker_routes/worker_routes_mock_test.go
@@ -6,7 +6,7 @@ import (
 	"github.com/cloudflare/cloudflare-go"
 	"github.com/cloudquery/cloudquery/plugins/source/cloudflare/client"
 	"github.com/cloudquery/cloudquery/plugins/source/cloudflare/client/mocks"
-	"github.com/cloudquery/faker/v3"
+	"github.com/cloudquery/plugin-sdk/faker"
 	"github.com/golang/mock/gomock"
 )
 
@@ -14,7 +14,7 @@ func buildWorkerRoutes(t *testing.T, ctrl *gomock.Controller) client.Clients {
 	mock := mocks.NewMockApi(ctrl)
 
 	var workerRoute cloudflare.WorkerRoute
-	if err := faker.FakeData(&workerRoute); err != nil {
+	if err := faker.FakeObject(&workerRoute); err != nil {
 		t.Fatal(err)
 	}
 	mock.EXPECT().ListWorkerRoutes(

--- a/plugins/source/cloudflare/resources/services/zones/zones_mock_test.go
+++ b/plugins/source/cloudflare/resources/services/zones/zones_mock_test.go
@@ -6,7 +6,7 @@ import (
 	"github.com/cloudflare/cloudflare-go"
 	"github.com/cloudquery/cloudquery/plugins/source/cloudflare/client"
 	"github.com/cloudquery/cloudquery/plugins/source/cloudflare/client/mocks"
-	"github.com/cloudquery/faker/v3"
+	"github.com/cloudquery/plugin-sdk/faker"
 	"github.com/golang/mock/gomock"
 )
 
@@ -14,7 +14,7 @@ func buildZones(t *testing.T, ctrl *gomock.Controller) client.Clients {
 	mock := mocks.NewMockApi(ctrl)
 
 	var zonesResp cloudflare.ZonesResponse
-	if err := faker.FakeData(&zonesResp); err != nil {
+	if err := faker.FakeObject(&zonesResp); err != nil {
 		t.Fatal(err)
 	}
 	mock.EXPECT().ListZonesContext(

--- a/plugins/source/digitalocean/go.mod
+++ b/plugins/source/digitalocean/go.mod
@@ -8,7 +8,6 @@ require (
 	github.com/aws/aws-sdk-go-v2/config v1.8.0
 	github.com/aws/aws-sdk-go-v2/service/s3 v1.27.1
 	github.com/aws/smithy-go v1.13.3
-	github.com/cloudquery/faker/v3 v3.7.7
 	github.com/cloudquery/plugin-sdk v0.13.6
 	github.com/digitalocean/godo v1.81.0
 	github.com/gertd/go-pluralize v0.2.1
@@ -32,6 +31,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/internal/s3shared v1.13.8 // indirect
 	github.com/aws/aws-sdk-go-v2/service/sso v1.4.0 // indirect
 	github.com/aws/aws-sdk-go-v2/service/sts v1.7.0 // indirect
+	github.com/cloudquery/faker/v3 v3.7.7 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/getsentry/sentry-go v0.13.0 // indirect
 	github.com/ghodss/yaml v1.0.0 // indirect

--- a/plugins/source/digitalocean/resources/services/accounts/accounts_mock_test.go
+++ b/plugins/source/digitalocean/resources/services/accounts/accounts_mock_test.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/cloudquery/cloudquery/plugins/source/digitalocean/client"
 	"github.com/cloudquery/cloudquery/plugins/source/digitalocean/client/mocks"
-	"github.com/cloudquery/faker/v3"
+	"github.com/cloudquery/plugin-sdk/faker"
 	"github.com/digitalocean/godo"
 	"github.com/golang/mock/gomock"
 )
@@ -14,7 +14,7 @@ func createAccount(t *testing.T, ctrl *gomock.Controller) client.Services {
 	m := mocks.NewMockAccountService(ctrl)
 
 	var data godo.Account
-	if err := faker.FakeData(&data); err != nil {
+	if err := faker.FakeObject(&data); err != nil {
 		t.Fatal(err)
 	}
 	m.EXPECT().Get(gomock.Any()).Return(&data, nil, nil)

--- a/plugins/source/digitalocean/resources/services/balances/balances_mock_test.go
+++ b/plugins/source/digitalocean/resources/services/balances/balances_mock_test.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/cloudquery/cloudquery/plugins/source/digitalocean/client"
 	"github.com/cloudquery/cloudquery/plugins/source/digitalocean/client/mocks"
-	"github.com/cloudquery/faker/v3"
+	"github.com/cloudquery/plugin-sdk/faker"
 	"github.com/digitalocean/godo"
 	"github.com/golang/mock/gomock"
 )
@@ -14,7 +14,7 @@ func createBalance(t *testing.T, ctrl *gomock.Controller) client.Services {
 	m := mocks.NewMockBalanceService(ctrl)
 
 	var data godo.Balance
-	if err := faker.FakeData(&data); err != nil {
+	if err := faker.FakeObject(&data); err != nil {
 		t.Fatal(err)
 	}
 	m.EXPECT().Get(gomock.Any()).Return(&data, nil, nil)

--- a/plugins/source/digitalocean/resources/services/billing_history/billing_history_mock_test.go
+++ b/plugins/source/digitalocean/resources/services/billing_history/billing_history_mock_test.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/cloudquery/cloudquery/plugins/source/digitalocean/client"
 	"github.com/cloudquery/cloudquery/plugins/source/digitalocean/client/mocks"
-	"github.com/cloudquery/faker/v3"
+	"github.com/cloudquery/plugin-sdk/faker"
 	"github.com/digitalocean/godo"
 	"github.com/golang/mock/gomock"
 )
@@ -14,7 +14,7 @@ func createBillingHistory(t *testing.T, ctrl *gomock.Controller) client.Services
 	m := mocks.NewMockBillingHistoryService(ctrl)
 
 	data := &godo.BillingHistory{}
-	if err := faker.FakeData(data); err != nil {
+	if err := faker.FakeObject(data); err != nil {
 		t.Fatal(err)
 	}
 	data.Links = nil

--- a/plugins/source/digitalocean/resources/services/cdns/cdns_mock_test.go
+++ b/plugins/source/digitalocean/resources/services/cdns/cdns_mock_test.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/cloudquery/cloudquery/plugins/source/digitalocean/client"
 	"github.com/cloudquery/cloudquery/plugins/source/digitalocean/client/mocks"
-	"github.com/cloudquery/faker/v3"
+	"github.com/cloudquery/plugin-sdk/faker"
 	"github.com/digitalocean/godo"
 	"github.com/golang/mock/gomock"
 )
@@ -14,7 +14,7 @@ func createCdn(t *testing.T, ctrl *gomock.Controller) client.Services {
 	m := mocks.NewMockCdnService(ctrl)
 
 	var data []godo.CDN
-	if err := faker.FakeData(&data); err != nil {
+	if err := faker.FakeObject(&data); err != nil {
 		t.Fatal(err)
 	}
 

--- a/plugins/source/digitalocean/resources/services/certificates/certificates_mock_test.go
+++ b/plugins/source/digitalocean/resources/services/certificates/certificates_mock_test.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/cloudquery/cloudquery/plugins/source/digitalocean/client"
 	"github.com/cloudquery/cloudquery/plugins/source/digitalocean/client/mocks"
-	"github.com/cloudquery/faker/v3"
+	"github.com/cloudquery/plugin-sdk/faker"
 	"github.com/digitalocean/godo"
 	"github.com/golang/mock/gomock"
 )
@@ -14,7 +14,7 @@ func createCertificates(t *testing.T, ctrl *gomock.Controller) client.Services {
 	m := mocks.NewMockCertificatesService(ctrl)
 
 	var data []godo.Certificate
-	if err := faker.FakeData(&data); err != nil {
+	if err := faker.FakeObject(&data); err != nil {
 		t.Fatal(err)
 	}
 

--- a/plugins/source/digitalocean/resources/services/databases/backups_mock_test.go
+++ b/plugins/source/digitalocean/resources/services/databases/backups_mock_test.go
@@ -4,14 +4,14 @@ import (
 	"testing"
 
 	"github.com/cloudquery/cloudquery/plugins/source/digitalocean/client/mocks"
-	"github.com/cloudquery/faker/v3"
+	"github.com/cloudquery/plugin-sdk/faker"
 	"github.com/digitalocean/godo"
 	"github.com/golang/mock/gomock"
 )
 
 func createBackups(t *testing.T, m *mocks.MockDatabasesService) {
 	var data []godo.DatabaseBackup
-	if err := faker.FakeData(&data); err != nil {
+	if err := faker.FakeObject(&data); err != nil {
 		t.Fatal(err)
 	}
 

--- a/plugins/source/digitalocean/resources/services/databases/databases_mock_test.go
+++ b/plugins/source/digitalocean/resources/services/databases/databases_mock_test.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/cloudquery/cloudquery/plugins/source/digitalocean/client"
 	"github.com/cloudquery/cloudquery/plugins/source/digitalocean/client/mocks"
-	"github.com/cloudquery/faker/v3"
+	"github.com/cloudquery/plugin-sdk/faker"
 	"github.com/digitalocean/godo"
 	"github.com/golang/mock/gomock"
 )
@@ -14,7 +14,7 @@ func createDatabases(t *testing.T, ctrl *gomock.Controller) client.Services {
 	m := mocks.NewMockDatabasesService(ctrl)
 
 	var data []godo.Database
-	if err := faker.FakeData(&data); err != nil {
+	if err := faker.FakeObject(&data); err != nil {
 		t.Fatal(err)
 	}
 

--- a/plugins/source/digitalocean/resources/services/databases/firewall_rules_mock_test.go
+++ b/plugins/source/digitalocean/resources/services/databases/firewall_rules_mock_test.go
@@ -4,14 +4,14 @@ import (
 	"testing"
 
 	"github.com/cloudquery/cloudquery/plugins/source/digitalocean/client/mocks"
-	"github.com/cloudquery/faker/v3"
+	"github.com/cloudquery/plugin-sdk/faker"
 	"github.com/digitalocean/godo"
 	"github.com/golang/mock/gomock"
 )
 
 func createFirewallRules(t *testing.T, m *mocks.MockDatabasesService) {
 	var data []godo.DatabaseFirewallRule
-	if err := faker.FakeData(&data); err != nil {
+	if err := faker.FakeObject(&data); err != nil {
 		t.Fatal(err)
 	}
 

--- a/plugins/source/digitalocean/resources/services/databases/replicas_mock_test.go
+++ b/plugins/source/digitalocean/resources/services/databases/replicas_mock_test.go
@@ -4,14 +4,14 @@ import (
 	"testing"
 
 	"github.com/cloudquery/cloudquery/plugins/source/digitalocean/client/mocks"
-	"github.com/cloudquery/faker/v3"
+	"github.com/cloudquery/plugin-sdk/faker"
 	"github.com/digitalocean/godo"
 	"github.com/golang/mock/gomock"
 )
 
 func createReplicas(t *testing.T, m *mocks.MockDatabasesService) {
 	var data []godo.DatabaseReplica
-	if err := faker.FakeData(&data); err != nil {
+	if err := faker.FakeObject(&data); err != nil {
 		t.Fatal(err)
 	}
 

--- a/plugins/source/digitalocean/resources/services/domains/domains_mock_test.go
+++ b/plugins/source/digitalocean/resources/services/domains/domains_mock_test.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/cloudquery/cloudquery/plugins/source/digitalocean/client"
 	"github.com/cloudquery/cloudquery/plugins/source/digitalocean/client/mocks"
-	"github.com/cloudquery/faker/v3"
+	"github.com/cloudquery/plugin-sdk/faker"
 	"github.com/digitalocean/godo"
 	"github.com/golang/mock/gomock"
 )
@@ -14,7 +14,7 @@ func createDomains(t *testing.T, ctrl *gomock.Controller) client.Services {
 	m := mocks.NewMockDomainsService(ctrl)
 
 	var data []godo.Domain
-	if err := faker.FakeData(&data); err != nil {
+	if err := faker.FakeObject(&data); err != nil {
 		t.Fatal(err)
 	}
 

--- a/plugins/source/digitalocean/resources/services/domains/records_mock_test.go
+++ b/plugins/source/digitalocean/resources/services/domains/records_mock_test.go
@@ -4,14 +4,14 @@ import (
 	"testing"
 
 	"github.com/cloudquery/cloudquery/plugins/source/digitalocean/client/mocks"
-	"github.com/cloudquery/faker/v3"
+	"github.com/cloudquery/plugin-sdk/faker"
 	"github.com/digitalocean/godo"
 	"github.com/golang/mock/gomock"
 )
 
 func createRecords(t *testing.T, m *mocks.MockDomainsService) {
 	var data []godo.DomainRecord
-	if err := faker.FakeData(&data); err != nil {
+	if err := faker.FakeObject(&data); err != nil {
 		t.Fatal(err)
 	}
 

--- a/plugins/source/digitalocean/resources/services/droplets/droplets_mock_test.go
+++ b/plugins/source/digitalocean/resources/services/droplets/droplets_mock_test.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/cloudquery/cloudquery/plugins/source/digitalocean/client"
 	"github.com/cloudquery/cloudquery/plugins/source/digitalocean/client/mocks"
-	"github.com/cloudquery/faker/v3"
+	"github.com/cloudquery/plugin-sdk/faker"
 	"github.com/digitalocean/godo"
 	"github.com/golang/mock/gomock"
 )
@@ -14,7 +14,7 @@ func createDroplets(t *testing.T, ctrl *gomock.Controller) client.Services {
 	m := mocks.NewMockDropletsService(ctrl)
 
 	var data []godo.Droplet
-	if err := faker.FakeData(&data); err != nil {
+	if err := faker.FakeObject(&data); err != nil {
 		t.Fatal(err)
 	}
 

--- a/plugins/source/digitalocean/resources/services/droplets/neighbors_mock_test.go
+++ b/plugins/source/digitalocean/resources/services/droplets/neighbors_mock_test.go
@@ -4,14 +4,14 @@ import (
 	"testing"
 
 	"github.com/cloudquery/cloudquery/plugins/source/digitalocean/client/mocks"
-	"github.com/cloudquery/faker/v3"
+	"github.com/cloudquery/plugin-sdk/faker"
 	"github.com/digitalocean/godo"
 	"github.com/golang/mock/gomock"
 )
 
 func createNeighbors(t *testing.T, m *mocks.MockDropletsService) {
 	var data []godo.Droplet
-	if err := faker.FakeData(&data); err != nil {
+	if err := faker.FakeObject(&data); err != nil {
 		t.Fatal(err)
 	}
 

--- a/plugins/source/digitalocean/resources/services/firewalls/firewalls_mock_test.go
+++ b/plugins/source/digitalocean/resources/services/firewalls/firewalls_mock_test.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/cloudquery/cloudquery/plugins/source/digitalocean/client"
 	"github.com/cloudquery/cloudquery/plugins/source/digitalocean/client/mocks"
-	"github.com/cloudquery/faker/v3"
+	"github.com/cloudquery/plugin-sdk/faker"
 	"github.com/digitalocean/godo"
 	"github.com/golang/mock/gomock"
 )
@@ -14,7 +14,7 @@ func createFirewalls(t *testing.T, ctrl *gomock.Controller) client.Services {
 	m := mocks.NewMockFirewallsService(ctrl)
 
 	var data []godo.Firewall
-	if err := faker.FakeData(&data); err != nil {
+	if err := faker.FakeObject(&data); err != nil {
 		t.Fatal(err)
 	}
 

--- a/plugins/source/digitalocean/resources/services/floating_ips/floating_ips_mock_test.go
+++ b/plugins/source/digitalocean/resources/services/floating_ips/floating_ips_mock_test.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/cloudquery/cloudquery/plugins/source/digitalocean/client"
 	"github.com/cloudquery/cloudquery/plugins/source/digitalocean/client/mocks"
-	"github.com/cloudquery/faker/v3"
+	"github.com/cloudquery/plugin-sdk/faker"
 	"github.com/digitalocean/godo"
 	"github.com/golang/mock/gomock"
 )
@@ -14,7 +14,7 @@ func createFloatingIps(t *testing.T, ctrl *gomock.Controller) client.Services {
 	m := mocks.NewMockFloatingIpsService(ctrl)
 
 	var data []godo.FloatingIP
-	if err := faker.FakeData(&data); err != nil {
+	if err := faker.FakeObject(&data); err != nil {
 		t.Fatal(err)
 	}
 

--- a/plugins/source/digitalocean/resources/services/images/images_mock_test.go
+++ b/plugins/source/digitalocean/resources/services/images/images_mock_test.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/cloudquery/cloudquery/plugins/source/digitalocean/client"
 	"github.com/cloudquery/cloudquery/plugins/source/digitalocean/client/mocks"
-	"github.com/cloudquery/faker/v3"
+	"github.com/cloudquery/plugin-sdk/faker"
 	"github.com/digitalocean/godo"
 	"github.com/golang/mock/gomock"
 )
@@ -14,7 +14,7 @@ func createImages(t *testing.T, ctrl *gomock.Controller) client.Services {
 	m := mocks.NewMockImagesService(ctrl)
 
 	var data []godo.Image
-	if err := faker.FakeData(&data); err != nil {
+	if err := faker.FakeObject(&data); err != nil {
 		t.Fatal(err)
 	}
 

--- a/plugins/source/digitalocean/resources/services/keys/keys_mock_test.go
+++ b/plugins/source/digitalocean/resources/services/keys/keys_mock_test.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/cloudquery/cloudquery/plugins/source/digitalocean/client"
 	"github.com/cloudquery/cloudquery/plugins/source/digitalocean/client/mocks"
-	"github.com/cloudquery/faker/v3"
+	"github.com/cloudquery/plugin-sdk/faker"
 	"github.com/digitalocean/godo"
 	"github.com/golang/mock/gomock"
 )
@@ -14,7 +14,7 @@ func createKeys(t *testing.T, ctrl *gomock.Controller) client.Services {
 	m := mocks.NewMockKeysService(ctrl)
 
 	var data []godo.Key
-	if err := faker.FakeData(&data); err != nil {
+	if err := faker.FakeObject(&data); err != nil {
 		t.Fatal(err)
 	}
 

--- a/plugins/source/digitalocean/resources/services/monitoring/alert_policies_mock_test.go
+++ b/plugins/source/digitalocean/resources/services/monitoring/alert_policies_mock_test.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/cloudquery/cloudquery/plugins/source/digitalocean/client"
 	"github.com/cloudquery/cloudquery/plugins/source/digitalocean/client/mocks"
-	"github.com/cloudquery/faker/v3"
+	"github.com/cloudquery/plugin-sdk/faker"
 	"github.com/digitalocean/godo"
 	"github.com/golang/mock/gomock"
 )
@@ -14,7 +14,7 @@ func createAlertPolicies(t *testing.T, ctrl *gomock.Controller) client.Services 
 	m := mocks.NewMockMonitoringService(ctrl)
 
 	var data []godo.AlertPolicy
-	if err := faker.FakeData(&data); err != nil {
+	if err := faker.FakeObject(&data); err != nil {
 		t.Fatal(err)
 	}
 

--- a/plugins/source/digitalocean/resources/services/projects/projects_mock_test.go
+++ b/plugins/source/digitalocean/resources/services/projects/projects_mock_test.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/cloudquery/cloudquery/plugins/source/digitalocean/client"
 	"github.com/cloudquery/cloudquery/plugins/source/digitalocean/client/mocks"
-	"github.com/cloudquery/faker/v3"
+	"github.com/cloudquery/plugin-sdk/faker"
 	"github.com/digitalocean/godo"
 	"github.com/golang/mock/gomock"
 )
@@ -14,7 +14,7 @@ func createProjects(t *testing.T, ctrl *gomock.Controller) client.Services {
 	m := mocks.NewMockProjectsService(ctrl)
 
 	var data []godo.Project
-	if err := faker.FakeData(&data); err != nil {
+	if err := faker.FakeObject(&data); err != nil {
 		t.Fatal(err)
 	}
 

--- a/plugins/source/digitalocean/resources/services/projects/resources_mock_test.go
+++ b/plugins/source/digitalocean/resources/services/projects/resources_mock_test.go
@@ -4,14 +4,14 @@ import (
 	"testing"
 
 	"github.com/cloudquery/cloudquery/plugins/source/digitalocean/client/mocks"
-	"github.com/cloudquery/faker/v3"
+	"github.com/cloudquery/plugin-sdk/faker"
 	"github.com/digitalocean/godo"
 	"github.com/golang/mock/gomock"
 )
 
 func createResources(t *testing.T, m *mocks.MockProjectsService) {
 	var data []godo.ProjectResource
-	if err := faker.FakeData(&data); err != nil {
+	if err := faker.FakeObject(&data); err != nil {
 		t.Fatal(err)
 	}
 

--- a/plugins/source/digitalocean/resources/services/registries/registries_mock_test.go
+++ b/plugins/source/digitalocean/resources/services/registries/registries_mock_test.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/cloudquery/cloudquery/plugins/source/digitalocean/client"
 	"github.com/cloudquery/cloudquery/plugins/source/digitalocean/client/mocks"
-	"github.com/cloudquery/faker/v3"
+	"github.com/cloudquery/plugin-sdk/faker"
 	"github.com/digitalocean/godo"
 	"github.com/golang/mock/gomock"
 )
@@ -14,7 +14,7 @@ func createRegistry(t *testing.T, ctrl *gomock.Controller) client.Services {
 	m := mocks.NewMockRegistryService(ctrl)
 
 	var data godo.Registry
-	if err := faker.FakeData(&data); err != nil {
+	if err := faker.FakeObject(&data); err != nil {
 		t.Fatal(err)
 	}
 	m.EXPECT().Get(gomock.Any()).Return(&data, nil, nil)

--- a/plugins/source/digitalocean/resources/services/registries/repositories_mock_test.go
+++ b/plugins/source/digitalocean/resources/services/registries/repositories_mock_test.go
@@ -4,14 +4,14 @@ import (
 	"testing"
 
 	"github.com/cloudquery/cloudquery/plugins/source/digitalocean/client/mocks"
-	"github.com/cloudquery/faker/v3"
+	"github.com/cloudquery/plugin-sdk/faker"
 	"github.com/digitalocean/godo"
 	"github.com/golang/mock/gomock"
 )
 
 func createRepositories(t *testing.T, m *mocks.MockRegistryService) {
 	var data []*godo.Repository
-	if err := faker.FakeData(&data); err != nil {
+	if err := faker.FakeObject(&data); err != nil {
 		t.Fatal(err)
 	}
 

--- a/plugins/source/digitalocean/resources/services/sizes/sizes_mock_test.go
+++ b/plugins/source/digitalocean/resources/services/sizes/sizes_mock_test.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/cloudquery/cloudquery/plugins/source/digitalocean/client"
 	"github.com/cloudquery/cloudquery/plugins/source/digitalocean/client/mocks"
-	"github.com/cloudquery/faker/v3"
+	"github.com/cloudquery/plugin-sdk/faker"
 	"github.com/digitalocean/godo"
 	"github.com/golang/mock/gomock"
 )
@@ -14,7 +14,7 @@ func createSizes(t *testing.T, ctrl *gomock.Controller) client.Services {
 	m := mocks.NewMockSizesService(ctrl)
 
 	var data []godo.Size
-	if err := faker.FakeData(&data); err != nil {
+	if err := faker.FakeObject(&data); err != nil {
 		t.Fatal(err)
 	}
 

--- a/plugins/source/digitalocean/resources/services/snapshots/snapshots_mock_test.go
+++ b/plugins/source/digitalocean/resources/services/snapshots/snapshots_mock_test.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/cloudquery/cloudquery/plugins/source/digitalocean/client"
 	"github.com/cloudquery/cloudquery/plugins/source/digitalocean/client/mocks"
-	"github.com/cloudquery/faker/v3"
+	"github.com/cloudquery/plugin-sdk/faker"
 	"github.com/digitalocean/godo"
 	"github.com/golang/mock/gomock"
 )
@@ -14,7 +14,7 @@ func createSnapshots(t *testing.T, ctrl *gomock.Controller) client.Services {
 	m := mocks.NewMockSnapshotsService(ctrl)
 
 	var data []godo.Snapshot
-	if err := faker.FakeData(&data); err != nil {
+	if err := faker.FakeObject(&data); err != nil {
 		t.Fatal(err)
 	}
 

--- a/plugins/source/digitalocean/resources/services/spaces/spaces_mock_test.go
+++ b/plugins/source/digitalocean/resources/services/spaces/spaces_mock_test.go
@@ -6,7 +6,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/s3"
 	"github.com/cloudquery/cloudquery/plugins/source/digitalocean/client"
 	"github.com/cloudquery/cloudquery/plugins/source/digitalocean/client/mocks"
-	"github.com/cloudquery/faker/v3"
+	"github.com/cloudquery/plugin-sdk/faker"
 	"github.com/golang/mock/gomock"
 )
 
@@ -14,19 +14,19 @@ func createSpaces(t *testing.T, ctrl *gomock.Controller) client.Services {
 	m := mocks.NewMockSpacesService(ctrl)
 
 	var data *s3.ListBucketsOutput
-	if err := faker.FakeData(&data); err != nil {
+	if err := faker.FakeObject(&data); err != nil {
 		t.Fatal(err)
 	}
 	m.EXPECT().ListBuckets(gomock.Any(), gomock.Any(), gomock.Any()).Return(data, nil)
 
 	var cors *s3.GetBucketCorsOutput
-	if err := faker.FakeData(&cors); err != nil {
+	if err := faker.FakeObject(&cors); err != nil {
 		t.Fatal(err)
 	}
 	m.EXPECT().GetBucketCors(gomock.Any(), gomock.Any(), gomock.Any()).Return(cors, nil)
 
 	var acl *s3.GetBucketAclOutput
-	if err := faker.FakeData(&acl); err != nil {
+	if err := faker.FakeObject(&acl); err != nil {
 		t.Fatal(err)
 	}
 	m.EXPECT().GetBucketAcl(gomock.Any(), gomock.Any(), gomock.Any()).Return(acl, nil)

--- a/plugins/source/digitalocean/resources/services/storage/volumes_mock_test.go
+++ b/plugins/source/digitalocean/resources/services/storage/volumes_mock_test.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/cloudquery/cloudquery/plugins/source/digitalocean/client"
 	"github.com/cloudquery/cloudquery/plugins/source/digitalocean/client/mocks"
-	"github.com/cloudquery/faker/v3"
+	"github.com/cloudquery/plugin-sdk/faker"
 	"github.com/digitalocean/godo"
 	"github.com/golang/mock/gomock"
 )
@@ -14,7 +14,7 @@ func createVolumes(t *testing.T, ctrl *gomock.Controller) client.Services {
 	m := mocks.NewMockStorageService(ctrl)
 
 	var data []godo.Volume
-	if err := faker.FakeData(&data); err != nil {
+	if err := faker.FakeObject(&data); err != nil {
 		t.Fatal(err)
 	}
 

--- a/plugins/source/digitalocean/resources/services/vpcs/members_mock_test.go
+++ b/plugins/source/digitalocean/resources/services/vpcs/members_mock_test.go
@@ -4,14 +4,14 @@ import (
 	"testing"
 
 	"github.com/cloudquery/cloudquery/plugins/source/digitalocean/client/mocks"
-	"github.com/cloudquery/faker/v3"
+	"github.com/cloudquery/plugin-sdk/faker"
 	"github.com/digitalocean/godo"
 	"github.com/golang/mock/gomock"
 )
 
 func createMembers(t *testing.T, m *mocks.MockVpcsService) {
 	var data []*godo.VPCMember
-	if err := faker.FakeData(&data); err != nil {
+	if err := faker.FakeObject(&data); err != nil {
 		t.Fatal(err)
 	}
 

--- a/plugins/source/digitalocean/resources/services/vpcs/vpcs_mock_test.go
+++ b/plugins/source/digitalocean/resources/services/vpcs/vpcs_mock_test.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/cloudquery/cloudquery/plugins/source/digitalocean/client"
 	"github.com/cloudquery/cloudquery/plugins/source/digitalocean/client/mocks"
-	"github.com/cloudquery/faker/v3"
+	"github.com/cloudquery/plugin-sdk/faker"
 	"github.com/digitalocean/godo"
 	"github.com/golang/mock/gomock"
 )
@@ -14,7 +14,7 @@ func createVpcs(t *testing.T, ctrl *gomock.Controller) client.Services {
 	m := mocks.NewMockVpcsService(ctrl)
 
 	var data []*godo.VPC
-	if err := faker.FakeData(&data); err != nil {
+	if err := faker.FakeObject(&data); err != nil {
 		t.Fatal(err)
 	}
 

--- a/plugins/source/github/go.mod
+++ b/plugins/source/github/go.mod
@@ -3,7 +3,6 @@ module github.com/cloudquery/cloudquery/plugins/source/github
 go 1.19
 
 require (
-	github.com/cloudquery/faker/v3 v3.7.7
 	github.com/cloudquery/plugin-sdk v0.13.6
 	github.com/golang/mock v1.6.0
 	github.com/google/go-github/v45 v45.2.0
@@ -14,6 +13,7 @@ require (
 )
 
 require (
+	github.com/cloudquery/faker/v3 v3.7.7 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/getsentry/sentry-go v0.13.0 // indirect
 	github.com/ghodss/yaml v1.0.0 // indirect

--- a/plugins/source/github/resources/services/billing/action_test.go
+++ b/plugins/source/github/resources/services/billing/action_test.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/cloudquery/cloudquery/plugins/source/github/client"
 	"github.com/cloudquery/cloudquery/plugins/source/github/client/mocks"
-	"github.com/cloudquery/faker/v3"
+	"github.com/cloudquery/plugin-sdk/faker"
 	"github.com/golang/mock/gomock"
 	"github.com/google/go-github/v45/github"
 )
@@ -14,7 +14,7 @@ func buildAction(t *testing.T, ctrl *gomock.Controller) client.GithubServices {
 	mock := mocks.NewMockBillingService(ctrl)
 
 	var cs *github.ActionBilling
-	if err := faker.FakeData(&cs); err != nil {
+	if err := faker.FakeObject(&cs); err != nil {
 		t.Fatal(err)
 	}
 	mock.EXPECT().GetActionsBillingOrg(gomock.Any(), "testorg").Return(cs, &github.Response{}, nil)

--- a/plugins/source/github/resources/services/billing/packing_test.go
+++ b/plugins/source/github/resources/services/billing/packing_test.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/cloudquery/cloudquery/plugins/source/github/client"
 	"github.com/cloudquery/cloudquery/plugins/source/github/client/mocks"
-	"github.com/cloudquery/faker/v3"
+	"github.com/cloudquery/plugin-sdk/faker"
 	"github.com/golang/mock/gomock"
 	"github.com/google/go-github/v45/github"
 )
@@ -14,7 +14,7 @@ func buildPackage(t *testing.T, ctrl *gomock.Controller) client.GithubServices {
 	mock := mocks.NewMockBillingService(ctrl)
 
 	var cs *github.PackageBilling
-	if err := faker.FakeData(&cs); err != nil {
+	if err := faker.FakeObject(&cs); err != nil {
 		t.Fatal(err)
 	}
 	mock.EXPECT().GetPackagesBillingOrg(gomock.Any(), "testorg").Return(cs, &github.Response{}, nil)

--- a/plugins/source/github/resources/services/billing/storage_test.go
+++ b/plugins/source/github/resources/services/billing/storage_test.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/cloudquery/cloudquery/plugins/source/github/client"
 	"github.com/cloudquery/cloudquery/plugins/source/github/client/mocks"
-	"github.com/cloudquery/faker/v3"
+	"github.com/cloudquery/plugin-sdk/faker"
 	"github.com/golang/mock/gomock"
 	"github.com/google/go-github/v45/github"
 )
@@ -14,7 +14,7 @@ func buildStorage(t *testing.T, ctrl *gomock.Controller) client.GithubServices {
 	mock := mocks.NewMockBillingService(ctrl)
 
 	var cs *github.StorageBilling
-	if err := faker.FakeData(&cs); err != nil {
+	if err := faker.FakeObject(&cs); err != nil {
 		t.Fatal(err)
 	}
 	mock.EXPECT().GetStorageBillingOrg(gomock.Any(), "testorg").Return(cs, &github.Response{}, nil)

--- a/plugins/source/github/resources/services/external/groups_test.go
+++ b/plugins/source/github/resources/services/external/groups_test.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/cloudquery/cloudquery/plugins/source/github/client"
 	"github.com/cloudquery/cloudquery/plugins/source/github/client/mocks"
-	"github.com/cloudquery/faker/v3"
+	"github.com/cloudquery/plugin-sdk/faker"
 	"github.com/golang/mock/gomock"
 	"github.com/google/go-github/v45/github"
 )
@@ -14,7 +14,7 @@ func buildExternalGroups(t *testing.T, ctrl *gomock.Controller) client.GithubSer
 	mock := mocks.NewMockTeamsService(ctrl)
 
 	var cs *github.ExternalGroupList
-	if err := faker.FakeData(&cs); err != nil {
+	if err := faker.FakeObject(&cs); err != nil {
 		t.Fatal(err)
 	}
 	mock.EXPECT().ListExternalGroups(gomock.Any(), "testorg", gomock.Any()).Return(cs, &github.Response{}, nil)

--- a/plugins/source/github/resources/services/hooks/hooks_test.go
+++ b/plugins/source/github/resources/services/hooks/hooks_test.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/cloudquery/cloudquery/plugins/source/github/client"
 	"github.com/cloudquery/cloudquery/plugins/source/github/client/mocks"
-	"github.com/cloudquery/faker/v3"
+	"github.com/cloudquery/plugin-sdk/faker"
 	"github.com/golang/mock/gomock"
 	"github.com/google/go-github/v45/github"
 )
@@ -14,7 +14,7 @@ func buildHooks(t *testing.T, ctrl *gomock.Controller) client.GithubServices {
 	mock := mocks.NewMockOrganizationsService(ctrl)
 
 	var cs github.Hook
-	if err := faker.FakeDataSkipFields(&cs, []string{"LastResponse", "Config"}); err != nil {
+	if err := faker.FakeObject(&cs); err != nil {
 		t.Fatal(err)
 	}
 	cs.Config = make(map[string]interface{})
@@ -22,7 +22,7 @@ func buildHooks(t *testing.T, ctrl *gomock.Controller) client.GithubServices {
 	mock.EXPECT().ListHooks(gomock.Any(), "testorg", gomock.Any()).Return([]*github.Hook{&cs}, &github.Response{}, nil)
 
 	var hd *github.HookDelivery
-	if err := faker.FakeData(&hd); err != nil {
+	if err := faker.FakeObject(&hd); err != nil {
 		t.Fatal(err)
 	}
 	mock.EXPECT().ListHookDeliveries(gomock.Any(), "testorg", *cs.ID, gomock.Any()).Return([]*github.HookDelivery{hd}, &github.Response{}, nil)

--- a/plugins/source/github/resources/services/installations/installations_test.go
+++ b/plugins/source/github/resources/services/installations/installations_test.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/cloudquery/cloudquery/plugins/source/github/client"
 	"github.com/cloudquery/cloudquery/plugins/source/github/client/mocks"
-	"github.com/cloudquery/faker/v3"
+	"github.com/cloudquery/plugin-sdk/faker"
 	"github.com/golang/mock/gomock"
 	"github.com/google/go-github/v45/github"
 )
@@ -14,7 +14,7 @@ func buildInstallations(t *testing.T, ctrl *gomock.Controller) client.GithubServ
 	mock := mocks.NewMockOrganizationsService(ctrl)
 
 	var cs github.Installation
-	if err := faker.FakeData(&cs); err != nil {
+	if err := faker.FakeObject(&cs); err != nil {
 		t.Fatal(err)
 	}
 	total := 1

--- a/plugins/source/github/resources/services/issues/issues_test.go
+++ b/plugins/source/github/resources/services/issues/issues_test.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/cloudquery/cloudquery/plugins/source/github/client"
 	"github.com/cloudquery/cloudquery/plugins/source/github/client/mocks"
-	"github.com/cloudquery/faker/v3"
+	"github.com/cloudquery/plugin-sdk/faker"
 	"github.com/golang/mock/gomock"
 	"github.com/google/go-github/v45/github"
 )
@@ -14,7 +14,7 @@ func buildIssues(t *testing.T, ctrl *gomock.Controller) client.GithubServices {
 	mock := mocks.NewMockIssuesService(ctrl)
 
 	var cs github.Issue
-	if err := faker.FakeDataSkipFields(&cs, []string{"Repository"}); err != nil {
+	if err := faker.FakeObject(&cs); err != nil {
 		t.Fatal(err)
 	}
 	someId := int64(5555555)

--- a/plugins/source/github/resources/services/organizations/organizations_test.go
+++ b/plugins/source/github/resources/services/organizations/organizations_test.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/cloudquery/cloudquery/plugins/source/github/client"
 	"github.com/cloudquery/cloudquery/plugins/source/github/client/mocks"
-	"github.com/cloudquery/faker/v3"
+	"github.com/cloudquery/plugin-sdk/faker"
 	"github.com/golang/mock/gomock"
 	"github.com/google/go-github/v45/github"
 )
@@ -14,20 +14,20 @@ func buildOrganizations(t *testing.T, ctrl *gomock.Controller) client.GithubServ
 	mock := mocks.NewMockOrganizationsService(ctrl)
 
 	var cs *github.Organization
-	if err := faker.FakeData(&cs); err != nil {
+	if err := faker.FakeObject(&cs); err != nil {
 		t.Fatal(err)
 	}
 	mock.EXPECT().Get(gomock.Any(), gomock.Any()).Return(cs, &github.Response{}, nil)
 
 	var u github.User
-	if err := faker.FakeDataSkipFields(&u, []string{"Parent"}); err != nil {
+	if err := faker.FakeObject(&u); err != nil {
 		t.Fatal(err)
 	}
 	mock.EXPECT().ListMembers(gomock.Any(), gomock.Any(), gomock.Any()).Return(
 		[]*github.User{&u}, &github.Response{}, nil)
 
 	var m github.Membership
-	if err := faker.FakeDataSkipFields(&m, []string{}); err != nil {
+	if err := faker.FakeObject(&m); err != nil {
 		t.Fatal(err)
 	}
 	mock.EXPECT().GetOrgMembership(gomock.Any(), *u.Login, gomock.Any()).Return(

--- a/plugins/source/github/resources/services/repositories/repositories_test.go
+++ b/plugins/source/github/resources/services/repositories/repositories_test.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/cloudquery/cloudquery/plugins/source/github/client"
 	"github.com/cloudquery/cloudquery/plugins/source/github/client/mocks"
-	"github.com/cloudquery/faker/v3"
+	"github.com/cloudquery/plugin-sdk/faker"
 	"github.com/golang/mock/gomock"
 	"github.com/google/go-github/v45/github"
 )
@@ -14,7 +14,7 @@ func buildRepositiories(t *testing.T, ctrl *gomock.Controller) client.GithubServ
 	mock := mocks.NewMockRepositoriesService(ctrl)
 
 	var cs github.Repository
-	if err := faker.FakeDataSkipFields(&cs, []string{"Parent", "Source", "TemplateRepository"}); err != nil {
+	if err := faker.FakeObject(&cs); err != nil {
 		t.Fatal(err)
 	}
 	someId := int64(5555555)

--- a/plugins/source/github/resources/services/teams/teams_test.go
+++ b/plugins/source/github/resources/services/teams/teams_test.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/cloudquery/cloudquery/plugins/source/github/client"
 	"github.com/cloudquery/cloudquery/plugins/source/github/client/mocks"
-	"github.com/cloudquery/faker/v3"
+	"github.com/cloudquery/plugin-sdk/faker"
 	"github.com/golang/mock/gomock"
 	"github.com/google/go-github/v45/github"
 )
@@ -14,7 +14,7 @@ func buildTeams(t *testing.T, ctrl *gomock.Controller) client.GithubServices {
 	mock := mocks.NewMockTeamsService(ctrl)
 
 	var cs github.Team
-	if err := faker.FakeDataSkipFields(&cs, []string{"Parent", "MembersURL"}); err != nil {
+	if err := faker.FakeObject(&cs); err != nil {
 		t.Fatal(err)
 	}
 	someId := int64(5555555)
@@ -26,14 +26,14 @@ func buildTeams(t *testing.T, ctrl *gomock.Controller) client.GithubServices {
 		[]*github.Team{&cs}, &github.Response{}, nil)
 
 	var u github.User
-	if err := faker.FakeDataSkipFields(&u, []string{"Parent"}); err != nil {
+	if err := faker.FakeObject(&u); err != nil {
 		t.Fatal(err)
 	}
 	mock.EXPECT().ListTeamMembersByID(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(
 		[]*github.User{&u}, &github.Response{}, nil)
 
 	var r github.Repository
-	if err := faker.FakeDataSkipFields(&r, []string{"Parent", "Source", "TemplateRepository"}); err != nil {
+	if err := faker.FakeObject(&r); err != nil {
 		t.Fatal(err)
 	}
 	r.Parent = &github.Repository{ID: &someId}
@@ -44,7 +44,7 @@ func buildTeams(t *testing.T, ctrl *gomock.Controller) client.GithubServices {
 		[]*github.Repository{&r}, &github.Response{}, nil)
 
 	var m github.Membership
-	if err := faker.FakeDataSkipFields(&m, []string{}); err != nil {
+	if err := faker.FakeObject(&m); err != nil {
 		t.Fatal(err)
 	}
 	mock.EXPECT().GetTeamMembershipBySlug(gomock.Any(), "testorg", *cs.Slug, *u.Login).Return(

--- a/plugins/source/heroku/codegen/templates/relational_resource_list_mock_test.go.tpl
+++ b/plugins/source/heroku/codegen/templates/relational_resource_list_mock_test.go.tpl
@@ -8,7 +8,7 @@ import (
 	"net/http/httptest"
 	"testing"
 
-	faker "github.com/cloudquery/faker/v3"
+	"github.com/cloudquery/plugin-sdk/faker"
 	"github.com/cloudquery/cloudquery/plugins/source/heroku/client"
 	"github.com/julienschmidt/httprouter"
 	heroku "github.com/heroku/heroku-go/v5"
@@ -16,11 +16,11 @@ import (
 
 func create{{.HerokuStructName | Pluralize }}() (*heroku.Service, error) {
 	primaryItems := make(heroku.{{.HerokuPrimaryStructName}}ListResult, 1)
-	if err := faker.FakeData(&primaryItems); err != nil {
+	if err := faker.FakeObject(&primaryItems); err != nil {
 		return nil, err
 	}
     items := make(heroku.{{.HerokuStructName}}ListResult, 1)
-	if err := faker.FakeData(&items); err != nil {
+	if err := faker.FakeObject(&items); err != nil {
 		return nil, err
 	}
 	mux := httprouter.New()

--- a/plugins/source/heroku/codegen/templates/resource_list_mock_test.go.tpl
+++ b/plugins/source/heroku/codegen/templates/resource_list_mock_test.go.tpl
@@ -8,7 +8,7 @@ import (
 	"net/http/httptest"
 	"testing"
 
-	faker "github.com/cloudquery/faker/v3"
+	"github.com/cloudquery/plugin-sdk/faker"
 	"github.com/cloudquery/cloudquery/plugins/source/heroku/client"
 	"github.com/julienschmidt/httprouter"
 	heroku "github.com/heroku/heroku-go/v5"
@@ -16,7 +16,7 @@ import (
 
 func create{{.HerokuStructName | Pluralize }}() (*heroku.Service, error) {
     items := make(heroku.{{.HerokuStructName}}ListResult, 1)
-	if err := faker.FakeData(&items); err != nil {
+	if err := faker.FakeObject(&items); err != nil {
 		return nil, err
 	}
 	mux := httprouter.New()

--- a/plugins/source/heroku/go.mod
+++ b/plugins/source/heroku/go.mod
@@ -4,7 +4,6 @@ go 1.19
 
 require (
 	github.com/cloudquery/cq-gen v0.0.12
-	github.com/cloudquery/faker/v3 v3.7.7
 	github.com/cloudquery/plugin-sdk v0.13.6
 	github.com/golang/mock v1.6.0
 	github.com/google/go-cmp v0.5.9
@@ -26,6 +25,7 @@ require (
 	github.com/apparentlymart/go-textseg/v13 v13.0.0 // indirect
 	github.com/cenkalti/backoff v2.2.1+incompatible // indirect
 	github.com/cloudquery/cq-provider-sdk v0.14.7 // indirect
+	github.com/cloudquery/faker/v3 v3.7.7 // indirect
 	github.com/creasty/defaults v1.6.0 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/fatih/color v1.13.0 // indirect

--- a/plugins/source/heroku/resources/services/account_feature_mock_test.go
+++ b/plugins/source/heroku/resources/services/account_feature_mock_test.go
@@ -9,14 +9,14 @@ import (
 	"testing"
 
 	"github.com/cloudquery/cloudquery/plugins/source/heroku/client"
-	faker "github.com/cloudquery/faker/v3"
+	"github.com/cloudquery/plugin-sdk/faker"
 	heroku "github.com/heroku/heroku-go/v5"
 	"github.com/julienschmidt/httprouter"
 )
 
 func createAccountFeatures() (*heroku.Service, error) {
 	items := make(heroku.AccountFeatureListResult, 1)
-	if err := faker.FakeData(&items); err != nil {
+	if err := faker.FakeObject(&items); err != nil {
 		return nil, err
 	}
 	mux := httprouter.New()

--- a/plugins/source/heroku/resources/services/add_on_attachment_mock_test.go
+++ b/plugins/source/heroku/resources/services/add_on_attachment_mock_test.go
@@ -9,14 +9,14 @@ import (
 	"testing"
 
 	"github.com/cloudquery/cloudquery/plugins/source/heroku/client"
-	faker "github.com/cloudquery/faker/v3"
+	"github.com/cloudquery/plugin-sdk/faker"
 	heroku "github.com/heroku/heroku-go/v5"
 	"github.com/julienschmidt/httprouter"
 )
 
 func createAddOnAttachments() (*heroku.Service, error) {
 	items := make(heroku.AddOnAttachmentListResult, 1)
-	if err := faker.FakeData(&items); err != nil {
+	if err := faker.FakeObject(&items); err != nil {
 		return nil, err
 	}
 	mux := httprouter.New()

--- a/plugins/source/heroku/resources/services/add_on_config_mock_test.go
+++ b/plugins/source/heroku/resources/services/add_on_config_mock_test.go
@@ -9,18 +9,18 @@ import (
 	"testing"
 
 	"github.com/cloudquery/cloudquery/plugins/source/heroku/client"
-	faker "github.com/cloudquery/faker/v3"
+	"github.com/cloudquery/plugin-sdk/faker"
 	heroku "github.com/heroku/heroku-go/v5"
 	"github.com/julienschmidt/httprouter"
 )
 
 func createAddOnConfigs() (*heroku.Service, error) {
 	primaryItems := make(heroku.AddOnListResult, 1)
-	if err := faker.FakeData(&primaryItems); err != nil {
+	if err := faker.FakeObject(&primaryItems); err != nil {
 		return nil, err
 	}
 	items := make(heroku.AddOnConfigListResult, 1)
-	if err := faker.FakeData(&items); err != nil {
+	if err := faker.FakeObject(&items); err != nil {
 		return nil, err
 	}
 	mux := httprouter.New()

--- a/plugins/source/heroku/resources/services/add_on_mock_test.go
+++ b/plugins/source/heroku/resources/services/add_on_mock_test.go
@@ -9,14 +9,14 @@ import (
 	"testing"
 
 	"github.com/cloudquery/cloudquery/plugins/source/heroku/client"
-	faker "github.com/cloudquery/faker/v3"
+	"github.com/cloudquery/plugin-sdk/faker"
 	heroku "github.com/heroku/heroku-go/v5"
 	"github.com/julienschmidt/httprouter"
 )
 
 func createAddOns() (*heroku.Service, error) {
 	items := make(heroku.AddOnListResult, 1)
-	if err := faker.FakeData(&items); err != nil {
+	if err := faker.FakeObject(&items); err != nil {
 		return nil, err
 	}
 	mux := httprouter.New()

--- a/plugins/source/heroku/resources/services/add_on_region_capability_mock_test.go
+++ b/plugins/source/heroku/resources/services/add_on_region_capability_mock_test.go
@@ -9,14 +9,14 @@ import (
 	"testing"
 
 	"github.com/cloudquery/cloudquery/plugins/source/heroku/client"
-	faker "github.com/cloudquery/faker/v3"
+	"github.com/cloudquery/plugin-sdk/faker"
 	heroku "github.com/heroku/heroku-go/v5"
 	"github.com/julienschmidt/httprouter"
 )
 
 func createAddOnRegionCapabilities() (*heroku.Service, error) {
 	items := make(heroku.AddOnRegionCapabilityListResult, 1)
-	if err := faker.FakeData(&items); err != nil {
+	if err := faker.FakeObject(&items); err != nil {
 		return nil, err
 	}
 	mux := httprouter.New()

--- a/plugins/source/heroku/resources/services/add_on_service_mock_test.go
+++ b/plugins/source/heroku/resources/services/add_on_service_mock_test.go
@@ -9,14 +9,14 @@ import (
 	"testing"
 
 	"github.com/cloudquery/cloudquery/plugins/source/heroku/client"
-	faker "github.com/cloudquery/faker/v3"
+	"github.com/cloudquery/plugin-sdk/faker"
 	heroku "github.com/heroku/heroku-go/v5"
 	"github.com/julienschmidt/httprouter"
 )
 
 func createAddOnServices() (*heroku.Service, error) {
 	items := make(heroku.AddOnServiceListResult, 1)
-	if err := faker.FakeData(&items); err != nil {
+	if err := faker.FakeObject(&items); err != nil {
 		return nil, err
 	}
 	mux := httprouter.New()

--- a/plugins/source/heroku/resources/services/add_on_webhook_delivery_mock_test.go
+++ b/plugins/source/heroku/resources/services/add_on_webhook_delivery_mock_test.go
@@ -9,18 +9,18 @@ import (
 	"testing"
 
 	"github.com/cloudquery/cloudquery/plugins/source/heroku/client"
-	faker "github.com/cloudquery/faker/v3"
+	"github.com/cloudquery/plugin-sdk/faker"
 	heroku "github.com/heroku/heroku-go/v5"
 	"github.com/julienschmidt/httprouter"
 )
 
 func createAddOnWebhookDeliveries() (*heroku.Service, error) {
 	primaryItems := make(heroku.AddOnListResult, 1)
-	if err := faker.FakeData(&primaryItems); err != nil {
+	if err := faker.FakeObject(&primaryItems); err != nil {
 		return nil, err
 	}
 	items := make(heroku.AddOnWebhookDeliveryListResult, 1)
-	if err := faker.FakeData(&items); err != nil {
+	if err := faker.FakeObject(&items); err != nil {
 		return nil, err
 	}
 	mux := httprouter.New()

--- a/plugins/source/heroku/resources/services/add_on_webhook_event_mock_test.go
+++ b/plugins/source/heroku/resources/services/add_on_webhook_event_mock_test.go
@@ -9,18 +9,18 @@ import (
 	"testing"
 
 	"github.com/cloudquery/cloudquery/plugins/source/heroku/client"
-	faker "github.com/cloudquery/faker/v3"
+	"github.com/cloudquery/plugin-sdk/faker"
 	heroku "github.com/heroku/heroku-go/v5"
 	"github.com/julienschmidt/httprouter"
 )
 
 func createAddOnWebhookEvents() (*heroku.Service, error) {
 	primaryItems := make(heroku.AddOnListResult, 1)
-	if err := faker.FakeData(&primaryItems); err != nil {
+	if err := faker.FakeObject(&primaryItems); err != nil {
 		return nil, err
 	}
 	items := make(heroku.AddOnWebhookEventListResult, 1)
-	if err := faker.FakeData(&items); err != nil {
+	if err := faker.FakeObject(&items); err != nil {
 		return nil, err
 	}
 	mux := httprouter.New()

--- a/plugins/source/heroku/resources/services/add_on_webhook_mock_test.go
+++ b/plugins/source/heroku/resources/services/add_on_webhook_mock_test.go
@@ -9,18 +9,18 @@ import (
 	"testing"
 
 	"github.com/cloudquery/cloudquery/plugins/source/heroku/client"
-	faker "github.com/cloudquery/faker/v3"
+	"github.com/cloudquery/plugin-sdk/faker"
 	heroku "github.com/heroku/heroku-go/v5"
 	"github.com/julienschmidt/httprouter"
 )
 
 func createAddOnWebhooks() (*heroku.Service, error) {
 	primaryItems := make(heroku.AddOnListResult, 1)
-	if err := faker.FakeData(&primaryItems); err != nil {
+	if err := faker.FakeObject(&primaryItems); err != nil {
 		return nil, err
 	}
 	items := make(heroku.AddOnWebhookListResult, 1)
-	if err := faker.FakeData(&items); err != nil {
+	if err := faker.FakeObject(&items); err != nil {
 		return nil, err
 	}
 	mux := httprouter.New()

--- a/plugins/source/heroku/resources/services/app_feature_mock_test.go
+++ b/plugins/source/heroku/resources/services/app_feature_mock_test.go
@@ -9,18 +9,18 @@ import (
 	"testing"
 
 	"github.com/cloudquery/cloudquery/plugins/source/heroku/client"
-	faker "github.com/cloudquery/faker/v3"
+	"github.com/cloudquery/plugin-sdk/faker"
 	heroku "github.com/heroku/heroku-go/v5"
 	"github.com/julienschmidt/httprouter"
 )
 
 func createAppFeatures() (*heroku.Service, error) {
 	primaryItems := make(heroku.AppListResult, 1)
-	if err := faker.FakeData(&primaryItems); err != nil {
+	if err := faker.FakeObject(&primaryItems); err != nil {
 		return nil, err
 	}
 	items := make(heroku.AppFeatureListResult, 1)
-	if err := faker.FakeData(&items); err != nil {
+	if err := faker.FakeObject(&items); err != nil {
 		return nil, err
 	}
 	mux := httprouter.New()

--- a/plugins/source/heroku/resources/services/app_mock_test.go
+++ b/plugins/source/heroku/resources/services/app_mock_test.go
@@ -9,14 +9,14 @@ import (
 	"testing"
 
 	"github.com/cloudquery/cloudquery/plugins/source/heroku/client"
-	faker "github.com/cloudquery/faker/v3"
+	"github.com/cloudquery/plugin-sdk/faker"
 	heroku "github.com/heroku/heroku-go/v5"
 	"github.com/julienschmidt/httprouter"
 )
 
 func createApps() (*heroku.Service, error) {
 	items := make(heroku.AppListResult, 1)
-	if err := faker.FakeData(&items); err != nil {
+	if err := faker.FakeObject(&items); err != nil {
 		return nil, err
 	}
 	mux := httprouter.New()

--- a/plugins/source/heroku/resources/services/app_transfer_mock_test.go
+++ b/plugins/source/heroku/resources/services/app_transfer_mock_test.go
@@ -9,14 +9,14 @@ import (
 	"testing"
 
 	"github.com/cloudquery/cloudquery/plugins/source/heroku/client"
-	faker "github.com/cloudquery/faker/v3"
+	"github.com/cloudquery/plugin-sdk/faker"
 	heroku "github.com/heroku/heroku-go/v5"
 	"github.com/julienschmidt/httprouter"
 )
 
 func createAppTransfers() (*heroku.Service, error) {
 	items := make(heroku.AppTransferListResult, 1)
-	if err := faker.FakeData(&items); err != nil {
+	if err := faker.FakeObject(&items); err != nil {
 		return nil, err
 	}
 	mux := httprouter.New()

--- a/plugins/source/heroku/resources/services/app_webhook_delivery_mock_test.go
+++ b/plugins/source/heroku/resources/services/app_webhook_delivery_mock_test.go
@@ -9,18 +9,18 @@ import (
 	"testing"
 
 	"github.com/cloudquery/cloudquery/plugins/source/heroku/client"
-	faker "github.com/cloudquery/faker/v3"
+	"github.com/cloudquery/plugin-sdk/faker"
 	heroku "github.com/heroku/heroku-go/v5"
 	"github.com/julienschmidt/httprouter"
 )
 
 func createAppWebhookDeliveries() (*heroku.Service, error) {
 	primaryItems := make(heroku.AppListResult, 1)
-	if err := faker.FakeData(&primaryItems); err != nil {
+	if err := faker.FakeObject(&primaryItems); err != nil {
 		return nil, err
 	}
 	items := make(heroku.AppWebhookDeliveryListResult, 1)
-	if err := faker.FakeData(&items); err != nil {
+	if err := faker.FakeObject(&items); err != nil {
 		return nil, err
 	}
 	mux := httprouter.New()

--- a/plugins/source/heroku/resources/services/app_webhook_event_mock_test.go
+++ b/plugins/source/heroku/resources/services/app_webhook_event_mock_test.go
@@ -9,18 +9,18 @@ import (
 	"testing"
 
 	"github.com/cloudquery/cloudquery/plugins/source/heroku/client"
-	faker "github.com/cloudquery/faker/v3"
+	"github.com/cloudquery/plugin-sdk/faker"
 	heroku "github.com/heroku/heroku-go/v5"
 	"github.com/julienschmidt/httprouter"
 )
 
 func createAppWebhookEvents() (*heroku.Service, error) {
 	primaryItems := make(heroku.AppListResult, 1)
-	if err := faker.FakeData(&primaryItems); err != nil {
+	if err := faker.FakeObject(&primaryItems); err != nil {
 		return nil, err
 	}
 	items := make(heroku.AppWebhookEventListResult, 1)
-	if err := faker.FakeData(&items); err != nil {
+	if err := faker.FakeObject(&items); err != nil {
 		return nil, err
 	}
 	mux := httprouter.New()

--- a/plugins/source/heroku/resources/services/app_webhook_mock_test.go
+++ b/plugins/source/heroku/resources/services/app_webhook_mock_test.go
@@ -9,18 +9,18 @@ import (
 	"testing"
 
 	"github.com/cloudquery/cloudquery/plugins/source/heroku/client"
-	faker "github.com/cloudquery/faker/v3"
+	"github.com/cloudquery/plugin-sdk/faker"
 	heroku "github.com/heroku/heroku-go/v5"
 	"github.com/julienschmidt/httprouter"
 )
 
 func createAppWebhooks() (*heroku.Service, error) {
 	primaryItems := make(heroku.AppListResult, 1)
-	if err := faker.FakeData(&primaryItems); err != nil {
+	if err := faker.FakeObject(&primaryItems); err != nil {
 		return nil, err
 	}
 	items := make(heroku.AppWebhookListResult, 1)
-	if err := faker.FakeData(&items); err != nil {
+	if err := faker.FakeObject(&items); err != nil {
 		return nil, err
 	}
 	mux := httprouter.New()

--- a/plugins/source/heroku/resources/services/build_mock_test.go
+++ b/plugins/source/heroku/resources/services/build_mock_test.go
@@ -9,18 +9,18 @@ import (
 	"testing"
 
 	"github.com/cloudquery/cloudquery/plugins/source/heroku/client"
-	faker "github.com/cloudquery/faker/v3"
+	"github.com/cloudquery/plugin-sdk/faker"
 	heroku "github.com/heroku/heroku-go/v5"
 	"github.com/julienschmidt/httprouter"
 )
 
 func createBuilds() (*heroku.Service, error) {
 	primaryItems := make(heroku.AppListResult, 1)
-	if err := faker.FakeData(&primaryItems); err != nil {
+	if err := faker.FakeObject(&primaryItems); err != nil {
 		return nil, err
 	}
 	items := make(heroku.BuildListResult, 1)
-	if err := faker.FakeData(&items); err != nil {
+	if err := faker.FakeObject(&items); err != nil {
 		return nil, err
 	}
 	mux := httprouter.New()

--- a/plugins/source/heroku/resources/services/buildpack_installation_mock_test.go
+++ b/plugins/source/heroku/resources/services/buildpack_installation_mock_test.go
@@ -9,18 +9,18 @@ import (
 	"testing"
 
 	"github.com/cloudquery/cloudquery/plugins/source/heroku/client"
-	faker "github.com/cloudquery/faker/v3"
+	"github.com/cloudquery/plugin-sdk/faker"
 	heroku "github.com/heroku/heroku-go/v5"
 	"github.com/julienschmidt/httprouter"
 )
 
 func createBuildpackInstallations() (*heroku.Service, error) {
 	primaryItems := make(heroku.AppListResult, 1)
-	if err := faker.FakeData(&primaryItems); err != nil {
+	if err := faker.FakeObject(&primaryItems); err != nil {
 		return nil, err
 	}
 	items := make(heroku.BuildpackInstallationListResult, 1)
-	if err := faker.FakeData(&items); err != nil {
+	if err := faker.FakeObject(&items); err != nil {
 		return nil, err
 	}
 	mux := httprouter.New()

--- a/plugins/source/heroku/resources/services/collaborator_mock_test.go
+++ b/plugins/source/heroku/resources/services/collaborator_mock_test.go
@@ -9,18 +9,18 @@ import (
 	"testing"
 
 	"github.com/cloudquery/cloudquery/plugins/source/heroku/client"
-	faker "github.com/cloudquery/faker/v3"
+	"github.com/cloudquery/plugin-sdk/faker"
 	heroku "github.com/heroku/heroku-go/v5"
 	"github.com/julienschmidt/httprouter"
 )
 
 func createCollaborators() (*heroku.Service, error) {
 	primaryItems := make(heroku.AppListResult, 1)
-	if err := faker.FakeData(&primaryItems); err != nil {
+	if err := faker.FakeObject(&primaryItems); err != nil {
 		return nil, err
 	}
 	items := make(heroku.CollaboratorListResult, 1)
-	if err := faker.FakeData(&items); err != nil {
+	if err := faker.FakeObject(&items); err != nil {
 		return nil, err
 	}
 	mux := httprouter.New()

--- a/plugins/source/heroku/resources/services/credit_mock_test.go
+++ b/plugins/source/heroku/resources/services/credit_mock_test.go
@@ -9,14 +9,14 @@ import (
 	"testing"
 
 	"github.com/cloudquery/cloudquery/plugins/source/heroku/client"
-	faker "github.com/cloudquery/faker/v3"
+	"github.com/cloudquery/plugin-sdk/faker"
 	heroku "github.com/heroku/heroku-go/v5"
 	"github.com/julienschmidt/httprouter"
 )
 
 func createCredits() (*heroku.Service, error) {
 	items := make(heroku.CreditListResult, 1)
-	if err := faker.FakeData(&items); err != nil {
+	if err := faker.FakeObject(&items); err != nil {
 		return nil, err
 	}
 	mux := httprouter.New()

--- a/plugins/source/heroku/resources/services/domain_mock_test.go
+++ b/plugins/source/heroku/resources/services/domain_mock_test.go
@@ -9,18 +9,18 @@ import (
 	"testing"
 
 	"github.com/cloudquery/cloudquery/plugins/source/heroku/client"
-	faker "github.com/cloudquery/faker/v3"
+	"github.com/cloudquery/plugin-sdk/faker"
 	heroku "github.com/heroku/heroku-go/v5"
 	"github.com/julienschmidt/httprouter"
 )
 
 func createDomains() (*heroku.Service, error) {
 	primaryItems := make(heroku.AppListResult, 1)
-	if err := faker.FakeData(&primaryItems); err != nil {
+	if err := faker.FakeObject(&primaryItems); err != nil {
 		return nil, err
 	}
 	items := make(heroku.DomainListResult, 1)
-	if err := faker.FakeData(&items); err != nil {
+	if err := faker.FakeObject(&items); err != nil {
 		return nil, err
 	}
 	mux := httprouter.New()

--- a/plugins/source/heroku/resources/services/dyno_mock_test.go
+++ b/plugins/source/heroku/resources/services/dyno_mock_test.go
@@ -9,18 +9,18 @@ import (
 	"testing"
 
 	"github.com/cloudquery/cloudquery/plugins/source/heroku/client"
-	faker "github.com/cloudquery/faker/v3"
+	"github.com/cloudquery/plugin-sdk/faker"
 	heroku "github.com/heroku/heroku-go/v5"
 	"github.com/julienschmidt/httprouter"
 )
 
 func createDynos() (*heroku.Service, error) {
 	primaryItems := make(heroku.AppListResult, 1)
-	if err := faker.FakeData(&primaryItems); err != nil {
+	if err := faker.FakeObject(&primaryItems); err != nil {
 		return nil, err
 	}
 	items := make(heroku.DynoListResult, 1)
-	if err := faker.FakeData(&items); err != nil {
+	if err := faker.FakeObject(&items); err != nil {
 		return nil, err
 	}
 	mux := httprouter.New()

--- a/plugins/source/heroku/resources/services/dyno_size_mock_test.go
+++ b/plugins/source/heroku/resources/services/dyno_size_mock_test.go
@@ -9,14 +9,14 @@ import (
 	"testing"
 
 	"github.com/cloudquery/cloudquery/plugins/source/heroku/client"
-	faker "github.com/cloudquery/faker/v3"
+	"github.com/cloudquery/plugin-sdk/faker"
 	heroku "github.com/heroku/heroku-go/v5"
 	"github.com/julienschmidt/httprouter"
 )
 
 func createDynoSizes() (*heroku.Service, error) {
 	items := make(heroku.DynoSizeListResult, 1)
-	if err := faker.FakeData(&items); err != nil {
+	if err := faker.FakeObject(&items); err != nil {
 		return nil, err
 	}
 	mux := httprouter.New()

--- a/plugins/source/heroku/resources/services/enterprise_account_member_mock_test.go
+++ b/plugins/source/heroku/resources/services/enterprise_account_member_mock_test.go
@@ -9,18 +9,18 @@ import (
 	"testing"
 
 	"github.com/cloudquery/cloudquery/plugins/source/heroku/client"
-	faker "github.com/cloudquery/faker/v3"
+	"github.com/cloudquery/plugin-sdk/faker"
 	heroku "github.com/heroku/heroku-go/v5"
 	"github.com/julienschmidt/httprouter"
 )
 
 func createEnterpriseAccountMembers() (*heroku.Service, error) {
 	primaryItems := make(heroku.EnterpriseAccountListResult, 1)
-	if err := faker.FakeData(&primaryItems); err != nil {
+	if err := faker.FakeObject(&primaryItems); err != nil {
 		return nil, err
 	}
 	items := make(heroku.EnterpriseAccountMemberListResult, 1)
-	if err := faker.FakeData(&items); err != nil {
+	if err := faker.FakeObject(&items); err != nil {
 		return nil, err
 	}
 	mux := httprouter.New()

--- a/plugins/source/heroku/resources/services/enterprise_account_mock_test.go
+++ b/plugins/source/heroku/resources/services/enterprise_account_mock_test.go
@@ -9,14 +9,14 @@ import (
 	"testing"
 
 	"github.com/cloudquery/cloudquery/plugins/source/heroku/client"
-	faker "github.com/cloudquery/faker/v3"
+	"github.com/cloudquery/plugin-sdk/faker"
 	heroku "github.com/heroku/heroku-go/v5"
 	"github.com/julienschmidt/httprouter"
 )
 
 func createEnterpriseAccounts() (*heroku.Service, error) {
 	items := make(heroku.EnterpriseAccountListResult, 1)
-	if err := faker.FakeData(&items); err != nil {
+	if err := faker.FakeObject(&items); err != nil {
 		return nil, err
 	}
 	mux := httprouter.New()

--- a/plugins/source/heroku/resources/services/formation_mock_test.go
+++ b/plugins/source/heroku/resources/services/formation_mock_test.go
@@ -9,18 +9,18 @@ import (
 	"testing"
 
 	"github.com/cloudquery/cloudquery/plugins/source/heroku/client"
-	faker "github.com/cloudquery/faker/v3"
+	"github.com/cloudquery/plugin-sdk/faker"
 	heroku "github.com/heroku/heroku-go/v5"
 	"github.com/julienschmidt/httprouter"
 )
 
 func createFormations() (*heroku.Service, error) {
 	primaryItems := make(heroku.AppListResult, 1)
-	if err := faker.FakeData(&primaryItems); err != nil {
+	if err := faker.FakeObject(&primaryItems); err != nil {
 		return nil, err
 	}
 	items := make(heroku.FormationListResult, 1)
-	if err := faker.FakeData(&items); err != nil {
+	if err := faker.FakeObject(&items); err != nil {
 		return nil, err
 	}
 	mux := httprouter.New()

--- a/plugins/source/heroku/resources/services/inbound_ruleset_mock_test.go
+++ b/plugins/source/heroku/resources/services/inbound_ruleset_mock_test.go
@@ -9,18 +9,18 @@ import (
 	"testing"
 
 	"github.com/cloudquery/cloudquery/plugins/source/heroku/client"
-	faker "github.com/cloudquery/faker/v3"
+	"github.com/cloudquery/plugin-sdk/faker"
 	heroku "github.com/heroku/heroku-go/v5"
 	"github.com/julienschmidt/httprouter"
 )
 
 func createInboundRulesets() (*heroku.Service, error) {
 	primaryItems := make(heroku.SpaceListResult, 1)
-	if err := faker.FakeData(&primaryItems); err != nil {
+	if err := faker.FakeObject(&primaryItems); err != nil {
 		return nil, err
 	}
 	items := make(heroku.InboundRulesetListResult, 1)
-	if err := faker.FakeData(&items); err != nil {
+	if err := faker.FakeObject(&items); err != nil {
 		return nil, err
 	}
 	mux := httprouter.New()

--- a/plugins/source/heroku/resources/services/invoice_mock_test.go
+++ b/plugins/source/heroku/resources/services/invoice_mock_test.go
@@ -9,14 +9,14 @@ import (
 	"testing"
 
 	"github.com/cloudquery/cloudquery/plugins/source/heroku/client"
-	faker "github.com/cloudquery/faker/v3"
+	"github.com/cloudquery/plugin-sdk/faker"
 	heroku "github.com/heroku/heroku-go/v5"
 	"github.com/julienschmidt/httprouter"
 )
 
 func createInvoices() (*heroku.Service, error) {
 	items := make(heroku.InvoiceListResult, 1)
-	if err := faker.FakeData(&items); err != nil {
+	if err := faker.FakeObject(&items); err != nil {
 		return nil, err
 	}
 	mux := httprouter.New()

--- a/plugins/source/heroku/resources/services/key_mock_test.go
+++ b/plugins/source/heroku/resources/services/key_mock_test.go
@@ -9,14 +9,14 @@ import (
 	"testing"
 
 	"github.com/cloudquery/cloudquery/plugins/source/heroku/client"
-	faker "github.com/cloudquery/faker/v3"
+	"github.com/cloudquery/plugin-sdk/faker"
 	heroku "github.com/heroku/heroku-go/v5"
 	"github.com/julienschmidt/httprouter"
 )
 
 func createKeys() (*heroku.Service, error) {
 	items := make(heroku.KeyListResult, 1)
-	if err := faker.FakeData(&items); err != nil {
+	if err := faker.FakeObject(&items); err != nil {
 		return nil, err
 	}
 	mux := httprouter.New()

--- a/plugins/source/heroku/resources/services/log_drain_mock_test.go
+++ b/plugins/source/heroku/resources/services/log_drain_mock_test.go
@@ -9,18 +9,18 @@ import (
 	"testing"
 
 	"github.com/cloudquery/cloudquery/plugins/source/heroku/client"
-	faker "github.com/cloudquery/faker/v3"
+	"github.com/cloudquery/plugin-sdk/faker"
 	heroku "github.com/heroku/heroku-go/v5"
 	"github.com/julienschmidt/httprouter"
 )
 
 func createLogDrains() (*heroku.Service, error) {
 	primaryItems := make(heroku.AppListResult, 1)
-	if err := faker.FakeData(&primaryItems); err != nil {
+	if err := faker.FakeObject(&primaryItems); err != nil {
 		return nil, err
 	}
 	items := make(heroku.LogDrainListResult, 1)
-	if err := faker.FakeData(&items); err != nil {
+	if err := faker.FakeObject(&items); err != nil {
 		return nil, err
 	}
 	mux := httprouter.New()

--- a/plugins/source/heroku/resources/services/o_auth_authorization_mock_test.go
+++ b/plugins/source/heroku/resources/services/o_auth_authorization_mock_test.go
@@ -9,14 +9,14 @@ import (
 	"testing"
 
 	"github.com/cloudquery/cloudquery/plugins/source/heroku/client"
-	faker "github.com/cloudquery/faker/v3"
+	"github.com/cloudquery/plugin-sdk/faker"
 	heroku "github.com/heroku/heroku-go/v5"
 	"github.com/julienschmidt/httprouter"
 )
 
 func createOAuthAuthorizations() (*heroku.Service, error) {
 	items := make(heroku.OAuthAuthorizationListResult, 1)
-	if err := faker.FakeData(&items); err != nil {
+	if err := faker.FakeObject(&items); err != nil {
 		return nil, err
 	}
 	mux := httprouter.New()

--- a/plugins/source/heroku/resources/services/o_auth_client_mock_test.go
+++ b/plugins/source/heroku/resources/services/o_auth_client_mock_test.go
@@ -9,14 +9,14 @@ import (
 	"testing"
 
 	"github.com/cloudquery/cloudquery/plugins/source/heroku/client"
-	faker "github.com/cloudquery/faker/v3"
+	"github.com/cloudquery/plugin-sdk/faker"
 	heroku "github.com/heroku/heroku-go/v5"
 	"github.com/julienschmidt/httprouter"
 )
 
 func createOAuthClients() (*heroku.Service, error) {
 	items := make(heroku.OAuthClientListResult, 1)
-	if err := faker.FakeData(&items); err != nil {
+	if err := faker.FakeObject(&items); err != nil {
 		return nil, err
 	}
 	mux := httprouter.New()

--- a/plugins/source/heroku/resources/services/outbound_ruleset_mock_test.go
+++ b/plugins/source/heroku/resources/services/outbound_ruleset_mock_test.go
@@ -9,18 +9,18 @@ import (
 	"testing"
 
 	"github.com/cloudquery/cloudquery/plugins/source/heroku/client"
-	faker "github.com/cloudquery/faker/v3"
+	"github.com/cloudquery/plugin-sdk/faker"
 	heroku "github.com/heroku/heroku-go/v5"
 	"github.com/julienschmidt/httprouter"
 )
 
 func createOutboundRulesets() (*heroku.Service, error) {
 	primaryItems := make(heroku.SpaceListResult, 1)
-	if err := faker.FakeData(&primaryItems); err != nil {
+	if err := faker.FakeObject(&primaryItems); err != nil {
 		return nil, err
 	}
 	items := make(heroku.OutboundRulesetListResult, 1)
-	if err := faker.FakeData(&items); err != nil {
+	if err := faker.FakeObject(&items); err != nil {
 		return nil, err
 	}
 	mux := httprouter.New()

--- a/plugins/source/heroku/resources/services/peering_mock_test.go
+++ b/plugins/source/heroku/resources/services/peering_mock_test.go
@@ -9,18 +9,18 @@ import (
 	"testing"
 
 	"github.com/cloudquery/cloudquery/plugins/source/heroku/client"
-	faker "github.com/cloudquery/faker/v3"
+	"github.com/cloudquery/plugin-sdk/faker"
 	heroku "github.com/heroku/heroku-go/v5"
 	"github.com/julienschmidt/httprouter"
 )
 
 func createPeerings() (*heroku.Service, error) {
 	primaryItems := make(heroku.SpaceListResult, 1)
-	if err := faker.FakeData(&primaryItems); err != nil {
+	if err := faker.FakeObject(&primaryItems); err != nil {
 		return nil, err
 	}
 	items := make(heroku.PeeringListResult, 1)
-	if err := faker.FakeData(&items); err != nil {
+	if err := faker.FakeObject(&items); err != nil {
 		return nil, err
 	}
 	mux := httprouter.New()

--- a/plugins/source/heroku/resources/services/permission_entity_mock_test.go
+++ b/plugins/source/heroku/resources/services/permission_entity_mock_test.go
@@ -9,18 +9,18 @@ import (
 	"testing"
 
 	"github.com/cloudquery/cloudquery/plugins/source/heroku/client"
-	faker "github.com/cloudquery/faker/v3"
+	"github.com/cloudquery/plugin-sdk/faker"
 	heroku "github.com/heroku/heroku-go/v5"
 	"github.com/julienschmidt/httprouter"
 )
 
 func createPermissionEntities() (*heroku.Service, error) {
 	primaryItems := make(heroku.TeamListResult, 1)
-	if err := faker.FakeData(&primaryItems); err != nil {
+	if err := faker.FakeObject(&primaryItems); err != nil {
 		return nil, err
 	}
 	items := make(heroku.PermissionEntityListResult, 1)
-	if err := faker.FakeData(&items); err != nil {
+	if err := faker.FakeObject(&items); err != nil {
 		return nil, err
 	}
 	mux := httprouter.New()

--- a/plugins/source/heroku/resources/services/pipeline_build_mock_test.go
+++ b/plugins/source/heroku/resources/services/pipeline_build_mock_test.go
@@ -9,18 +9,18 @@ import (
 	"testing"
 
 	"github.com/cloudquery/cloudquery/plugins/source/heroku/client"
-	faker "github.com/cloudquery/faker/v3"
+	"github.com/cloudquery/plugin-sdk/faker"
 	heroku "github.com/heroku/heroku-go/v5"
 	"github.com/julienschmidt/httprouter"
 )
 
 func createPipelineBuilds() (*heroku.Service, error) {
 	primaryItems := make(heroku.PipelineListResult, 1)
-	if err := faker.FakeData(&primaryItems); err != nil {
+	if err := faker.FakeObject(&primaryItems); err != nil {
 		return nil, err
 	}
 	items := make(heroku.PipelineBuildListResult, 1)
-	if err := faker.FakeData(&items); err != nil {
+	if err := faker.FakeObject(&items); err != nil {
 		return nil, err
 	}
 	mux := httprouter.New()

--- a/plugins/source/heroku/resources/services/pipeline_coupling_mock_test.go
+++ b/plugins/source/heroku/resources/services/pipeline_coupling_mock_test.go
@@ -9,14 +9,14 @@ import (
 	"testing"
 
 	"github.com/cloudquery/cloudquery/plugins/source/heroku/client"
-	faker "github.com/cloudquery/faker/v3"
+	"github.com/cloudquery/plugin-sdk/faker"
 	heroku "github.com/heroku/heroku-go/v5"
 	"github.com/julienschmidt/httprouter"
 )
 
 func createPipelineCouplings() (*heroku.Service, error) {
 	items := make(heroku.PipelineCouplingListResult, 1)
-	if err := faker.FakeData(&items); err != nil {
+	if err := faker.FakeObject(&items); err != nil {
 		return nil, err
 	}
 	mux := httprouter.New()

--- a/plugins/source/heroku/resources/services/pipeline_deployment_mock_test.go
+++ b/plugins/source/heroku/resources/services/pipeline_deployment_mock_test.go
@@ -9,18 +9,18 @@ import (
 	"testing"
 
 	"github.com/cloudquery/cloudquery/plugins/source/heroku/client"
-	faker "github.com/cloudquery/faker/v3"
+	"github.com/cloudquery/plugin-sdk/faker"
 	heroku "github.com/heroku/heroku-go/v5"
 	"github.com/julienschmidt/httprouter"
 )
 
 func createPipelineDeployments() (*heroku.Service, error) {
 	primaryItems := make(heroku.PipelineListResult, 1)
-	if err := faker.FakeData(&primaryItems); err != nil {
+	if err := faker.FakeObject(&primaryItems); err != nil {
 		return nil, err
 	}
 	items := make(heroku.PipelineDeploymentListResult, 1)
-	if err := faker.FakeData(&items); err != nil {
+	if err := faker.FakeObject(&items); err != nil {
 		return nil, err
 	}
 	mux := httprouter.New()

--- a/plugins/source/heroku/resources/services/pipeline_mock_test.go
+++ b/plugins/source/heroku/resources/services/pipeline_mock_test.go
@@ -9,14 +9,14 @@ import (
 	"testing"
 
 	"github.com/cloudquery/cloudquery/plugins/source/heroku/client"
-	faker "github.com/cloudquery/faker/v3"
+	"github.com/cloudquery/plugin-sdk/faker"
 	heroku "github.com/heroku/heroku-go/v5"
 	"github.com/julienschmidt/httprouter"
 )
 
 func createPipelines() (*heroku.Service, error) {
 	items := make(heroku.PipelineListResult, 1)
-	if err := faker.FakeData(&items); err != nil {
+	if err := faker.FakeObject(&items); err != nil {
 		return nil, err
 	}
 	mux := httprouter.New()

--- a/plugins/source/heroku/resources/services/pipeline_release_mock_test.go
+++ b/plugins/source/heroku/resources/services/pipeline_release_mock_test.go
@@ -9,18 +9,18 @@ import (
 	"testing"
 
 	"github.com/cloudquery/cloudquery/plugins/source/heroku/client"
-	faker "github.com/cloudquery/faker/v3"
+	"github.com/cloudquery/plugin-sdk/faker"
 	heroku "github.com/heroku/heroku-go/v5"
 	"github.com/julienschmidt/httprouter"
 )
 
 func createPipelineReleases() (*heroku.Service, error) {
 	primaryItems := make(heroku.PipelineListResult, 1)
-	if err := faker.FakeData(&primaryItems); err != nil {
+	if err := faker.FakeObject(&primaryItems); err != nil {
 		return nil, err
 	}
 	items := make(heroku.PipelineReleaseListResult, 1)
-	if err := faker.FakeData(&items); err != nil {
+	if err := faker.FakeObject(&items); err != nil {
 		return nil, err
 	}
 	mux := httprouter.New()

--- a/plugins/source/heroku/resources/services/region_mock_test.go
+++ b/plugins/source/heroku/resources/services/region_mock_test.go
@@ -9,14 +9,14 @@ import (
 	"testing"
 
 	"github.com/cloudquery/cloudquery/plugins/source/heroku/client"
-	faker "github.com/cloudquery/faker/v3"
+	"github.com/cloudquery/plugin-sdk/faker"
 	heroku "github.com/heroku/heroku-go/v5"
 	"github.com/julienschmidt/httprouter"
 )
 
 func createRegions() (*heroku.Service, error) {
 	items := make(heroku.RegionListResult, 1)
-	if err := faker.FakeData(&items); err != nil {
+	if err := faker.FakeObject(&items); err != nil {
 		return nil, err
 	}
 	mux := httprouter.New()

--- a/plugins/source/heroku/resources/services/release_mock_test.go
+++ b/plugins/source/heroku/resources/services/release_mock_test.go
@@ -9,18 +9,18 @@ import (
 	"testing"
 
 	"github.com/cloudquery/cloudquery/plugins/source/heroku/client"
-	faker "github.com/cloudquery/faker/v3"
+	"github.com/cloudquery/plugin-sdk/faker"
 	heroku "github.com/heroku/heroku-go/v5"
 	"github.com/julienschmidt/httprouter"
 )
 
 func createReleases() (*heroku.Service, error) {
 	primaryItems := make(heroku.AppListResult, 1)
-	if err := faker.FakeData(&primaryItems); err != nil {
+	if err := faker.FakeObject(&primaryItems); err != nil {
 		return nil, err
 	}
 	items := make(heroku.ReleaseListResult, 1)
-	if err := faker.FakeData(&items); err != nil {
+	if err := faker.FakeObject(&items); err != nil {
 		return nil, err
 	}
 	mux := httprouter.New()

--- a/plugins/source/heroku/resources/services/review_app_mock_test.go
+++ b/plugins/source/heroku/resources/services/review_app_mock_test.go
@@ -9,18 +9,18 @@ import (
 	"testing"
 
 	"github.com/cloudquery/cloudquery/plugins/source/heroku/client"
-	faker "github.com/cloudquery/faker/v3"
+	"github.com/cloudquery/plugin-sdk/faker"
 	heroku "github.com/heroku/heroku-go/v5"
 	"github.com/julienschmidt/httprouter"
 )
 
 func createReviewApps() (*heroku.Service, error) {
 	primaryItems := make(heroku.PipelineListResult, 1)
-	if err := faker.FakeData(&primaryItems); err != nil {
+	if err := faker.FakeObject(&primaryItems); err != nil {
 		return nil, err
 	}
 	items := make(heroku.ReviewAppListResult, 1)
-	if err := faker.FakeData(&items); err != nil {
+	if err := faker.FakeObject(&items); err != nil {
 		return nil, err
 	}
 	mux := httprouter.New()

--- a/plugins/source/heroku/resources/services/space_app_access_mock_test.go
+++ b/plugins/source/heroku/resources/services/space_app_access_mock_test.go
@@ -9,18 +9,18 @@ import (
 	"testing"
 
 	"github.com/cloudquery/cloudquery/plugins/source/heroku/client"
-	faker "github.com/cloudquery/faker/v3"
+	"github.com/cloudquery/plugin-sdk/faker"
 	heroku "github.com/heroku/heroku-go/v5"
 	"github.com/julienschmidt/httprouter"
 )
 
 func createSpaceAppAccesses() (*heroku.Service, error) {
 	primaryItems := make(heroku.SpaceListResult, 1)
-	if err := faker.FakeData(&primaryItems); err != nil {
+	if err := faker.FakeObject(&primaryItems); err != nil {
 		return nil, err
 	}
 	items := make(heroku.SpaceAppAccessListResult, 1)
-	if err := faker.FakeData(&items); err != nil {
+	if err := faker.FakeObject(&items); err != nil {
 		return nil, err
 	}
 	mux := httprouter.New()

--- a/plugins/source/heroku/resources/services/space_mock_test.go
+++ b/plugins/source/heroku/resources/services/space_mock_test.go
@@ -9,14 +9,14 @@ import (
 	"testing"
 
 	"github.com/cloudquery/cloudquery/plugins/source/heroku/client"
-	faker "github.com/cloudquery/faker/v3"
+	"github.com/cloudquery/plugin-sdk/faker"
 	heroku "github.com/heroku/heroku-go/v5"
 	"github.com/julienschmidt/httprouter"
 )
 
 func createSpaces() (*heroku.Service, error) {
 	items := make(heroku.SpaceListResult, 1)
-	if err := faker.FakeData(&items); err != nil {
+	if err := faker.FakeObject(&items); err != nil {
 		return nil, err
 	}
 	mux := httprouter.New()

--- a/plugins/source/heroku/resources/services/stack_mock_test.go
+++ b/plugins/source/heroku/resources/services/stack_mock_test.go
@@ -9,14 +9,14 @@ import (
 	"testing"
 
 	"github.com/cloudquery/cloudquery/plugins/source/heroku/client"
-	faker "github.com/cloudquery/faker/v3"
+	"github.com/cloudquery/plugin-sdk/faker"
 	heroku "github.com/heroku/heroku-go/v5"
 	"github.com/julienschmidt/httprouter"
 )
 
 func createStacks() (*heroku.Service, error) {
 	items := make(heroku.StackListResult, 1)
-	if err := faker.FakeData(&items); err != nil {
+	if err := faker.FakeObject(&items); err != nil {
 		return nil, err
 	}
 	mux := httprouter.New()

--- a/plugins/source/heroku/resources/services/team_app_permission_mock_test.go
+++ b/plugins/source/heroku/resources/services/team_app_permission_mock_test.go
@@ -9,14 +9,14 @@ import (
 	"testing"
 
 	"github.com/cloudquery/cloudquery/plugins/source/heroku/client"
-	faker "github.com/cloudquery/faker/v3"
+	"github.com/cloudquery/plugin-sdk/faker"
 	heroku "github.com/heroku/heroku-go/v5"
 	"github.com/julienschmidt/httprouter"
 )
 
 func createTeamAppPermissions() (*heroku.Service, error) {
 	items := make(heroku.TeamAppPermissionListResult, 1)
-	if err := faker.FakeData(&items); err != nil {
+	if err := faker.FakeObject(&items); err != nil {
 		return nil, err
 	}
 	mux := httprouter.New()

--- a/plugins/source/heroku/resources/services/team_feature_mock_test.go
+++ b/plugins/source/heroku/resources/services/team_feature_mock_test.go
@@ -9,18 +9,18 @@ import (
 	"testing"
 
 	"github.com/cloudquery/cloudquery/plugins/source/heroku/client"
-	faker "github.com/cloudquery/faker/v3"
+	"github.com/cloudquery/plugin-sdk/faker"
 	heroku "github.com/heroku/heroku-go/v5"
 	"github.com/julienschmidt/httprouter"
 )
 
 func createTeamFeatures() (*heroku.Service, error) {
 	primaryItems := make(heroku.TeamListResult, 1)
-	if err := faker.FakeData(&primaryItems); err != nil {
+	if err := faker.FakeObject(&primaryItems); err != nil {
 		return nil, err
 	}
 	items := make(heroku.TeamFeatureListResult, 1)
-	if err := faker.FakeData(&items); err != nil {
+	if err := faker.FakeObject(&items); err != nil {
 		return nil, err
 	}
 	mux := httprouter.New()

--- a/plugins/source/heroku/resources/services/team_invitation_mock_test.go
+++ b/plugins/source/heroku/resources/services/team_invitation_mock_test.go
@@ -9,18 +9,18 @@ import (
 	"testing"
 
 	"github.com/cloudquery/cloudquery/plugins/source/heroku/client"
-	faker "github.com/cloudquery/faker/v3"
+	"github.com/cloudquery/plugin-sdk/faker"
 	heroku "github.com/heroku/heroku-go/v5"
 	"github.com/julienschmidt/httprouter"
 )
 
 func createTeamInvitations() (*heroku.Service, error) {
 	primaryItems := make(heroku.TeamListResult, 1)
-	if err := faker.FakeData(&primaryItems); err != nil {
+	if err := faker.FakeObject(&primaryItems); err != nil {
 		return nil, err
 	}
 	items := make(heroku.TeamInvitationListResult, 1)
-	if err := faker.FakeData(&items); err != nil {
+	if err := faker.FakeObject(&items); err != nil {
 		return nil, err
 	}
 	mux := httprouter.New()

--- a/plugins/source/heroku/resources/services/team_invoice_mock_test.go
+++ b/plugins/source/heroku/resources/services/team_invoice_mock_test.go
@@ -9,18 +9,18 @@ import (
 	"testing"
 
 	"github.com/cloudquery/cloudquery/plugins/source/heroku/client"
-	faker "github.com/cloudquery/faker/v3"
+	"github.com/cloudquery/plugin-sdk/faker"
 	heroku "github.com/heroku/heroku-go/v5"
 	"github.com/julienschmidt/httprouter"
 )
 
 func createTeamInvoices() (*heroku.Service, error) {
 	primaryItems := make(heroku.TeamListResult, 1)
-	if err := faker.FakeData(&primaryItems); err != nil {
+	if err := faker.FakeObject(&primaryItems); err != nil {
 		return nil, err
 	}
 	items := make(heroku.TeamInvoiceListResult, 1)
-	if err := faker.FakeData(&items); err != nil {
+	if err := faker.FakeObject(&items); err != nil {
 		return nil, err
 	}
 	mux := httprouter.New()

--- a/plugins/source/heroku/resources/services/team_member_mock_test.go
+++ b/plugins/source/heroku/resources/services/team_member_mock_test.go
@@ -9,18 +9,18 @@ import (
 	"testing"
 
 	"github.com/cloudquery/cloudquery/plugins/source/heroku/client"
-	faker "github.com/cloudquery/faker/v3"
+	"github.com/cloudquery/plugin-sdk/faker"
 	heroku "github.com/heroku/heroku-go/v5"
 	"github.com/julienschmidt/httprouter"
 )
 
 func createTeamMembers() (*heroku.Service, error) {
 	primaryItems := make(heroku.TeamListResult, 1)
-	if err := faker.FakeData(&primaryItems); err != nil {
+	if err := faker.FakeObject(&primaryItems); err != nil {
 		return nil, err
 	}
 	items := make(heroku.TeamMemberListResult, 1)
-	if err := faker.FakeData(&items); err != nil {
+	if err := faker.FakeObject(&items); err != nil {
 		return nil, err
 	}
 	mux := httprouter.New()

--- a/plugins/source/heroku/resources/services/team_mock_test.go
+++ b/plugins/source/heroku/resources/services/team_mock_test.go
@@ -9,14 +9,14 @@ import (
 	"testing"
 
 	"github.com/cloudquery/cloudquery/plugins/source/heroku/client"
-	faker "github.com/cloudquery/faker/v3"
+	"github.com/cloudquery/plugin-sdk/faker"
 	heroku "github.com/heroku/heroku-go/v5"
 	"github.com/julienschmidt/httprouter"
 )
 
 func createTeams() (*heroku.Service, error) {
 	items := make(heroku.TeamListResult, 1)
-	if err := faker.FakeData(&items); err != nil {
+	if err := faker.FakeObject(&items); err != nil {
 		return nil, err
 	}
 	mux := httprouter.New()

--- a/plugins/source/heroku/resources/services/team_space_mock_test.go
+++ b/plugins/source/heroku/resources/services/team_space_mock_test.go
@@ -9,18 +9,18 @@ import (
 	"testing"
 
 	"github.com/cloudquery/cloudquery/plugins/source/heroku/client"
-	faker "github.com/cloudquery/faker/v3"
+	"github.com/cloudquery/plugin-sdk/faker"
 	heroku "github.com/heroku/heroku-go/v5"
 	"github.com/julienschmidt/httprouter"
 )
 
 func createTeamSpaces() (*heroku.Service, error) {
 	primaryItems := make(heroku.TeamListResult, 1)
-	if err := faker.FakeData(&primaryItems); err != nil {
+	if err := faker.FakeObject(&primaryItems); err != nil {
 		return nil, err
 	}
 	items := make(heroku.TeamSpaceListResult, 1)
-	if err := faker.FakeData(&items); err != nil {
+	if err := faker.FakeObject(&items); err != nil {
 		return nil, err
 	}
 	mux := httprouter.New()

--- a/plugins/source/heroku/resources/services/vpn_connection_mock_test.go
+++ b/plugins/source/heroku/resources/services/vpn_connection_mock_test.go
@@ -9,18 +9,18 @@ import (
 	"testing"
 
 	"github.com/cloudquery/cloudquery/plugins/source/heroku/client"
-	faker "github.com/cloudquery/faker/v3"
+	"github.com/cloudquery/plugin-sdk/faker"
 	heroku "github.com/heroku/heroku-go/v5"
 	"github.com/julienschmidt/httprouter"
 )
 
 func createVPNConnections() (*heroku.Service, error) {
 	primaryItems := make(heroku.SpaceListResult, 1)
-	if err := faker.FakeData(&primaryItems); err != nil {
+	if err := faker.FakeObject(&primaryItems); err != nil {
 		return nil, err
 	}
 	items := make(heroku.VPNConnectionListResult, 1)
-	if err := faker.FakeData(&items); err != nil {
+	if err := faker.FakeObject(&items); err != nil {
 		return nil, err
 	}
 	mux := httprouter.New()


### PR DESCRIPTION
Around 300 files. Some got removed, some (k8s) didn't.

Continuation of https://github.com/cloudquery/cloudquery/pull/2622

To remove more old faker references, we need to implement the equivalent of `SetIgnoreInterface(bool)` ~and `SkipFields([]string)`~ as `faker.Option` in plugin-sdk/faker.