### PR TITLE
chore(ci): Don't set default working directory for validate-release

### DIFF
--- a/.github/workflows/cli.yml
+++ b/.github/workflows/cli.yml
@@ -6,14 +6,13 @@ on:
       - "cli/**"
       - ".github/workflows/cli.yml"
 
-defaults:
-  run:
-    working-directory: ./cli
-
 jobs:
   cli:
     name: "cli"
     runs-on: ${{ matrix.os }}
+    defaults:
+      run:
+        working-directory: ./cli
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]

--- a/.github/workflows/dest_postgresql.yml
+++ b/.github/workflows/dest_postgresql.yml
@@ -12,14 +12,13 @@ on:
       - "plugins/destination/postgresql/**"
       - ".github/workflows/dest_postgresql.yml"
 
-defaults:
-  run:
-    working-directory: ./plugins/destination/postgresql
-
 jobs:
   plugins-destination-postgresql:
     name: "plugins/destination/postgresql"
     runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: ./plugins/destination/postgresql
     services:
       # Label used to access the service container
       postgres:

--- a/.github/workflows/dest_test.yml
+++ b/.github/workflows/dest_test.yml
@@ -12,14 +12,13 @@ on:
       - "plugins/destination/test/**"
       - ".github/workflows/dest_test.yml"
 
-defaults:
-  run:
-    working-directory: ./plugins/destination/test
-
 jobs:
   plugins-destination-test:
     name: "plugins/destination/test"
     runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: ./plugins/destination/test
     steps:
       - uses: actions/checkout@v3
         with:

--- a/.github/workflows/source_aws.yml
+++ b/.github/workflows/source_aws.yml
@@ -12,14 +12,13 @@ on:
       - "plugins/source/aws/**"
       - ".github/workflows/source_aws.yml"
 
-defaults:
-  run:
-    working-directory: ./plugins/source/aws
-
 jobs:
   plugins-source-aws:
     name: "plugins/source/aws"
     runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: ./plugins/source/aws
     steps:
       - uses: actions/checkout@v3
         with:

--- a/.github/workflows/source_azure.yml
+++ b/.github/workflows/source_azure.yml
@@ -12,14 +12,13 @@ on:
       - "plugins/source/azure/**"
       - ".github/workflows/source_azure.yml"
 
-defaults:
-  run:
-    working-directory: ./plugins/source/azure
-
 jobs:
   plugins-source-azure:
     name: "plugins/source/azure"
     runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: ./plugins/source/azure
     steps:
       - uses: actions/checkout@v3
         with:

--- a/.github/workflows/source_cloudflare.yml
+++ b/.github/workflows/source_cloudflare.yml
@@ -12,14 +12,13 @@ on:
       - "plugins/source/cloudflare/**"
       - ".github/workflows/source_cloudflare.yml"
 
-defaults:
-  run:
-    working-directory: ./plugins/source/cloudflare
-
 jobs:
   plugins-source-cloudflare:
     name: "plugins/source/cloudflare"
     runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: ./plugins/source/cloudflare
     steps:
       - uses: actions/checkout@v3
         with:

--- a/.github/workflows/source_digitalocean.yml
+++ b/.github/workflows/source_digitalocean.yml
@@ -12,14 +12,13 @@ on:
       - "plugins/source/digitalocean/**"
       - ".github/workflows/source_digitalocean.yml"
 
-defaults:
-  run:
-    working-directory: ./plugins/source/digitalocean
-
 jobs:
   plugins-source-digitalocean:
     name: "plugins/source/digitalocean"
     runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: ./plugins/source/digitalocean
     steps:
       - uses: actions/checkout@v3
         with:

--- a/.github/workflows/source_gcp.yml
+++ b/.github/workflows/source_gcp.yml
@@ -12,14 +12,13 @@ on:
       - "plugins/source/gcp/**"
       - ".github/workflows/source_gcp.yml"
 
