### PR TITLE
chore(ci): Remove large runners from small plugins

### DIFF
--- a/.github/workflows/dest_csv.yml
+++ b/.github/workflows/dest_csv.yml
@@ -13,30 +13,10 @@ on:
       - ".github/workflows/dest_csv.yml"
 
 jobs:
-  resolve-runner:
-    timeout-minutes: 5
-    runs-on: ubuntu-latest
-    outputs:
-      runner: ${{ steps.resolve.outputs.runner }}
-    steps:
-      - name: Check if should use large runner
-        id: large-runner
-        # We want to speed runs on the main branch which prime the cache
-        # We allow large runners only in this case to prevent forks from abusing them (it's enforced via runner groups access rules)
-        # IF YOU WANT TO USE A LARGE RUNNER YOU NEED TO ADD THE WORKFLOW TO THE `CloudQuery releases` GROUP IN https://github.com/organizations/cloudquery/settings/actions/runner-groups
-        if: github.event_name == 'push'
-        run: |
-          echo "runner=cloudquery-release-runner" >> $GITHUB_OUTPUT
-      - name: Resolve runner
-        id: resolve
-        run: |
-          RUNNER=${{ steps.large-runner.outputs.runner }}
-          echo "runner=${RUNNER:-"ubuntu-latest"}" >> $GITHUB_OUTPUT
   plugins-destination-csv:
     timeout-minutes: 30
     name: "plugins/destination/csv"
-    needs: [resolve-runner]
-    runs-on: ${{ needs.resolve-runner.outputs.runner }}
+    runs-on: ubuntu-latest
     defaults:
       run:
         working-directory: ./plugins/destination/csv
@@ -64,8 +44,7 @@ jobs:
         run: make test
   validate-release:
     timeout-minutes: 30
-    needs: [resolve-runner]
-    runs-on: ${{ needs.resolve-runner.outputs.runner }}
+    runs-on: ubuntu-latest
     env:
       CGO_ENABLED: 0
     steps:

--- a/.github/workflows/dest_postgresql.yml
+++ b/.github/workflows/dest_postgresql.yml
@@ -13,30 +13,10 @@ on:
       - ".github/workflows/dest_postgresql.yml"
 
 jobs:
-  resolve-runner:
-    timeout-minutes: 5
-    runs-on: ubuntu-latest
-    outputs:
-      runner: ${{ steps.resolve.outputs.runner }}
-    steps:
-      - name: Check if should use large runner
-        id: large-runner
-        # We want to speed runs on the main branch which prime the cache
-        # We allow large runners only in this case to prevent forks from abusing them (it's enforced via runner groups access rules)
-        # IF YOU WANT TO USE A LARGE RUNNER YOU NEED TO ADD THE WORKFLOW TO THE `CloudQuery releases` GROUP IN https://github.com/organizations/cloudquery/settings/actions/runner-groups
-        if: github.event_name == 'push'
-        run: |
-          echo "runner=cloudquery-release-runner" >> $GITHUB_OUTPUT
-      - name: Resolve runner
-        id: resolve
-        run: |
-          RUNNER=${{ steps.large-runner.outputs.runner }}
-          echo "runner=${RUNNER:-"ubuntu-latest"}" >> $GITHUB_OUTPUT
   plugins-destination-postgresql:
     timeout-minutes: 30
     name: "plugins/destination/postgresql"
-    needs: [resolve-runner]
-    runs-on: ${{ needs.resolve-runner.outputs.runner }}
+    runs-on: ubuntu-latest
     defaults:
       run:
         working-directory: ./plugins/destination/postgresql
@@ -89,8 +69,7 @@ jobs:
         run: CQ_DEST_PG_TEST_CONN="postgresql://root@localhost:26257/postgres?sslmode=disable" make test
   validate-release:
     timeout-minutes: 30
-    needs: [resolve-runner]
-    runs-on: ${{ needs.resolve-runner.outputs.runner }}
+    runs-on: ubuntu-latest
     env:
       CGO_ENABLED: 0
     steps:

--- a/.github/workflows/dest_sqlite.yml
+++ b/.github/workflows/dest_sqlite.yml
@@ -13,30 +13,10 @@ on:
       - ".github/workflows/dest_sqlite.yml"
 
 jobs:
