### PR TITLE
fix(aws): Fixed typo in JSON key

### DIFF
--- a/plugins/source/aws/policies/queries/apigateway/api_gw_publicly_accessible.sql
+++ b/plugins/source/aws/policies/queries/apigateway/api_gw_publicly_accessible.sql
@@ -11,4 +11,4 @@ select
         else 'pass'
         end as status
 from
-    aws_apigateway_rest_apis, jsonb_array_elements_text(endpoint_configuration->'types') as t
+    aws_apigateway_rest_apis, jsonb_array_elements_text(endpoint_configuration->'Types') as t


### PR DESCRIPTION
<!-- 🎉 Thank you for making CloudQuery awesome by submitting a PR 🎉 -->

#### Summary

Fixed typo in JSON key in  plugins/source/aws/policies/queries/apigateway/api_gw_publicly_accessible.sql
Fixing #4837
