### PR TITLE
chore(ci): Change docs command to gen command

### DIFF
--- a/.github/workflows/manual_commands.yml
+++ b/.github/workflows/manual_commands.yml
@@ -14,5 +14,5 @@ jobs:
           token: ${{ secrets.GH_CQ_BOT }}
           reaction-token: ${{ secrets.GITHUB_TOKEN }}
           issue-type: pull-request
-          commands: docs
+          commands: gen
           permission: write

--- a/.github/workflows/manual_commands_triggers.yml
+++ b/.github/workflows/manual_commands_triggers.yml
@@ -2,7 +2,7 @@ name: Manual Commands Triggers
 
 on:
   repository_dispatch:
-    types: [docs-command]
+    types: [gen-command]
 
 jobs:
   ok-to-run:
@@ -15,9 +15,9 @@ jobs:
         run: |
           manually_approved=${{ github.event_name == 'repository_dispatch' && github.event.client_payload.slash_command.args.named.sha != '' && contains(github.event.client_payload.pull_request.head.sha, github.event.client_payload.slash_command.args.named.sha) }}
           echo ::set-output name=result::"$manually_approved"
-  docs:
+  gen:
     needs: [ok-to-run]
-    if: github.event_name == 'repository_dispatch' && github.event.action == 'docs-command' && needs.ok-to-run.outputs.status == 'true'
+    if: github.event_name == 'repository_dispatch' && github.event.action == 'gen-command' && needs.ok-to-run.outputs.status == 'true'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -34,11 +34,19 @@ jobs:
           cache: true
           cache-dependency-path: plugins/source/${{ github.event.client_payload.slash_command.args.named.plugin }}/go.sum
 
+      - name: Generate code
+        run: make gen-code
+        # Not all plugins have code generation
+        continue-on-error: true
+        working-directory: plugins/source/${{ github.event.client_payload.slash_command.args.named.plugin }}
+
       - name: Generate docs
         run: make gen-docs
+        # All plugins should have docs generation
+        continue-on-error: false
         working-directory: plugins/source/${{ github.event.client_payload.slash_command.args.named.plugin }}
 
       - uses: stefanzweifel/git-auto-commit-action@v4
         with:
-          commit_message: "chore: Update docs"
+          commit_message: "chore: Update code and docs"
           branch: ${{ github.event.client_payload.pull_request.head.ref }}


### PR DESCRIPTION
<!-- 🎉 Thank you for making CloudQuery awesome by submitting a PR 🎉 -->

#### Summary

Related to https://github.com/cloudquery/cloudquery/issues/3326.

This PRs changes the `/docs` command to a `/gen` command so it generates both code and docs.

See example for the docs command in:
https://github.com/cloudquery/cloudquery/pull/3005#issuecomment-1296194616
https://github.com/cloudquery/cloudquery/pull/3005/commits/c7f72fd6f6ceb23c7508a485caba436f5f850fa8

We could have separate commands, but I think an update to code generation always requires a doc generation

<!--
Use the following steps to ensure your PR is ready to be reviewed

- [ ] Read the [contribution guidelines](../blob/main/CONTRIBUTING.md) 🧑‍🎓
- [ ] Test locally on your own infrastructure
- [ ] Run `go fmt` to format your code 🖊
- [ ] Lint your changes via `golangci-lint run` 🚨 (install golangci-lint [here](https://golangci-lint.run/usage/install/#local-installation))
- [ ] Update or add tests 🧪
- [ ] Ensure the status checks below are successful ✅
--->