-defaults:
-  run:
-    working-directory: ./plugins/source/gcp
-
 jobs:
   plugins-source-gcp:
     name: "plugins/source/gcp"
     runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: ./plugins/source/gcp
     steps:
       - uses: actions/checkout@v3
         with:

--- a/.github/workflows/source_github.yml
+++ b/.github/workflows/source_github.yml
@@ -12,14 +12,13 @@ on:
       - "plugins/source/github/**"
       - ".github/workflows/source_github.yml"
 
-defaults:
-  run:
-    working-directory: ./plugins/source/github
-
 jobs:
   plugins-source-github:
     name: "plugins/source/github"
     runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: ./plugins/source/github
     steps:
       - uses: actions/checkout@v3
         with:

--- a/.github/workflows/source_heroku.yml
+++ b/.github/workflows/source_heroku.yml
@@ -12,14 +12,13 @@ on:
       - "plugins/source/heroku/**"
       - ".github/workflows/source_heroku.yml"
 
-defaults:
-  run:
-    working-directory: ./plugins/source/heroku
-
 jobs:
   plugins-source-heroku:
     name: "plugins/source/heroku"
     runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: ./plugins/source/heroku
     steps:
       - uses: actions/checkout@v3
         with:

--- a/.github/workflows/source_k8s.yml
+++ b/.github/workflows/source_k8s.yml
@@ -12,14 +12,13 @@ on:
       - "plugins/source/k8s/**"
       - ".github/workflows/source_k8s.yml"
 
-defaults:
-  run:
-    working-directory: ./plugins/source/k8s
-
 jobs:
   plugins-source-k8s:
     name: "plugins/source/k8s"
     runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: ./plugins/source/k8s
     steps:
       - uses: actions/checkout@v3
         with:

--- a/.github/workflows/source_okta.yml
+++ b/.github/workflows/source_okta.yml
@@ -12,14 +12,13 @@ on:
       - "plugins/source/okta/**"
       - ".github/workflows/source_okta.yml"
 
-defaults:
-  run:
-    working-directory: ./plugins/source/okta
-
 jobs:
   plugins-source-okta:
     name: "plugins/source/okta"
     runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: ./plugins/source/okta
     steps:
       - uses: actions/checkout@v3
         with:

--- a/.github/workflows/source_terraform.yml
+++ b/.github/workflows/source_terraform.yml
@@ -12,14 +12,13 @@ on:
       - "plugins/source/terraform/**"
       - ".github/workflows/source_terraform.yml"
 
-defaults:
-  run:
-    working-directory: ./plugins/source/terraform
-
 jobs:
   plugins-source-terraform:
     name: "plugins/source/terraform"
     runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: ./plugins/source/terraform
     steps:
       - uses: actions/checkout@v3
         with:

--- a/.github/workflows/source_test.yml
+++ b/.github/workflows/source_test.yml
@@ -12,14 +12,13 @@ on:
       - "plugins/source/test/**"
       - ".github/workflows/source_test.yml"
 
-defaults:
-  run:
-    working-directory: ./plugins/source/test
-
 jobs:
   plugins-source-test:
     name: "plugins/source/test"
     runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: ./plugins/source/test
     steps:
       - uses: actions/checkout@v3
         with:


### PR DESCRIPTION
<!-- 🎉 Thank you for making CloudQuery awesome by submitting a PR 🎉 -->

#### Summary

Follow up to https://github.com/cloudquery/cloudquery/pull/3059. Go releaser needs to run from the repo root, so this moves the setting for a default working directory to the specific job that requires it

<!--
Use the following steps to ensure your PR is ready to be reviewed

- [ ] Read the [contribution guidelines](../blob/main/CONTRIBUTING.md) 🧑‍🎓
- [ ] Test locally on your own infrastructure
- [ ] Run `go fmt` to format your code 🖊
- [ ] Lint your changes via `golangci-lint run` 🚨 (install golangci-lint [here](https://golangci-lint.run/usage/install/#local-installation))
- [ ] Update or add tests 🧪
- [ ] Ensure the status checks below are successful ✅
--->
