### PR TITLE
chore(ci): Run lint,built,test on `main` to prime cache

### DIFF
--- a/.github/workflows/dest_postgresql.yml
+++ b/.github/workflows/dest_postgresql.yml
@@ -5,6 +5,12 @@ on:
     paths:
       - "plugins/destination/postgresql/**"
       - ".github/workflows/dest_postgresql.yml"
+  push:
+    branches:
+      - main
+    paths:
+      - "plugins/destination/postgresql/**"
+      - ".github/workflows/dest_postgresql.yml"
 
 defaults:
   run:

--- a/.github/workflows/dest_test.yml
+++ b/.github/workflows/dest_test.yml
@@ -5,6 +5,12 @@ on:
     paths:
       - "plugins/destination/test/**"
       - ".github/workflows/dest_test.yml"
+  push:
+    branches:
+      - main
+    paths:
+      - "plugins/destination/test/**"
+      - ".github/workflows/dest_test.yml"
 
 defaults:
   run:

--- a/.github/workflows/source_aws.yml
+++ b/.github/workflows/source_aws.yml
@@ -5,6 +5,12 @@ on:
     paths:
       - "plugins/source/aws/**"
       - ".github/workflows/source_aws.yml"
+  push:
+    branches:
+      - main
+    paths:
+      - "plugins/source/aws/**"
+      - ".github/workflows/source_aws.yml"
 
 defaults:
   run:
@@ -37,10 +43,14 @@ jobs:
       - name: Test
         run: make test
       - name: gen-docs
+        if: github.event_name == 'pull_request'
         run: make gen-docs
       - name: Fail if docs are changed
+        if: github.event_name == 'pull_request'
         run: test "$(git status -s ./docs/tables | wc -l)" -eq 0
       - name: gen-code
+        if: github.event_name == 'pull_request'
         run: make gen-code
       - name: Fail if code generation changed services
+        if: github.event_name == 'pull_request'
         run: test "$(git status -s ./resources/services | wc -l)" -eq 0

--- a/.github/workflows/source_azure.yml
+++ b/.github/workflows/source_azure.yml
@@ -5,6 +5,12 @@ on:
     paths:
       - "plugins/source/azure/**"
       - ".github/workflows/source_azure.yml"
+  push:
+    branches:
+      - main
+    paths:
+      - "plugins/source/azure/**"
+      - ".github/workflows/source_azure.yml"
 
 defaults:
   run:
