### PR TITLE
fix: Filter results of getTablesForSpec to top-level tables in CLI

### DIFF
--- a/cli/cmd/sync2.go
+++ b/cli/cmd/sync2.go
@@ -39,6 +39,9 @@ func syncConnectionV2(ctx context.Context, cqDir string, sourceClient *clients.S
 	if err != nil {
 		return fmt.Errorf("failed to get tables for source %s: %w", sourceSpec.Name, err)
 	}
+	// make sure selectedTables only includes top-level tables; we don't want a flattened list
+	// (a bug in early versions of GetTablesForSpec returned a flattened list)
+	selectedTables = topLevelTables(allTables, selectedTables)
 
 	tableCount := len(selectedTables.FlattenTables())
 
@@ -185,4 +188,17 @@ func getTablesForSpec(ctx context.Context, sourceClient *clients.SourceClient, s
 		return tables, true, err
 	}
 	return tables, true, err
+}
+
+// returns only the top-level tables in the given tables list, i.e. tables
+// with no parents
+func topLevelTables(allTables, tables schema.Tables) schema.Tables {
+	var top schema.Tables
+	for _, t := range tables {
+		if allTables.GetTopLevel(t.Name) == nil {
+			continue
+		}
+		top = append(top, t)
+	}
+	return top
 }


### PR DESCRIPTION
This fixes a hanging bug in recent versions of the CLI and some destination plugins (e.g. BigQuery, Snowflake). The actual bug is in the `GetTablesForSpec` SDK function, which should not return a flattened list of tables, but this fix for the CLI means the CLI will work with any version of `GetTablesForSpec` (even versions with the bug). 

I will follow up shortly with a fix for the SDK.