-  resolve-runner:
-    timeout-minutes: 5
-    runs-on: ubuntu-latest
-    outputs:
-      runner: ${{ steps.resolve.outputs.runner }}
-    steps:
-      - name: Check if should use large runner
-        id: large-runner
-        # We want to speed runs on the main branch which prime the cache
-        # We allow large runners only in this case to prevent forks from abusing them (it's enforced via runner groups access rules)
-        # IF YOU WANT TO USE A LARGE RUNNER YOU NEED TO ADD THE WORKFLOW TO THE `CloudQuery releases` GROUP IN https://github.com/organizations/cloudquery/settings/actions/runner-groups
-        if: github.event_name == 'push'
-        run: |
-          echo "runner=cloudquery-release-runner" >> $GITHUB_OUTPUT
-      - name: Resolve runner
-        id: resolve
-        run: |
-          RUNNER=${{ steps.large-runner.outputs.runner }}
-          echo "runner=${RUNNER:-"ubuntu-latest"}" >> $GITHUB_OUTPUT
   plugins-destination-sqlite:
     timeout-minutes: 30
     name: "plugins/destination/sqlite"
-    needs: [resolve-runner]
-    runs-on: ${{ needs.resolve-runner.outputs.runner }}
+    runs-on: ubuntu-latest
     defaults:
       run:
         working-directory: ./plugins/destination/sqlite
@@ -64,8 +44,7 @@ jobs:
         run: make test
   validate-release:
     timeout-minutes: 30
-    needs: [resolve-runner]
-    runs-on: ${{ needs.resolve-runner.outputs.runner }}
+    runs-on: ubuntu-latest
     container:
       image: ghcr.io/cloudquery/golang-cross:v10.0.0
       env:

--- a/.github/workflows/dest_test.yml
+++ b/.github/workflows/dest_test.yml
@@ -13,30 +13,10 @@ on:
       - ".github/workflows/dest_test.yml"
 
 jobs:
-  resolve-runner:
-    timeout-minutes: 5
-    runs-on: ubuntu-latest
-    outputs:
-      runner: ${{ steps.resolve.outputs.runner }}
-    steps:
-      - name: Check if should use large runner
-        id: large-runner
-        # We want to speed runs on the main branch which prime the cache
-        # We allow large runners only in this case to prevent forks from abusing them (it's enforced via runner groups access rules)
-        # IF YOU WANT TO USE A LARGE RUNNER YOU NEED TO ADD THE WORKFLOW TO THE `CloudQuery releases` GROUP IN https://github.com/organizations/cloudquery/settings/actions/runner-groups
-        if: github.event_name == 'push'
-        run: |
-          echo "runner=cloudquery-release-runner" >> $GITHUB_OUTPUT
-      - name: Resolve runner
-        id: resolve
-        run: |
-          RUNNER=${{ steps.large-runner.outputs.runner }}
-          echo "runner=${RUNNER:-"ubuntu-latest"}" >> $GITHUB_OUTPUT
   plugins-destination-test:
     timeout-minutes: 30
     name: "plugins/destination/test"
-    needs: [resolve-runner]
-    runs-on: ${{ needs.resolve-runner.outputs.runner }}
+    runs-on: ubuntu-latest
     defaults:
       run:
         working-directory: ./plugins/destination/test
@@ -64,8 +44,7 @@ jobs:
         run: go test ./...
   validate-release:
     timeout-minutes: 30
-    needs: [resolve-runner]
-    runs-on: ${{ needs.resolve-runner.outputs.runner }}
+    runs-on: ubuntu-latest
     env:
       CGO_ENABLED: 0
     steps:

--- a/.github/workflows/source_cloudflare.yml
+++ b/.github/workflows/source_cloudflare.yml
@@ -13,30 +13,10 @@ on:
       - ".github/workflows/source_cloudflare.yml"
 
 jobs:
-  resolve-runner:
-    timeout-minutes: 5
-    runs-on: ubuntu-latest
-    outputs:
-      runner: ${{ steps.resolve.outputs.runner }}
-    steps:
-      - name: Check if should use large runner
-        id: large-runner
-        # We want to speed runs on the main branch which prime the cache
-        # We allow large runners only in this case to prevent forks from abusing them (it's enforced via runner groups access rules)
-        # IF YOU WANT TO USE A LARGE RUNNER YOU NEED TO ADD THE WORKFLOW TO THE `CloudQuery releases` GROUP IN https://github.com/organizations/cloudquery/settings/actions/runner-groups
-        if: github.event_name == 'push'
-        run: |
-          echo "runner=cloudquery-release-runner" >> $GITHUB_OUTPUT
-      - name: Resolve runner
-        id: resolve
-        run: |
-          RUNNER=${{ steps.large-runner.outputs.runner }}
-          echo "runner=${RUNNER:-"ubuntu-latest"}" >> $GITHUB_OUTPUT
   plugins-source-cloudflare:
     timeout-minutes: 30
     name: "plugins/source/cloudflare"
