### PR TITLE
fix: Rename template variable 'r' to more indicative 'parent'

### DIFF
--- a/plugins/source/gcp/codegen/templates/newapi_get.go.tpl
+++ b/plugins/source/gcp/codegen/templates/newapi_get.go.tpl
@@ -20,7 +20,7 @@ func {{.SubService | ToCamel}}() *schema.Table {
     return &schema.Table{{template "table.go.tpl" .Table}}
 }
 
-func fetch{{.SubService | ToCamel}}(ctx context.Context, meta schema.ClientMeta, r *schema.Resource, res chan<- interface{}) error {
+func fetch{{.SubService | ToCamel}}(ctx context.Context, meta schema.ClientMeta, parent *schema.Resource, res chan<- interface{}) error {
 	c := meta.(*client.Client)
 	req := &pb.{{.RequestStructName}}{
 		{{if .RequestStructFields}}{{.RequestStructFields}}{{end}}

--- a/plugins/source/gcp/codegen/templates/newapi_list.go.tpl
+++ b/plugins/source/gcp/codegen/templates/newapi_list.go.tpl
@@ -23,7 +23,7 @@ func {{.SubService | ToCamel}}() *schema.Table {
 }
 
 {{if not .SkipFetch}}
-func fetch{{.SubService | ToCamel}}(ctx context.Context, meta schema.ClientMeta, r *schema.Resource, res chan<- interface{}) error {
+func fetch{{.SubService | ToCamel}}(ctx context.Context, meta schema.ClientMeta, parent *schema.Resource, res chan<- interface{}) error {
 	c := meta.(*client.Client)
 	req := &pb.{{.RequestStructName}}{
 		{{if .RequestStructFields}}{{.RequestStructFields}}{{end}}

--- a/plugins/source/gcp/codegen/templates/resource_agg_list.go.tpl
+++ b/plugins/source/gcp/codegen/templates/resource_agg_list.go.tpl
@@ -16,7 +16,7 @@ func {{.SubService | ToCamel}}() *schema.Table {
     return &schema.Table{{template "table.go.tpl" .Table}}
 }
 
-func fetch{{.SubService | ToCamel}}(ctx context.Context, meta schema.ClientMeta, r *schema.Resource, res chan<- interface{}) error {
+func fetch{{.SubService | ToCamel}}(ctx context.Context, meta schema.ClientMeta, parent *schema.Resource, res chan<- interface{}) error {
 	c := meta.(*client.Client)
 	nextPageToken := ""
 	for {

--- a/plugins/source/gcp/codegen/templates/resource_get.go.tpl
+++ b/plugins/source/gcp/codegen/templates/resource_get.go.tpl
@@ -16,7 +16,7 @@ func {{.SubService | ToCamel}}() *schema.Table {
     return &schema.Table{{template "table.go.tpl" .Table}}
 }
 
-func fetch{{.SubService | ToCamel}}(ctx context.Context, meta schema.ClientMeta, _ *schema.Resource, res chan<- interface{}) error {
+func fetch{{.SubService | ToCamel}}(ctx context.Context, meta schema.ClientMeta, parent *schema.Resource, res chan<- interface{}) error {
 	c := meta.(*client.Client)
 	output, err := {{.ListFunction}}
 	if err != nil {

--- a/plugins/source/gcp/codegen/templates/resource_list.go.tpl
+++ b/plugins/source/gcp/codegen/templates/resource_list.go.tpl
@@ -17,7 +17,7 @@ func {{.SubService | ToCamel}}() *schema.Table {
     return &schema.Table{{template "table.go.tpl" .Table}}
 }
 
-func fetch{{.SubService | ToCamel}}(ctx context.Context, meta schema.ClientMeta, r *schema.Resource, res chan<- interface{}) error {
+func fetch{{.SubService | ToCamel}}(ctx context.Context, meta schema.ClientMeta, parent *schema.Resource, res chan<- interface{}) error {
 	c := meta.(*client.Client)
 	nextPageToken := ""
 	for {

--- a/plugins/source/gcp/codegen/templates/resource_list_one.go.tpl
+++ b/plugins/source/gcp/codegen/templates/resource_list_one.go.tpl
@@ -16,7 +16,7 @@ func {{.SubService | ToCamel}}() *schema.Table {
     return &schema.Table{{template "table.go.tpl" .Table}}
 }
 
-func fetch{{.SubService | ToCamel}}(ctx context.Context, meta schema.ClientMeta, r *schema.Resource, res chan<- interface{}) error {
+func fetch{{.SubService | ToCamel}}(ctx context.Context, meta schema.ClientMeta, parent *schema.Resource, res chan<- interface{}) error {
 	c := meta.(*client.Client)
 	output, err := {{.ListFunction}}
 	if err != nil {

--- a/plugins/source/gcp/resources/services/apikeys/keys.go
+++ b/plugins/source/gcp/resources/services/apikeys/keys.go
@@ -84,7 +84,7 @@ func Keys() *schema.Table {
 	}
 }
 
-func fetchKeys(ctx context.Context, meta schema.ClientMeta, r *schema.Resource, res chan<- interface{}) error {
+func fetchKeys(ctx context.Context, meta schema.ClientMeta, parent *schema.Resource, res chan<- interface{}) error {
 	c := meta.(*client.Client)
 	req := &pb.ListKeysRequest{
 		Parent: "projects/" + c.ProjectId + "/locations/global",

--- a/plugins/source/gcp/resources/services/billing/billing_accounts.go
+++ b/plugins/source/gcp/resources/services/billing/billing_accounts.go
@@ -50,7 +50,7 @@ func BillingAccounts() *schema.Table {
 	}
 }
 
-func fetchBillingAccounts(ctx context.Context, meta schema.ClientMeta, r *schema.Resource, res chan<- interface{}) error {
+func fetchBillingAccounts(ctx context.Context, meta schema.ClientMeta, parent *schema.Resource, res chan<- interface{}) error {
 	c := meta.(*client.Client)
 	req := &pb.ListBillingAccountsRequest{}
 	it := c.Services.BillingCloudBillingClient.ListBillingAccounts(ctx, req)

--- a/plugins/source/gcp/resources/services/billing/services.go
+++ b/plugins/source/gcp/resources/services/billing/services.go
@@ -50,7 +50,7 @@ func Services() *schema.Table {
 	}
 }
 
-func fetchServices(ctx context.Context, meta schema.ClientMeta, r *schema.Resource, res chan<- interface{}) error {
+func fetchServices(ctx context.Context, meta schema.ClientMeta, parent *schema.Resource, res chan<- interface{}) error {
 	c := meta.(*client.Client)
 	req := &pb.ListServicesRequest{}
 	it := c.Services.BillingCloudCatalogClient.ListServices(ctx, req)

--- a/plugins/source/gcp/resources/services/compute/addresses.go
+++ b/plugins/source/gcp/resources/services/compute/addresses.go
@@ -120,7 +120,7 @@ func Addresses() *schema.Table {
 	}
 }
 
-func fetchAddresses(ctx context.Context, meta schema.ClientMeta, r *schema.Resource, res chan<- interface{}) error {
+func fetchAddresses(ctx context.Context, meta schema.ClientMeta, parent *schema.Resource, res chan<- interface{}) error {
 	c := meta.(*client.Client)
 	req := &pb.AggregatedListAddressesRequest{
 		Project: c.ProjectId,

--- a/plugins/source/gcp/resources/services/compute/autoscalers.go
+++ b/plugins/source/gcp/resources/services/compute/autoscalers.go
@@ -100,7 +100,7 @@ func Autoscalers() *schema.Table {
 	}
 }
 
-func fetchAutoscalers(ctx context.Context, meta schema.ClientMeta, r *schema.Resource, res chan<- interface{}) error {
+func fetchAutoscalers(ctx context.Context, meta schema.ClientMeta, parent *schema.Resource, res chan<- interface{}) error {
 	c := meta.(*client.Client)
 	req := &pb.AggregatedListAutoscalersRequest{
 		Project: c.ProjectId,

--- a/plugins/source/gcp/resources/services/compute/backend_services.go
+++ b/plugins/source/gcp/resources/services/compute/backend_services.go
@@ -225,7 +225,7 @@ func BackendServices() *schema.Table {
 	}
 }
 
-func fetchBackendServices(ctx context.Context, meta schema.ClientMeta, r *schema.Resource, res chan<- interface{}) error {
+func fetchBackendServices(ctx context.Context, meta schema.ClientMeta, parent *schema.Resource, res chan<- interface{}) error {
 	c := meta.(*client.Client)
 	req := &pb.AggregatedListBackendServicesRequest{
 		Project: c.ProjectId,

--- a/plugins/source/gcp/resources/services/compute/disk_types.go
+++ b/plugins/source/gcp/resources/services/compute/disk_types.go
@@ -85,7 +85,7 @@ func DiskTypes() *schema.Table {
 	}
 }
 
-func fetchDiskTypes(ctx context.Context, meta schema.ClientMeta, r *schema.Resource, res chan<- interface{}) error {
+func fetchDiskTypes(ctx context.Context, meta schema.ClientMeta, parent *schema.Resource, res chan<- interface{}) error {
 	c := meta.(*client.Client)
 	req := &pb.AggregatedListDiskTypesRequest{
 		Project: c.ProjectId,

--- a/plugins/source/gcp/resources/services/compute/disks.go
+++ b/plugins/source/gcp/resources/services/compute/disks.go
@@ -220,7 +220,7 @@ func Disks() *schema.Table {
 	}
 }
 
-func fetchDisks(ctx context.Context, meta schema.ClientMeta, r *schema.Resource, res chan<- interface{}) error {
+func fetchDisks(ctx context.Context, meta schema.ClientMeta, parent *schema.Resource, res chan<- interface{}) error {
 	c := meta.(*client.Client)
 	req := &pb.AggregatedListDisksRequest{
 		Project: c.ProjectId,

--- a/plugins/source/gcp/resources/services/compute/firewalls.go
+++ b/plugins/source/gcp/resources/services/compute/firewalls.go
@@ -125,7 +125,7 @@ func Firewalls() *schema.Table {
 	}
 }
 
-func fetchFirewalls(ctx context.Context, meta schema.ClientMeta, r *schema.Resource, res chan<- interface{}) error {
+func fetchFirewalls(ctx context.Context, meta schema.ClientMeta, parent *schema.Resource, res chan<- interface{}) error {
 	c := meta.(*client.Client)
 	req := &pb.ListFirewallsRequest{
 		Project: c.ProjectId,

--- a/plugins/source/gcp/resources/services/compute/forwarding_rules.go
+++ b/plugins/source/gcp/resources/services/compute/forwarding_rules.go
@@ -185,7 +185,7 @@ func ForwardingRules() *schema.Table {
 	}
 }
 
-func fetchForwardingRules(ctx context.Context, meta schema.ClientMeta, r *schema.Resource, res chan<- interface{}) error {
+func fetchForwardingRules(ctx context.Context, meta schema.ClientMeta, parent *schema.Resource, res chan<- interface{}) error {
 	c := meta.(*client.Client)
 	req := &pb.AggregatedListForwardingRulesRequest{
 		Project: c.ProjectId,

--- a/plugins/source/gcp/resources/services/compute/images.go
+++ b/plugins/source/gcp/resources/services/compute/images.go
@@ -190,7 +190,7 @@ func Images() *schema.Table {
 	}
 }
 
-func fetchImages(ctx context.Context, meta schema.ClientMeta, r *schema.Resource, res chan<- interface{}) error {
+func fetchImages(ctx context.Context, meta schema.ClientMeta, parent *schema.Resource, res chan<- interface{}) error {
 	c := meta.(*client.Client)
 	req := &pb.ListImagesRequest{
 		Project: c.ProjectId,

--- a/plugins/source/gcp/resources/services/compute/instance_groups.go
+++ b/plugins/source/gcp/resources/services/compute/instance_groups.go
@@ -95,7 +95,7 @@ func InstanceGroups() *schema.Table {
 	}
 }
 
-func fetchInstanceGroups(ctx context.Context, meta schema.ClientMeta, r *schema.Resource, res chan<- interface{}) error {
+func fetchInstanceGroups(ctx context.Context, meta schema.ClientMeta, parent *schema.Resource, res chan<- interface{}) error {
 	c := meta.(*client.Client)
 	req := &pb.AggregatedListInstanceGroupsRequest{
 		Project: c.ProjectId,

--- a/plugins/source/gcp/resources/services/compute/instances.go
+++ b/plugins/source/gcp/resources/services/compute/instances.go
@@ -250,7 +250,7 @@ func Instances() *schema.Table {
 	}
 }
 
-func fetchInstances(ctx context.Context, meta schema.ClientMeta, r *schema.Resource, res chan<- interface{}) error {
+func fetchInstances(ctx context.Context, meta schema.ClientMeta, parent *schema.Resource, res chan<- interface{}) error {
 	c := meta.(*client.Client)
 	req := &pb.AggregatedListInstancesRequest{
 		Project: c.ProjectId,

--- a/plugins/source/gcp/resources/services/compute/interconnects.go
+++ b/plugins/source/gcp/resources/services/compute/interconnects.go
@@ -145,7 +145,7 @@ func Interconnects() *schema.Table {
 	}
 }
 
-func fetchInterconnects(ctx context.Context, meta schema.ClientMeta, r *schema.Resource, res chan<- interface{}) error {
+func fetchInterconnects(ctx context.Context, meta schema.ClientMeta, parent *schema.Resource, res chan<- interface{}) error {
 	c := meta.(*client.Client)
 	req := &pb.ListInterconnectsRequest{
 		Project: c.ProjectId,

--- a/plugins/source/gcp/resources/services/compute/networks.go
+++ b/plugins/source/gcp/resources/services/compute/networks.go
@@ -120,7 +120,7 @@ func Networks() *schema.Table {
 	}
 }
 
-func fetchNetworks(ctx context.Context, meta schema.ClientMeta, r *schema.Resource, res chan<- interface{}) error {
+func fetchNetworks(ctx context.Context, meta schema.ClientMeta, parent *schema.Resource, res chan<- interface{}) error {
 	c := meta.(*client.Client)
 	req := &pb.ListNetworksRequest{
 		Project: c.ProjectId,

--- a/plugins/source/gcp/resources/services/compute/projects.go
+++ b/plugins/source/gcp/resources/services/compute/projects.go
@@ -94,7 +94,7 @@ func Projects() *schema.Table {
 	}
 }
 
-func fetchProjects(ctx context.Context, meta schema.ClientMeta, r *schema.Resource, res chan<- interface{}) error {
+func fetchProjects(ctx context.Context, meta schema.ClientMeta, parent *schema.Resource, res chan<- interface{}) error {
 	c := meta.(*client.Client)
 	req := &pb.GetProjectRequest{
 		Project: c.ProjectId,

--- a/plugins/source/gcp/resources/services/compute/ssl_certificates.go
+++ b/plugins/source/gcp/resources/services/compute/ssl_certificates.go
@@ -100,7 +100,7 @@ func SslCertificates() *schema.Table {
 	}
 }
 
-func fetchSslCertificates(ctx context.Context, meta schema.ClientMeta, r *schema.Resource, res chan<- interface{}) error {
+func fetchSslCertificates(ctx context.Context, meta schema.ClientMeta, parent *schema.Resource, res chan<- interface{}) error {
 	c := meta.(*client.Client)
 	req := &pb.AggregatedListSslCertificatesRequest{
 		Project: c.ProjectId,

--- a/plugins/source/gcp/resources/services/compute/ssl_policies.go
+++ b/plugins/source/gcp/resources/services/compute/ssl_policies.go
@@ -95,7 +95,7 @@ func SslPolicies() *schema.Table {
 	}
 }
 
-func fetchSslPolicies(ctx context.Context, meta schema.ClientMeta, r *schema.Resource, res chan<- interface{}) error {
+func fetchSslPolicies(ctx context.Context, meta schema.ClientMeta, parent *schema.Resource, res chan<- interface{}) error {
 	c := meta.(*client.Client)
 	req := &pb.ListSslPoliciesRequest{
 		Project: c.ProjectId,

--- a/plugins/source/gcp/resources/services/compute/subnetworks.go
+++ b/plugins/source/gcp/resources/services/compute/subnetworks.go
@@ -150,7 +150,7 @@ func Subnetworks() *schema.Table {
 	}
 }
 
-func fetchSubnetworks(ctx context.Context, meta schema.ClientMeta, r *schema.Resource, res chan<- interface{}) error {
+func fetchSubnetworks(ctx context.Context, meta schema.ClientMeta, parent *schema.Resource, res chan<- interface{}) error {
 	c := meta.(*client.Client)
 	req := &pb.AggregatedListSubnetworksRequest{
 		Project: c.ProjectId,

--- a/plugins/source/gcp/resources/services/compute/target_http_proxies.go
+++ b/plugins/source/gcp/resources/services/compute/target_http_proxies.go
@@ -80,7 +80,7 @@ func TargetHttpProxies() *schema.Table {
 	}
 }
 
-func fetchTargetHttpProxies(ctx context.Context, meta schema.ClientMeta, r *schema.Resource, res chan<- interface{}) error {
+func fetchTargetHttpProxies(ctx context.Context, meta schema.ClientMeta, parent *schema.Resource, res chan<- interface{}) error {
 	c := meta.(*client.Client)
 	req := &pb.AggregatedListTargetHttpProxiesRequest{
 		Project: c.ProjectId,

--- a/plugins/source/gcp/resources/services/compute/target_ssl_proxies.go
+++ b/plugins/source/gcp/resources/services/compute/target_ssl_proxies.go
@@ -85,7 +85,7 @@ func TargetSslProxies() *schema.Table {
 	}
 }
 
-func fetchTargetSslProxies(ctx context.Context, meta schema.ClientMeta, r *schema.Resource, res chan<- interface{}) error {
+func fetchTargetSslProxies(ctx context.Context, meta schema.ClientMeta, parent *schema.Resource, res chan<- interface{}) error {
 	c := meta.(*client.Client)
 	req := &pb.ListTargetSslProxiesRequest{
 		Project: c.ProjectId,

--- a/plugins/source/gcp/resources/services/compute/url_maps.go
+++ b/plugins/source/gcp/resources/services/compute/url_maps.go
@@ -105,7 +105,7 @@ func UrlMaps() *schema.Table {
 	}
 }
 
-func fetchUrlMaps(ctx context.Context, meta schema.ClientMeta, r *schema.Resource, res chan<- interface{}) error {
+func fetchUrlMaps(ctx context.Context, meta schema.ClientMeta, parent *schema.Resource, res chan<- interface{}) error {
 	c := meta.(*client.Client)
 	req := &pb.AggregatedListUrlMapsRequest{
 		Project: c.ProjectId,

--- a/plugins/source/gcp/resources/services/compute/vpn_gateways.go
+++ b/plugins/source/gcp/resources/services/compute/vpn_gateways.go
@@ -90,7 +90,7 @@ func VpnGateways() *schema.Table {
 	}
 }
 
-func fetchVpnGateways(ctx context.Context, meta schema.ClientMeta, r *schema.Resource, res chan<- interface{}) error {
+func fetchVpnGateways(ctx context.Context, meta schema.ClientMeta, parent *schema.Resource, res chan<- interface{}) error {
 	c := meta.(*client.Client)
 	req := &pb.AggregatedListVpnGatewaysRequest{
 		Project: c.ProjectId,

--- a/plugins/source/gcp/resources/services/domains/registrations.go
+++ b/plugins/source/gcp/resources/services/domains/registrations.go
@@ -90,7 +90,7 @@ func Registrations() *schema.Table {
 	}
 }
 
-func fetchRegistrations(ctx context.Context, meta schema.ClientMeta, r *schema.Resource, res chan<- interface{}) error {
+func fetchRegistrations(ctx context.Context, meta schema.ClientMeta, parent *schema.Resource, res chan<- interface{}) error {
 	c := meta.(*client.Client)
 	req := &pb.ListRegistrationsRequest{
 		Parent: fmt.Sprintf("projects/%s/locations/-", c.ProjectId),

--- a/plugins/source/gcp/resources/services/functions/functions.go
+++ b/plugins/source/gcp/resources/services/functions/functions.go
@@ -168,7 +168,7 @@ func Functions() *schema.Table {
 	}
 }
 
-func fetchFunctions(ctx context.Context, meta schema.ClientMeta, r *schema.Resource, res chan<- interface{}) error {
+func fetchFunctions(ctx context.Context, meta schema.ClientMeta, parent *schema.Resource, res chan<- interface{}) error {
 	c := meta.(*client.Client)
 	req := &pb.ListFunctionsRequest{
 		Parent: "projects/" + c.ProjectId + "/locations/-",

--- a/plugins/source/gcp/resources/services/logging/metrics.go
+++ b/plugins/source/gcp/resources/services/logging/metrics.go
@@ -86,7 +86,7 @@ func Metrics() *schema.Table {
 	}
 }
 
-func fetchMetrics(ctx context.Context, meta schema.ClientMeta, r *schema.Resource, res chan<- interface{}) error {
+func fetchMetrics(ctx context.Context, meta schema.ClientMeta, parent *schema.Resource, res chan<- interface{}) error {
 	c := meta.(*client.Client)
 	req := &pb.ListLogMetricsRequest{
 		Parent: "projects/" + c.ProjectId,

--- a/plugins/source/gcp/resources/services/logging/sinks.go
+++ b/plugins/source/gcp/resources/services/logging/sinks.go
@@ -86,7 +86,7 @@ func Sinks() *schema.Table {
 	}
 }
 
-func fetchSinks(ctx context.Context, meta schema.ClientMeta, r *schema.Resource, res chan<- interface{}) error {
+func fetchSinks(ctx context.Context, meta schema.ClientMeta, parent *schema.Resource, res chan<- interface{}) error {
 	c := meta.(*client.Client)
 	req := &pb.ListSinksRequest{
 		Parent: "projects/" + c.ProjectId,

--- a/plugins/source/gcp/resources/services/monitoring/alert_policies.go
+++ b/plugins/source/gcp/resources/services/monitoring/alert_policies.go
@@ -90,7 +90,7 @@ func AlertPolicies() *schema.Table {
 	}
 }
 
-func fetchAlertPolicies(ctx context.Context, meta schema.ClientMeta, r *schema.Resource, res chan<- interface{}) error {
+func fetchAlertPolicies(ctx context.Context, meta schema.ClientMeta, parent *schema.Resource, res chan<- interface{}) error {
 	c := meta.(*client.Client)
 	req := &pb.ListAlertPoliciesRequest{
 		Name: "projects/" + c.ProjectId,

--- a/plugins/source/gcp/resources/services/redis/instances.go
+++ b/plugins/source/gcp/resources/services/redis/instances.go
@@ -181,7 +181,7 @@ func Instances() *schema.Table {
 	}
 }
 
-func fetchInstances(ctx context.Context, meta schema.ClientMeta, r *schema.Resource, res chan<- interface{}) error {
+func fetchInstances(ctx context.Context, meta schema.ClientMeta, parent *schema.Resource, res chan<- interface{}) error {
 	c := meta.(*client.Client)
 	req := &pb.ListInstancesRequest{
 		Parent: "projects/" + c.ProjectId + "/locations/-",

--- a/plugins/source/gcp/resources/services/resourcemanager/folders.go
+++ b/plugins/source/gcp/resources/services/resourcemanager/folders.go
@@ -68,7 +68,7 @@ func Folders() *schema.Table {
 	}
 }
 
-func fetchFolders(ctx context.Context, meta schema.ClientMeta, r *schema.Resource, res chan<- interface{}) error {
+func fetchFolders(ctx context.Context, meta schema.ClientMeta, parent *schema.Resource, res chan<- interface{}) error {
 	c := meta.(*client.Client)
 	req := &pb.ListFoldersRequest{}
 	it := c.Services.ResourcemanagerFoldersClient.ListFolders(ctx, req)

--- a/plugins/source/gcp/resources/services/run/services.go
+++ b/plugins/source/gcp/resources/services/run/services.go
@@ -168,7 +168,7 @@ func Services() *schema.Table {
 	}
 }
 
-func fetchServices(ctx context.Context, meta schema.ClientMeta, r *schema.Resource, res chan<- interface{}) error {
+func fetchServices(ctx context.Context, meta schema.ClientMeta, parent *schema.Resource, res chan<- interface{}) error {
 	c := meta.(*client.Client)
 	req := &pb.ListServicesRequest{
 		Parent: "projects/" + c.ProjectId + "locations/-",

--- a/plugins/source/gcp/resources/services/secretmanager/secrets.go
+++ b/plugins/source/gcp/resources/services/secretmanager/secrets.go
@@ -71,7 +71,7 @@ func Secrets() *schema.Table {
 	}
 }
 
-func fetchSecrets(ctx context.Context, meta schema.ClientMeta, r *schema.Resource, res chan<- interface{}) error {
+func fetchSecrets(ctx context.Context, meta schema.ClientMeta, parent *schema.Resource, res chan<- interface{}) error {
 	c := meta.(*client.Client)
 	req := &pb.ListSecretsRequest{
 		Parent: "projects/" + c.ProjectId,

--- a/plugins/source/gcp/resources/services/serviceusage/services.go
+++ b/plugins/source/gcp/resources/services/serviceusage/services.go
@@ -50,7 +50,7 @@ func Services() *schema.Table {
 	}
 }
 
-func fetchServices(ctx context.Context, meta schema.ClientMeta, r *schema.Resource, res chan<- interface{}) error {
+func fetchServices(ctx context.Context, meta schema.ClientMeta, parent *schema.Resource, res chan<- interface{}) error {
 	c := meta.(*client.Client)
 	req := &pb.ListServicesRequest{
 		Parent: "projects/" + c.ProjectId,


### PR DESCRIPTION
<!-- 🎉 Thank you for making CloudQuery awesome by submitting a PR 🎉 -->

#### Summary

Required for autogenerating relational tables.

<!--
Explain what problem this PR addresses
-->

<!--
Use the following steps to ensure your PR is ready to be reviewed

- [ ] Read the [contribution guidelines](../blob/main/CONTRIBUTING.md) 🧑‍🎓
- [ ] Test locally on your own infrastructure
- [ ] Run `go fmt` to format your code 🖊
- [ ] Lint your changes via `golangci-lint run` 🚨 (install golangci-lint [here](https://golangci-lint.run/usage/install/#local-installation))
- [ ] Update or add tests 🧪
- [ ] Ensure the status checks below are successful ✅
--->
