### PR TITLE
feat: Project filter

### DIFF
--- a/plugins/source/gcp/client/client.go
+++ b/plugins/source/gcp/client/client.go
@@ -188,7 +188,7 @@ func listFolders(ctx context.Context, folderClient *resourcemanagerv3.FoldersCli
 	})
 
 	for {
-		folder, err := it.Next()
+		child, err := it.Next()
 
 		if err == iterator.Done {
 			break
@@ -197,8 +197,12 @@ func listFolders(ctx context.Context, folderClient *resourcemanagerv3.FoldersCli
 			return nil, err
 		}
 
-		if folder.State == resourcemanagerv3pb.Folder_ACTIVE {
-			folders = append(folders, folder.Name)
+		if child.State == resourcemanagerv3pb.Folder_ACTIVE {
+			childFolders, err := listFolders(ctx, folderClient, child.Name, recursionDepth-1)
+			if err != nil {
+				return nil, err
+			}
+			folders = append(folders, childFolders...)
 		}
 	}
 

--- a/plugins/source/gcp/client/client.go
+++ b/plugins/source/gcp/client/client.go
@@ -105,7 +105,7 @@ func New(ctx context.Context, logger zerolog.Logger, s specs.Source) (schema.Cli
 
 		c.logger.Info().Msg("listing folder projects..")
 		folderProjects, err := listProjectsInFolders(ctx, c.Services.ResourcemanagerProjectsClient, folderIds)
-		projects = append(projects, folderProjects...)
+		projects = setUnion(projects, folderProjects)
 		if err != nil {
 			return nil, fmt.Errorf("failed to list projects: %w", err)
 		}
@@ -229,4 +229,20 @@ func listProjectsInFolders(ctx context.Context, projectClient *resourcemanagerv3
 	}
 
 	return projects, nil
+}
+
+func setUnion(a []string, b []string) []string {
+	set := map[string]bool{}
+	for _, s := range a {
+		set[s] = true
+	}
+	for _, s := range b {
+		set[s] = true
+	}
+
+	union := []string{}
+	for s := range set {
+		union = append(union, s)
+	}
+	return union
 }

--- a/plugins/source/gcp/client/client_test.go
+++ b/plugins/source/gcp/client/client_test.go
@@ -1,0 +1,13 @@
+package client
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestSetUnion(t *testing.T) {
+	assert.ElementsMatch(t, []string{"a", "b", "c"}, setUnion([]string{"a", "b"}, []string{"b", "c"}))
+	assert.ElementsMatch(t, []string{"a", "b"}, setUnion([]string{"a", "b"}, []string{"a"}))
+	assert.ElementsMatch(t, []string{"a", "b"}, setUnion([]string{"a", "b"}, []string{}))
+}

--- a/plugins/source/gcp/client/spec.go
+++ b/plugins/source/gcp/client/spec.go
@@ -6,6 +6,7 @@ type Spec struct {
 	ServiceAccountKeyJSON string   `json:"service_account_key_json"`
 	FolderIDs             []string `json:"folder_ids"`
 	FolderRecursionDepth  *int     `json:"folder_recursion_depth"`
+	ProjectFilter         string   `json:"project_filter"`
 }
 
 func (spec *Spec) setDefaults() {

--- a/plugins/source/gcp/docs/configuration.md
+++ b/plugins/source/gcp/docs/configuration.md
@@ -6,7 +6,8 @@ This is the top level spec used by GCP Source Plugin
 
 - `project_ids` ([]string) (default: empty. will use all available projects available to the current authenticated account)
 
-  specify specific projects to connect to.
+  Specify specific projects to connect to. If either `folder_ids` or `project_filter` is specified, these projects will be fetched in addition
+  to the projects from the folder/filter.
 
 - `service_account_key_json` (string)
 
@@ -17,7 +18,14 @@ This is the top level spec used by GCP Source Plugin
   cloudquery will `sync` from all the projects in the specified folders, recursively. `folder_ids` must be of the format
   `folders/<folder_id>` or `organizations/<organization_id>`. This feature requires the `resourcemanager.folders.list` permission. 
   By default cloudquery will also `sync` from subfolders recursively (up to depth 100) - to reduce this, set `folder_recursion_depth` to a lower value (or 0 to disable recursion completely).
+  Mutually exclusive with `project_filter`.
 
 - `folder_recursion_depth` (int) (default: 100).
   
   the maximum depth to recurse into subfolders. 0 means no recursion (only the top-level projects in folders will be used for `sync`).
+
+- `project_filter` (string) (default: empty).
+
+  A filter to determine the projects that are synced. For instance, to only sync projects where the name starts with `how-`,
+  set `project_filter` to `name:how-*`. Another example is: `"name:how-* OR name:test-*"`. For syntax and example queries refer to API Reference [here](https://cloud.google.com/resource-manager/reference/rest/v1/projects/list#google.cloudresourcemanager.v1.Projects.ListProjects).
+  Mutually exclusive with `folder_ids`.


### PR DESCRIPTION
<!-- 🎉 Thank you for making CloudQuery awesome by submitting a PR 🎉 -->

#### Summary

See individual commits for easier reviewing.

1) Fixes two previous bugs in the folder feature [forgotten recursion, forgotten set-union].
2) Adds support for the project-filter feature.

The project-filter is mutually exclusive with `folder_ids`, but `project_ids` that are specified will be added to the projects from the filter. More explicitly:
![image](https://user-images.githubusercontent.com/37939765/197198988-f6b3551f-2680-4500-803c-6f0e8172050a.png)

<!--
Use the following steps to ensure your PR is ready to be reviewed

- [ ] Read the [contribution guidelines](../blob/main/CONTRIBUTING.md) 🧑‍🎓
- [ ] Test locally on your own infrastructure
- [ ] Run `go fmt` to format your code 🖊
- [ ] Lint your changes via `golangci-lint run` 🚨 (install golangci-lint [here](https://golangci-lint.run/usage/install/#local-installation))
- [ ] Update or add tests 🧪
- [ ] Ensure the status checks below are successful ✅
--->
