### PR TITLE
feat(aws): Increase inspector v1 ListFindings MaxResults to maximum

### DIFF
--- a/plugins/source/aws/resources/services/inspector/findings_fetch.go
+++ b/plugins/source/aws/resources/services/inspector/findings_fetch.go
@@ -12,7 +12,7 @@ import (
 func fetchInspectorFindings(ctx context.Context, meta schema.ClientMeta, parent *schema.Resource, res chan<- interface{}) error {
 	c := meta.(*client.Client)
 	svc := c.Services().Inspector
-	input := inspector.ListFindingsInput{MaxResults: aws.Int32(100)}
+	input := inspector.ListFindingsInput{MaxResults: aws.Int32(500)}
 	for {
 		response, err := svc.ListFindings(ctx, &input)
 		if err != nil {


### PR DESCRIPTION
<!-- 🎉 Thank you for making CloudQuery awesome by submitting a PR 🎉 -->

#### Summary

Related to https://github.com/cloudquery/cloudquery/issues/3203

~~v1 inspector findings can have a `MaxResults` of 500 per the Go API docs and also [here](https://docs.aws.amazon.com/inspector/v1/APIReference/API_ListFindings.html#Inspector-ListFindings-request-maxResults)~~ Actually seems like this won't work, as `DescribeFindings` has a limit of 10 ARNs 🙃 , so we should actually decrease the number per https://docs.aws.amazon.com/inspector/v1/APIReference/API_DescribeFindings.html#Inspector-DescribeFindings-request-findingArns.

What's more confusing is that the docs say the response can have 100 items:
https://docs.aws.amazon.com/inspector/v1/APIReference/API_DescribeFindings.html#Inspector-DescribeFindings-response-findings

v2 Go API docs don't say what's the limit but [here](https://docs.aws.amazon.com/inspector/v2/APIReference/API_ListFindings.html#inspector2-ListFindings-request-maxResults) is says 100, so needs more experimenting

<!--
Use the following steps to ensure your PR is ready to be reviewed

- [ ] Read the [contribution guidelines](../blob/main/CONTRIBUTING.md) 🧑‍🎓
- [ ] Test locally on your own infrastructure
- [ ] Run `go fmt` to format your code 🖊
- [ ] Lint your changes via `golangci-lint run` 🚨 (install golangci-lint [here](https://golangci-lint.run/usage/install/#local-installation))
- [ ] Update or add tests 🧪
- [ ] Ensure the status checks below are successful ✅
--->
