### PR TITLE
fix(website): Link directly to docs in recipes instead of GitHub

### DIFF
--- a/website/pages/docs/recipes/destinations/csv.md
+++ b/website/pages/docs/recipes/destinations/csv.md
@@ -1,7 +1,6 @@
 # CSV Destination Plugin Recipes
 
-Full spec options for CSV destination available [here](https://github.com/cloudquery/cloudquery/tree/main/plugins/destination/csv).
-
+Full spec options for the CSV destination plugin are available [here](/docs/plugins/destinations/csv/overview#csv-spec).
 
 ## Basic
 

--- a/website/pages/docs/recipes/destinations/postgresql.md
+++ b/website/pages/docs/recipes/destinations/postgresql.md
@@ -1,6 +1,6 @@
 # PostgreSQL Destination Plugin Recipes
 
-Full spec options for PostgreSQL destination available [here](https://github.com/cloudquery/cloudquery/tree/main/plugins/destination/postgresql).
+Full spec options for the PostgreSQL destination plugin are available [here](/docs/plugins/destinations/postgresql/overview#postgresql-spec).
 
 Note: Make sure you use environment variable expansion in production instead of committing the credentials to the configuration file directly.
 

--- a/website/pages/docs/recipes/destinations/snowflake.md
+++ b/website/pages/docs/recipes/destinations/snowflake.md
@@ -1,6 +1,6 @@
 # Snowflake Destination Plugin Recipes
 
-Full spec options for Snowflake destination available [here](https://github.com/cloudquery/cloudquery/tree/main/plugins/destination/snowflake).
+Full spec options for the Snowflake destination plugin are available [here](/docs/plugins/destinations/snowflake/overview#snowflake-spec).
 
 Note: Make sure you use environment variable expansion in production instead of committing the credentials to the configuration file directly.
 
@@ -15,4 +15,3 @@ spec:
   spec:
     connection_string: ${SNOWFLAKE_CONNECTION_STRING}
 ```
-

--- a/website/pages/docs/recipes/destinations/sqlite.md
+++ b/website/pages/docs/recipes/destinations/sqlite.md
@@ -1,7 +1,6 @@
 # SQLite Destination Plugin Recipes
 
-Full spec options for CSV destination available [here](https://github.com/cloudquery/cloudquery/tree/main/plugins/destination/csv).
-
+Full spec options for the SQLite destination plugin are available [here](/docs/plugins/destinations/sqlite/overview#sqlite-spec).
 
 ## Basic
 

--- a/website/pages/docs/recipes/sources/aws.md
+++ b/website/pages/docs/recipes/sources/aws.md
@@ -1,6 +1,6 @@
 # AWS Source Plugin Recipes
 
-Full spec options for AWS Source available [here](https://github.com/cloudquery/cloudquery/blob/main/plugins/source/aws/docs/configuration.md).
+Full spec options for the AWS source plugin are available [here](/docs/plugins/sources/aws/configuration#aws-spec).
 
 ```yaml copy
 kind: source

--- a/website/pages/docs/recipes/sources/azure.md
+++ b/website/pages/docs/recipes/sources/azure.md
@@ -1,6 +1,6 @@
 # Azure Source Plugin Recipes
 
-Full spec options for Azure Source available [here](https://github.com/cloudquery/cloudquery/blob/main/plugins/source/azure/docs/configuration.md).
+Full spec options for the Azure source plugin are available [here](/docs/plugins/sources/azure/configuration#azure-spec).
 
 ```yaml copy
 kind: source

--- a/website/pages/docs/recipes/sources/gcp.md
+++ b/website/pages/docs/recipes/sources/gcp.md
@@ -1,6 +1,6 @@
 # GCP Source Plugin Recipes
 
-Full spec options for GCP Source available [here](https://github.com/cloudquery/cloudquery/blob/main/plugins/source/gcp/docs/configuration.md).
+Full spec options for the GCP source plugin are available [here](/docs/plugins/sources/gcp/configuration#gcp-spec).
 
 ```yaml copy
 kind: source


### PR DESCRIPTION
<!-- 🎉 Thank you for making CloudQuery awesome by submitting a PR 🎉 -->

#### Summary

The GitHub docs are deprecated and link back to our website

<!--
Use the following steps to ensure your PR is ready to be reviewed

- [ ] Read the [contribution guidelines](../blob/main/CONTRIBUTING.md) 🧑‍🎓
- [ ] Test locally on your own infrastructure
- [ ] Run `go fmt` to format your code 🖊
- [ ] Lint your changes via `golangci-lint run` 🚨 (install golangci-lint [here](https://golangci-lint.run/usage/install/#local-installation))
- [ ] Update or add tests 🧪
- [ ] Ensure the status checks below are successful ✅
--->
