### PR TITLE
fix(cli): Flush sentry before exiting

### DIFF
--- a/cli/main.go
+++ b/cli/main.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"os/signal"
 	"runtime/debug"
+	"time"
 
 	"github.com/cloudquery/cloudquery/cli/cmd"
 	"github.com/getsentry/sentry-go"
@@ -41,6 +42,7 @@ func main() {
 		if err != nil {
 			originalMessage := fmt.Sprintf("panic: %v\n\n%s", err, string(debug.Stack()))
 			sentry.CurrentHub().CaptureMessage(originalMessage)
+			_ = sentry.Flush(5 * time.Second)
 			panic(err)
 		}
 


### PR DESCRIPTION
<!-- 🎉 Thank you for making CloudQuery awesome by submitting a PR 🎉 -->

#### Summary

This is unrelated to the issue with plugins panics not showing up in sentry, but we still need to do it for the CLI.
I think this is the only place we actually send something to sentry in the CLI

<!--
Use the following steps to ensure your PR is ready to be reviewed

- [ ] Read the [contribution guidelines](../blob/main/CONTRIBUTING.md) 🧑‍🎓
- [ ] Test locally on your own infrastructure
- [ ] Run `go fmt` to format your code 🖊
- [ ] Lint your changes via `golangci-lint run` 🚨 (install golangci-lint [here](https://golangci-lint.run/usage/install/#local-installation))
- [ ] Update or add tests 🧪
- [ ] Ensure the status checks below are successful ✅
--->
