### PR TITLE
fix: Fix Name tag reference in grafana dashboard

### DIFF
--- a/plugins/source/aws/dashboards/grafana/aws_ec2_public_private.json
+++ b/plugins/source/aws/dashboards/grafana/aws_ec2_public_private.json
@@ -147,7 +147,7 @@
           "group": [],
           "metricColumn": "none",
           "rawQuery": true,
-          "rawSql": "SELECT\n  jsonb_path_query_first(tags, '$[*]? (@.Key == \"Name\")') ->> 'Value' as Name,\n  vpc_id,\n  subnet_id,\n  instance_id,\n  region,\n  private_ip_address,\n  public_ip_address\nFROM aws_ec2_instances where (\n  ('${ALL}' in (${VPCs}) OR aws_ec2_instances.vpc_id in (${VPCs}))\n  AND ('${ALL}' in (${Subnets}) OR aws_ec2_instances.subnet_id in (${Subnets}))\n  AND ('${ALL}' in (${Region}) OR aws_ec2_instances.region in (${Region}))\n  AND (aws_ec2_instances.public_ip_address is not null)\n)",
+          "rawSql": "SELECT\n  tags ->> 'Name' as Name,\n  vpc_id,\n  subnet_id,\n  instance_id,\n  region,\n  private_ip_address,\n  public_ip_address\nFROM aws_ec2_instances where (\n  ('${ALL}' in (${VPCs}) OR aws_ec2_instances.vpc_id in (${VPCs}))\n  AND ('${ALL}' in (${Subnets}) OR aws_ec2_instances.subnet_id in (${Subnets}))\n  AND ('${ALL}' in (${Region}) OR aws_ec2_instances.region in (${Region}))\n  AND (aws_ec2_instances.public_ip_address is not null)\n)",
           "refId": "A",
           "select": [
             [
@@ -402,7 +402,7 @@
           "group": [],
           "metricColumn": "none",
           "rawQuery": true,
-          "rawSql": "SELECT\n  jsonb_path_query_first(tags, '$[*]? (@.Key == \"Name\")') ->> 'Value' as Name,\n  vpc_id,\n  subnet_id,\n  instance_id,\n  region,\n  private_ip_address\nFROM aws_ec2_instances where (\n('${ALL}' in (${VPCs}) OR aws_ec2_instances.vpc_id in (${VPCs}))\nAND ('${ALL}' in (${Subnets}) OR aws_ec2_instances.subnet_id in (${Subnets})) \nAND ('${ALL}' in (${Region}) OR aws_ec2_instances.region in (${Region})) \nAND (aws_ec2_instances.public_ip_address is null)\n)",
+          "rawSql": "SELECT\n  tags ->> 'Name' as Name,\n  vpc_id,\n  subnet_id,\n  instance_id,\n  region,\n  private_ip_address\nFROM aws_ec2_instances where (\n('${ALL}' in (${VPCs}) OR aws_ec2_instances.vpc_id in (${VPCs}))\nAND ('${ALL}' in (${Subnets}) OR aws_ec2_instances.subnet_id in (${Subnets})) \nAND ('${ALL}' in (${Region}) OR aws_ec2_instances.region in (${Region})) \nAND (aws_ec2_instances.public_ip_address is null)\n)",
           "refId": "A",
           "select": [
             [


### PR DESCRIPTION
#### Summary

When using the AWS grafana dashboard for that displays public and prviate EC2 instances the 'name' column wouldn't populate with the query provided so after playing around a bit I found an 'easier' way to get the name to appear in the column successfully.

**Current Dashboard Example:**
<img width="1148" alt="Screenshot 2022-11-18 at 08 03 51" src="https://user-images.githubusercontent.com/95309754/202711645-6afc3ab0-a439-4e97-810e-9da1b37aa525.png">

---

**After applying this PR:**
<img width="1160" alt="Screenshot 2022-11-18 at 08 04 28" src="https://user-images.githubusercontent.com/95309754/202711751-45789711-bf96-47c1-8c6c-3e99ef07a39c.png">
