### PR TITLE
chore(ci): Add slash when matching actions to files

### DIFF
--- a/.github/workflows/wait_for_required_workflows.yml
+++ b/.github/workflows/wait_for_required_workflows.yml
@@ -37,7 +37,7 @@ jobs:
               return contents.includes(`name: "${action}"`)
             }
             const matchesFile = (action) => {
-              return files.some(file => file.startsWith(action) || matchesWorkflow(file, action))
+              return files.some(file => file.startsWith(`${action}/`) || matchesWorkflow(file, action))
             }
             let actions = ["cli",
                            "plugins/source/aws",


### PR DESCRIPTION
<!-- 🎉 Thank you for making CloudQuery awesome by submitting a PR 🎉 -->

#### Summary

Otherwise `plugins/source/azure` matches `plugins/source/azuredevops` files, see https://github.com/cloudquery/cloudquery/pull/5558

<!--
Use the following steps to ensure your PR is ready to be reviewed

- [ ] Read the [contribution guidelines](../blob/main/CONTRIBUTING.md) 🧑‍🎓
- [ ] Test locally on your own infrastructure
- [ ] Run `go fmt` to format your code 🖊
- [ ] Lint your changes via `golangci-lint run` 🚨 (install golangci-lint [here](https://golangci-lint.run/usage/install/#local-installation))
- [ ] Update or add tests 🧪
- [ ] Ensure the status checks below are successful ✅
--->
