### PR TITLE
chore: Fix release CLI replace version regex

### DIFF
--- a/.github/workflows/release_cli.yml
+++ b/.github/workflows/release_cli.yml
@@ -85,7 +85,7 @@ jobs:
         continue-on-error: true
         with:
           include: "sites/versions/vercel.json"
-          find: 'releases\/download\/cli\-v[^\/]+[\s\S]+?,'
+          find: 'releases\/download\/cli\-v[^\/]+[\s\S]+?},'
           replace: 'releases/download/${{github.ref_name}}" },'
           
       - name: Create Pull Request


### PR DESCRIPTION
<!-- 🎉 Thank you for making CloudQuery awesome by submitting a PR 🎉 -->

#### Summary

In https://github.com/cloudquery/cloudquery/pull/3080 we changed the format of our CLI binaries, [which required bumping the latest link to v2](https://github.com/cloudquery/cloudquery/pull/3083/files).
This PR fixes the replace regex to correctly replace the CLI version only in the v2 link (see problem in https://github.com/cloudquery/cloudquery/pull/3125/commits/9407faca8ef4366648023f7fd1c67262132ee4cb).

<!--
Use the following steps to ensure your PR is ready to be reviewed

- [ ] Read the [contribution guidelines](../blob/main/CONTRIBUTING.md) 🧑‍🎓
- [ ] Test locally on your own infrastructure
- [ ] Run `go fmt` to format your code 🖊
- [ ] Lint your changes via `golangci-lint run` 🚨 (install golangci-lint [here](https://golangci-lint.run/usage/install/#local-installation))
- [ ] Update or add tests 🧪
- [ ] Ensure the status checks below are successful ✅
--->
