### PR TITLE
fix(aws-grafana-ec2_public_private): Fix Name column

### DIFF
--- a/plugins/source/aws/dashboards/grafana/aws_ec2_public_private.json
+++ b/plugins/source/aws/dashboards/grafana/aws_ec2_public_private.json
@@ -122,7 +122,7 @@
             "group": [],
             "metricColumn": "none",
             "rawQuery": true,
-            "rawSql": "SELECT\n  (Tags->>'Name') as Name,\n  subnet_id,\n  instance_id,\n  region,\n  private_ip_address,\n  public_ip_address\nFROM aws_ec2_instances where (aws_ec2_instances.subnet_id in (${Subnets}) and aws_ec2_instances.region in (${Region}) and aws_ec2_instances.public_ip_address is not null)",
+            "rawSql": "SELECT\n  jsonb_path_query_first(tags, '$[*]? (@.Key == \"Name\")') ->> 'Value' as Name,\n  subnet_id,\n  instance_id,\n  region,\n  private_ip_address,\n  public_ip_address\nFROM aws_ec2_instances where (aws_ec2_instances.subnet_id in (${Subnets}) and aws_ec2_instances.region in (${Region}) and aws_ec2_instances.public_ip_address is not null)",
             "refId": "A",
             "select": [
               [
@@ -263,7 +263,7 @@
             "hide": false,
             "metricColumn": "none",
             "rawQuery": true,
-            "rawSql": "SELECT\n  count(*) as \"Privatee Instances\"\nFROM aws_ec2_instances where (aws_ec2_instances.subnet_id in (${Subnets}) and aws_ec2_instances.region in (${Region}) and aws_ec2_instances.public_ip_address is null)",
+            "rawSql": "SELECT\n  count(*) as \"Private Instances\"\nFROM aws_ec2_instances where (aws_ec2_instances.subnet_id in (${Subnets}) and aws_ec2_instances.region in (${Region}) and aws_ec2_instances.public_ip_address is null)",
             "refId": "B",
             "select": [
               [
@@ -350,7 +350,7 @@
             "group": [],
             "metricColumn": "none",
             "rawQuery": true,
-            "rawSql": "SELECT\n  (Tags->>'Name') as Name,\n  subnet_id,\n  instance_id,\n  region,\n  private_ip_address\nFROM aws_ec2_instances where (aws_ec2_instances.subnet_id in (${Subnets}) and region in (${Region}) and aws_ec2_instances.public_ip_address is null)",
+            "rawSql": "SELECT\n  jsonb_path_query_first(tags, '$[*]? (@.Key == \"Name\")') ->> 'Value' as Name,\n  subnet_id,\n  instance_id,\n  region,\n  private_ip_address\nFROM aws_ec2_instances where (aws_ec2_instances.subnet_id in (${Subnets}) and region in (${Region}) and aws_ec2_instances.public_ip_address is null)",
             "refId": "A",
             "select": [
               [


### PR DESCRIPTION
Fix Name column in Grafana AWS Dashboard ec2_public_private.json

Previous context :
  aws_ec2_instances.tags format :
  {"Name": "test-cloudinventory"}
New context :
  aws_ec2_instances.tags format :
  [{"Key": "Name", "Value": "test-cloudinventory"}]

<!-- 🎉 Thank you for making CloudQuery awesome by submitting a PR 🎉 -->

#### Summary

<!--
The Name column in AWS Grafana Dashboard ec2_public_private.json was not working as the tags column format in aws_ec2_instances has changed
-->

<!--
Use the following steps to ensure your PR is ready to be reviewed

- [x] Read the [contribution guidelines](../blob/main/CONTRIBUTING.md) 🧑‍🎓
- [x] Test locally on your own infrastructure
- [x] Run `go fmt` to format your code 🖊
- [x] Lint your changes via `golangci-lint run` 🚨 (install golangci-lint [here](https://golangci-lint.run/usage/install/#local-installation))
- [x] Update or add tests 🧪
- [x] Ensure the status checks below are successful ✅
--->
