### PR TITLE
fix: Fix multiplexer for AWS Organizations

### DIFF
--- a/plugins/source/aws/codegen/recipes/organizations.go
+++ b/plugins/source/aws/codegen/recipes/organizations.go
@@ -12,7 +12,7 @@ func OrganizationsResources() []*Resource {
 			SubService: "accounts",
 			Struct:     &types.Account{},
 			SkipFields: []string{"Arn"},
-			Multiplex:  `client.ServiceAccountRegionMultiplexer("dax")`,
+			Multiplex:  `client.ServiceAccountRegionMultiplexer("organizations")`,
 			ExtraColumns: append(
 				defaultAccountColumns,
 				[]codegen.ColumnDefinition{

--- a/plugins/source/aws/codegen/recipes/organizations.go
+++ b/plugins/source/aws/codegen/recipes/organizations.go
@@ -12,7 +12,7 @@ func OrganizationsResources() []*Resource {
 			SubService: "accounts",
 			Struct:     &types.Account{},
 			SkipFields: []string{"Arn"},
-			Multiplex:  `client.ServiceAccountRegionMultiplexer("organizations")`,
+			Multiplex:  `client.AccountMultiplex`,
 			ExtraColumns: append(
 				defaultAccountColumns,
 				[]codegen.ColumnDefinition{

--- a/plugins/source/aws/resources/services/organizations/accounts.go
+++ b/plugins/source/aws/resources/services/organizations/accounts.go
@@ -11,7 +11,7 @@ func Accounts() *schema.Table {
 	return &schema.Table{
 		Name:      "aws_organizations_accounts",
 		Resolver:  fetchOrganizationsAccounts,
-		Multiplex: client.ServiceAccountRegionMultiplexer("organizations"),
+		Multiplex: client.AccountMultiplex,
 		Columns: []schema.Column{
 			{
 				Name:     "account_id",

--- a/plugins/source/aws/resources/services/organizations/accounts.go
+++ b/plugins/source/aws/resources/services/organizations/accounts.go
@@ -11,7 +11,7 @@ func Accounts() *schema.Table {
 	return &schema.Table{
 		Name:      "aws_organizations_accounts",
 		Resolver:  fetchOrganizationsAccounts,
-		Multiplex: client.ServiceAccountRegionMultiplexer("dax"),
+		Multiplex: client.ServiceAccountRegionMultiplexer("organizations"),
 		Columns: []schema.Column{
 			{
 				Name:     "account_id",


### PR DESCRIPTION
The organizations resource was using (what seems like) the incorrect multiplexer. Previously, in v0, this resource was using an account multiplexer: https://github.com/cloudquery/cq-provider-aws/blob/main/resources/services/organizations/accounts.go#L22 and I think changing the multiplexer was a mistake during the migration of resources from v0 to v1.
