### PR TITLE
fix(website): Use `>=` instead of `>` for database versions

### DIFF
--- a/website/pages/docs/plugins/destinations/postgresql/overview.md
+++ b/website/pages/docs/plugins/destinations/postgresql/overview.md
@@ -4,8 +4,8 @@ This destination plugin lets you sync data from a CloudQuery source to a Postgre
 
 Supported database versions:
 
-- PostgreSQL > v10
-- CockroachDB > v20.2
+- PostgreSQL >= v10
+- CockroachDB >= v20.2
 
 ## Configuration
 


### PR DESCRIPTION
<!-- 🎉 Thank you for making CloudQuery awesome by submitting a PR 🎉 -->

#### Summary

We support versions v10 and v20.2 (inclusive)

<!--
Use the following steps to ensure your PR is ready to be reviewed

- [ ] Read the [contribution guidelines](../blob/main/CONTRIBUTING.md) 🧑‍🎓
- [ ] Test locally on your own infrastructure
- [ ] Run `go fmt` to format your code 🖊
- [ ] Lint your changes via `golangci-lint run` 🚨 (install golangci-lint [here](https://golangci-lint.run/usage/install/#local-installation))
- [ ] Update or add tests 🧪
- [ ] Ensure the status checks below are successful ✅
--->
