### PR TITLE
fix(aws): Unused EIP policy - check associations not instance_ids

### DIFF
--- a/plugins/source/aws/policies/queries/ec2/eips_unused.sql
+++ b/plugins/source/aws/policies/queries/ec2/eips_unused.sql
@@ -7,4 +7,4 @@ select :'execution_time' as execution_time,
        allocation_id     as resource_id,
        'fail'            as status
 from aws_ec2_eips
-where instance_id is null
+where association_id is null


### PR DESCRIPTION
<!-- 🎉 Thank you for making CloudQuery awesome by submitting a PR 🎉 -->

#### Summary

The unused EIP policy check is generating a lot of false positives because it only checks for association to an EC2 instance. this misses various other valid associations (e.g. NAT Gateways, AWS Transfer servers).

<!--
Use the following steps to ensure your PR is ready to be reviewed

- [ ] Read the [contribution guidelines](../blob/main/CONTRIBUTING.md) 🧑‍🎓
- [ ] Test locally on your own infrastructure
- [ ] Run `go fmt` to format your code 🖊
- [ ] Lint your changes via `golangci-lint run` 🚨 (install golangci-lint [here](https://golangci-lint.run/usage/install/#local-installation))
- [ ] Update or add tests 🧪
- [ ] Ensure the status checks below are successful ✅
--->
