### PR TITLE
fix: Fix filename of zones_with_dnssec_disabled in gcp cis v1.2.0 section3

### DIFF
--- a/plugins/source/gcp/policies_v1/cis_v1.2.0/section_3.sql
+++ b/plugins/source/gcp/policies_v1/cis_v1.2.0/section_3.sql
@@ -10,7 +10,7 @@
 \ir ../queries/compute/legacy_network_exist.sql
 \set check_id '3.3'
 \echo "Executing check 3.3"
-\ir ../queries/dns/zones_without_dnssec.sql 
+\ir ../queries/dns/zones_with_dnssec_disabled.sql
 \set check_id '3.4'
 \echo "Executing check 3.4"
 \ir ../queries/dns/key_signing_with_rsasha1.sql


### PR DESCRIPTION
It looks like `zones_without_dnssec` was renamed to `zones_with_dnssec_disabled` but the policy not updated. 

(Thanks to user `lolcat` for reporting this on Discord!)