### PR TITLE
chore(docs): Update GCP version

### DIFF
--- a/website/pages/docs/recipes/gcp-postgresql.md
+++ b/website/pages/docs/recipes/gcp-postgresql.md
@@ -5,7 +5,7 @@ kind: source
 spec:
   name: gcp
   path: cloudquery/gcp
-  version: "1.0.3" # latest version of gcp plugin
+  version: "v2.2.0" # latest version of gcp plugin
   tables: ["*"]
   destinations: ["postgresql"]
 ---


### PR DESCRIPTION
Version string was missing the "v"; and referenced an older version

<!-- 🎉 Thank you for making CloudQuery awesome by submitting a PR 🎉 -->

#### Summary

<!--
Sample config file failed due to missing "v" in version. Also the referenced version was old.
-->

<!--
Use the following steps to ensure your PR is ready to be reviewed

- [ ] Read the [contribution guidelines](../blob/main/CONTRIBUTING.md) 🧑‍🎓
- [ ] Test locally on your own infrastructure
- [ ] Run `go fmt` to format your code 🖊
- [ ] Lint your changes via `golangci-lint run` 🚨 (install golangci-lint [here](https://golangci-lint.run/usage/install/#local-installation))
- [ ] Update or add tests 🧪
- [ ] Ensure the status checks below are successful ✅
--->
