### PR TITLE
chore(ci): Add workflow to re-gen source plugins docs

### DIFF
--- a/.github/workflows/manual_approve.yml
+++ b/.github/workflows/manual_approve.yml
@@ -1,0 +1,18 @@
+name: Manual Approve
+
+on:
+  issue_comment:
+    types: [created]
+
+jobs:
+  docs:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Trigger Source Plugin Docs Generation Command
+        uses: peter-evans/slash-command-dispatch@v3
+        with:
+          token: ${{ secrets.GH_CQ_BOT }}
+          reaction-token: ${{ secrets.GITHUB_TOKEN }}
+          issue-type: pull-request
+          commands: docs
+          permission: write

--- a/.github/workflows/manual_triggers.yml
+++ b/.github/workflows/manual_triggers.yml
@@ -1,0 +1,37 @@
+name: Manual Triggers
+
+on:
+  repository_dispatch:
+    types: [docs-command]
+
+jobs:
+  ok-to-run:
+    runs-on: ubuntu-latest
+    outputs:
+      status: ${{ steps.manually_approved.outputs.result }}
+    steps:
+      - name: Check if was manually approved
+        id: manually_approved
+        run: |
+          manually_approved=${{ github.event_name == 'repository_dispatch' && github.event.client_payload.slash_command.args.named.sha != '' && contains(github.event.client_payload.pull_request.head.sha, github.event.client_payload.slash_command.args.named.sha) }}
+          echo ::set-output name=result::"$manually_approved"
+  docs:
+    needs: [ok-to-run]
+    if: github.event_name == 'repository_dispatch' && github.event.action == 'docs-command' && needs.ok-to-run.outputs.status == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          ref: ${{ github.event.client_payload.slash_command.args.named.sha }}
+          repository: ${{ github.event.client_payload.pull_request.head.repo.full_name }}
+          token: ${{ secrets.GH_CQ_BOT }}
+
+      - name: Generate docs
+        run: make gen-docs
+        working-directory: plugins/source/${{ github.event.client_payload.slash_command.args.named.plugin }}
+
+      - uses: stefanzweifel/git-auto-commit-action@v4
+        with:
+          commit_message: "chore: Update docs"
+          branch: ${{ github.event.client_payload.pull_request.head.ref }}


### PR DESCRIPTION
<!-- 🎉 Thank you for making CloudQuery awesome by submitting a PR 🎉 -->

#### Summary

This adds a workflow so we can comment on a PR with:
`/docs sha=<sha> plugin=aws` and it will re-generate the docs a commit them back to the PR branch.

See example https://github.com/cloudquery/helm-charts/pull/137#issuecomment-1282648601

That should make it easier to handle SDK changes to docs generation

<!--
Use the following steps to ensure your PR is ready to be reviewed

- [ ] Read the [contribution guidelines](../blob/main/CONTRIBUTING.md) 🧑‍🎓
- [ ] Test locally on your own infrastructure
- [ ] Run `go fmt` to format your code 🖊
- [ ] Lint your changes via `golangci-lint run` 🚨 (install golangci-lint [here](https://golangci-lint.run/usage/install/#local-installation))
- [ ] Update or add tests 🧪
- [ ] Ensure the status checks below are successful ✅
--->
