### PR TITLE
fix(gcp)!: Only list enabled Services

### DIFF
--- a/plugins/source/gcp/codegen/recipes/serviceusage.go
+++ b/plugins/source/gcp/codegen/recipes/serviceusage.go
@@ -7,8 +7,6 @@ import (
 	pb "google.golang.org/genproto/googleapis/api/serviceusage/v1"
 )
 
-
-
 func init() {
 	resources := []*Resource{
 		{
@@ -37,7 +35,8 @@ func init() {
 		resource.Template = "newapi_list"
 		resource.MockTemplate = "newapi_list_grpc_mock"
 		resource.RequestStructFields = `Parent: "projects/" + c.ProjectId,
-		PageSize: 200,`
+		PageSize: 200,
+		Filter: "state:ENABLED",`
 	}
 
 	Resources = append(Resources, resources...)

--- a/plugins/source/gcp/resources/services/serviceusage/services.go
+++ b/plugins/source/gcp/resources/services/serviceusage/services.go
@@ -56,6 +56,7 @@ func fetchServices(ctx context.Context, meta schema.ClientMeta, parent *schema.R
 	req := &pb.ListServicesRequest{
 		Parent:   "projects/" + c.ProjectId,
 		PageSize: 200,
+		Filter:   "state:ENABLED",
 	}
 	gcpClient, err := serviceusage.NewClient(ctx, c.ClientOptions...)
 	if err != nil {


### PR DESCRIPTION
<!-- 🎉 Thank you for making CloudQuery awesome by submitting a PR 🎉 -->

#### Summary

Currently we list *ALL* services... According to GCP docs this can take 30 seconds and takes 15 API calls...The default quota for this is 60 req/min... If we change it to only Enabled services the default quota is 600 req/min and most projects will have fewer than 200 enabled services


<!--
Explain what problem this PR addresses
-->

<!--
Use the following steps to ensure your PR is ready to be reviewed

- [ ] Read the [contribution guidelines](../blob/main/CONTRIBUTING.md) 🧑‍🎓
- [ ] Test locally on your own infrastructure
- [ ] Run `go fmt` to format your code 🖊
- [ ] Lint your changes via `golangci-lint run` 🚨 (install golangci-lint [here](https://golangci-lint.run/usage/install/#local-installation))
- [ ] Update or add tests 🧪
- [ ] Ensure the status checks below are successful ✅
--->
