### PR TITLE
fix(aws-functions): Return error in case of access denied

### DIFF
--- a/plugins/source/aws/client/helpers.go
+++ b/plugins/source/aws/client/helpers.go
@@ -305,15 +305,6 @@ func isNotFoundError(err error) bool {
 	return false
 }
 
-// IsAccessDeniedError checks if api error should be classified as a permissions issue
-func (c *Client) IsAccessDeniedError(err error) bool {
-	if isAccessDeniedError(err) {
-		c.logger.Warn().Err(err).Msg("API returned an Access Denied error, ignoring it and continuing...")
-		return true
-	}
-	return false
-}
-
 func isAccessDeniedError(err error) bool {
 	var ae smithy.APIError
 	if !errors.As(err, &ae) {

--- a/plugins/source/aws/resources/services/lambda/functions_fetch.go
+++ b/plugins/source/aws/resources/services/lambda/functions_fetch.go
@@ -41,8 +41,7 @@ func getFunction(ctx context.Context, meta schema.ClientMeta, resource *schema.R
 		FunctionName: f.FunctionName,
 	})
 	if err != nil {
-		if c.IsNotFoundError(err) || c.IsAccessDeniedError(err) {
-			c.Logger().Warn().Err(err).Msg("Failed to get function")
+		if c.IsNotFoundError(err) {
 			resource.Item = &lambda.GetFunctionOutput{
 				Configuration: &f,
 			}


### PR DESCRIPTION
<!-- 🎉 Thank you for making CloudQuery awesome by submitting a PR 🎉 -->

#### Summary

Fixes https://github.com/cloudquery/cloudquery/issues/5525

I kept the `IsNotFoundError` as that seems to be the pattern for everything in AWS. Also not sure if we should return `nil` or set the `Item`. I think since it's a pre resource resolver we have to?

<!--
Use the following steps to ensure your PR is ready to be reviewed

- [ ] Read the [contribution guidelines](../blob/main/CONTRIBUTING.md) 🧑‍🎓
- [ ] Test locally on your own infrastructure
- [ ] Run `go fmt` to format your code 🖊
- [ ] Lint your changes via `golangci-lint run` 🚨 (install golangci-lint [here](https://golangci-lint.run/usage/install/#local-installation))
- [ ] Update or add tests 🧪
- [ ] Ensure the status checks below are successful ✅
--->
