### PR TITLE
chore: Use large runners only on `push`

### DIFF
--- a/.github/workflows/source_test.yml
+++ b/.github/workflows/source_test.yml
@@ -20,9 +20,9 @@ jobs:
     steps:
       - name: Check if should use large runner
         id: large-runner
-        # We want to speed up SDK updates, release PRs and runs on the main branch which prime the cache
-        # We allow large runners only in these cases to prevent forks from abusing them (it's enforced via runner groups access rules)
-        if: github.event_name == 'push' || (github.head_ref =='release-please--branches--main--components--plugins-source-test') || (github.head_ref == 'renovate/plugins/source/test-github.com-cloudquery-plugin-sdk-0.x')
+        # We want to speed runs on the main branch which prime the cache
+        # We allow large runners only in this case to prevent forks from abusing them (it's enforced via runner groups access rules)
+        if: github.event_name == 'push'
         run: |
           echo "runner=cloudquery-release-runner" >> $GITHUB_OUTPUT
       - name: Resolve runner


### PR DESCRIPTION
<!-- 🎉 Thank you for making CloudQuery awesome by submitting a PR 🎉 -->

#### Summary

Follow up to https://github.com/cloudquery/cloudquery/pull/3322.
Looks like we can't use large runners on PRs in a safe way.
I configured the following access rules:
![image](https://user-images.githubusercontent.com/26760571/198974661-24b0c9fe-bc65-48d8-887e-f6d14102bf19.png)

But only the one on `main` works as PRs refs are based on the PR number, e.g. `refs/pull/<pr_number>/merge`.

This PR keeps the large runners only on `push` events. I'm hoping that should be sufficient to improve performance by priming the cache for all other PRs

<!--
Use the following steps to ensure your PR is ready to be reviewed

- [ ] Read the [contribution guidelines](../blob/main/CONTRIBUTING.md) 🧑‍🎓
- [ ] Test locally on your own infrastructure
- [ ] Run `go fmt` to format your code 🖊
- [ ] Lint your changes via `golangci-lint run` 🚨 (install golangci-lint [here](https://golangci-lint.run/usage/install/#local-installation))
- [ ] Update or add tests 🧪
- [ ] Ensure the status checks below are successful ✅
--->
