### PR TITLE
fix(website): Fix source plugins tables pagination link

### DIFF
--- a/website/pages/docs/plugins/sources/aws/_meta.json
+++ b/website/pages/docs/plugins/sources/aws/_meta.json
@@ -5,6 +5,7 @@
   "tables": {
     "title": "Tables ↗",
     "href": "https://github.com/cloudquery/cloudquery/blob/main/plugins/source/aws/docs/tables/README.md",
-    "newWindow": true
+    "newWindow": true,
+    "route": "https://github.com/cloudquery/cloudquery/blob/main/plugins/source/aws/docs/tables/README.md"
   }
 }

--- a/website/pages/docs/plugins/sources/azure/_meta.json
+++ b/website/pages/docs/plugins/sources/azure/_meta.json
@@ -4,6 +4,7 @@
   "tables": {
     "title": "Tables ↗",
     "href": "https://github.com/cloudquery/cloudquery/blob/main/plugins/source/azure/docs/tables/README.md",
-    "newWindow": true
+    "newWindow": true,
+    "route": "https://github.com/cloudquery/cloudquery/blob/main/plugins/source/azure/docs/tables/README.md"
   }
 }

--- a/website/pages/docs/plugins/sources/cloudflare/_meta.json
+++ b/website/pages/docs/plugins/sources/cloudflare/_meta.json
@@ -4,6 +4,7 @@
   "tables": {
     "title": "Tables ↗",
     "href": "https://github.com/cloudquery/cloudquery/blob/main/plugins/source/cloudflare/docs/tables/README.md",
-    "newWindow": true
+    "newWindow": true,
+    "route": "https://github.com/cloudquery/cloudquery/blob/main/plugins/source/cloudflare/docs/tables/README.md"
   }
 }

--- a/website/pages/docs/plugins/sources/digitalocean/_meta.json
+++ b/website/pages/docs/plugins/sources/digitalocean/_meta.json
@@ -3,6 +3,7 @@
   "tables": {
     "title": "Tables ↗",
     "href": "https://github.com/cloudquery/cloudquery/blob/main/plugins/source/digitalocean/docs/tables/README.md",
-    "newWindow": true
+    "newWindow": true,
+    "route": "https://github.com/cloudquery/cloudquery/blob/main/plugins/source/digitalocean/docs/tables/README.md"
   }
 }

--- a/website/pages/docs/plugins/sources/gcp/_meta.json
+++ b/website/pages/docs/plugins/sources/gcp/_meta.json
@@ -4,6 +4,7 @@
   "tables": {
     "title": "Tables ↗",
     "href": "https://github.com/cloudquery/cloudquery/blob/main/plugins/source/gcp/docs/tables/README.md",
-    "newWindow": true
+    "newWindow": true,
+    "route": "https://github.com/cloudquery/cloudquery/blob/main/plugins/source/gcp/docs/tables/README.md"
   }
 }

--- a/website/pages/docs/plugins/sources/github/_meta.json
+++ b/website/pages/docs/plugins/sources/github/_meta.json
@@ -3,6 +3,7 @@
   "tables": {
     "title": "Tables ↗",
     "href": "https://github.com/cloudquery/cloudquery/blob/main/plugins/source/github/docs/tables/README.md",
-    "newWindow": true
+    "newWindow": true,
+    "route": "https://github.com/cloudquery/cloudquery/blob/main/plugins/source/github/docs/tables/README.md"
   }
 }

--- a/website/pages/docs/plugins/sources/heroku/_meta.json
+++ b/website/pages/docs/plugins/sources/heroku/_meta.json
@@ -4,6 +4,7 @@
   "tables": {
     "title": "Tables ↗",
     "href": "https://github.com/cloudquery/cloudquery/blob/main/plugins/source/heroku/docs/tables/README.md",
-    "newWindow": true
+    "newWindow": true,
+    "route": "https://github.com/cloudquery/cloudquery/blob/main/plugins/source/heroku/docs/tables/README.md"
   }
 }

--- a/website/pages/docs/plugins/sources/k8s/_meta.json
+++ b/website/pages/docs/plugins/sources/k8s/_meta.json
@@ -4,6 +4,7 @@
   "tables": {
     "title": "Tables ↗",
     "href": "https://github.com/cloudquery/cloudquery/blob/main/plugins/source/k8s/docs/tables/README.md",
-    "newWindow": true
+    "newWindow": true,
+    "route": "https://github.com/cloudquery/cloudquery/blob/main/plugins/source/k8s/docs/tables/README.md"
   }
 }

--- a/website/pages/docs/plugins/sources/okta/_meta.json
+++ b/website/pages/docs/plugins/sources/okta/_meta.json
@@ -3,6 +3,7 @@
   "tables": {
     "title": "Tables ↗",
     "href": "https://github.com/cloudquery/cloudquery/blob/main/plugins/source/okta/docs/tables/README.md",
-    "newWindow": true
+    "newWindow": true,
+    "route": "https://github.com/cloudquery/cloudquery/blob/main/plugins/source/okta/docs/tables/README.md"
   }
 }

--- a/website/pages/docs/plugins/sources/terraform/_meta.json
+++ b/website/pages/docs/plugins/sources/terraform/_meta.json
@@ -3,6 +3,7 @@
   "tables": {
     "title": "Tables ↗",
     "href": "https://github.com/cloudquery/cloudquery/blob/main/plugins/source/terraform/docs/tables/README.md",
-    "newWindow": true
+    "newWindow": true,
+    "route": "https://github.com/cloudquery/cloudquery/blob/main/plugins/source/terraform/docs/tables/README.md"
   }
 }


### PR DESCRIPTION
<!-- 🎉 Thank you for making CloudQuery awesome by submitting a PR 🎉 -->

#### Summary

The `Tables ↗` pagination link at the bottom of each source plugin page doesn't work, for example in AWS:
![image](https://user-images.githubusercontent.com/26760571/204533613-79f1880f-3951-4196-86a3-233cda16a46e.png)
https://www.cloudquery.io/docs/plugins/sources/aws/multi_account

The fix is similar to https://github.com/cloudquery/cloudquery/pull/3207, however I couldn't find a way to make the pagination link open in a new tab so this is only a partial fix.

<!--
Use the following steps to ensure your PR is ready to be reviewed

- [ ] Read the [contribution guidelines](../blob/main/CONTRIBUTING.md) 🧑‍🎓
- [ ] Test locally on your own infrastructure
- [ ] Run `go fmt` to format your code 🖊
- [ ] Lint your changes via `golangci-lint run` 🚨 (install golangci-lint [here](https://golangci-lint.run/usage/install/#local-installation))
- [ ] Update or add tests 🧪
- [ ] Ensure the status checks below are successful ✅
--->
