### PR TITLE
fix: Error handling omissions in sync2

### DIFF
--- a/cli/cmd/sync2.go
+++ b/cli/cmd/sync2.go
@@ -92,7 +92,7 @@ func syncConnectionV2(ctx context.Context, cqDir string, sourceClient *clients.S
 			if err = destClients[i].Write2(gctx, tables, sourceSpec.Name, syncTime, destSubscriptions[i]); err != nil {
 				return fmt.Errorf("failed to write for %s->%s: %w", sourceSpec.Name, destination, err)
 			}
-			if destClients[i].Close(ctx); err != nil {
+			if err := destClients[i].Close(ctx); err != nil {
 				return fmt.Errorf("failed to close destination client for %s->%s: %w", sourceSpec.Name, destination, err)
 			}
 			failedWrites += destFailedWrites


### PR DESCRIPTION
<!-- 🎉 Thank you for making CloudQuery awesome by submitting a PR 🎉 -->

#### Summary

I also found  error handling omissions in `cli/cmd/sync2.go` !
ref: https://github.com/cloudquery/cloudquery/pull/4486

<!--
Explain what problem this PR addresses
-->

<!--
Use the following steps to ensure your PR is ready to be reviewed

- [ ] Read the [contribution guidelines](../blob/main/CONTRIBUTING.md) 🧑‍🎓
- [ ] Test locally on your own infrastructure
- [ ] Run `go fmt` to format your code 🖊
- [ ] Lint your changes via `golangci-lint run` 🚨 (install golangci-lint [here](https://golangci-lint.run/usage/install/#local-installation))
- [ ] Update or add tests 🧪
- [ ] Ensure the status checks below are successful ✅
--->
