### PR TITLE
fix(aws): Typo in lambda query

### DIFF
--- a/plugins/source/aws/policies/queries/lambda/functions_with_public_egress.sql
+++ b/plugins/source/aws/policies/queries/lambda/functions_with_public_egress.sql
@@ -3,7 +3,7 @@ select distinct
     :'execution_time'::timestamp as execution_time,
     :'framework' as framework,
     :'check_id' as check_id,
-    'Find all ec2 instances that have unrestricted access to the internet' AS title,
+    'Find all lambda functions that have unrestricted access to the internet' AS title,
     account_id,
     arn AS resource_id,
     'fail' AS status -- TODO FIXME
@@ -25,7 +25,7 @@ select distinct
     :'execution_time'::timestamp as execution_time,
     :'framework' as framework,
     :'check_id' as check_id,
-    'Find all ec2 instances that have unrestricted access to the internet' AS title,
+    'Find all lambda functions that have unrestricted access to the internet' AS title,
     account_id,
     arn AS resource_id,
     'fail' AS status -- TODO FIXME


### PR DESCRIPTION
<!-- 🎉 Thank you for making CloudQuery awesome by submitting a PR 🎉 -->

#### Summary

Replaced "ec2 instances" with "lambda functions" in plugins/source/aws/policies/queries/lambda/functions_with_public_egress.sql
Just to make it clear to the receivers of the data.