### PR TITLE
chore(ci-release): Add 'CGO_ENABLED: 0' to validate-release

### DIFF
--- a/.github/workflows/cli.yml
+++ b/.github/workflows/cli.yml
@@ -52,6 +52,8 @@ jobs:
         run: test "$(git status -s ../website/pages/docs/reference/cli/*.md | wc -l)" -eq 0
   validate-release:
     runs-on: ubuntu-latest
+    env:
+      CGO_ENABLED: 0
     steps:
       - name: Checkout
         if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'

--- a/.github/workflows/dest_postgresql.yml
+++ b/.github/workflows/dest_postgresql.yml
@@ -68,6 +68,8 @@ jobs:
         run: CQ_DEST_PG_TEST_CONN="postgresql://root@localhost:26257/postgres?sslmode=disable" make test
   validate-release:
     runs-on: ubuntu-latest
+    env:
+      CGO_ENABLED: 0
     steps:
       - name: Checkout
         if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'

--- a/.github/workflows/dest_test.yml
+++ b/.github/workflows/dest_test.yml
@@ -43,6 +43,8 @@ jobs:
         run: go test ./...
   validate-release:
     runs-on: ubuntu-latest
+    env:
+      CGO_ENABLED: 0
     steps:
       - name: Checkout
         if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'

--- a/.github/workflows/source_aws.yml
+++ b/.github/workflows/source_aws.yml
@@ -55,6 +55,8 @@ jobs:
         run: test "$(git status -s ./resources/services | wc -l)" -eq 0
   validate-release:
     runs-on: ubuntu-latest
+    env:
+      CGO_ENABLED: 0
     steps:
       - name: Checkout
         if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'

--- a/.github/workflows/source_azure.yml
+++ b/.github/workflows/source_azure.yml
@@ -57,6 +57,8 @@ jobs:
         run: test "$(git status -s ./resources/services | wc -l)" -eq 0
   validate-release:
     runs-on: ubuntu-latest
+    env:
+      CGO_ENABLED: 0
     steps:
       - name: Checkout
         if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'

--- a/.github/workflows/source_cloudflare.yml
+++ b/.github/workflows/source_cloudflare.yml
@@ -55,6 +55,8 @@ jobs:
         run: test "$(git status -s ./resources/services | wc -l)" -eq 0
   validate-release:
     runs-on: ubuntu-latest
+    env:
+      CGO_ENABLED: 0
     steps:
       - name: Checkout
         if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'

--- a/.github/workflows/source_digitalocean.yml
+++ b/.github/workflows/source_digitalocean.yml
@@ -55,6 +55,8 @@ jobs:
         run: test "$(git status -s ./resources/services | wc -l)" -eq 0
   validate-release:
     runs-on: ubuntu-latest
+    env:
+      CGO_ENABLED: 0
     steps:
       - name: Checkout
         if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'

--- a/.github/workflows/source_gcp.yml
+++ b/.github/workflows/source_gcp.yml
@@ -55,6 +55,8 @@ jobs:
         run: test "$(git status -s ./resources/services | wc -l)" -eq 0
   validate-release:
     runs-on: ubuntu-latest
+    env:
+      CGO_ENABLED: 0
     steps:
       - name: Checkout
         if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'

--- a/.github/workflows/source_github.yml
+++ b/.github/workflows/source_github.yml
@@ -55,6 +55,8 @@ jobs:
         run: test "$(git status -s ./resources/services | wc -l)" -eq 0
   validate-release:
     runs-on: ubuntu-latest
+    env:
+      CGO_ENABLED: 0
     steps:
       - name: Checkout
         if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'

--- a/.github/workflows/source_heroku.yml
+++ b/.github/workflows/source_heroku.yml
@@ -55,6 +55,8 @@ jobs:
         run: test "$(git status -s ./resources/services | wc -l)" -eq 0
   validate-release:
     runs-on: ubuntu-latest
+    env:
+      CGO_ENABLED: 0
     steps:
       - name: Checkout
         if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'

--- a/.github/workflows/source_k8s.yml
+++ b/.github/workflows/source_k8s.yml
@@ -55,6 +55,8 @@ jobs:
         run: test "$(git status -s ./resources/services | wc -l)" -eq 0
   validate-release:
     runs-on: ubuntu-latest
+    env:
+      CGO_ENABLED: 0
     steps:
       - name: Checkout
         if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'

--- a/.github/workflows/source_okta.yml
+++ b/.github/workflows/source_okta.yml
@@ -49,6 +49,8 @@ jobs:
         run: test "$(git status -s ./docs/tables | wc -l)" -eq 0
   validate-release:
     runs-on: ubuntu-latest
+    env:
+      CGO_ENABLED: 0
     steps:
       - name: Checkout
         if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'

--- a/.github/workflows/source_terraform.yml
+++ b/.github/workflows/source_terraform.yml
@@ -49,6 +49,8 @@ jobs:
         run: test "$(git status -s ./docs/tables | wc -l)" -eq 0
   validate-release:
     runs-on: ubuntu-latest
+    env:
+      CGO_ENABLED: 0
     steps:
       - name: Checkout
         if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'

--- a/.github/workflows/source_test.yml
+++ b/.github/workflows/source_test.yml
@@ -49,6 +49,8 @@ jobs:
         run: test "$(git status -s ./docs/tables | wc -l)" -eq 0
   validate-release:
     runs-on: ubuntu-latest
+    env:
+      CGO_ENABLED: 0
     steps:
       - name: Checkout
         if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'


### PR DESCRIPTION
<!-- 🎉 Thank you for making CloudQuery awesome by submitting a PR 🎉 -->

#### Summary

We use `CGO_ENABLED: 0` in our release workflows, so we should do the same with `validate-release`

<!--
Use the following steps to ensure your PR is ready to be reviewed

- [ ] Read the [contribution guidelines](../blob/main/CONTRIBUTING.md) 🧑‍🎓
- [ ] Test locally on your own infrastructure
- [ ] Run `go fmt` to format your code 🖊
- [ ] Lint your changes via `golangci-lint run` 🚨 (install golangci-lint [here](https://golangci-lint.run/usage/install/#local-installation))
- [ ] Update or add tests 🧪
- [ ] Ensure the status checks below are successful ✅
--->
