### PR TITLE
chore(website): Use append mode in BigQuery recipe

### DIFF
--- a/website/pages/docs/recipes/destinations/bigquery.md
+++ b/website/pages/docs/recipes/destinations/bigquery.md
@@ -10,7 +10,7 @@ spec:
   name: bigquery
   path: cloudquery/bigquery
   version: "VERSION_DESTINATION_BIGQUERY"
-  write_mode: "overwrite-delete-stale"
+  write_mode: "append"
   spec:
     project_id: ${PROJECT_ID}
     dataset_id: ${DATASET_ID}


### PR DESCRIPTION
Left over from when the BigQuery plugin still (tried to) support `overwrite-delete-stale` mode. It now only supports `append` mode.