-    needs: [resolve-runner]
-    runs-on: ${{ needs.resolve-runner.outputs.runner }}
+    runs-on: ubuntu-latest
     defaults:
       run:
         working-directory: ./plugins/source/cloudflare
@@ -70,8 +50,7 @@ jobs:
         run: test "$(git status -s | wc -l)" -eq 0
   validate-release:
     timeout-minutes: 30
-    needs: [resolve-runner]
-    runs-on: ${{ needs.resolve-runner.outputs.runner }}
+    runs-on: ubuntu-latest
     env:
       CGO_ENABLED: 0
     steps:

--- a/.github/workflows/source_datadog.yml
+++ b/.github/workflows/source_datadog.yml
@@ -13,30 +13,10 @@ on:
       - ".github/workflows/source_datadog.yml"
 
 jobs:
-  resolve-runner:
-    timeout-minutes: 5
-    runs-on: ubuntu-latest
-    outputs:
-      runner: ${{ steps.resolve.outputs.runner }}
-    steps:
-      - name: Check if should use large runner
-        id: large-runner
-        # We want to speed runs on the main branch which prime the cache
-        # We allow large runners only in this case to prevent forks from abusing them (it's enforced via runner groups access rules)
-        # IF YOU WANT TO USE A LARGE RUNNER YOU NEED TO ADD THE WORKFLOW TO THE `CloudQuery releases` GROUP IN https://github.com/organizations/cloudquery/settings/actions/runner-groups
-        if: github.event_name == 'push'
-        run: |
-          echo "runner=cloudquery-release-runner" >> $GITHUB_OUTPUT
-      - name: Resolve runner
-        id: resolve
-        run: |
-          RUNNER=${{ steps.large-runner.outputs.runner }}
-          echo "runner=${RUNNER:-"ubuntu-latest"}" >> $GITHUB_OUTPUT
   plugins-source-datadog:
     timeout-minutes: 45
     name: "plugins/source/datadog"
-    needs: [resolve-runner]
-    runs-on: ${{ needs.resolve-runner.outputs.runner }}
+    runs-on: ubuntu-latest
     defaults:
       run:
         working-directory: ./plugins/source/datadog
@@ -70,8 +50,7 @@ jobs:
         run: test "$(git status -s | wc -l)" -eq 0
   validate-release:
     timeout-minutes: 45
-    needs: [resolve-runner]
-    runs-on: ${{ needs.resolve-runner.outputs.runner }}
+    runs-on: ubuntu-latest
     env:
       CGO_ENABLED: 0
     steps:

--- a/.github/workflows/source_digitalocean.yml
+++ b/.github/workflows/source_digitalocean.yml
@@ -13,30 +13,10 @@ on:
       - ".github/workflows/source_digitalocean.yml"
 
 jobs:
-  resolve-runner:
-    timeout-minutes: 5
-    runs-on: ubuntu-latest
-    outputs:
-      runner: ${{ steps.resolve.outputs.runner }}
-    steps:
-      - name: Check if should use large runner
-        id: large-runner
-        # We want to speed runs on the main branch which prime the cache
-        # We allow large runners only in this case to prevent forks from abusing them (it's enforced via runner groups access rules)
-        # IF YOU WANT TO USE A LARGE RUNNER YOU NEED TO ADD THE WORKFLOW TO THE `CloudQuery releases` GROUP IN https://github.com/organizations/cloudquery/settings/actions/runner-groups
-        if: github.event_name == 'push'
-        run: |
-          echo "runner=cloudquery-release-runner" >> $GITHUB_OUTPUT
-      - name: Resolve runner
-        id: resolve
-        run: |
-          RUNNER=${{ steps.large-runner.outputs.runner }}
-          echo "runner=${RUNNER:-"ubuntu-latest"}" >> $GITHUB_OUTPUT
   plugins-source-digitalocean:
     timeout-minutes: 30
     name: "plugins/source/digitalocean"