@@ -39,10 +45,14 @@ jobs:
       - name: remove all docs
         run: rm -f ./docs/tables/*.md
       - name: gen-docs
+        if: github.event_name == 'pull_request'
         run: make gen-docs
       - name: Fail if docs are changed
+        if: github.event_name == 'pull_request'
         run: test "$(git status -s ./docs/tables | wc -l)" -eq 0
       - name: gen-code
+        if: github.event_name == 'pull_request'
         run: make gen-code
       - name: Fail if code generation changed services
+        if: github.event_name == 'pull_request'
         run: test "$(git status -s ./resources/services | wc -l)" -eq 0

--- a/.github/workflows/source_cloudflare.yml
+++ b/.github/workflows/source_cloudflare.yml
@@ -5,6 +5,12 @@ on:
     paths:
       - "plugins/source/cloudflare/**"
       - ".github/workflows/source_cloudflare.yml"
+  push:
+    branches:
+      - main
+    paths:
+      - "plugins/source/cloudflare/**"
+      - ".github/workflows/source_cloudflare.yml"
 
 defaults:
   run:
@@ -37,10 +43,14 @@ jobs:
       - name: Test
         run: make test
       - name: gen-docs
+        if: github.event_name == 'pull_request'
         run: make gen-docs
       - name: Fail if docs are changed
+        if: github.event_name == 'pull_request'
         run: test "$(git status -s ./docs/tables | wc -l)" -eq 0
       - name: gen-code
+        if: github.event_name == 'pull_request'
         run: make gen-code
       - name: Fail if code generation changed services
+        if: github.event_name == 'pull_request'
         run: test "$(git status -s ./resources/services | wc -l)" -eq 0

--- a/.github/workflows/source_digitalocean.yml
+++ b/.github/workflows/source_digitalocean.yml
@@ -5,6 +5,12 @@ on:
     paths:
       - "plugins/source/digitalocean/**"
       - ".github/workflows/source_digitalocean.yml"
+  push:
+    branches:
+      - main
+    paths:
+      - "plugins/source/digitalocean/**"
+      - ".github/workflows/source_digitalocean.yml"
 
 defaults:
   run:
@@ -37,10 +43,14 @@ jobs:
       - name: Test
         run: make test
       - name: gen-docs
+        if: github.event_name == 'pull_request'
         run: make gen-docs
       - name: Fail if docs are changed
+        if: github.event_name == 'pull_request'
         run: test "$(git status -s ./docs/tables | wc -l)" -eq 0
       - name: gen-code
+        if: github.event_name == 'pull_request'
         run: make gen-code
       - name: Fail if code generation changed services
+        if: github.event_name == 'pull_request'
         run: test "$(git status -s ./resources/services | wc -l)" -eq 0

--- a/.github/workflows/source_gcp.yml
+++ b/.github/workflows/source_gcp.yml
@@ -5,6 +5,12 @@ on:
     paths:
       - "plugins/source/gcp/**"
       - ".github/workflows/source_gcp.yml"
+  push:
+    branches:
+      - main
+    paths:
+      - "plugins/source/gcp/**"
+      - ".github/workflows/source_gcp.yml"
 
 defaults:
   run:
@@ -37,10 +43,14 @@ jobs:
       - name: Test
         run: make test
       - name: gen-docs
+        if: github.event_name == 'pull_request'
         run: make gen-docs
       - name: Fail if docs are changed
+        if: github.event_name == 'pull_request'
         run: test "$(git status -s ./docs/tables | wc -l)" -eq 0
       - name: gen-code
+        if: github.event_name == 'pull_request'
         run: make gen-code
       - name: Fail if code generation changed services
+        if: github.event_name == 'pull_request'
         run: test "$(git status -s ./resources/services | wc -l)" -eq 0

--- a/.github/workflows/source_github.yml
+++ b/.github/workflows/source_github.yml
@@ -5,6 +5,12 @@ on:
     paths:
       - "plugins/source/github/**"
       - ".github/workflows/source_github.yml"
+  push:
+    branches:
+      - main
+    paths:
+      - "plugins/source/github/**"
+      - ".github/workflows/source_github.yml"
 
 defaults:
   run:
@@ -37,10 +43,14 @@ jobs:
       - name: Test
         run: make test
       - name: gen-docs
+        if: github.event_name == 'pull_request'
         run: make gen-docs
       - name: Fail if docs are changed
+        if: github.event_name == 'pull_request'
         run: test "$(git status -s ./docs/tables | wc -l)" -eq 0
       - name: gen-code
+        if: github.event_name == 'pull_request'
         run: make gen-code
       - name: Fail if code generation changed services
+        if: github.event_name == 'pull_request'
         run: test "$(git status -s ./resources/services | wc -l)" -eq 0

--- a/.github/workflows/source_heroku.yml
+++ b/.github/workflows/source_heroku.yml
@@ -5,6 +5,12 @@ on:
     paths:
       - "plugins/source/heroku/**"
       - ".github/workflows/source_heroku.yml"
+  push:
+    branches:
+      - main
+    paths:
+      - "plugins/source/heroku/**"
+      - ".github/workflows/source_heroku.yml"
 
 defaults:
   run:
@@ -37,10 +43,14 @@ jobs:
       - name: Test
         run: go test ./...
       - name: gen-docs
+        if: github.event_name == 'pull_request'
         run: make gen-docs
       - name: Fail if docs are changed
+        if: github.event_name == 'pull_request'
         run: test "$(git status -s ./docs/tables | wc -l)" -eq 0
       - name: gen-code
+        if: github.event_name == 'pull_request'
         run: make gen-code
       - name: Fail if code generation changed services
+        if: github.event_name == 'pull_request'
         run: test "$(git status -s ./resources/services | wc -l)" -eq 0

--- a/.github/workflows/source_k8s.yml
+++ b/.github/workflows/source_k8s.yml
@@ -5,6 +5,12 @@ on:
     paths:
       - "plugins/source/k8s/**"
       - ".github/workflows/source_k8s.yml"
+  push:
+    branches:
+      - main
+    paths:
+      - "plugins/source/k8s/**"
+      - ".github/workflows/source_k8s.yml"
 
 defaults:
   run:
@@ -37,10 +43,14 @@ jobs:
       - name: Test
         run: make test
       - name: gen-docs
+        if: github.event_name == 'pull_request'
         run: make gen-docs
       - name: Fail if docs are changed
+        if: github.event_name == 'pull_request'
         run: test "$(git status -s ./docs/tables | wc -l)" -eq 0
       - name: gen-code
+        if: github.event_name == 'pull_request'
         run: make gen-code
       - name: Fail if code generation changed services
+        if: github.event_name == 'pull_request'
         run: test "$(git status -s ./resources/services | wc -l)" -eq 0

--- a/.github/workflows/source_okta.yml
+++ b/.github/workflows/source_okta.yml
@@ -5,6 +5,12 @@ on:
     paths:
       - "plugins/source/okta/**"
       - ".github/workflows/source_okta.yml"
+  push:
+    branches:
+      - main
+    paths:
+      - "plugins/source/okta/**"
+      - ".github/workflows/source_okta.yml"
 
 defaults:
   run:
@@ -37,6 +43,8 @@ jobs:
       - name: Test
         run: make test
       - name: gen-docs
+        if: github.event_name == 'pull_request'
         run: make gen-docs
       - name: Fail if docs are changed
+        if: github.event_name == 'pull_request'
         run: test "$(git status -s ./docs/tables | wc -l)" -eq 0

--- a/.github/workflows/source_terraform.yml
+++ b/.github/workflows/source_terraform.yml
@@ -5,6 +5,12 @@ on:
     paths:
       - "plugins/source/terraform/**"
       - ".github/workflows/source_terraform.yml"
+  push:
+    branches:
+      - main
+    paths:
+      - "plugins/source/terraform/**"
+      - ".github/workflows/source_terraform.yml"
 
 defaults:
   run:
@@ -37,6 +43,8 @@ jobs:
       - name: Test
         run: make test
       - name: gen-docs
+        if: github.event_name == 'pull_request'
         run: make gen-docs
       - name: Fail if docs are changed
+        if: github.event_name == 'pull_request'
         run: test "$(git status -s ./docs/tables | wc -l)" -eq 0

--- a/.github/workflows/source_test.yml
+++ b/.github/workflows/source_test.yml
@@ -5,6 +5,12 @@ on:
     paths:
       - "plugins/source/test/**"
       - ".github/workflows/source_test.yml"
+  push:
+    branches:
+      - main
+    paths:
+      - "plugins/source/test/**"
+      - ".github/workflows/source_test.yml"
 
 defaults:
   run:
@@ -37,6 +43,8 @@ jobs:
       - name: Test
         run: make test
       - name: build-docs
+        if: github.event_name == 'pull_request'
         run: make gen-docs
       - name: Fail if docs are changed
+        if: github.event_name == 'pull_request'
         run: test "$(git status -s ./docs/tables | wc -l)" -eq 0


### PR DESCRIPTION
<!-- 🎉 Thank you for making CloudQuery awesome by submitting a PR 🎉 -->

#### Summary

This is a follow up to https://github.com/cloudquery/cloudquery/pull/2949. [GitHub actions caching works like this](https://docs.github.com/en/actions/using-workflows/caching-dependencies-to-speed-up-workflows#restrictions-for-accessing-a-cache):
1. PRs can use cache saved on `main`
2. PRs can use cache saved on the PR brach
3. `main` Can't use cache saved on PRs branches

This PRs re-runs our lint, build and tests workflows on `main` to prime the cache so it can be used for follow up PRs.
Once merged I'll verify caching does help in a significant enough way to justify this way.

This seems counter intuitive but might also save us build minutes, as now we are leveraging caching only for re-runs of the same PR.

<!--
Use the following steps to ensure your PR is ready to be reviewed

- [ ] Read the [contribution guidelines](../blob/main/CONTRIBUTING.md) 🧑‍🎓
- [ ] Test locally on your own infrastructure
- [ ] Run `go fmt` to format your code 🖊
- [ ] Lint your changes via `golangci-lint run` 🚨 (install golangci-lint [here](https://golangci-lint.run/usage/install/#local-installation))
- [ ] Update or add tests 🧪
- [ ] Ensure the status checks below are successful ✅
--->
