### PR TITLE
chore(website): Use Github shield in top bar

### DIFF
--- a/website/theme.config.tsx
+++ b/website/theme.config.tsx
@@ -7,6 +7,7 @@ const theme: DocsThemeConfig = {
   github: "https://github.com/cloudquery/cloudquery",
   project: {
     link: "https://github.com/cloudquery/cloudquery",
+    icon: <img alt="CloudQuery Github repo stars" src='https://img.shields.io/github/stars/cloudquery/cloudquery?style=social'/>,
   },
   sidebar: {
     defaultMenuCollapsed: true,


### PR DESCRIPTION
Changes the Github logo in the top bar to a shield from shields.io:

![Screenshot 2022-11-08 at 10 24 20](https://user-images.githubusercontent.com/1121616/200540829-33650144-a7f6-4b1d-af09-2143b5750b54.png)
