### PR TITLE
fix: Fix test destination plugin hang

### DIFF
--- a/cli/cmd/testdata/dest.test.yml
+++ b/cli/cmd/testdata/dest.test.yml
@@ -1,6 +1,5 @@
 kind: "destination"
 spec:
   name: "test"
-  path: "localhost:7778"
-  registry: "grpc"
+  path: "cloudquery/test"
   version: "v1.2.19" # latest version of destination test plugin

--- a/cli/cmd/testdata/dest.test.yml
+++ b/cli/cmd/testdata/dest.test.yml
@@ -2,4 +2,4 @@ kind: "destination"
 spec:
   name: "test"
   path: "cloudquery/test"
-  version: "v1.2.19" # latest version of destination test plugin
+  version: "v1.2.0" # latest version of destination test plugin

--- a/cli/cmd/testdata/dest.test.yml
+++ b/cli/cmd/testdata/dest.test.yml
@@ -1,5 +1,6 @@
 kind: "destination"
 spec:
   name: "test"
-  path: "cloudquery/test"
-  version: "v1.2.0" # latest version of destination test plugin
+  path: "localhost:7778"
+  registry: "grpc"
+  version: "v1.2.19" # latest version of destination test plugin

--- a/cli/cmd/testdata/source.test.yml
+++ b/cli/cmd/testdata/source.test.yml
@@ -1,6 +1,7 @@
 kind: "source"
 spec:
   name: "test"
-  path: "cloudquery/test"
+  path: "localhost:7777"
+  registry: "grpc"
   destinations: [test]
-  version: "v1.2.1" # latest version of source test plugin
+  version: "v1.3.10" # latest version of source test plugin

--- a/cli/cmd/testdata/source.test.yml
+++ b/cli/cmd/testdata/source.test.yml
@@ -3,4 +3,4 @@ spec:
   name: "test"
   path: "cloudquery/test"
   destinations: [test]
-  version: "v1.3.10" # latest version of source test plugin
+  version: "v1.2.1" # latest version of source test plugin

--- a/cli/cmd/testdata/source.test.yml
+++ b/cli/cmd/testdata/source.test.yml
@@ -1,7 +1,6 @@
 kind: "source"
 spec:
   name: "test"
-  path: "localhost:7777"
-  registry: "grpc"
+  path: "cloudquery/test"
   destinations: [test]
   version: "v1.3.10" # latest version of source test plugin

--- a/plugins/destination/test/client/client.go
+++ b/plugins/destination/test/client/client.go
@@ -35,7 +35,9 @@ func (*Client) Migrate(ctx context.Context, tables schema.Tables) error {
 }
 
 func (*Client) Write(ctx context.Context, tables schema.Tables, res <-chan *plugins.ClientResource) error {
-	<-res
+	for range res {
+		// do nothing
+	}
 	return nil
 }
 

--- a/plugins/destination/test/client/client.go
+++ b/plugins/destination/test/client/client.go
@@ -34,6 +34,7 @@ func (*Client) Migrate(ctx context.Context, tables schema.Tables) error {
 	return nil
 }
 
+//revive:disable We need to range over the channel to clear it, but revive thinks it can be removed
 func (*Client) Write(ctx context.Context, tables schema.Tables, res <-chan *plugins.ClientResource) error {
 	for range res {
 		// do nothing

--- a/plugins/destination/test/client/client.go
+++ b/plugins/destination/test/client/client.go
@@ -35,6 +35,7 @@ func (*Client) Migrate(ctx context.Context, tables schema.Tables) error {
 }
 
 func (*Client) Write(ctx context.Context, tables schema.Tables, res <-chan *plugins.ClientResource) error {
+	<-res
 	return nil
 }
 


### PR DESCRIPTION
As best I can tell, the test destination plugin wasn't reading from the channel, causing a deadlock. 