### PR TITLE
fix: Update Snowflake spec and docs

### DIFF
--- a/plugins/destination/snowflake/README.md
+++ b/plugins/destination/snowflake/README.md
@@ -12,11 +12,11 @@ There are two ways to sync data to Snowflake:
 
 This is the top level spec used by the Snowflake destination plugin.
 
-- `dsn` (string) (required)
+- `connection_string` (string) (required)
 
-  Snowflake DSN
+  Snowflake `connection_string`
 
-  Example DSN:
+  Example `connection_string`:
 
   ```
   // user[:password]@account/database/schema[?param1=value1&paramN=valueN]

--- a/plugins/destination/snowflake/client/client.go
+++ b/plugins/destination/snowflake/client/client.go
@@ -37,11 +37,11 @@ func New(ctx context.Context, logger zerolog.Logger, destSpec specs.Destination)
 	if err := spec.Validate(); err != nil {
 		return nil, err
 	}
-	_, err := gosnowflake.ParseDSN(spec.DSN)
+	_, err := gosnowflake.ParseDSN(spec.ConnectionString)
 	if err != nil {
 		return nil, err
 	}
-	db, err := sql.Open("snowflake", spec.DSN)
+	db, err := sql.Open("snowflake", spec.ConnectionString)
 	if err != nil {
 		return nil, err
 	}

--- a/plugins/destination/snowflake/client/client_test.go
+++ b/plugins/destination/snowflake/client/client_test.go
@@ -11,7 +11,7 @@ func TestPlugin(t *testing.T) {
 	p := plugins.NewDestinationPlugin("snowflake", "development", New)
 	plugins.DestinationPluginTestSuiteRunner(t, p,
 		Spec{
-			DSN: os.Getenv("SNOW_TEST_DSN"),
+			ConnectionString: os.Getenv("SNOW_TEST_DSN"),
 		},
 		plugins.DestinationTestSuiteTests{
 			SkipOverwrite: true,

--- a/plugins/destination/snowflake/client/spec.go
+++ b/plugins/destination/snowflake/client/spec.go
@@ -3,7 +3,7 @@ package client
 import "fmt"
 
 type Spec struct {
-	DSN string `json:"dsn,omitempty"`
+	ConnectionString string `json:"connection_string,omitempty"`
 }
 
 func (*Spec) SetDefaults() {
@@ -11,8 +11,8 @@ func (*Spec) SetDefaults() {
 }
 
 func (s *Spec) Validate() error {
-	if s.DSN == "" {
-		return fmt.Errorf("dsn is required")
+	if s.ConnectionString == "" {
+		return fmt.Errorf("connection_string is required")
 	}
 	return nil
 }

--- a/website/pages/docs/plugins/destinations.mdx
+++ b/website/pages/docs/plugins/destinations.mdx
@@ -15,6 +15,7 @@ This is a list of all official and community destination plugins.
 | [PostgreSQL][postgresql] | {getLatestVersion("destination", "postgresql")}         | [Changelog][PostgreSQL-Changelog] | GA    |
 | [CSV][csv] | {getLatestVersion("destination", "csv")}         | [Changelog][CSV-Changelog] | Preview|
 | [SQLite][sqlite] | {getLatestVersion("destination", "sqlite")}         | [Changelog][SQLite-Changelog] | Preview|
+| [Snowflake][snowflake] | {getLatestVersion("destination", "snowflake")}         | [Changelog][Snowflake-Changelog] | Preview|
 
 [PostgreSQL]: https://github.com/cloudquery/cloudquery/blob/main/plugins/destination/postgresql/README.md
 [PostgreSQL-Changelog]: https://github.com/cloudquery/cloudquery/blob/main/plugins/destination/postgresql/CHANGELOG.md
@@ -22,3 +23,5 @@ This is a list of all official and community destination plugins.
 [CSV-Changelog]: https://github.com/cloudquery/cloudquery/blob/main/plugins/destination/csv/CHANGELOG.md
 [SQLite]: https://github.com/cloudquery/cloudquery/blob/main/plugins/destination/sqlite/README.md
 [SQLite-Changelog]: https://github.com/cloudquery/cloudquery/blob/main/plugins/destination/sqlite/CHANGELOG.md
+[Snowflake]: https://github.com/cloudquery/cloudquery/blob/main/plugins/destination/snowflake/README.md
+[Snowflake-Changelog]: https://github.com/cloudquery/cloudquery/blob/main/plugins/destination/snowflake/CHANGELOG.md

--- a/website/pages/docs/recipes/destinations/_meta.json
+++ b/website/pages/docs/recipes/destinations/_meta.json
@@ -1,5 +1,6 @@
 {
   "postgresql": "PostgreSQL",
   "csv": "CSV",
-  "sqlite": "SQLite"
+  "sqlite": "SQLite",
+  "snowflake": "Snowflake"
 }

--- a/website/pages/docs/recipes/destinations/snowflake.md
+++ b/website/pages/docs/recipes/destinations/snowflake.md
@@ -1,0 +1,18 @@
+# Snowflake Destination Plugin Recipes
+
+Full spec options for Snowflake destination available [here](https://github.com/cloudquery/cloudquery/tree/main/plugins/destination/snowflake).
+
+Note: Make sure you use environment variable expansion in production instead of committing the credentials to the configuration file directly.
+
+## Basic
+
+```yaml copy
+kind: destination
+spec:
+  name: snowflake
+  path: cloudquery/snow
+  version: "v1.0.1" # latest version of postgresql plugin
+  spec:
+    connection_string: ${SNOW_CONNECTION_STRING}
+```
+

--- a/website/pages/docs/recipes/destinations/snowflake.md
+++ b/website/pages/docs/recipes/destinations/snowflake.md
@@ -13,6 +13,6 @@ spec:
   path: cloudquery/snowflake
   version: "v1.0.1" # latest version of snowflake plugin
   spec:
-    connection_string: ${SNOW_CONNECTION_STRING}
+    connection_string: ${SNOWFLAKE_CONNECTION_STRING}
 ```
 

--- a/website/pages/docs/recipes/destinations/snowflake.md
+++ b/website/pages/docs/recipes/destinations/snowflake.md
@@ -11,7 +11,7 @@ kind: destination
 spec:
   name: snowflake
   path: cloudquery/snowflake
-  version: "v1.0.1" # latest version of postgresql plugin
+  version: "v1.0.1" # latest version of snowflake plugin
   spec:
     connection_string: ${SNOW_CONNECTION_STRING}
 ```

--- a/website/pages/docs/recipes/destinations/snowflake.md
+++ b/website/pages/docs/recipes/destinations/snowflake.md
@@ -10,7 +10,7 @@ Note: Make sure you use environment variable expansion in production instead of 
 kind: destination
 spec:
   name: snowflake
-  path: cloudquery/snow
+  path: cloudquery/snowflake
   version: "v1.0.1" # latest version of postgresql plugin
   spec:
     connection_string: ${SNOW_CONNECTION_STRING}


### PR DESCRIPTION
I realised the `dsn` in snowflake spec is inconsistent with other plugins so changed it to `connection_string` and added a recipe + docs. Blog will come after that in a separate PR. 