-    needs: [resolve-runner]
-    runs-on: ${{ needs.resolve-runner.outputs.runner }}
+    runs-on: ubuntu-latest
     defaults:
       run:
         working-directory: ./plugins/source/digitalocean
@@ -70,8 +50,7 @@ jobs:
         run: test "$(git status -s | wc -l)" -eq 0
   validate-release:
     timeout-minutes: 30
-    needs: [resolve-runner]
-    runs-on: ${{ needs.resolve-runner.outputs.runner }}
+    runs-on: ubuntu-latest
     env:
       CGO_ENABLED: 0
     steps:

--- a/.github/workflows/source_gandi.yml
+++ b/.github/workflows/source_gandi.yml
@@ -13,30 +13,10 @@ on:
       - ".github/workflows/source_gandi.yml"
 
 jobs:
-  resolve-runner:
-    timeout-minutes: 5
-    runs-on: ubuntu-latest
-    outputs:
-      runner: ${{ steps.resolve.outputs.runner }}
-    steps:
-      - name: Check if should use large runner
-        id: large-runner
-        # We want to speed runs on the main branch which prime the cache
-        # We allow large runners only in this case to prevent forks from abusing them (it's enforced via runner groups access rules)
-        # IF YOU WANT TO USE A LARGE RUNNER YOU NEED TO ADD THE WORKFLOW TO THE `CloudQuery releases` GROUP IN https://github.com/organizations/cloudquery/settings/actions/runner-groups
-        if: github.event_name == 'push'
-        run: |
-          echo "runner=cloudquery-release-runner" >> $GITHUB_OUTPUT
-      - name: Resolve runner
-        id: resolve
-        run: |
-          RUNNER=${{ steps.large-runner.outputs.runner }}
-          echo "runner=${RUNNER:-"ubuntu-latest"}" >> $GITHUB_OUTPUT
   plugins-source-gandi:
     timeout-minutes: 30
     name: "plugins/source/gandi"
-    needs: [resolve-runner]
-    runs-on: ${{ needs.resolve-runner.outputs.runner }}
+    runs-on: ubuntu-latest
     defaults:
       run:
         working-directory: ./plugins/source/gandi
@@ -70,8 +50,7 @@ jobs:
         run: test "$(git status -s | wc -l)" -eq 0
   validate-release:
     timeout-minutes: 30
-    needs: [resolve-runner]
-    runs-on: ${{ needs.resolve-runner.outputs.runner }}
+    runs-on: ubuntu-latest
     env:
       CGO_ENABLED: 0
     steps:

--- a/.github/workflows/source_github.yml
+++ b/.github/workflows/source_github.yml
@@ -13,30 +13,10 @@ on:
       - ".github/workflows/source_github.yml"
 
 jobs:
-  resolve-runner:
-    timeout-minutes: 5
-    runs-on: ubuntu-latest
-    outputs:
-      runner: ${{ steps.resolve.outputs.runner }}
-    steps:
-      - name: Check if should use large runner
-        id: large-runner
-        # We want to speed runs on the main branch which prime the cache
-        # We allow large runners only in this case to prevent forks from abusing them (it's enforced via runner groups access rules)
-        # IF YOU WANT TO USE A LARGE RUNNER YOU NEED TO ADD THE WORKFLOW TO THE `CloudQuery releases` GROUP IN https://github.com/organizations/cloudquery/settings/actions/runner-groups
-        if: github.event_name == 'push'
-        run: |
-          echo "runner=cloudquery-release-runner" >> $GITHUB_OUTPUT
-      - name: Resolve runner
-        id: resolve
-        run: |
-          RUNNER=${{ steps.large-runner.outputs.runner }}
-          echo "runner=${RUNNER:-"ubuntu-latest"}" >> $GITHUB_OUTPUT
   plugins-source-github:
     timeout-minutes: 30
     name: "plugins/source/github"
-    needs: [resolve-runner]
-    runs-on: ${{ needs.resolve-runner.outputs.runner }}
+    runs-on: ubuntu-latest
     defaults:
       run:
         working-directory: ./plugins/source/github
@@ -70,8 +50,7 @@ jobs:
         run: test "$(git status -s | wc -l)" -eq 0
   validate-release:
     timeout-minutes: 30
