### PR TITLE
fix!: Rollback: Remove the 'functions.Timeout' column

### DIFF
--- a/plugins/source/gcp/codegen/recipes/functions.go
+++ b/plugins/source/gcp/codegen/recipes/functions.go
@@ -17,7 +17,8 @@ var functionsResources = []*Resource{
 		RequestStructFields: `Parent: "projects/" + c.ProjectId + "/locations/-",`,
 		UnimplementedServer: &pb.UnimplementedCloudFunctionsServiceServer{},
 		FakerFieldsToIgnore: []string{"SourceCode", "Trigger"},
-		SkipFields:          []string{"SourceCode", "Trigger"},
+		// Skipping Timeout because `TypeInterval` is broken right now, and breaks the plugin completely.
+		SkipFields: []string{"SourceCode", "Trigger", "Timeout"},
 	},
 }
 

--- a/plugins/source/gcp/docs/tables/gcp_functions_functions.md
+++ b/plugins/source/gcp/docs/tables/gcp_functions_functions.md
@@ -18,7 +18,6 @@ The primary key for this table is **_cq_id**.
 |status|Int|
 |entry_point|String|
 |runtime|String|
-|timeout|TimeInterval|
 |available_memory_mb|Int|
 |service_account_email|String|
 |update_time|Timestamp|

--- a/plugins/source/gcp/resources/services/functions/functions.go
+++ b/plugins/source/gcp/resources/services/functions/functions.go
@@ -50,11 +50,6 @@ func Functions() *schema.Table {
 				Resolver: schema.PathResolver("Runtime"),
 			},
 			{
-				Name:     "timeout",
-				Type:     schema.TypeTimeInterval,
-				Resolver: client.ResolveProtoDuration("Timeout"),
-			},
-			{
 				Name:     "available_memory_mb",
 				Type:     schema.TypeInt,
 				Resolver: schema.PathResolver("AvailableMemoryMb"),


### PR DESCRIPTION
The 'TypeInterval' type is broken right now.
Because of the new batching functionality, this failure completely breaks the GCP plugin (any failure in an INSERT causes all other INSERTS to also fail due to the batch).

<!-- 🎉 Thank you for making CloudQuery awesome by submitting a PR 🎉 -->

#### Summary

<!--
Explain what problem this PR addresses
-->

<!--
Use the following steps to ensure your PR is ready to be reviewed

- [ ] Read the [contribution guidelines](../blob/main/CONTRIBUTING.md) 🧑‍🎓
- [ ] Test locally on your own infrastructure
- [ ] Run `go fmt` to format your code 🖊
- [ ] Lint your changes via `golangci-lint run` 🚨 (install golangci-lint [here](https://golangci-lint.run/usage/install/#local-installation))
- [ ] Update or add tests 🧪
- [ ] Ensure the status checks below are successful ✅
--->
