### PR TITLE
feat(codegen): Add PrimaryKeys field to codegen

### DIFF
--- a/plugins/source/gcp/codegen/main.go
+++ b/plugins/source/gcp/codegen/main.go
@@ -25,8 +25,6 @@ import (
 //go:embed templates/*.go.tpl
 var gcpTemplatesFS embed.FS
 
-
-
 func main() {
 
 	for _, r := range recipes.Resources {
@@ -72,11 +70,6 @@ func needsProjectIDColumn(r recipes.Resource) bool {
 		return false
 	}
 
-	for _, c := range r.ExtraColumns {
-		if c.Name == "project_id" {
-			return false
-		}
-	}
 	return true
 }
 
@@ -128,13 +121,9 @@ func generateResource(r recipes.Resource, mock bool) {
 		r.MockImports = []string{reflect.TypeOf(r.Struct).Elem().PkgPath()}
 	}
 
-	for _, f := range r.ExtraColumns {
-		r.SkipFields = append(r.SkipFields, strcase.ToCamel(f.Name))
-	}
-
 	extraColumns := r.ExtraColumns
 	if needsProjectIDColumn(r) {
-		extraColumns = append([]codegen.ColumnDefinition{recipes.ProjectIdColumn}, extraColumns...)
+		extraColumns = append([]codegen.ColumnDefinition{recipes.ProjectIdColumn}, r.ExtraColumns...)
 	}
 
 	opts := []codegen.TableOption{
@@ -187,6 +176,15 @@ func generateResource(r recipes.Resource, mock bool) {
 	} else {
 		r.Table.Multiplex = *r.Multiplex
 	}
+
+	for _, f := range r.PrimaryKeys {
+		for i := range r.Table.Columns {
+			if r.Table.Columns[i].Name == f {
+				r.Table.Columns[i].Options.PrimaryKey = true
+			}
+		}
+	}
+
 	r.Table.Resolver = "fetch" + strcase.ToCamel(r.SubService)
 	if r.PreResourceResolver != "" {
 		r.Table.PreResourceResolver = r.PreResourceResolver

--- a/plugins/source/gcp/codegen/main.go
+++ b/plugins/source/gcp/codegen/main.go
@@ -66,11 +66,7 @@ func generatePlugin(rr []*recipes.Resource) {
 }
 
 func needsProjectIDColumn(r recipes.Resource) bool {
-	if r.Multiplex == &recipes.OrgMultiplex {
-		return false
-	}
-
-	return true
+	return r.Multiplex != &recipes.OrgMultiplex
 }
 
 func generateResource(r recipes.Resource, mock bool) {

--- a/plugins/source/gcp/codegen/recipes/apikeys.go
+++ b/plugins/source/gcp/codegen/recipes/apikeys.go
@@ -2,28 +2,15 @@ package recipes
 
 import (
 	apikeys "cloud.google.com/go/apikeys/apiv2"
-	"github.com/cloudquery/plugin-sdk/codegen"
-	"github.com/cloudquery/plugin-sdk/schema"
 	pb "google.golang.org/genproto/googleapis/api/apikeys/v2"
 )
-
 
 func init() {
 	resources := []*Resource{
 		{
-			SubService: "keys",
-			Struct:     &pb.Key{},
-			SkipFields: []string{"Uid"},
-			ExtraColumns: []codegen.ColumnDefinition{
-				ProjectIdColumnPk,
-				{
-					Name:     "uid",
-					Type:     schema.TypeString,
-					Resolver: `schema.PathResolver("Uid")`,
-					Options:  schema.ColumnCreationOptions{PrimaryKey: true},
-				},
-			},
-	
+			SubService:          "keys",
+			Struct:              &pb.Key{},
+			PrimaryKeys:         []string{ProjectIdColumn.Name, "uid"},
 			ListFunction:        (&apikeys.Client{}).ListKeys,
 			RequestStruct:       &pb.ListKeysRequest{},
 			ResponseStruct:      &pb.ListKeysResponse{},

--- a/plugins/source/gcp/codegen/recipes/base.go
+++ b/plugins/source/gcp/codegen/recipes/base.go
@@ -80,8 +80,8 @@ type Resource struct {
 	// Don't generate fetch
 	SkipFetch bool
 	// SkipFields fields in go struct to skip when generating the table from the go struct
-	SkipFields []string
-	// ExtraColumns override, override generated columns
+	SkipFields   []string
+	PrimaryKeys  []string
 	ExtraColumns []codegen.ColumnDefinition
 	// NameTransformer custom name transformer for resource
 	NameTransformer func(field reflect.StructField) (string, error)
@@ -91,13 +91,6 @@ var ProjectIdColumn = codegen.ColumnDefinition{
 	Name:     "project_id",
 	Type:     schema.TypeString,
 	Resolver: "client.ResolveProject",
-}
-
-var ProjectIdColumnPk = codegen.ColumnDefinition{
-	Name:     "project_id",
-	Type:     schema.TypeString,
-	Resolver: "client.ResolveProject",
-	Options:  schema.ColumnCreationOptions{PrimaryKey: true},
 }
 
 func CreateReplaceTransformer(replace map[string]string) func(field reflect.StructField) (string, error) {

--- a/plugins/source/gcp/codegen/recipes/billing.go
+++ b/plugins/source/gcp/codegen/recipes/billing.go
@@ -3,11 +3,7 @@ package recipes
 import (
 	billing "cloud.google.com/go/billing/apiv1"
 	pb "cloud.google.com/go/billing/apiv1/billingpb"
-	"github.com/cloudquery/plugin-sdk/codegen"
-	"github.com/cloudquery/plugin-sdk/schema"
 )
-
-
 
 func init() {
 	resources := []*Resource{
@@ -20,13 +16,7 @@ func init() {
 			ListFunction:        (&billing.CloudBillingClient{}).ListBillingAccounts,
 			RegisterServer:      pb.RegisterCloudBillingServer,
 			UnimplementedServer: &pb.UnimplementedCloudBillingServer{},
-			ExtraColumns: []codegen.ColumnDefinition{
-				{
-					Name:    "name",
-					Type:    schema.TypeString,
-					Options: schema.ColumnCreationOptions{PrimaryKey: true},
-				},
-			},
+			PrimaryKeys:         []string{"name"},
 		},
 		{
 			SubService:          "services",
@@ -37,13 +27,7 @@ func init() {
 			ListFunction:        (&billing.CloudCatalogClient{}).ListServices,
 			RegisterServer:      pb.RegisterCloudCatalogServer,
 			UnimplementedServer: &pb.UnimplementedCloudCatalogServer{},
-			ExtraColumns: []codegen.ColumnDefinition{
-				{
-					Name:    "name",
-					Type:    schema.TypeString,
-					Options: schema.ColumnCreationOptions{PrimaryKey: true},
-				},
-			},
+			PrimaryKeys:         []string{"name"},
 		},
 	}
 

--- a/plugins/source/gcp/codegen/recipes/compute.go
+++ b/plugins/source/gcp/codegen/recipes/compute.go
@@ -6,8 +6,6 @@ import (
 	"strings"
 
 	compute "cloud.google.com/go/compute/apiv1"
-	"github.com/cloudquery/plugin-sdk/codegen"
-	"github.com/cloudquery/plugin-sdk/schema"
 	"github.com/iancoleman/strcase"
 	pb "google.golang.org/genproto/googleapis/cloud/compute/v1"
 )
@@ -227,14 +225,8 @@ func init() {
 		}
 		resource.MockImports = []string{"cloud.google.com/go/compute/apiv1"}
 		resource.ProtobufImport = "google.golang.org/genproto/googleapis/cloud/compute/v1"
-		if resource.ExtraColumns == nil {
-			resource.ExtraColumns = []codegen.ColumnDefinition{
-				{
-					Name:    "self_link",
-					Type:    schema.TypeString,
-					Options: schema.ColumnCreationOptions{PrimaryKey: true},
-				},
-			}
+		if resource.PrimaryKeys == nil {
+			resource.PrimaryKeys = []string{"self_link"}
 		}
 	}
 

--- a/plugins/source/gcp/codegen/recipes/container.go
+++ b/plugins/source/gcp/codegen/recipes/container.go
@@ -1,27 +1,17 @@
 package recipes
 
 import (
-	"github.com/cloudquery/plugin-sdk/codegen"
-	"github.com/cloudquery/plugin-sdk/schema"
 	pb "google.golang.org/genproto/googleapis/container/v1"
 )
-
-
 
 func init() {
 	resources := []*Resource{
 		{
-			SubService: "clusters",
-			Struct:     &pb.Cluster{},
-			SkipFetch:  true,
-			SkipMock:   true,
-			ExtraColumns: []codegen.ColumnDefinition{
-				{
-					Name:    "self_link",
-					Type:    schema.TypeString,
-					Options: schema.ColumnCreationOptions{PrimaryKey: true},
-				},
-			},
+			SubService:      "clusters",
+			Struct:          &pb.Cluster{},
+			SkipFetch:       true,
+			SkipMock:        true,
+			PrimaryKeys:     []string{"self_link"},
 			NameTransformer: CreateReplaceTransformer(map[string]string{"ipv_4": "ipv4"}),
 		},
 	}

--- a/plugins/source/gcp/codegen/recipes/containeranalysis.go
+++ b/plugins/source/gcp/codegen/recipes/containeranalysis.go
@@ -3,25 +3,14 @@ package recipes
 import (
 	containeranalysis "cloud.google.com/go/containeranalysis/apiv1beta1"
 	grafeaspb "cloud.google.com/go/containeranalysis/apiv1beta1/grafeas/grafeaspb"
-	"github.com/cloudquery/plugin-sdk/codegen"
-	"github.com/cloudquery/plugin-sdk/schema"
 )
 
-func init(){
+func init() {
 	resources := []*Resource{
 		{
-			SubService: "occurrences",
-			Struct:     &grafeaspb.Occurrence{},
-			SkipFields: []string{"Name"},
-			ExtraColumns: []codegen.ColumnDefinition{
-				ProjectIdColumn,
-				{
-					Name:     "name",
-					Type:     schema.TypeString,
-					Resolver: `schema.PathResolver("Name")`,
-					Options:  schema.ColumnCreationOptions{PrimaryKey: true},
-				},
-			},
+			SubService:          "occurrences",
+			Struct:              &grafeaspb.Occurrence{},
+			PrimaryKeys:         []string{"name"},
 			Template:            "newapi_list",
 			ListFunction:        (&containeranalysis.GrafeasV1Beta1Client{}).ListOccurrences,
 			RequestStruct:       &grafeaspb.ListOccurrencesRequest{},

--- a/plugins/source/gcp/codegen/recipes/dns.go
+++ b/plugins/source/gcp/codegen/recipes/dns.go
@@ -1,13 +1,9 @@
 package recipes
 
 import (
-	"github.com/cloudquery/plugin-sdk/codegen"
-	"github.com/cloudquery/plugin-sdk/schema"
 	"github.com/iancoleman/strcase"
 	"google.golang.org/api/dns/v1"
 )
-
-
 
 func init() {
 	resources := []*Resource{
@@ -16,28 +12,14 @@ func init() {
 			Struct:       &dns.Policy{},
 			NewFunction:  dns.NewService,
 			ListFunction: (&dns.PoliciesService{}).List,
-			ExtraColumns: []codegen.ColumnDefinition{
-				{
-					Name:     "id",
-					Type:     schema.TypeInt,
-					Options:  schema.ColumnCreationOptions{PrimaryKey: true},
-					Resolver: `schema.PathResolver("Id")`,
-				},
-			},
+			PrimaryKeys:  []string{"id"},
 		},
 		{
 			SubService:   "managed_zones",
 			Struct:       &dns.ManagedZone{},
 			NewFunction:  dns.NewManagedZoneOperationsService,
 			ListFunction: (&dns.ManagedZonesService{}).List,
-			ExtraColumns: []codegen.ColumnDefinition{
-				{
-					Name:     "id",
-					Type:     schema.TypeInt,
-					Options:  schema.ColumnCreationOptions{PrimaryKey: true},
-					Resolver: `schema.PathResolver("Id")`,
-				},
-			},
+			PrimaryKeys:  []string{"id"},
 		},
 	}
 

--- a/plugins/source/gcp/codegen/recipes/iam.go
+++ b/plugins/source/gcp/codegen/recipes/iam.go
@@ -7,39 +7,18 @@ import (
 	"google.golang.org/api/iam/v1"
 )
 
-
-
 func init() {
 	resources := []*Resource{
 		{
-			SubService: "roles",
-			Struct:     &iam.Role{},
-			ExtraColumns: []codegen.ColumnDefinition{
-				{
-					Name:     "project_id",
-					Type:     schema.TypeString,
-					Options:  schema.ColumnCreationOptions{PrimaryKey: true},
-					Resolver: "client.ResolveProject",
-				},
-				{
-					Name:    "name",
-					Type:    schema.TypeString,
-					Options: schema.ColumnCreationOptions{PrimaryKey: true},
-				},
-			},
+			SubService:  "roles",
+			Struct:      &iam.Role{},
+			PrimaryKeys: []string{ProjectIdColumn.Name, "name"},
 		},
 		{
-			SubService:  "service_accounts",
-			Struct:      &iam.ServiceAccount{},
-			OutputField: "Accounts",
-			ExtraColumns: []codegen.ColumnDefinition{
-				{
-					Name:     "unique_id",
-					Type:     schema.TypeString,
-					Options:  schema.ColumnCreationOptions{PrimaryKey: true},
-					Resolver: `schema.PathResolver("UniqueId")`,
-				},
-			},
+			SubService:      "service_accounts",
+			Struct:          &iam.ServiceAccount{},
+			OutputField:     "Accounts",
+			PrimaryKeys:     []string{"unique_id"},
 			SkipFields:      []string{"ProjectId"},
 			NameTransformer: CreateReplaceTransformer(map[string]string{"oauth_2": "oauth2"}),
 			Relations:       []string{"ServiceAccountKeys()"},

--- a/plugins/source/gcp/codegen/recipes/kms.go
+++ b/plugins/source/gcp/codegen/recipes/kms.go
@@ -17,7 +17,6 @@ func init() {
 			ChildTable: true,
 			SkipMock:   true,
 			SkipFetch:  true,
-			SkipFields: []string{"RotationSchedule"},
 			ExtraColumns: codegen.ColumnDefinitions{
 				{
 					Name:     "rotation_period",

--- a/plugins/source/gcp/codegen/recipes/logging.go
+++ b/plugins/source/gcp/codegen/recipes/logging.go
@@ -2,12 +2,8 @@ package recipes
 
 import (
 	logging "cloud.google.com/go/logging/apiv2"
-	"github.com/cloudquery/plugin-sdk/codegen"
-	"github.com/cloudquery/plugin-sdk/schema"
 	pb "google.golang.org/genproto/googleapis/logging/v2"
 )
-
-
 
 func init() {
 	resources := []*Resource{
@@ -20,14 +16,7 @@ func init() {
 			RegisterServer:      pb.RegisterMetricsServiceV2Server,
 			ListFunction:        (&pb.UnimplementedMetricsServiceV2Server{}).ListLogMetrics,
 			UnimplementedServer: &pb.UnimplementedMetricsServiceV2Server{},
-			ExtraColumns: []codegen.ColumnDefinition{
-				{
-					Name:     "name",
-					Type:     schema.TypeString,
-					Options:  schema.ColumnCreationOptions{PrimaryKey: true},
-					Resolver: `schema.PathResolver("Name")`,
-				},
-			},
+			PrimaryKeys:         []string{"name"},
 		},
 		{
 			SubService:          "sinks",
@@ -38,15 +27,8 @@ func init() {
 			RegisterServer:      pb.RegisterConfigServiceV2Server,
 			ListFunction:        (&pb.UnimplementedConfigServiceV2Server{}).ListSinks,
 			UnimplementedServer: &pb.UnimplementedConfigServiceV2Server{},
-			ExtraColumns: []codegen.ColumnDefinition{
-				{
-					Name:     "name",
-					Type:     schema.TypeString,
-					Options:  schema.ColumnCreationOptions{PrimaryKey: true},
-					Resolver: `schema.PathResolver("Name")`,
-				},
-			},
-			SkipFields: []string{"Options"},
+			PrimaryKeys:         []string{"name"},
+			SkipFields:          []string{"Options"},
 		},
 	}
 

--- a/plugins/source/gcp/codegen/recipes/monitoring.go
+++ b/plugins/source/gcp/codegen/recipes/monitoring.go
@@ -3,14 +3,10 @@ package recipes
 import (
 	monitoring "cloud.google.com/go/monitoring/apiv3/v2"
 	pb "cloud.google.com/go/monitoring/apiv3/v2/monitoringpb"
-	"github.com/cloudquery/plugin-sdk/codegen"
-	"github.com/cloudquery/plugin-sdk/schema"
 )
 
-
-
 func init() {
-	resources :=  []*Resource{
+	resources := []*Resource{
 		{
 			SubService:          "alert_policies",
 			Struct:              &pb.AlertPolicy{},
@@ -20,13 +16,7 @@ func init() {
 			RegisterServer:      pb.RegisterAlertPolicyServiceServer,
 			ListFunction:        (&pb.UnimplementedAlertPolicyServiceServer{}).ListAlertPolicies,
 			UnimplementedServer: &pb.UnimplementedAlertPolicyServiceServer{},
-			ExtraColumns: []codegen.ColumnDefinition{
-				{
-					Name:    "name",
-					Type:    schema.TypeString,
-					Options: schema.ColumnCreationOptions{PrimaryKey: true},
-				},
-			},
+			PrimaryKeys:         []string{"name"},
 		},
 	}
 

--- a/plugins/source/gcp/codegen/recipes/redis.go
+++ b/plugins/source/gcp/codegen/recipes/redis.go
@@ -3,8 +3,6 @@ package recipes
 import (
 	redis "cloud.google.com/go/redis/apiv1"
 	pb "cloud.google.com/go/redis/apiv1/redispb"
-	"github.com/cloudquery/plugin-sdk/codegen"
-	"github.com/cloudquery/plugin-sdk/schema"
 )
 
 func init() {
@@ -18,14 +16,7 @@ func init() {
 			RegisterServer:      pb.RegisterCloudRedisServer,
 			UnimplementedServer: &pb.UnimplementedCloudRedisServer{},
 			ListFunction:        (&pb.UnimplementedCloudRedisServer{}).ListInstances,
-			ExtraColumns: []codegen.ColumnDefinition{
-				{
-					Name:     "name",
-					Type:     schema.TypeString,
-					Options:  schema.ColumnCreationOptions{PrimaryKey: true},
-					Resolver: `schema.PathResolver("Name")`,
-				},
-			},
+			PrimaryKeys:         []string{"name"},
 		},
 	}
 

--- a/plugins/source/gcp/codegen/recipes/secretmanager.go
+++ b/plugins/source/gcp/codegen/recipes/secretmanager.go
@@ -3,11 +3,7 @@ package recipes
 import (
 	secretmanager "cloud.google.com/go/secretmanager/apiv1"
 	pb "cloud.google.com/go/secretmanager/apiv1/secretmanagerpb"
-	"github.com/cloudquery/plugin-sdk/codegen"
-	"github.com/cloudquery/plugin-sdk/schema"
 )
-
-
 
 func init() {
 	resources := []*Resource{
@@ -20,15 +16,8 @@ func init() {
 			RegisterServer:      pb.RegisterSecretManagerServiceServer,
 			ListFunction:        (&pb.UnimplementedSecretManagerServiceServer{}).ListSecrets,
 			UnimplementedServer: &pb.UnimplementedSecretManagerServiceServer{},
-			ExtraColumns: []codegen.ColumnDefinition{
-				{
-					Name:     "name",
-					Type:     schema.TypeString,
-					Options:  schema.ColumnCreationOptions{PrimaryKey: true},
-					Resolver: `schema.PathResolver("Name")`,
-				},
-			},
-			SkipFields: []string{"Expiration"},
+			PrimaryKeys:         []string{"name"},
+			SkipFields:          []string{"Expiration"},
 		},
 	}
 

--- a/plugins/source/gcp/codegen/recipes/serviceusage.go
+++ b/plugins/source/gcp/codegen/recipes/serviceusage.go
@@ -3,8 +3,6 @@ package recipes
 import (
 	serviceusage "cloud.google.com/go/serviceusage/apiv1"
 	pb "cloud.google.com/go/serviceusage/apiv1/serviceusagepb"
-	"github.com/cloudquery/plugin-sdk/codegen"
-	"github.com/cloudquery/plugin-sdk/schema"
 )
 
 func init() {
@@ -18,13 +16,7 @@ func init() {
 			RegisterServer:      pb.RegisterServiceUsageServer,
 			ListFunction:        (&pb.UnimplementedServiceUsageServer{}).ListServices,
 			UnimplementedServer: &pb.UnimplementedServiceUsageServer{},
-			ExtraColumns: []codegen.ColumnDefinition{
-				{
-					Name:    "name",
-					Type:    schema.TypeString,
-					Options: schema.ColumnCreationOptions{PrimaryKey: true},
-				},
-			},
+			PrimaryKeys:         []string{"name"},
 		},
 	}
 

--- a/plugins/source/gcp/codegen/recipes/sqladmin.go
+++ b/plugins/source/gcp/codegen/recipes/sqladmin.go
@@ -1,55 +1,27 @@
 package recipes
 
 import (
-	"github.com/cloudquery/plugin-sdk/codegen"
-	"github.com/cloudquery/plugin-sdk/schema"
 	sqladmin "google.golang.org/api/sqladmin/v1beta4"
 )
 
 func init() {
 	resources := []*Resource{
 		{
-			SubService: "instances",
-			Struct:     &sqladmin.DatabaseInstance{},
-			SkipMock:   true,
-			SkipFetch:  true,
-			ExtraColumns: []codegen.ColumnDefinition{
-				{
-					Name:     "self_link",
-					Type:     schema.TypeString,
-					Options:  schema.ColumnCreationOptions{PrimaryKey: true},
-					Resolver: `schema.PathResolver("SelfLink")`,
-				},
-			},
+			SubService:      "instances",
+			Struct:          &sqladmin.DatabaseInstance{},
+			SkipMock:        true,
+			SkipFetch:       true,
+			PrimaryKeys:     []string{"self_link"},
 			NameTransformer: CreateReplaceTransformer(map[string]string{"ipv_6": "ipv6"}),
 			Relations:       []string{"Users()"},
 		},
 		{
-			SubService: "users",
-			Struct:     &sqladmin.User{},
-			SkipMock:   true,
-			SkipFetch:  true,
-			ChildTable: true,
-			ExtraColumns: []codegen.ColumnDefinition{
-				{
-					Name:     "project_id",
-					Type:     schema.TypeString,
-					Options:  schema.ColumnCreationOptions{PrimaryKey: true},
-					Resolver: "client.ResolveProject",
-				},
-				{
-					Name:     "instance",
-					Type:     schema.TypeString,
-					Options:  schema.ColumnCreationOptions{PrimaryKey: true},
-					Resolver: `schema.PathResolver("Instance")`,
-				},
-				{
-					Name:     "name",
-					Type:     schema.TypeString,
-					Options:  schema.ColumnCreationOptions{PrimaryKey: true},
-					Resolver: `schema.PathResolver("Name")`,
-				},
-			},
+			SubService:  "users",
+			Struct:      &sqladmin.User{},
+			SkipMock:    true,
+			SkipFetch:   true,
+			ChildTable:  true,
+			PrimaryKeys: []string{ProjectIdColumn.Name, "instance", "name"},
 		},
 	}
 

--- a/plugins/source/gcp/codegen/recipes/storage.go
+++ b/plugins/source/gcp/codegen/recipes/storage.go
@@ -7,8 +7,6 @@ import (
 	"github.com/cloudquery/plugin-sdk/schema"
 )
 
-
-
 func init() {
 	resources := []*Resource{
 		{
@@ -17,15 +15,8 @@ func init() {
 			SkipFetch:       true,
 			SkipMock:        true,
 			NameTransformer: CreateReplaceTransformer(map[string]string{"c_o_r_s": "cors", "r_p_o": "rpo"}),
-			ExtraColumns: []codegen.ColumnDefinition{
-				{
-					Name:     "name",
-					Type:     schema.TypeString,
-					Options:  schema.ColumnCreationOptions{PrimaryKey: true},
-					Resolver: `schema.PathResolver("Name")`,
-				},
-			},
-			Relations: []string{"BucketPolicies()"},
+			PrimaryKeys:     []string{"name"},
+			Relations:       []string{"BucketPolicies()"},
 		},
 		{
 			SubService: "bucket_policies",

--- a/plugins/source/gcp/docs/tables/gcp_apikeys_keys.md
+++ b/plugins/source/gcp/docs/tables/gcp_apikeys_keys.md
@@ -14,8 +14,8 @@ The composite primary key for this table is (**project_id**, **uid**).
 |_cq_id|UUID|
 |_cq_parent_id|UUID|
 |project_id (PK)|String|
-|uid (PK)|String|
 |name|String|
+|uid (PK)|String|
 |display_name|String|
 |key_string|String|
 |create_time|Timestamp|

--- a/plugins/source/gcp/docs/tables/gcp_compute_addresses.md
+++ b/plugins/source/gcp/docs/tables/gcp_compute_addresses.md
@@ -14,7 +14,6 @@ The primary key for this table is **self_link**.
 |_cq_id|UUID|
 |_cq_parent_id|UUID|
 |project_id|String|
-|self_link (PK)|String|
 |address|String|
 |address_type|String|
 |creation_timestamp|String|
@@ -29,6 +28,7 @@ The primary key for this table is **self_link**.
 |prefix_length|Int|
 |purpose|String|
 |region|String|
+|self_link (PK)|String|
 |status|String|
 |subnetwork|String|
 |users|StringArray|

--- a/plugins/source/gcp/docs/tables/gcp_compute_autoscalers.md
+++ b/plugins/source/gcp/docs/tables/gcp_compute_autoscalers.md
@@ -14,7 +14,6 @@ The primary key for this table is **self_link**.
 |_cq_id|UUID|
 |_cq_parent_id|UUID|
 |project_id|String|
-|self_link (PK)|String|
 |autoscaling_policy|JSON|
 |creation_timestamp|String|
 |description|String|
@@ -24,6 +23,7 @@ The primary key for this table is **self_link**.
 |recommended_size|Int|
 |region|String|
 |scaling_schedule_status|JSON|
+|self_link (PK)|String|
 |status|String|
 |status_details|JSON|
 |target|String|

--- a/plugins/source/gcp/docs/tables/gcp_compute_backend_services.md
+++ b/plugins/source/gcp/docs/tables/gcp_compute_backend_services.md
@@ -14,7 +14,6 @@ The primary key for this table is **self_link**.
 |_cq_id|UUID|
 |_cq_parent_id|UUID|
 |project_id|String|
-|self_link (PK)|String|
 |affinity_cookie_ttl_sec|Int|
 |backends|JSON|
 |cdn_policy|JSON|
@@ -49,6 +48,7 @@ The primary key for this table is **self_link**.
 |region|String|
 |security_policy|String|
 |security_settings|JSON|
+|self_link (PK)|String|
 |service_bindings|StringArray|
 |session_affinity|String|
 |subsetting|JSON|

--- a/plugins/source/gcp/docs/tables/gcp_compute_disk_types.md
+++ b/plugins/source/gcp/docs/tables/gcp_compute_disk_types.md
@@ -14,7 +14,6 @@ The primary key for this table is **self_link**.
 |_cq_id|UUID|
 |_cq_parent_id|UUID|
 |project_id|String|
-|self_link (PK)|String|
 |creation_timestamp|String|
 |default_disk_size_gb|Int|
 |deprecated|JSON|
@@ -23,5 +22,6 @@ The primary key for this table is **self_link**.
 |kind|String|
 |name|String|
 |region|String|
+|self_link (PK)|String|
 |valid_disk_size|String|
 |zone|String|

--- a/plugins/source/gcp/docs/tables/gcp_compute_disks.md
+++ b/plugins/source/gcp/docs/tables/gcp_compute_disks.md
@@ -14,7 +14,6 @@ The primary key for this table is **self_link**.
 |_cq_id|UUID|
 |_cq_parent_id|UUID|
 |project_id|String|
-|self_link (PK)|String|
 |architecture|String|
 |creation_timestamp|String|
 |description|String|
@@ -38,6 +37,7 @@ The primary key for this table is **self_link**.
 |replica_zones|StringArray|
 |resource_policies|StringArray|
 |satisfies_pzs|Bool|
+|self_link (PK)|String|
 |size_gb|Int|
 |source_disk|String|
 |source_disk_id|String|

--- a/plugins/source/gcp/docs/tables/gcp_compute_firewalls.md
+++ b/plugins/source/gcp/docs/tables/gcp_compute_firewalls.md
@@ -14,7 +14,6 @@ The primary key for this table is **self_link**.
 |_cq_id|UUID|
 |_cq_parent_id|UUID|
 |project_id|String|
-|self_link (PK)|String|
 |allowed|JSON|
 |creation_timestamp|String|
 |denied|JSON|
@@ -28,6 +27,7 @@ The primary key for this table is **self_link**.
 |name|String|
 |network|String|
 |priority|Int|
+|self_link (PK)|String|
 |source_ranges|StringArray|
 |source_service_accounts|StringArray|
 |source_tags|StringArray|

--- a/plugins/source/gcp/docs/tables/gcp_compute_forwarding_rules.md
+++ b/plugins/source/gcp/docs/tables/gcp_compute_forwarding_rules.md
@@ -14,7 +14,6 @@ The primary key for this table is **self_link**.
 |_cq_id|UUID|
 |_cq_parent_id|UUID|
 |project_id|String|
-|self_link (PK)|String|
 |ip_address|String|
 |ip_protocol|String|
 |all_ports|Bool|
@@ -40,6 +39,7 @@ The primary key for this table is **self_link**.
 |psc_connection_id|Int|
 |psc_connection_status|String|
 |region|String|
+|self_link (PK)|String|
 |service_directory_registrations|JSON|
 |service_label|String|
 |service_name|String|

--- a/plugins/source/gcp/docs/tables/gcp_compute_images.md
+++ b/plugins/source/gcp/docs/tables/gcp_compute_images.md
@@ -14,7 +14,6 @@ The primary key for this table is **self_link**.
 |_cq_id|UUID|
 |_cq_parent_id|UUID|
 |project_id|String|
-|self_link (PK)|String|
 |architecture|String|
 |archive_size_bytes|Int|
 |creation_timestamp|String|
@@ -33,6 +32,7 @@ The primary key for this table is **self_link**.
 |name|String|
 |raw_disk|JSON|
 |satisfies_pzs|Bool|
+|self_link (PK)|String|
 |shielded_instance_initial_state|JSON|
 |source_disk|String|
 |source_disk_encryption_key|JSON|

--- a/plugins/source/gcp/docs/tables/gcp_compute_instance_groups.md
+++ b/plugins/source/gcp/docs/tables/gcp_compute_instance_groups.md
@@ -14,7 +14,6 @@ The primary key for this table is **self_link**.
 |_cq_id|UUID|
 |_cq_parent_id|UUID|
 |project_id|String|
-|self_link (PK)|String|
 |creation_timestamp|String|
 |description|String|
 |fingerprint|String|
@@ -24,6 +23,7 @@ The primary key for this table is **self_link**.
 |named_ports|JSON|
 |network|String|
 |region|String|
+|self_link (PK)|String|
 |size|Int|
 |subnetwork|String|
 |zone|String|

--- a/plugins/source/gcp/docs/tables/gcp_compute_instances.md
+++ b/plugins/source/gcp/docs/tables/gcp_compute_instances.md
@@ -14,7 +14,6 @@ The primary key for this table is **self_link**.
 |_cq_id|UUID|
 |_cq_parent_id|UUID|
 |project_id|String|
-|self_link (PK)|String|
 |advanced_machine_features|JSON|
 |can_ip_forward|Bool|
 |confidential_instance_config|JSON|
@@ -48,6 +47,7 @@ The primary key for this table is **self_link**.
 |resource_status|JSON|
 |satisfies_pzs|Bool|
 |scheduling|JSON|
+|self_link (PK)|String|
 |service_accounts|JSON|
 |shielded_instance_config|JSON|
 |shielded_instance_integrity_policy|JSON|

--- a/plugins/source/gcp/docs/tables/gcp_compute_interconnects.md
+++ b/plugins/source/gcp/docs/tables/gcp_compute_interconnects.md
@@ -14,7 +14,6 @@ The primary key for this table is **self_link**.
 |_cq_id|UUID|
 |_cq_parent_id|UUID|
 |project_id|String|
-|self_link (PK)|String|
 |admin_enabled|Bool|
 |circuit_infos|JSON|
 |creation_timestamp|String|
@@ -36,4 +35,5 @@ The primary key for this table is **self_link**.
 |provisioned_link_count|Int|
 |requested_link_count|Int|
 |satisfies_pzs|Bool|
+|self_link (PK)|String|
 |state|String|

--- a/plugins/source/gcp/docs/tables/gcp_compute_networks.md
+++ b/plugins/source/gcp/docs/tables/gcp_compute_networks.md
@@ -14,7 +14,6 @@ The primary key for this table is **self_link**.
 |_cq_id|UUID|
 |_cq_parent_id|UUID|
 |project_id|String|
-|self_link (PK)|String|
 |ipv4_range|String|
 |auto_create_subnetworks|Bool|
 |creation_timestamp|String|
@@ -30,5 +29,6 @@ The primary key for this table is **self_link**.
 |network_firewall_policy_enforcement_order|String|
 |peerings|JSON|
 |routing_config|JSON|
+|self_link (PK)|String|
 |self_link_with_id|String|
 |subnetworks|StringArray|

--- a/plugins/source/gcp/docs/tables/gcp_compute_projects.md
+++ b/plugins/source/gcp/docs/tables/gcp_compute_projects.md
@@ -14,7 +14,6 @@ The primary key for this table is **self_link**.
 |_cq_id|UUID|
 |_cq_parent_id|UUID|
 |project_id|String|
-|self_link (PK)|String|
 |common_instance_metadata|JSON|
 |creation_timestamp|String|
 |default_network_tier|String|
@@ -25,5 +24,6 @@ The primary key for this table is **self_link**.
 |kind|String|
 |name|String|
 |quotas|JSON|
+|self_link (PK)|String|
 |usage_export_location|JSON|
 |xpn_project_status|String|

--- a/plugins/source/gcp/docs/tables/gcp_compute_ssl_certificates.md
+++ b/plugins/source/gcp/docs/tables/gcp_compute_ssl_certificates.md
@@ -14,7 +14,6 @@ The primary key for this table is **self_link**.
 |_cq_id|UUID|
 |_cq_parent_id|UUID|
 |project_id|String|
-|self_link (PK)|String|
 |certificate|String|
 |creation_timestamp|String|
 |description|String|
@@ -25,6 +24,7 @@ The primary key for this table is **self_link**.
 |name|String|
 |private_key|String|
 |region|String|
+|self_link (PK)|String|
 |self_managed|JSON|
 |subject_alternative_names|StringArray|
 |type|String|

--- a/plugins/source/gcp/docs/tables/gcp_compute_ssl_policies.md
+++ b/plugins/source/gcp/docs/tables/gcp_compute_ssl_policies.md
@@ -14,7 +14,6 @@ The primary key for this table is **self_link**.
 |_cq_id|UUID|
 |_cq_parent_id|UUID|
 |project_id|String|
-|self_link (PK)|String|
 |creation_timestamp|String|
 |custom_features|StringArray|
 |description|String|
@@ -26,4 +25,5 @@ The primary key for this table is **self_link**.
 |name|String|
 |profile|String|
 |region|String|
+|self_link (PK)|String|
 |warnings|JSON|

--- a/plugins/source/gcp/docs/tables/gcp_compute_subnetworks.md
+++ b/plugins/source/gcp/docs/tables/gcp_compute_subnetworks.md
@@ -14,7 +14,6 @@ The primary key for this table is **self_link**.
 |_cq_id|UUID|
 |_cq_parent_id|UUID|
 |project_id|String|
-|self_link (PK)|String|
 |creation_timestamp|String|
 |description|String|
 |enable_flow_logs|Bool|
@@ -36,5 +35,6 @@ The primary key for this table is **self_link**.
 |region|String|
 |role|String|
 |secondary_ip_ranges|JSON|
+|self_link (PK)|String|
 |stack_type|String|
 |state|String|

--- a/plugins/source/gcp/docs/tables/gcp_compute_target_http_proxies.md
+++ b/plugins/source/gcp/docs/tables/gcp_compute_target_http_proxies.md
@@ -14,7 +14,6 @@ The primary key for this table is **self_link**.
 |_cq_id|UUID|
 |_cq_parent_id|UUID|
 |project_id|String|
-|self_link (PK)|String|
 |creation_timestamp|String|
 |description|String|
 |fingerprint|String|
@@ -23,4 +22,5 @@ The primary key for this table is **self_link**.
 |name|String|
 |proxy_bind|Bool|
 |region|String|
+|self_link (PK)|String|
 |url_map|String|

--- a/plugins/source/gcp/docs/tables/gcp_compute_target_ssl_proxies.md
+++ b/plugins/source/gcp/docs/tables/gcp_compute_target_ssl_proxies.md
@@ -14,7 +14,6 @@ The primary key for this table is **self_link**.
 |_cq_id|UUID|
 |_cq_parent_id|UUID|
 |project_id|String|
-|self_link (PK)|String|
 |certificate_map|String|
 |creation_timestamp|String|
 |description|String|
@@ -22,6 +21,7 @@ The primary key for this table is **self_link**.
 |kind|String|
 |name|String|
 |proxy_header|String|
+|self_link (PK)|String|
 |service|String|
 |ssl_certificates|StringArray|
 |ssl_policy|String|

--- a/plugins/source/gcp/docs/tables/gcp_compute_url_maps.md
+++ b/plugins/source/gcp/docs/tables/gcp_compute_url_maps.md
@@ -14,7 +14,6 @@ The primary key for this table is **self_link**.
 |_cq_id|UUID|
 |_cq_parent_id|UUID|
 |project_id|String|
-|self_link (PK)|String|
 |creation_timestamp|String|
 |default_route_action|JSON|
 |default_service|String|
@@ -28,4 +27,5 @@ The primary key for this table is **self_link**.
 |name|String|
 |path_matchers|JSON|
 |region|String|
+|self_link (PK)|String|
 |tests|JSON|

--- a/plugins/source/gcp/docs/tables/gcp_compute_vpn_gateways.md
+++ b/plugins/source/gcp/docs/tables/gcp_compute_vpn_gateways.md
@@ -14,7 +14,6 @@ The primary key for this table is **self_link**.
 |_cq_id|UUID|
 |_cq_parent_id|UUID|
 |project_id|String|
-|self_link (PK)|String|
 |creation_timestamp|String|
 |description|String|
 |id|Int|
@@ -24,5 +23,6 @@ The primary key for this table is **self_link**.
 |name|String|
 |network|String|
 |region|String|
+|self_link (PK)|String|
 |stack_type|String|
 |vpn_interfaces|JSON|

--- a/plugins/source/gcp/docs/tables/gcp_container_clusters.md
+++ b/plugins/source/gcp/docs/tables/gcp_container_clusters.md
@@ -14,7 +14,6 @@ The primary key for this table is **self_link**.
 |_cq_id|UUID|
 |_cq_parent_id|UUID|
 |project_id|String|
-|self_link (PK)|String|
 |name|String|
 |description|String|
 |initial_node_count|Int|
@@ -53,6 +52,7 @@ The primary key for this table is **self_link**.
 |notification_config|JSON|
 |confidential_nodes|JSON|
 |identity_service_config|JSON|
+|self_link (PK)|String|
 |zone|String|
 |endpoint|String|
 |initial_cluster_version|String|

--- a/plugins/source/gcp/docs/tables/gcp_dns_managed_zones.md
+++ b/plugins/source/gcp/docs/tables/gcp_dns_managed_zones.md
@@ -14,13 +14,13 @@ The primary key for this table is **id**.
 |_cq_id|UUID|
 |_cq_parent_id|UUID|
 |project_id|String|
-|id (PK)|Int|
 |cloud_logging_config|JSON|
 |creation_time|String|
 |description|String|
 |dns_name|String|
 |dnssec_config|JSON|
 |forwarding_config|JSON|
+|id (PK)|Int|
 |kind|String|
 |labels|JSON|
 |name|String|

--- a/plugins/source/gcp/docs/tables/gcp_dns_policies.md
+++ b/plugins/source/gcp/docs/tables/gcp_dns_policies.md
@@ -14,11 +14,11 @@ The primary key for this table is **id**.
 |_cq_id|UUID|
 |_cq_parent_id|UUID|
 |project_id|String|
-|id (PK)|Int|
 |alternative_name_server_config|JSON|
 |description|String|
 |enable_inbound_forwarding|Bool|
 |enable_logging|Bool|
+|id (PK)|Int|
 |kind|String|
 |name|String|
 |networks|JSON|

--- a/plugins/source/gcp/docs/tables/gcp_iam_roles.md
+++ b/plugins/source/gcp/docs/tables/gcp_iam_roles.md
@@ -14,10 +14,10 @@ The composite primary key for this table is (**project_id**, **name**).
 |_cq_id|UUID|
 |_cq_parent_id|UUID|
 |project_id (PK)|String|
-|name (PK)|String|
 |deleted|Bool|
 |description|String|
 |etag|String|
 |included_permissions|StringArray|
+|name (PK)|String|
 |stage|String|
 |title|String|

--- a/plugins/source/gcp/docs/tables/gcp_iam_service_accounts.md
+++ b/plugins/source/gcp/docs/tables/gcp_iam_service_accounts.md
@@ -17,7 +17,6 @@ The following tables depend on gcp_iam_service_accounts:
 |_cq_id|UUID|
 |_cq_parent_id|UUID|
 |project_id|String|
-|unique_id (PK)|String|
 |description|String|
 |disabled|Bool|
 |display_name|String|
@@ -25,3 +24,4 @@ The following tables depend on gcp_iam_service_accounts:
 |etag|String|
 |name|String|
 |oauth2_client_id|String|
+|unique_id (PK)|String|

--- a/plugins/source/gcp/docs/tables/gcp_sql_instances.md
+++ b/plugins/source/gcp/docs/tables/gcp_sql_instances.md
@@ -17,7 +17,6 @@ The following tables depend on gcp_sql_instances:
 |_cq_id|UUID|
 |_cq_parent_id|UUID|
 |project_id|String|
-|self_link (PK)|String|
 |available_maintenance_versions|StringArray|
 |backend_type|String|
 |connection_name|String|
@@ -48,6 +47,7 @@ The following tables depend on gcp_sql_instances:
 |satisfies_pzs|Bool|
 |scheduled_maintenance|JSON|
 |secondary_gce_zone|String|
+|self_link (PK)|String|
 |server_ca_cert|JSON|
 |service_account_email_address|String|
 |settings|JSON|

--- a/plugins/source/gcp/docs/tables/gcp_sql_users.md
+++ b/plugins/source/gcp/docs/tables/gcp_sql_users.md
@@ -16,12 +16,12 @@ This table depends on [gcp_sql_instances](gcp_sql_instances.md).
 |_cq_id|UUID|
 |_cq_parent_id|UUID|
 |project_id (PK)|String|
-|instance (PK)|String|
-|name (PK)|String|
 |dual_password_type|String|
 |etag|String|
 |host|String|
+|instance (PK)|String|
 |kind|String|
+|name (PK)|String|
 |password|String|
 |password_policy|JSON|
 |project|String|

--- a/plugins/source/gcp/resources/services/apikeys/keys.go
+++ b/plugins/source/gcp/resources/services/apikeys/keys.go
@@ -29,17 +29,17 @@ func Keys() *schema.Table {
 				},
 			},
 			{
+				Name:     "name",
+				Type:     schema.TypeString,
+				Resolver: schema.PathResolver("Name"),
+			},
+			{
 				Name:     "uid",
 				Type:     schema.TypeString,
 				Resolver: schema.PathResolver("Uid"),
 				CreationOptions: schema.ColumnCreationOptions{
 					PrimaryKey: true,
 				},
-			},
-			{
-				Name:     "name",
-				Type:     schema.TypeString,
-				Resolver: schema.PathResolver("Name"),
 			},
 			{
 				Name:     "display_name",

--- a/plugins/source/gcp/resources/services/billing/billing_accounts.go
+++ b/plugins/source/gcp/resources/services/billing/billing_accounts.go
@@ -26,8 +26,9 @@ func BillingAccounts() *schema.Table {
 				Resolver: client.ResolveProject,
 			},
 			{
-				Name: "name",
-				Type: schema.TypeString,
+				Name:     "name",
+				Type:     schema.TypeString,
+				Resolver: schema.PathResolver("Name"),
 				CreationOptions: schema.ColumnCreationOptions{
 					PrimaryKey: true,
 				},

--- a/plugins/source/gcp/resources/services/billing/services.go
+++ b/plugins/source/gcp/resources/services/billing/services.go
@@ -26,8 +26,9 @@ func Services() *schema.Table {
 				Resolver: client.ResolveProject,
 			},
 			{
-				Name: "name",
-				Type: schema.TypeString,
+				Name:     "name",
+				Type:     schema.TypeString,
+				Resolver: schema.PathResolver("Name"),
 				CreationOptions: schema.ColumnCreationOptions{
 					PrimaryKey: true,
 				},

--- a/plugins/source/gcp/resources/services/compute/addresses.go
+++ b/plugins/source/gcp/resources/services/compute/addresses.go
@@ -26,13 +26,6 @@ func Addresses() *schema.Table {
 				Resolver: client.ResolveProject,
 			},
 			{
-				Name: "self_link",
-				Type: schema.TypeString,
-				CreationOptions: schema.ColumnCreationOptions{
-					PrimaryKey: true,
-				},
-			},
-			{
 				Name:     "address",
 				Type:     schema.TypeString,
 				Resolver: schema.PathResolver("Address"),
@@ -101,6 +94,14 @@ func Addresses() *schema.Table {
 				Name:     "region",
 				Type:     schema.TypeString,
 				Resolver: schema.PathResolver("Region"),
+			},
+			{
+				Name:     "self_link",
+				Type:     schema.TypeString,
+				Resolver: schema.PathResolver("SelfLink"),
+				CreationOptions: schema.ColumnCreationOptions{
+					PrimaryKey: true,
+				},
 			},
 			{
 				Name:     "status",

--- a/plugins/source/gcp/resources/services/compute/autoscalers.go
+++ b/plugins/source/gcp/resources/services/compute/autoscalers.go
@@ -26,13 +26,6 @@ func Autoscalers() *schema.Table {
 				Resolver: client.ResolveProject,
 			},
 			{
-				Name: "self_link",
-				Type: schema.TypeString,
-				CreationOptions: schema.ColumnCreationOptions{
-					PrimaryKey: true,
-				},
-			},
-			{
 				Name:     "autoscaling_policy",
 				Type:     schema.TypeJSON,
 				Resolver: schema.PathResolver("AutoscalingPolicy"),
@@ -76,6 +69,14 @@ func Autoscalers() *schema.Table {
 				Name:     "scaling_schedule_status",
 				Type:     schema.TypeJSON,
 				Resolver: schema.PathResolver("ScalingScheduleStatus"),
+			},
+			{
+				Name:     "self_link",
+				Type:     schema.TypeString,
+				Resolver: schema.PathResolver("SelfLink"),
+				CreationOptions: schema.ColumnCreationOptions{
+					PrimaryKey: true,
+				},
 			},
 			{
 				Name:     "status",

--- a/plugins/source/gcp/resources/services/compute/backend_services.go
+++ b/plugins/source/gcp/resources/services/compute/backend_services.go
@@ -26,13 +26,6 @@ func BackendServices() *schema.Table {
 				Resolver: client.ResolveProject,
 			},
 			{
-				Name: "self_link",
-				Type: schema.TypeString,
-				CreationOptions: schema.ColumnCreationOptions{
-					PrimaryKey: true,
-				},
-			},
-			{
 				Name:     "affinity_cookie_ttl_sec",
 				Type:     schema.TypeInt,
 				Resolver: schema.PathResolver("AffinityCookieTtlSec"),
@@ -201,6 +194,14 @@ func BackendServices() *schema.Table {
 				Name:     "security_settings",
 				Type:     schema.TypeJSON,
 				Resolver: schema.PathResolver("SecuritySettings"),
+			},
+			{
+				Name:     "self_link",
+				Type:     schema.TypeString,
+				Resolver: schema.PathResolver("SelfLink"),
+				CreationOptions: schema.ColumnCreationOptions{
+					PrimaryKey: true,
+				},
 			},
 			{
 				Name:     "service_bindings",

--- a/plugins/source/gcp/resources/services/compute/disk_types.go
+++ b/plugins/source/gcp/resources/services/compute/disk_types.go
@@ -26,13 +26,6 @@ func DiskTypes() *schema.Table {
 				Resolver: client.ResolveProject,
 			},
 			{
-				Name: "self_link",
-				Type: schema.TypeString,
-				CreationOptions: schema.ColumnCreationOptions{
-					PrimaryKey: true,
-				},
-			},
-			{
 				Name:     "creation_timestamp",
 				Type:     schema.TypeString,
 				Resolver: schema.PathResolver("CreationTimestamp"),
@@ -71,6 +64,14 @@ func DiskTypes() *schema.Table {
 				Name:     "region",
 				Type:     schema.TypeString,
 				Resolver: schema.PathResolver("Region"),
+			},
+			{
+				Name:     "self_link",
+				Type:     schema.TypeString,
+				Resolver: schema.PathResolver("SelfLink"),
+				CreationOptions: schema.ColumnCreationOptions{
+					PrimaryKey: true,
+				},
 			},
 			{
 				Name:     "valid_disk_size",

--- a/plugins/source/gcp/resources/services/compute/disks.go
+++ b/plugins/source/gcp/resources/services/compute/disks.go
@@ -26,13 +26,6 @@ func Disks() *schema.Table {
 				Resolver: client.ResolveProject,
 			},
 			{
-				Name: "self_link",
-				Type: schema.TypeString,
-				CreationOptions: schema.ColumnCreationOptions{
-					PrimaryKey: true,
-				},
-			},
-			{
 				Name:     "architecture",
 				Type:     schema.TypeString,
 				Resolver: schema.PathResolver("Architecture"),
@@ -146,6 +139,14 @@ func Disks() *schema.Table {
 				Name:     "satisfies_pzs",
 				Type:     schema.TypeBool,
 				Resolver: schema.PathResolver("SatisfiesPzs"),
+			},
+			{
+				Name:     "self_link",
+				Type:     schema.TypeString,
+				Resolver: schema.PathResolver("SelfLink"),
+				CreationOptions: schema.ColumnCreationOptions{
+					PrimaryKey: true,
+				},
 			},
 			{
 				Name:     "size_gb",

--- a/plugins/source/gcp/resources/services/compute/firewalls.go
+++ b/plugins/source/gcp/resources/services/compute/firewalls.go
@@ -26,13 +26,6 @@ func Firewalls() *schema.Table {
 				Resolver: client.ResolveProject,
 			},
 			{
-				Name: "self_link",
-				Type: schema.TypeString,
-				CreationOptions: schema.ColumnCreationOptions{
-					PrimaryKey: true,
-				},
-			},
-			{
 				Name:     "allowed",
 				Type:     schema.TypeJSON,
 				Resolver: schema.PathResolver("Allowed"),
@@ -96,6 +89,14 @@ func Firewalls() *schema.Table {
 				Name:     "priority",
 				Type:     schema.TypeInt,
 				Resolver: schema.PathResolver("Priority"),
+			},
+			{
+				Name:     "self_link",
+				Type:     schema.TypeString,
+				Resolver: schema.PathResolver("SelfLink"),
+				CreationOptions: schema.ColumnCreationOptions{
+					PrimaryKey: true,
+				},
 			},
 			{
 				Name:     "source_ranges",

--- a/plugins/source/gcp/resources/services/compute/forwarding_rules.go
+++ b/plugins/source/gcp/resources/services/compute/forwarding_rules.go
@@ -26,13 +26,6 @@ func ForwardingRules() *schema.Table {
 				Resolver: client.ResolveProject,
 			},
 			{
-				Name: "self_link",
-				Type: schema.TypeString,
-				CreationOptions: schema.ColumnCreationOptions{
-					PrimaryKey: true,
-				},
-			},
-			{
 				Name:     "ip_address",
 				Type:     schema.TypeString,
 				Resolver: schema.PathResolver("IPAddress"),
@@ -156,6 +149,14 @@ func ForwardingRules() *schema.Table {
 				Name:     "region",
 				Type:     schema.TypeString,
 				Resolver: schema.PathResolver("Region"),
+			},
+			{
+				Name:     "self_link",
+				Type:     schema.TypeString,
+				Resolver: schema.PathResolver("SelfLink"),
+				CreationOptions: schema.ColumnCreationOptions{
+					PrimaryKey: true,
+				},
 			},
 			{
 				Name:     "service_directory_registrations",

--- a/plugins/source/gcp/resources/services/compute/images.go
+++ b/plugins/source/gcp/resources/services/compute/images.go
@@ -26,13 +26,6 @@ func Images() *schema.Table {
 				Resolver: client.ResolveProject,
 			},
 			{
-				Name: "self_link",
-				Type: schema.TypeString,
-				CreationOptions: schema.ColumnCreationOptions{
-					PrimaryKey: true,
-				},
-			},
-			{
 				Name:     "architecture",
 				Type:     schema.TypeString,
 				Resolver: schema.PathResolver("Architecture"),
@@ -121,6 +114,14 @@ func Images() *schema.Table {
 				Name:     "satisfies_pzs",
 				Type:     schema.TypeBool,
 				Resolver: schema.PathResolver("SatisfiesPzs"),
+			},
+			{
+				Name:     "self_link",
+				Type:     schema.TypeString,
+				Resolver: schema.PathResolver("SelfLink"),
+				CreationOptions: schema.ColumnCreationOptions{
+					PrimaryKey: true,
+				},
 			},
 			{
 				Name:     "shielded_instance_initial_state",

--- a/plugins/source/gcp/resources/services/compute/instance_groups.go
+++ b/plugins/source/gcp/resources/services/compute/instance_groups.go
@@ -26,13 +26,6 @@ func InstanceGroups() *schema.Table {
 				Resolver: client.ResolveProject,
 			},
 			{
-				Name: "self_link",
-				Type: schema.TypeString,
-				CreationOptions: schema.ColumnCreationOptions{
-					PrimaryKey: true,
-				},
-			},
-			{
 				Name:     "creation_timestamp",
 				Type:     schema.TypeString,
 				Resolver: schema.PathResolver("CreationTimestamp"),
@@ -76,6 +69,14 @@ func InstanceGroups() *schema.Table {
 				Name:     "region",
 				Type:     schema.TypeString,
 				Resolver: schema.PathResolver("Region"),
+			},
+			{
+				Name:     "self_link",
+				Type:     schema.TypeString,
+				Resolver: schema.PathResolver("SelfLink"),
+				CreationOptions: schema.ColumnCreationOptions{
+					PrimaryKey: true,
+				},
 			},
 			{
 				Name:     "size",

--- a/plugins/source/gcp/resources/services/compute/instances.go
+++ b/plugins/source/gcp/resources/services/compute/instances.go
@@ -26,13 +26,6 @@ func Instances() *schema.Table {
 				Resolver: client.ResolveProject,
 			},
 			{
-				Name: "self_link",
-				Type: schema.TypeString,
-				CreationOptions: schema.ColumnCreationOptions{
-					PrimaryKey: true,
-				},
-			},
-			{
 				Name:     "advanced_machine_features",
 				Type:     schema.TypeJSON,
 				Resolver: schema.PathResolver("AdvancedMachineFeatures"),
@@ -196,6 +189,14 @@ func Instances() *schema.Table {
 				Name:     "scheduling",
 				Type:     schema.TypeJSON,
 				Resolver: schema.PathResolver("Scheduling"),
+			},
+			{
+				Name:     "self_link",
+				Type:     schema.TypeString,
+				Resolver: schema.PathResolver("SelfLink"),
+				CreationOptions: schema.ColumnCreationOptions{
+					PrimaryKey: true,
+				},
 			},
 			{
 				Name:     "service_accounts",

--- a/plugins/source/gcp/resources/services/compute/interconnects.go
+++ b/plugins/source/gcp/resources/services/compute/interconnects.go
@@ -26,13 +26,6 @@ func Interconnects() *schema.Table {
 				Resolver: client.ResolveProject,
 			},
 			{
-				Name: "self_link",
-				Type: schema.TypeString,
-				CreationOptions: schema.ColumnCreationOptions{
-					PrimaryKey: true,
-				},
-			},
-			{
 				Name:     "admin_enabled",
 				Type:     schema.TypeBool,
 				Resolver: schema.PathResolver("AdminEnabled"),
@@ -136,6 +129,14 @@ func Interconnects() *schema.Table {
 				Name:     "satisfies_pzs",
 				Type:     schema.TypeBool,
 				Resolver: schema.PathResolver("SatisfiesPzs"),
+			},
+			{
+				Name:     "self_link",
+				Type:     schema.TypeString,
+				Resolver: schema.PathResolver("SelfLink"),
+				CreationOptions: schema.ColumnCreationOptions{
+					PrimaryKey: true,
+				},
 			},
 			{
 				Name:     "state",

--- a/plugins/source/gcp/resources/services/compute/networks.go
+++ b/plugins/source/gcp/resources/services/compute/networks.go
@@ -26,13 +26,6 @@ func Networks() *schema.Table {
 				Resolver: client.ResolveProject,
 			},
 			{
-				Name: "self_link",
-				Type: schema.TypeString,
-				CreationOptions: schema.ColumnCreationOptions{
-					PrimaryKey: true,
-				},
-			},
-			{
 				Name:     "ipv4_range",
 				Type:     schema.TypeString,
 				Resolver: schema.PathResolver("IPv4Range"),
@@ -106,6 +99,14 @@ func Networks() *schema.Table {
 				Name:     "routing_config",
 				Type:     schema.TypeJSON,
 				Resolver: schema.PathResolver("RoutingConfig"),
+			},
+			{
+				Name:     "self_link",
+				Type:     schema.TypeString,
+				Resolver: schema.PathResolver("SelfLink"),
+				CreationOptions: schema.ColumnCreationOptions{
+					PrimaryKey: true,
+				},
 			},
 			{
 				Name:     "self_link_with_id",

--- a/plugins/source/gcp/resources/services/compute/projects.go
+++ b/plugins/source/gcp/resources/services/compute/projects.go
@@ -19,13 +19,6 @@ func Projects() *schema.Table {
 				Resolver: client.ResolveProject,
 			},
 			{
-				Name: "self_link",
-				Type: schema.TypeString,
-				CreationOptions: schema.ColumnCreationOptions{
-					PrimaryKey: true,
-				},
-			},
-			{
 				Name:     "common_instance_metadata",
 				Type:     schema.TypeJSON,
 				Resolver: schema.PathResolver("CommonInstanceMetadata"),
@@ -74,6 +67,14 @@ func Projects() *schema.Table {
 				Name:     "quotas",
 				Type:     schema.TypeJSON,
 				Resolver: schema.PathResolver("Quotas"),
+			},
+			{
+				Name:     "self_link",
+				Type:     schema.TypeString,
+				Resolver: schema.PathResolver("SelfLink"),
+				CreationOptions: schema.ColumnCreationOptions{
+					PrimaryKey: true,
+				},
 			},
 			{
 				Name:     "usage_export_location",

--- a/plugins/source/gcp/resources/services/compute/ssl_certificates.go
+++ b/plugins/source/gcp/resources/services/compute/ssl_certificates.go
@@ -26,13 +26,6 @@ func SslCertificates() *schema.Table {
 				Resolver: client.ResolveProject,
 			},
 			{
-				Name: "self_link",
-				Type: schema.TypeString,
-				CreationOptions: schema.ColumnCreationOptions{
-					PrimaryKey: true,
-				},
-			},
-			{
 				Name:     "certificate",
 				Type:     schema.TypeString,
 				Resolver: schema.PathResolver("Certificate"),
@@ -81,6 +74,14 @@ func SslCertificates() *schema.Table {
 				Name:     "region",
 				Type:     schema.TypeString,
 				Resolver: schema.PathResolver("Region"),
+			},
+			{
+				Name:     "self_link",
+				Type:     schema.TypeString,
+				Resolver: schema.PathResolver("SelfLink"),
+				CreationOptions: schema.ColumnCreationOptions{
+					PrimaryKey: true,
+				},
 			},
 			{
 				Name:     "self_managed",

--- a/plugins/source/gcp/resources/services/compute/ssl_policies.go
+++ b/plugins/source/gcp/resources/services/compute/ssl_policies.go
@@ -26,13 +26,6 @@ func SslPolicies() *schema.Table {
 				Resolver: client.ResolveProject,
 			},
 			{
-				Name: "self_link",
-				Type: schema.TypeString,
-				CreationOptions: schema.ColumnCreationOptions{
-					PrimaryKey: true,
-				},
-			},
-			{
 				Name:     "creation_timestamp",
 				Type:     schema.TypeString,
 				Resolver: schema.PathResolver("CreationTimestamp"),
@@ -86,6 +79,14 @@ func SslPolicies() *schema.Table {
 				Name:     "region",
 				Type:     schema.TypeString,
 				Resolver: schema.PathResolver("Region"),
+			},
+			{
+				Name:     "self_link",
+				Type:     schema.TypeString,
+				Resolver: schema.PathResolver("SelfLink"),
+				CreationOptions: schema.ColumnCreationOptions{
+					PrimaryKey: true,
+				},
 			},
 			{
 				Name:     "warnings",

--- a/plugins/source/gcp/resources/services/compute/subnetworks.go
+++ b/plugins/source/gcp/resources/services/compute/subnetworks.go
@@ -26,13 +26,6 @@ func Subnetworks() *schema.Table {
 				Resolver: client.ResolveProject,
 			},
 			{
-				Name: "self_link",
-				Type: schema.TypeString,
-				CreationOptions: schema.ColumnCreationOptions{
-					PrimaryKey: true,
-				},
-			},
-			{
 				Name:     "creation_timestamp",
 				Type:     schema.TypeString,
 				Resolver: schema.PathResolver("CreationTimestamp"),
@@ -136,6 +129,14 @@ func Subnetworks() *schema.Table {
 				Name:     "secondary_ip_ranges",
 				Type:     schema.TypeJSON,
 				Resolver: schema.PathResolver("SecondaryIpRanges"),
+			},
+			{
+				Name:     "self_link",
+				Type:     schema.TypeString,
+				Resolver: schema.PathResolver("SelfLink"),
+				CreationOptions: schema.ColumnCreationOptions{
+					PrimaryKey: true,
+				},
 			},
 			{
 				Name:     "stack_type",

--- a/plugins/source/gcp/resources/services/compute/target_http_proxies.go
+++ b/plugins/source/gcp/resources/services/compute/target_http_proxies.go
@@ -26,13 +26,6 @@ func TargetHttpProxies() *schema.Table {
 				Resolver: client.ResolveProject,
 			},
 			{
-				Name: "self_link",
-				Type: schema.TypeString,
-				CreationOptions: schema.ColumnCreationOptions{
-					PrimaryKey: true,
-				},
-			},
-			{
 				Name:     "creation_timestamp",
 				Type:     schema.TypeString,
 				Resolver: schema.PathResolver("CreationTimestamp"),
@@ -71,6 +64,14 @@ func TargetHttpProxies() *schema.Table {
 				Name:     "region",
 				Type:     schema.TypeString,
 				Resolver: schema.PathResolver("Region"),
+			},
+			{
+				Name:     "self_link",
+				Type:     schema.TypeString,
+				Resolver: schema.PathResolver("SelfLink"),
+				CreationOptions: schema.ColumnCreationOptions{
+					PrimaryKey: true,
+				},
 			},
 			{
 				Name:     "url_map",

--- a/plugins/source/gcp/resources/services/compute/target_ssl_proxies.go
+++ b/plugins/source/gcp/resources/services/compute/target_ssl_proxies.go
@@ -26,13 +26,6 @@ func TargetSslProxies() *schema.Table {
 				Resolver: client.ResolveProject,
 			},
 			{
-				Name: "self_link",
-				Type: schema.TypeString,
-				CreationOptions: schema.ColumnCreationOptions{
-					PrimaryKey: true,
-				},
-			},
-			{
 				Name:     "certificate_map",
 				Type:     schema.TypeString,
 				Resolver: schema.PathResolver("CertificateMap"),
@@ -66,6 +59,14 @@ func TargetSslProxies() *schema.Table {
 				Name:     "proxy_header",
 				Type:     schema.TypeString,
 				Resolver: schema.PathResolver("ProxyHeader"),
+			},
+			{
+				Name:     "self_link",
+				Type:     schema.TypeString,
+				Resolver: schema.PathResolver("SelfLink"),
+				CreationOptions: schema.ColumnCreationOptions{
+					PrimaryKey: true,
+				},
 			},
 			{
 				Name:     "service",

--- a/plugins/source/gcp/resources/services/compute/url_maps.go
+++ b/plugins/source/gcp/resources/services/compute/url_maps.go
@@ -26,13 +26,6 @@ func UrlMaps() *schema.Table {
 				Resolver: client.ResolveProject,
 			},
 			{
-				Name: "self_link",
-				Type: schema.TypeString,
-				CreationOptions: schema.ColumnCreationOptions{
-					PrimaryKey: true,
-				},
-			},
-			{
 				Name:     "creation_timestamp",
 				Type:     schema.TypeString,
 				Resolver: schema.PathResolver("CreationTimestamp"),
@@ -96,6 +89,14 @@ func UrlMaps() *schema.Table {
 				Name:     "region",
 				Type:     schema.TypeString,
 				Resolver: schema.PathResolver("Region"),
+			},
+			{
+				Name:     "self_link",
+				Type:     schema.TypeString,
+				Resolver: schema.PathResolver("SelfLink"),
+				CreationOptions: schema.ColumnCreationOptions{
+					PrimaryKey: true,
+				},
 			},
 			{
 				Name:     "tests",

--- a/plugins/source/gcp/resources/services/compute/vpn_gateways.go
+++ b/plugins/source/gcp/resources/services/compute/vpn_gateways.go
@@ -26,13 +26,6 @@ func VpnGateways() *schema.Table {
 				Resolver: client.ResolveProject,
 			},
 			{
-				Name: "self_link",
-				Type: schema.TypeString,
-				CreationOptions: schema.ColumnCreationOptions{
-					PrimaryKey: true,
-				},
-			},
-			{
 				Name:     "creation_timestamp",
 				Type:     schema.TypeString,
 				Resolver: schema.PathResolver("CreationTimestamp"),
@@ -76,6 +69,14 @@ func VpnGateways() *schema.Table {
 				Name:     "region",
 				Type:     schema.TypeString,
 				Resolver: schema.PathResolver("Region"),
+			},
+			{
+				Name:     "self_link",
+				Type:     schema.TypeString,
+				Resolver: schema.PathResolver("SelfLink"),
+				CreationOptions: schema.ColumnCreationOptions{
+					PrimaryKey: true,
+				},
 			},
 			{
 				Name:     "stack_type",

--- a/plugins/source/gcp/resources/services/container/clusters.go
+++ b/plugins/source/gcp/resources/services/container/clusters.go
@@ -19,13 +19,6 @@ func Clusters() *schema.Table {
 				Resolver: client.ResolveProject,
 			},
 			{
-				Name: "self_link",
-				Type: schema.TypeString,
-				CreationOptions: schema.ColumnCreationOptions{
-					PrimaryKey: true,
-				},
-			},
-			{
 				Name:     "name",
 				Type:     schema.TypeString,
 				Resolver: schema.PathResolver("Name"),
@@ -214,6 +207,14 @@ func Clusters() *schema.Table {
 				Name:     "identity_service_config",
 				Type:     schema.TypeJSON,
 				Resolver: schema.PathResolver("IdentityServiceConfig"),
+			},
+			{
+				Name:     "self_link",
+				Type:     schema.TypeString,
+				Resolver: schema.PathResolver("SelfLink"),
+				CreationOptions: schema.ColumnCreationOptions{
+					PrimaryKey: true,
+				},
 			},
 			{
 				Name:     "zone",

--- a/plugins/source/gcp/resources/services/dns/managed_zones.go
+++ b/plugins/source/gcp/resources/services/dns/managed_zones.go
@@ -19,14 +19,6 @@ func ManagedZones() *schema.Table {
 				Resolver: client.ResolveProject,
 			},
 			{
-				Name:     "id",
-				Type:     schema.TypeInt,
-				Resolver: schema.PathResolver("Id"),
-				CreationOptions: schema.ColumnCreationOptions{
-					PrimaryKey: true,
-				},
-			},
-			{
 				Name:     "cloud_logging_config",
 				Type:     schema.TypeJSON,
 				Resolver: schema.PathResolver("CloudLoggingConfig"),
@@ -55,6 +47,14 @@ func ManagedZones() *schema.Table {
 				Name:     "forwarding_config",
 				Type:     schema.TypeJSON,
 				Resolver: schema.PathResolver("ForwardingConfig"),
+			},
+			{
+				Name:     "id",
+				Type:     schema.TypeInt,
+				Resolver: schema.PathResolver("Id"),
+				CreationOptions: schema.ColumnCreationOptions{
+					PrimaryKey: true,
+				},
 			},
 			{
 				Name:     "kind",

--- a/plugins/source/gcp/resources/services/dns/policies.go
+++ b/plugins/source/gcp/resources/services/dns/policies.go
@@ -19,14 +19,6 @@ func Policies() *schema.Table {
 				Resolver: client.ResolveProject,
 			},
 			{
-				Name:     "id",
-				Type:     schema.TypeInt,
-				Resolver: schema.PathResolver("Id"),
-				CreationOptions: schema.ColumnCreationOptions{
-					PrimaryKey: true,
-				},
-			},
-			{
 				Name:     "alternative_name_server_config",
 				Type:     schema.TypeJSON,
 				Resolver: schema.PathResolver("AlternativeNameServerConfig"),
@@ -45,6 +37,14 @@ func Policies() *schema.Table {
 				Name:     "enable_logging",
 				Type:     schema.TypeBool,
 				Resolver: schema.PathResolver("EnableLogging"),
+			},
+			{
+				Name:     "id",
+				Type:     schema.TypeInt,
+				Resolver: schema.PathResolver("Id"),
+				CreationOptions: schema.ColumnCreationOptions{
+					PrimaryKey: true,
+				},
 			},
 			{
 				Name:     "kind",

--- a/plugins/source/gcp/resources/services/iam/roles.go
+++ b/plugins/source/gcp/resources/services/iam/roles.go
@@ -22,13 +22,6 @@ func Roles() *schema.Table {
 				},
 			},
 			{
-				Name: "name",
-				Type: schema.TypeString,
-				CreationOptions: schema.ColumnCreationOptions{
-					PrimaryKey: true,
-				},
-			},
-			{
 				Name:     "deleted",
 				Type:     schema.TypeBool,
 				Resolver: schema.PathResolver("Deleted"),
@@ -47,6 +40,14 @@ func Roles() *schema.Table {
 				Name:     "included_permissions",
 				Type:     schema.TypeStringArray,
 				Resolver: schema.PathResolver("IncludedPermissions"),
+			},
+			{
+				Name:     "name",
+				Type:     schema.TypeString,
+				Resolver: schema.PathResolver("Name"),
+				CreationOptions: schema.ColumnCreationOptions{
+					PrimaryKey: true,
+				},
 			},
 			{
 				Name:     "stage",

--- a/plugins/source/gcp/resources/services/iam/service_accounts.go
+++ b/plugins/source/gcp/resources/services/iam/service_accounts.go
@@ -19,14 +19,6 @@ func ServiceAccounts() *schema.Table {
 				Resolver: client.ResolveProject,
 			},
 			{
-				Name:     "unique_id",
-				Type:     schema.TypeString,
-				Resolver: schema.PathResolver("UniqueId"),
-				CreationOptions: schema.ColumnCreationOptions{
-					PrimaryKey: true,
-				},
-			},
-			{
 				Name:     "description",
 				Type:     schema.TypeString,
 				Resolver: schema.PathResolver("Description"),
@@ -60,6 +52,14 @@ func ServiceAccounts() *schema.Table {
 				Name:     "oauth2_client_id",
 				Type:     schema.TypeString,
 				Resolver: schema.PathResolver("Oauth2ClientId"),
+			},
+			{
+				Name:     "unique_id",
+				Type:     schema.TypeString,
+				Resolver: schema.PathResolver("UniqueId"),
+				CreationOptions: schema.ColumnCreationOptions{
+					PrimaryKey: true,
+				},
 			},
 		},
 

--- a/plugins/source/gcp/resources/services/monitoring/alert_policies.go
+++ b/plugins/source/gcp/resources/services/monitoring/alert_policies.go
@@ -26,8 +26,9 @@ func AlertPolicies() *schema.Table {
 				Resolver: client.ResolveProject,
 			},
 			{
-				Name: "name",
-				Type: schema.TypeString,
+				Name:     "name",
+				Type:     schema.TypeString,
+				Resolver: schema.PathResolver("Name"),
 				CreationOptions: schema.ColumnCreationOptions{
 					PrimaryKey: true,
 				},

--- a/plugins/source/gcp/resources/services/serviceusage/services.go
+++ b/plugins/source/gcp/resources/services/serviceusage/services.go
@@ -26,8 +26,9 @@ func Services() *schema.Table {
 				Resolver: client.ResolveProject,
 			},
 			{
-				Name: "name",
-				Type: schema.TypeString,
+				Name:     "name",
+				Type:     schema.TypeString,
+				Resolver: schema.PathResolver("Name"),
 				CreationOptions: schema.ColumnCreationOptions{
 					PrimaryKey: true,
 				},

--- a/plugins/source/gcp/resources/services/sql/instances.go
+++ b/plugins/source/gcp/resources/services/sql/instances.go
@@ -19,14 +19,6 @@ func Instances() *schema.Table {
 				Resolver: client.ResolveProject,
 			},
 			{
-				Name:     "self_link",
-				Type:     schema.TypeString,
-				Resolver: schema.PathResolver("SelfLink"),
-				CreationOptions: schema.ColumnCreationOptions{
-					PrimaryKey: true,
-				},
-			},
-			{
 				Name:     "available_maintenance_versions",
 				Type:     schema.TypeStringArray,
 				Resolver: schema.PathResolver("AvailableMaintenanceVersions"),
@@ -175,6 +167,14 @@ func Instances() *schema.Table {
 				Name:     "secondary_gce_zone",
 				Type:     schema.TypeString,
 				Resolver: schema.PathResolver("SecondaryGceZone"),
+			},
+			{
+				Name:     "self_link",
+				Type:     schema.TypeString,
+				Resolver: schema.PathResolver("SelfLink"),
+				CreationOptions: schema.ColumnCreationOptions{
+					PrimaryKey: true,
+				},
 			},
 			{
 				Name:     "server_ca_cert",

--- a/plugins/source/gcp/resources/services/sql/users.go
+++ b/plugins/source/gcp/resources/services/sql/users.go
@@ -22,22 +22,6 @@ func Users() *schema.Table {
 				},
 			},
 			{
-				Name:     "instance",
-				Type:     schema.TypeString,
-				Resolver: schema.PathResolver("Instance"),
-				CreationOptions: schema.ColumnCreationOptions{
-					PrimaryKey: true,
-				},
-			},
-			{
-				Name:     "name",
-				Type:     schema.TypeString,
-				Resolver: schema.PathResolver("Name"),
-				CreationOptions: schema.ColumnCreationOptions{
-					PrimaryKey: true,
-				},
-			},
-			{
 				Name:     "dual_password_type",
 				Type:     schema.TypeString,
 				Resolver: schema.PathResolver("DualPasswordType"),
@@ -53,9 +37,25 @@ func Users() *schema.Table {
 				Resolver: schema.PathResolver("Host"),
 			},
 			{
+				Name:     "instance",
+				Type:     schema.TypeString,
+				Resolver: schema.PathResolver("Instance"),
+				CreationOptions: schema.ColumnCreationOptions{
+					PrimaryKey: true,
+				},
+			},
+			{
 				Name:     "kind",
 				Type:     schema.TypeString,
 				Resolver: schema.PathResolver("Kind"),
+			},
+			{
+				Name:     "name",
+				Type:     schema.TypeString,
+				Resolver: schema.PathResolver("Name"),
+				CreationOptions: schema.ColumnCreationOptions{
+					PrimaryKey: true,
+				},
 			},
 			{
 				Name:     "password",


### PR DESCRIPTION
<!-- 🎉 Thank you for making CloudQuery awesome by submitting a PR 🎉 -->

#### Summary

Looks like we're using `ExtraColumns` mostly for setting primary keys, so I changed it so we only pass the names of primary keys. This allowed to me to remove some boilerplate around skipping the field, just so we can extra column it.
Also this saves copy pasting the column type, resolver (which was missing in some cases), etc.

**While the order of primary keys columns changed between all columns, the order between primary keys of the same table is the same**.

I'm not sure how to classify this? `feat`? It is user facing, both in regards to columns and code gen.

<!--
Use the following steps to ensure your PR is ready to be reviewed

- [ ] Read the [contribution guidelines](../blob/main/CONTRIBUTING.md) 🧑‍🎓
- [ ] Test locally on your own infrastructure
- [ ] Run `go fmt` to format your code 🖊
- [ ] Lint your changes via `golangci-lint run` 🚨 (install golangci-lint [here](https://golangci-lint.run/usage/install/#local-installation))
- [ ] Update or add tests 🧪
- [ ] Ensure the status checks below are successful ✅
--->