-    needs: [resolve-runner]
-    runs-on: ${{ needs.resolve-runner.outputs.runner }}
+    runs-on: ubuntu-latest
     env:
       CGO_ENABLED: 0
     steps:

--- a/.github/workflows/source_heroku.yml
+++ b/.github/workflows/source_heroku.yml
@@ -13,30 +13,10 @@ on:
       - ".github/workflows/source_heroku.yml"
 
 jobs:
-  resolve-runner:
-    timeout-minutes: 5
-    runs-on: ubuntu-latest
-    outputs:
-      runner: ${{ steps.resolve.outputs.runner }}
-    steps:
-      - name: Check if should use large runner
-        id: large-runner
-        # We want to speed runs on the main branch which prime the cache
-        # We allow large runners only in this case to prevent forks from abusing them (it's enforced via runner groups access rules)
-        # IF YOU WANT TO USE A LARGE RUNNER YOU NEED TO ADD THE WORKFLOW TO THE `CloudQuery releases` GROUP IN https://github.com/organizations/cloudquery/settings/actions/runner-groups
-        if: github.event_name == 'push'
-        run: |
-          echo "runner=cloudquery-release-runner" >> $GITHUB_OUTPUT
-      - name: Resolve runner
-        id: resolve
-        run: |
-          RUNNER=${{ steps.large-runner.outputs.runner }}
-          echo "runner=${RUNNER:-"ubuntu-latest"}" >> $GITHUB_OUTPUT
   plugins-source-heroku:
     timeout-minutes: 30
     name: "plugins/source/heroku"
-    needs: [resolve-runner]
-    runs-on: ${{ needs.resolve-runner.outputs.runner }}
+    runs-on: ubuntu-latest
     defaults:
       run:
         working-directory: ./plugins/source/heroku
@@ -70,8 +50,7 @@ jobs:
         run: test "$(git status -s | wc -l)" -eq 0
   validate-release:
     timeout-minutes: 30
-    needs: [resolve-runner]
-    runs-on: ${{ needs.resolve-runner.outputs.runner }}
+    runs-on: ubuntu-latest
     env:
       CGO_ENABLED: 0
     steps:

--- a/.github/workflows/source_okta.yml
+++ b/.github/workflows/source_okta.yml
@@ -13,30 +13,10 @@ on:
       - ".github/workflows/source_okta.yml"
 
 jobs:
-  resolve-runner:
-    timeout-minutes: 5
-    runs-on: ubuntu-latest
-    outputs:
-      runner: ${{ steps.resolve.outputs.runner }}
-    steps:
-      - name: Check if should use large runner
-        id: large-runner
-        # We want to speed runs on the main branch which prime the cache
-        # We allow large runners only in this case to prevent forks from abusing them (it's enforced via runner groups access rules)
-        # IF YOU WANT TO USE A LARGE RUNNER YOU NEED TO ADD THE WORKFLOW TO THE `CloudQuery releases` GROUP IN https://github.com/organizations/cloudquery/settings/actions/runner-groups
-        if: github.event_name == 'push'
-        run: |
-          echo "runner=cloudquery-release-runner" >> $GITHUB_OUTPUT
-      - name: Resolve runner
-        id: resolve
-        run: |
-          RUNNER=${{ steps.large-runner.outputs.runner }}
-          echo "runner=${RUNNER:-"ubuntu-latest"}" >> $GITHUB_OUTPUT
   plugins-source-okta:
     timeout-minutes: 30
     name: "plugins/source/okta"
-    needs: [resolve-runner]
-    runs-on: ${{ needs.resolve-runner.outputs.runner }}
+    runs-on: ubuntu-latest
     defaults:
       run:
         working-directory: ./plugins/source/okta
@@ -70,8 +50,7 @@ jobs:
         run: test "$(git status -s | wc -l)" -eq 0
   validate-release:
     timeout-minutes: 30
-    needs: [resolve-runner]
-    runs-on: ${{ needs.resolve-runner.outputs.runner }}
+    runs-on: ubuntu-latest
     env:
       CGO_ENABLED: 0
     steps:

--- a/.github/workflows/source_terraform.yml
+++ b/.github/workflows/source_terraform.yml
@@ -13,30 +13,10 @@ on:
       - ".github/workflows/source_terraform.yml"
 
 jobs:
