### PR TITLE
chore(release-cli): Allow versioned installs via Homebrew

### DIFF
--- a/cli/.goreleaser.yaml
+++ b/cli/.goreleaser.yaml
@@ -41,3 +41,21 @@ brews:
       (zsh_completion/"_cloudquery").write output
       output = Utils.safe_popen_read("#{bin}/cloudquery", "completion", "fish")
       (fish_completion/"cloudquery.fish").write output
+  -
+    ids:
+      - homebrew
+    name: cloudquery@{{.Version}}
+    tap:
+      owner: cloudquery
+      name: homebrew-tap
+    url_template: "https://github.com/cloudquery/cloudquery/releases/download/{{ .PrefixedTag }}/{{ .ArtifactName }}"
+    homepage: "https://cloudquery.io"
+    description: "Easily monitor and ask questions about your infrastructure."
+    install: |-
+      bin.install "cloudquery"
+      output = Utils.safe_popen_read("#{bin}/cloudquery", "completion", "bash")
+      (bash_completion/"cloudquery").write output
+      output = Utils.safe_popen_read("#{bin}/cloudquery", "completion", "zsh")
+      (zsh_completion/"_cloudquery").write output
+      output = Utils.safe_popen_read("#{bin}/cloudquery", "completion", "fish")
+      (fish_completion/"cloudquery.fish").write output


### PR DESCRIPTION
<!-- 🎉 Thank you for making CloudQuery awesome by submitting a PR 🎉 -->

#### Summary

This should allow users to `brew install cloudquery@<version>`.
See example in https://github.com/erezrokah/homebrew-tap

Also run `goreleaser release --snapshot --rm-dist --skip-validate --skip-publish --skip-sign -f ./cli/.goreleaser.yaml` and look under `dist/` to see the versioned formula.

<!--
Use the following steps to ensure your PR is ready to be reviewed

- [ ] Read the [contribution guidelines](../blob/main/CONTRIBUTING.md) 🧑‍🎓
- [ ] Test locally on your own infrastructure
- [ ] Run `go fmt` to format your code 🖊
- [ ] Lint your changes via `golangci-lint run` 🚨 (install golangci-lint [here](https://golangci-lint.run/usage/install/#local-installation))
- [ ] Update or add tests 🧪
- [ ] Ensure the status checks below are successful ✅
--->
