### PR TITLE
fix: Fix broken links for specific guides section in adding_a_new_resource.md

### DIFF
--- a/contributing/adding_a_new_resource.md
+++ b/contributing/adding_a_new_resource.md
@@ -38,6 +38,6 @@ Here are the general steps to follow:
 
 See the following guides for deep-dives into adding resources for specific source plugins:
 
-- [Adding a new resource (AWS)](../plugins/source/aws/docs/contributing/adding_a_new_resource.md)
-- [Adding a new resource (Azure)](../plugins/source/azure/docs/contributing/adding_a_new_resource.md)
-- [Adding a new resource (GCP)](../plugins/source/gcp/docs/contributing/adding_a_new_resource.md)
+- [Adding a new resource (AWS)](../plugins/source/aws/CONTRIBUTING.md)
+- [Adding a new resource (Azure)](../plugins/source/azure/CONTRIBUTING.md)
+- [Adding a new resource (GCP)](../plugins/source/gcp/CONTRIBUTING.md)


### PR DESCRIPTION
#### Summary
I took a look on the `adding_a_new_resource.md` in `contributing` folder and found out that links in specific guides section are broken and resulted in 404. 

After go around the repo, I think the correct link should be as following for `AWS`, `Azure` and `GCP`.
- AWS -> `../plugins/source/aws/CONTRIBUTING.md`
- Azure -> `../plugins/source/azure/CONTRIBUTING.md`
- GCP -> `../plugins/source/azure/CONTRIBUTING.md`

#### Use the following steps to ensure your PR is ready to be reviewed
- [x] Read the [contribution guidelines](../blob/main/CONTRIBUTING.md) 🧑‍🎓
- [x] Test locally on your own infrastructure
- [x] Run `go fmt` to format your code 🖊
- [x] Lint your changes via `golangci-lint run` 🚨 (install golangci-lint [here](https://golangci-lint.run/usage/install/#local-installation))
- [x] Update or add tests 🧪
- [ ] Ensure the status checks below are successful ✅
