### PR TITLE
fix: Fix bug in s3_cross_region_replication policy

### DIFF
--- a/plugins/source/aws/policies_v1/queries/s3/s3_cross_region_replication.sql
+++ b/plugins/source/aws/policies_v1/queries/s3/s3_cross_region_replication.sql
@@ -10,6 +10,9 @@ select
         r->>'Status' is distinct from 'Enabled'
     then 'fail' else 'pass' end as status
 from
-    aws_s3_buckets, JSONB_ARRAY_ELEMENTS(replication_rules) as r
-
+     aws_s3_buckets, JSONB_ARRAY_ELEMENTS(
+         case jsonb_typeof(replication_rules)
+         when 'array' then replication_rules
+         else '[]' end
+     ) as r
 -- Note: This query doesn't validate that the destination bucket is actually in a different region


### PR DESCRIPTION
Fixes https://github.com/cloudquery/cloudquery/issues/3563

There is a wider question here about whether we should be placing null values in the column at all--maybe they should be empty arrays instead. But for now this change fixes this specific policy.