### PR TITLE
fix!: Make path a required config parameter

### DIFF
--- a/cli/cmd/testdata/dest.test.yml
+++ b/cli/cmd/testdata/dest.test.yml
@@ -1,4 +1,5 @@
 kind: destination
 spec:
   name: test
+  path: cloudquery/test
   version: v1.2.0

--- a/cli/cmd/testdata/source.test.yml
+++ b/cli/cmd/testdata/source.test.yml
@@ -1,5 +1,6 @@
 kind: source
 spec:
   name: test
+  path: cloudquery/test
   destinations: [test]
   version: v1.2.1

--- a/cli/go.mod
+++ b/cli/go.mod
@@ -3,7 +3,7 @@ module github.com/cloudquery/cloudquery/cli
 go 1.19
 
 require (
-	github.com/cloudquery/plugin-sdk v1.0.3
+	github.com/cloudquery/plugin-sdk v1.0.4
 	github.com/getsentry/sentry-go v0.14.0
 	github.com/google/uuid v1.3.0
 	github.com/rs/zerolog v1.28.0

--- a/cli/go.sum
+++ b/cli/go.sum
@@ -3,6 +3,8 @@ github.com/avast/retry-go/v4 v4.3.0/go.mod h1:bqOlT4nxk4phk9buiQFaghzjpqdchOSwPg
 github.com/bradleyjkemp/cupaloy/v2 v2.8.0 h1:any4BmKE+jGIaMpnU8YgH/I2LPiLBufr6oMMlVBbn9M=
 github.com/cloudquery/plugin-sdk v1.0.3 h1:PFeZtN0a+jNnSsgBnalhBw1E95iDEjVh2t9332x6uyg=
 github.com/cloudquery/plugin-sdk v1.0.3/go.mod h1:VbqV2BE0wbYbArSUNxAuh6jH1FlrHyJp0f/5ERuBcew=
+github.com/cloudquery/plugin-sdk v1.0.4 h1:5Vhp4AF538lxxXiZzm73XELDp00Wdc6cvE0AIZZOqss=
+github.com/cloudquery/plugin-sdk v1.0.4/go.mod h1:VbqV2BE0wbYbArSUNxAuh6jH1FlrHyJp0f/5ERuBcew=
 github.com/coreos/go-systemd/v22 v22.3.3-0.20220203105225-a9a7ef127534/go.mod h1:Y58oyj3AT4RCenI/lSvhwexgC+NSVTIJ3seZv2GcEnc=
 github.com/cpuguy83/go-md2man/v2 v2.0.2 h1:p1EgwI/C7NhT0JmVkwCD2ZBK8j4aeHQX2pMHHBfMQ6w=
 github.com/cpuguy83/go-md2man/v2 v2.0.2/go.mod h1:tgQtvFlXSQOSOSIRvRPT7W67SCa46tRHOmNcaadrF8o=


### PR DESCRIPTION
This SDK upgrade to the CLI adds the code in https://github.com/cloudquery/plugin-sdk/pull/371, and as such will make `path` a required config parameter. We consider this a breaking change, so the CLI version will be bumped to 2.0.0. 

As context, we are making `path` required (and not inferred from `name`) because there has been some confusion around these settings. Previously `path` could have been inferred from `name` in some circumstances, but when using multiple configs, this was not always possible, causing confusion.

From now on, `path` is a required parameter. It will usually take the form of `cloudquery/aws`, where `aws` is the source plugin name in this example. For the postgresql destination, it will be `cloudquery/postgresql`.

- `name` should be thought of as the unique identifier of the particular source/destination config. It needs to be unique, as it will be used for overwriting stale entries in `overwrite-delete-stale` mode, inserted as a column alongside all entries, and ensure there are no race conditions when running multiple configs in parallel.
- `path` is normally the unique path to download the plugin from. We have some special conventions around this, documented [here](https://www.cloudquery.io/docs/developers/creating-new-plugin#naming-conventions). It can also be used during development to point to a locally-running binary or GRPC server.

Related:
 - https://github.com/cloudquery/plugin-sdk/issues/317
 - https://github.com/cloudquery/plugin-sdk/issues/256

