### PR TITLE
fix(table-diff): Improve primary keys comments

### DIFF
--- a/scripts/table_diff/changes/changes.go
+++ b/scripts/table_diff/changes/changes.go
@@ -84,14 +84,14 @@ func getColumnChanges(file *gitdiff.File, table string) (changes []change) {
 
 			if addedColumn.pk && !deletedColumn.pk {
 				changes = append(changes, change{
-					Text:     fmt.Sprintf("Table %s: column primary key %s added", backtickStrings(table, deletedName)...),
+					Text:     fmt.Sprintf("Table %s: primary key constraint added to column %s", backtickStrings(table, deletedName)...),
 					Breaking: false,
 				})
 			}
 
 			if !addedColumn.pk && deletedColumn.pk {
 				changes = append(changes, change{
-					Text:     fmt.Sprintf("Table %s: column primary key %s removed", backtickStrings(table, deletedName)...),
+					Text:     fmt.Sprintf("Table %s: primary key constraint removed from column %s", backtickStrings(table, deletedName)...),
 					Breaking: false,
 				})
 			}
@@ -104,8 +104,12 @@ func getColumnChanges(file *gitdiff.File, table string) (changes []change) {
 	}
 	for addedName, addedColumn := range addedColumns {
 		if _, ok := deletedColumns[addedName]; !ok {
+			name := addedName
+			if addedColumn.pk {
+				name = fmt.Sprintf("%s (PK)", name)
+			}
 			changes = append(changes, change{
-				Text:     fmt.Sprintf("Table %s: column added with name %s and type %s", backtickStrings(table, addedName, addedColumn.dataType)...),
+				Text:     fmt.Sprintf("Table %s: column added with name %s and type %s", backtickStrings(table, name, addedColumn.dataType)...),
 				Breaking: false,
 			})
 		}

--- a/scripts/table_diff/changes/changes_test.go
+++ b/scripts/table_diff/changes/changes_test.go
@@ -166,15 +166,15 @@ func Test_getChanges(t *testing.T) {
 			diffDataFile: "testdata/pr_5636_diff.txt",
 			wantChanges: []change{
 				{
-					Text:     "Table `gcp_resourcemanager_projects`: column primary key `_cq_id` removed",
+					Text:     "Table `gcp_resourcemanager_projects`: primary key constraint added to column `name`",
 					Breaking: false,
 				},
 				{
-					Text:     "Table `gcp_resourcemanager_projects`: column primary key `name` added",
+					Text:     "Table `gcp_resourcemanager_projects`: primary key constraint added to column `project_id`",
 					Breaking: false,
 				},
 				{
-					Text:     "Table `gcp_resourcemanager_projects`: column primary key `project_id` added",
+					Text:     "Table `gcp_resourcemanager_projects`: primary key constraint removed from column `_cq_id`",
 					Breaking: false,
 				},
 			},


### PR DESCRIPTION
<!-- 🎉 Thank you for making CloudQuery awesome by submitting a PR 🎉 -->

#### Summary

This improves the table diff comment for primary keys. From the current comment:
![image](https://user-images.githubusercontent.com/26760571/208428236-52ae891b-53b1-430b-b3b4-29ff55457030.png)

It can be understood that the column was removed, but actually the primary key was removed

<!--
Use the following steps to ensure your PR is ready to be reviewed

- [ ] Read the [contribution guidelines](../blob/main/CONTRIBUTING.md) 🧑‍🎓
- [ ] Test locally on your own infrastructure
- [ ] Run `go fmt` to format your code 🖊
- [ ] Lint your changes via `golangci-lint run` 🚨 (install golangci-lint [here](https://golangci-lint.run/usage/install/#local-installation))
- [ ] Update or add tests 🧪
- [ ] Ensure the status checks below are successful ✅
--->
