### PR TITLE
chore(release-cli): Fix latest link regex

### DIFF
--- a/.github/workflows/release_cli.yml
+++ b/.github/workflows/release_cli.yml
@@ -86,7 +86,7 @@ jobs:
         with:
           include: "sites/versions/vercel.json"
           find: 'releases\/download\/cli\-v[^\/]+[\s\S]+?},'
-          replace: 'releases/download/${{github.ref_name}}" },'
+          replace: 'releases/download/${{github.ref_name}}/:binary" },'
           
       - name: Create Pull Request
         if: steps.semver_parser.outputs.prerelease == ''


### PR DESCRIPTION
<!-- 🎉 Thank you for making CloudQuery awesome by submitting a PR 🎉 -->

#### Summary

This is a follow up to https://github.com/cloudquery/cloudquery/pull/3080 and https://github.com/cloudquery/cloudquery/pull/3188.

Sine we have [2 latest links ](https://github.com/cloudquery/cloudquery/blob/f16542afe1f45809c793afa7631a69bc13bf7ea2/sites/versions/vercel.json#L5)in our `vercel.json` file, and we only want to [update the latest one](https://github.com/cloudquery/cloudquery/blob/f16542afe1f45809c793afa7631a69bc13bf7ea2/sites/versions/vercel.json#L9), we need the `/:binary` to be a part of the replace string

<!--
Use the following steps to ensure your PR is ready to be reviewed

- [ ] Read the [contribution guidelines](../blob/main/CONTRIBUTING.md) 🧑‍🎓
- [ ] Test locally on your own infrastructure
- [ ] Run `go fmt` to format your code 🖊
- [ ] Lint your changes via `golangci-lint run` 🚨 (install golangci-lint [here](https://golangci-lint.run/usage/install/#local-installation))
- [ ] Update or add tests 🧪
- [ ] Ensure the status checks below are successful ✅
--->
