### PR TITLE
feat: Support service account keys in BigQuery destination

### DIFF
--- a/plugins/destination/bigquery/client/spec.go
+++ b/plugins/destination/bigquery/client/spec.go
@@ -1,6 +1,7 @@
 package client
 
 import (
+	"encoding/json"
 	"fmt"
 )
 
@@ -28,9 +29,10 @@ func (t TimePartitioningOption) Validate() error {
 }
 
 type Spec struct {
-	ProjectID        string                 `json:"project_id"`
-	DatasetID        string                 `json:"dataset_id"`
-	TimePartitioning TimePartitioningOption `json:"time_partitioning"`
+	ProjectID             string                 `json:"project_id"`
+	DatasetID             string                 `json:"dataset_id"`
+	TimePartitioning      TimePartitioningOption `json:"time_partitioning"`
+	ServiceAccountKeyJSON string                 `json:"service_account_key_json"`
 }
 
 func (s *Spec) SetDefaults() {
@@ -48,6 +50,18 @@ func (s *Spec) Validate() error {
 	}
 	if err := s.TimePartitioning.Validate(); err != nil {
 		return fmt.Errorf("time_partitioning: %w", err)
+	}
+	if err := isValidJson(s.ServiceAccountKeyJSON); err != nil {
+		return fmt.Errorf("invalid json for service_account_key_json: %w", err)
+	}
+	return nil
+}
+
+func isValidJson(content string) error {
+	var v map[string]interface{}
+	err := json.Unmarshal([]byte(content), &v)
+	if err != nil {
+		return err
 	}
 	return nil
 }

--- a/website/pages/docs/advanced-topics/environment-variable-substitution.md
+++ b/website/pages/docs/advanced-topics/environment-variable-substitution.md
@@ -30,3 +30,15 @@ spec:
 ```
 
 Local path `./path/to/secret/file` will be read and replaced with the contents of the file before processing.
+
+## JSON Files
+
+If the file or environment variable being substituted in contains JSON, it should be imported inside single quotes:
+
+```yaml copy
+kind: "destination"
+spec:
+  name: "bigquery"
+  spec:
+    service_account_key_json: '${file:./path/to/secret/file.json}'
+```

--- a/website/pages/docs/plugins/destinations/bigquery/overview.md
+++ b/website/pages/docs/plugins/destinations/bigquery/overview.md
@@ -81,6 +81,11 @@ This is the top-level spec used by the BigQuery destination plugin.
 
   The time partitioning to use when creating tables. The partition time column used will always be `_cq_sync_time` so that all rows for a sync run will be partitioned on the hour/day the sync started.
 
+- `service_account_key_json` (string) (default: empty).
+
+  GCP service account key content. This allows for using different service accounts for the GCP source and BigQuery destination. If using service account keys, it is best to use [environment or file variable substitution](/docs/advanced-topics/environment-variable-substitution).
+
+
 ## Underlying library
 
 We use the official [cloud.google.com/go/bigquery](https://pkg.go.dev/cloud.google.com/go/bigquery) package for database connection.

--- a/website/pages/docs/plugins/sources/gcp/configuration.md
+++ b/website/pages/docs/plugins/sources/gcp/configuration.md
@@ -29,7 +29,7 @@ This is the (nested) spec used by GCP Source Plugin
 
 - `service_account_key_json` (string) (default: empty).
 
-  GCP service account key content. Using service accounts is not recommended, but if it is used it is better to use env variable expansion
+  GCP service account key content. Using service accounts is not recommended, but if it is used it is better to use [environment or file variable substitution](/docs/advanced-topics/environment-variable-substitution).
 
 - `folder_ids` ([]string) (default: empty).
   


### PR DESCRIPTION
This adds support for service account keys to the BigQuery destination, similar to what we have in the GCP source plugin. This allows for using different accounts for the source and destination plugins, which can be useful in some scenarios.