### PR TITLE
Fix: Minor adjustments to analytics

### DIFF
--- a/cli/cmd/analytics.go
+++ b/cli/cmd/analytics.go
@@ -53,7 +53,7 @@ func (c *AnalyticsClient) SendSyncSummary(ctx context.Context, sourceSpec specs.
 		}
 		for _, destinationSpec := range destinationsSpecs {
 			syncSummary.Destinations = append(syncSummary.Destinations, &pb.Destination{
-				Path:    destinationSpec.Name,
+				Path:    destinationSpec.Path,
 				Version: destinationSpec.Version,
 			})
 		}

--- a/cli/cmd/root.go
+++ b/cli/cmd/root.go
@@ -36,7 +36,14 @@ func NewCmdRoot() *cobra.Command {
 	logFileName := "cloudquery.log"
 	sentryDsn := sentryDsnDefault
 
-	err := telemetryLevel.Set(getEnvOrDefault("CQ_TELEMETRY_LEVEL", telemetryLevel.Value))
+	// support legacy telemetry environment variable,
+	// but the newer CQ_TELEMETRY_LEVEL environment variable takes precedence
+	defaultTelemetryValue := telemetryLevel.Value
+	legacyTelemetry := os.Getenv("CQ_NO_TELEMETRY")
+	if legacyTelemetry != "" {
+		defaultTelemetryValue = "none"
+	}
+	err := telemetryLevel.Set(getEnvOrDefault("CQ_TELEMETRY_LEVEL", defaultTelemetryValue))
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "failed to set telemetry level: "+err.Error())
 		os.Exit(1)


### PR DESCRIPTION
Quick follow-up to https://github.com/cloudquery/cloudquery/pull/2619

- Destination spec should be sending `Path`, not `Name`
- Add backwards-compatible support for `CQ_NO_TELEMETRY` in case someone is still relying on that from v0. We don't want to surprise anyone by sending telemetry even though they have that variable set, but `CQ_TELEMETRY_LEVEL` should be preferred from now on.