### PR TITLE
chore(ci-aws): Increase CI timeout

### DIFF
--- a/.github/workflows/source_aws.yml
+++ b/.github/workflows/source_aws.yml
@@ -33,7 +33,7 @@ jobs:
           RUNNER=${{ steps.large-runner.outputs.runner }}
           echo "runner=${RUNNER:-"ubuntu-latest"}" >> $GITHUB_OUTPUT
   plugins-source-aws:
-    timeout-minutes: 30
+    timeout-minutes: 45
     name: "plugins/source/aws"
     needs: [resolve-runner]
     runs-on: ${{ needs.resolve-runner.outputs.runner }}
@@ -75,7 +75,7 @@ jobs:
         if: github.event_name == 'pull_request'
         run: test "$(git status -s ./resources/services | wc -l)" -eq 0
   validate-release:
-    timeout-minutes: 30
+    timeout-minutes: 45
     needs: [resolve-runner]
     runs-on: ${{ needs.resolve-runner.outputs.runner }}
     env:

--- a/.github/workflows/wait_for_required_workflows.yml
+++ b/.github/workflows/wait_for_required_workflows.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   wait_for_required_workflows:
-    timeout-minutes: 30
+    timeout-minutes: 60
     name: wait-for-required-workflows
     runs-on: ubuntu-latest
     steps:
@@ -23,7 +23,7 @@ jobs:
             const files = process.env.FILES.split(' ')
             console.log(files)
             let now = new Date().getTime()
-            const deadline = now + 60 * 1000 * 25
+            const deadline = now + 60 * 1000 * 50
             const matchesWorkflow = (file, action) => {
               if (!file.startsWith('.github/workflows/')) {
                 return false


### PR DESCRIPTION
<!-- 🎉 Thank you for making CloudQuery awesome by submitting a PR 🎉 -->

#### Summary

AWS CI time can reach ~30 minutes which is the current timeout if uncached see https://github.com/cloudquery/cloudquery/actions/runs/3455334439/jobs/5767283053

<!--
Use the following steps to ensure your PR is ready to be reviewed

- [ ] Read the [contribution guidelines](../blob/main/CONTRIBUTING.md) 🧑‍🎓
- [ ] Test locally on your own infrastructure
- [ ] Run `go fmt` to format your code 🖊
- [ ] Lint your changes via `golangci-lint run` 🚨 (install golangci-lint [here](https://golangci-lint.run/usage/install/#local-installation))
- [ ] Update or add tests 🧪
- [ ] Ensure the status checks below are successful ✅
--->