-  resolve-runner:
-    timeout-minutes: 5
-    runs-on: ubuntu-latest
-    outputs:
-      runner: ${{ steps.resolve.outputs.runner }}
-    steps:
-      - name: Check if should use large runner
-        id: large-runner
-        # We want to speed runs on the main branch which prime the cache
-        # We allow large runners only in this case to prevent forks from abusing them (it's enforced via runner groups access rules)
-        # IF YOU WANT TO USE A LARGE RUNNER YOU NEED TO ADD THE WORKFLOW TO THE `CloudQuery releases` GROUP IN https://github.com/organizations/cloudquery/settings/actions/runner-groups
-        if: github.event_name == 'push'
-        run: |
-          echo "runner=cloudquery-release-runner" >> $GITHUB_OUTPUT
-      - name: Resolve runner
-        id: resolve
-        run: |
-          RUNNER=${{ steps.large-runner.outputs.runner }}
-          echo "runner=${RUNNER:-"ubuntu-latest"}" >> $GITHUB_OUTPUT
   plugins-source-terraform:
     timeout-minutes: 30
     name: "plugins/source/terraform"
-    needs: [resolve-runner]
-    runs-on: ${{ needs.resolve-runner.outputs.runner }}
+    runs-on: ubuntu-latest
     defaults:
       run:
         working-directory: ./plugins/source/terraform
@@ -70,8 +50,7 @@ jobs:
         run: test "$(git status -s | wc -l)" -eq 0
   validate-release:
     timeout-minutes: 30
-    needs: [resolve-runner]
-    runs-on: ${{ needs.resolve-runner.outputs.runner }}
+    runs-on: ubuntu-latest
     env:
       CGO_ENABLED: 0
     steps:

--- a/.github/workflows/source_test.yml
+++ b/.github/workflows/source_test.yml
@@ -13,30 +13,10 @@ on:
       - ".github/workflows/source_test.yml"
 
 jobs:
-  resolve-runner:
-    timeout-minutes: 5
-    runs-on: ubuntu-latest
-    outputs:
-      runner: ${{ steps.resolve.outputs.runner }}
-    steps:
-      - name: Check if should use large runner
-        id: large-runner
-        # We want to speed runs on the main branch which prime the cache
-        # We allow large runners only in this case to prevent forks from abusing them (it's enforced via runner groups access rules)
-        # IF YOU WANT TO USE A LARGE RUNNER YOU NEED TO ADD THE WORKFLOW TO THE `CloudQuery releases` GROUP IN https://github.com/organizations/cloudquery/settings/actions/runner-groups
-        if: github.event_name == 'push'
-        run: |
-          echo "runner=cloudquery-release-runner" >> $GITHUB_OUTPUT
-      - name: Resolve runner
-        id: resolve
-        run: |
-          RUNNER=${{ steps.large-runner.outputs.runner }}
-          echo "runner=${RUNNER:-"ubuntu-latest"}" >> $GITHUB_OUTPUT
   plugins-source-test:
     timeout-minutes: 30
     name: "plugins/source/test"
-    needs: [resolve-runner]
-    runs-on: ${{ needs.resolve-runner.outputs.runner }}
+    runs-on: ubuntu-latest
     defaults:
       run:
         working-directory: ./plugins/source/test
@@ -70,8 +50,7 @@ jobs:
         run: test "$(git status -s | wc -l)" -eq 0
   validate-release:
     timeout-minutes: 30
-    needs: [resolve-runner]
-    runs-on: ${{ needs.resolve-runner.outputs.runner }}
+    runs-on: ubuntu-latest
     env:
       CGO_ENABLED: 0
     steps:


### PR DESCRIPTION
<!-- 🎉 Thank you for making CloudQuery awesome by submitting a PR 🎉 -->

#### Summary

Remove large runners from small plugins. I looked at the build times, and removed large runners from plugins that their build time is under 5m without the large runner

<!--
Use the following steps to ensure your PR is ready to be reviewed

- [ ] Read the [contribution guidelines](../blob/main/CONTRIBUTING.md) 🧑‍🎓
- [ ] Test locally on your own infrastructure
- [ ] Run `go fmt` to format your code 🖊
- [ ] Lint your changes via `golangci-lint run` 🚨 (install golangci-lint [here](https://golangci-lint.run/usage/install/#local-installation))
- [ ] Update or add tests 🧪
- [ ] Ensure the status checks below are successful ✅
--->
