### PR TITLE
chore(ci): Error when a PR changes too many files

### DIFF
--- a/.github/workflows/wait_for_required_workflows.yml
+++ b/.github/workflows/wait_for_required_workflows.yml
@@ -22,6 +22,10 @@ jobs:
           script: |
             const files = process.env.FILES.split(' ')
             console.log(files)
+            if (files.length >= 300) {
+              // This is a GitHub limitation https://github.com/cloudquery/cloudquery/issues/2688
+              throw new Error('Too many files changed. Skipping check. Please split your PR into multiple ones.')
+            }
             let now = new Date().getTime()
             const deadline = now + 60 * 1000 * 25
             const matchesWorkflow = (file, action) => {


### PR DESCRIPTION
<!-- 🎉 Thank you for making CloudQuery awesome by submitting a PR 🎉 -->

#### Summary

Fixes https://github.com/cloudquery/cloudquery/issues/2688

Related to https://github.com/cloudquery/cloudquery/pull/4460.

Not sure what else to do here, as our CI breaks completely when this happens

<!--
Use the following steps to ensure your PR is ready to be reviewed

- [ ] Read the [contribution guidelines](../blob/main/CONTRIBUTING.md) 🧑‍🎓
- [ ] Test locally on your own infrastructure
- [ ] Run `go fmt` to format your code 🖊
- [ ] Lint your changes via `golangci-lint run` 🚨 (install golangci-lint [here](https://golangci-lint.run/usage/install/#local-installation))
- [ ] Update or add tests 🧪
- [ ] Ensure the status checks below are successful ✅
--->
