### PR TITLE
fix: Revert "chore: Update plugin `source-aws` version to v7.3.1"

### DIFF
--- a/website/versions/source-aws.json
+++ b/website/versions/source-aws.json
@@ -1,1 +1,1 @@
-{ "latest": "plugins-source-aws-v7.3.1" }
+{ "latest": "plugins-source-aws-v7.3.0" }


### PR DESCRIPTION
Reverts cloudquery/cloudquery#5479

Looks like there's a bug with this version