### PR TITLE
fix(aws)!: Fix PK in `aws_elasticsearch_domains`

### DIFF
--- a/plugins/source/aws/CONTRIBUTING.md
+++ b/plugins/source/aws/CONTRIBUTING.md
@@ -29,7 +29,7 @@ This will install `mockgen` and any other tools necessary to complete the proces
 
 1. Check in [client/services.go](client/services.go) that the service you need has an interface defined. If it does, you can skip to [2. Add a Code Generation Recipe](#2-add-a-code-generation-recipe). If not, read on to learn how to generate the interface.
 2. Inside [codegen/services/clients.go](codegen/services/clients.go), add the client for the AWS SDK you need to the `clients` slice. You may need to run `go get github.com/aws/aws-sdk-go-v2/service/<service-name>` (e.g. `go get github.com/aws/aws-sdk-go-v2/service/dynamodb`) to add the dependency first.
-3. Run `make gen`. This should add the interface for your client to [client/services.go](client/services.go) and create a mock for it that will be used in unit tests later.
+3. Run `make gen-mocks`. This should add the interface for your client to [client/services.go](client/services.go) and create a mock for it that will be used in unit tests later.
 
 ## 2. Add a Code Generation Recipe
 

--- a/plugins/source/aws/Makefile
+++ b/plugins/source/aws/Makefile
@@ -19,7 +19,7 @@ gen-code:
 	go run codegen/main.go
 
 .PHONY: gen-mocks
-gen-mocks:
+gen-mocks: gen-code
 	go install github.com/golang/mock/mockgen@v1.6.0
 	rm -rf ./client/mocks/*
 	go generate ./client/...
@@ -35,4 +35,4 @@ gen-docs:
 
 # All gen targets
 .PHONY: gen
-gen: gen-code gen-mocks gen-docs
+gen: gen-code gen-docs

--- a/plugins/source/aws/codegen/recipes/elasticsearch.go
+++ b/plugins/source/aws/codegen/recipes/elasticsearch.go
@@ -11,33 +11,15 @@ func ElasticsearchResources() []*Resource {
 		{
 			SubService:          "domains",
 			Struct:              &types.ElasticsearchDomainStatus{},
-			SkipFields:          []string{"DomainId"},
 			PreResourceResolver: "getDomain",
-			ExtraColumns: []codegen.ColumnDefinition{
-				{
-					Name:     "account_id",
-					Type:     schema.TypeString,
-					Resolver: `client.ResolveAWSAccount`,
-					Options:  schema.ColumnCreationOptions{PrimaryKey: true},
-				},
-				{
-					Name:     "region",
-					Type:     schema.TypeString,
-					Resolver: `client.ResolveAWSRegion`,
-					Options:  schema.ColumnCreationOptions{PrimaryKey: true},
-				},
-				{
+			PKColumns:           []string{"arn"},
+			ExtraColumns: append(defaultRegionalColumns,
+				codegen.ColumnDefinition{
 					Name:     "tags",
 					Type:     schema.TypeJSON,
-					Resolver: `resolveElasticsearchDomainTags`,
+					Resolver: `resolveTags`,
 				},
-				{
-					Name:     "id",
-					Type:     schema.TypeString,
-					Resolver: `schema.PathResolver("DomainId")`,
-					Options:  schema.ColumnCreationOptions{PrimaryKey: true},
-				},
-			},
+			),
 		},
 	}
 

--- a/plugins/source/aws/docs/tables/aws_elasticsearch_domains.md
+++ b/plugins/source/aws/docs/tables/aws_elasticsearch_domains.md
@@ -1,6 +1,6 @@
 # Table: aws_elasticsearch_domains
 
-The composite primary key for this table is (**account_id**, **region**, **id**).
+The primary key for this table is **arn**.
 
 ## Columns
 
@@ -10,11 +10,11 @@ The composite primary key for this table is (**account_id**, **region**, **id**)
 |_cq_sync_time|Timestamp|
 |_cq_id|UUID|
 |_cq_parent_id|UUID|
-|account_id (PK)|String|
-|region (PK)|String|
+|account_id|String|
+|region|String|
 |tags|JSON|
-|id (PK)|String|
-|arn|String|
+|arn (PK)|String|
+|domain_id|String|
 |domain_name|String|
 |elasticsearch_cluster_config|JSON|
 |access_policies|String|

--- a/plugins/source/aws/resources/services/elasticsearch/domains.go
+++ b/plugins/source/aws/resources/services/elasticsearch/domains.go
@@ -18,35 +18,29 @@ func Domains() *schema.Table {
 				Name:     "account_id",
 				Type:     schema.TypeString,
 				Resolver: client.ResolveAWSAccount,
-				CreationOptions: schema.ColumnCreationOptions{
-					PrimaryKey: true,
-				},
 			},
 			{
 				Name:     "region",
 				Type:     schema.TypeString,
 				Resolver: client.ResolveAWSRegion,
-				CreationOptions: schema.ColumnCreationOptions{
-					PrimaryKey: true,
-				},
 			},
 			{
 				Name:     "tags",
 				Type:     schema.TypeJSON,
-				Resolver: resolveElasticsearchDomainTags,
-			},
-			{
-				Name:     "id",
-				Type:     schema.TypeString,
-				Resolver: schema.PathResolver("DomainId"),
-				CreationOptions: schema.ColumnCreationOptions{
-					PrimaryKey: true,
-				},
+				Resolver: resolveTags,
 			},
 			{
 				Name:     "arn",
 				Type:     schema.TypeString,
 				Resolver: schema.PathResolver("ARN"),
+				CreationOptions: schema.ColumnCreationOptions{
+					PrimaryKey: true,
+				},
+			},
+			{
+				Name:     "domain_id",
+				Type:     schema.TypeString,
+				Resolver: schema.PathResolver("DomainId"),
 			},
 			{
 				Name:     "domain_name",

--- a/plugins/source/aws/resources/services/elasticsearch/domains_fetch.go
+++ b/plugins/source/aws/resources/services/elasticsearch/domains_fetch.go
@@ -35,25 +35,3 @@ func getDomain(ctx context.Context, meta schema.ClientMeta, resource *schema.Res
 	resource.Item = domainOutput.DomainStatus
 	return nil
 }
-
-func resolveElasticsearchDomainTags(ctx context.Context, meta schema.ClientMeta, resource *schema.Resource, c schema.Column) error {
-	region := meta.(*client.Client).Region
-	svc := meta.(*client.Client).Services().Elasticsearchservice
-	domain := resource.Item.(*types.ElasticsearchDomainStatus)
-	tagsOutput, err := svc.ListTags(ctx, &elasticsearchservice.ListTagsInput{
-		ARN: domain.ARN,
-	}, func(o *elasticsearchservice.Options) {
-		o.Region = region
-	})
-	if err != nil {
-		return err
-	}
-	if len(tagsOutput.TagList) == 0 {
-		return nil
-	}
-	tags := make(map[string]*string)
-	for _, s := range tagsOutput.TagList {
-		tags[*s.Key] = s.Value
-	}
-	return resource.Set(c.Name, tags)
-}

--- a/plugins/source/aws/resources/services/elasticsearch/domains_mock_test.go
+++ b/plugins/source/aws/resources/services/elasticsearch/domains_mock_test.go
@@ -31,11 +31,7 @@ func buildElasticSearchDomains(t *testing.T, ctrl *gomock.Controller) client.Ser
 		gomock.Any(),
 	).Return(&elasticsearchservice.DescribeElasticsearchDomainOutput{DomainStatus: &ds}, nil)
 
-	var tags elasticsearchservice.ListTagsOutput
-	if err := faker.FakeObject(&tags); err != nil {
-		t.Fatal(err)
-	}
-	m.EXPECT().ListTags(gomock.Any(), gomock.Any(), gomock.Any()).Return(&tags, nil)
+	addTagsCall(t, m)
 
 	return client.Services{Elasticsearchservice: m}
 }

--- a/plugins/source/aws/resources/services/elasticsearch/tags_fetch.go
+++ b/plugins/source/aws/resources/services/elasticsearch/tags_fetch.go
@@ -1,0 +1,35 @@
+package elasticsearch
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/aws/aws-sdk-go-v2/service/elasticsearchservice"
+	"github.com/aws/aws-sdk-go-v2/service/elasticsearchservice/types"
+	"github.com/cloudquery/cloudquery/plugins/source/aws/client"
+	"github.com/cloudquery/plugin-sdk/schema"
+)
+
+func resolveTags(ctx context.Context, meta schema.ClientMeta, resource *schema.Resource, c schema.Column) error {
+	region := meta.(*client.Client).Region
+	svc := meta.(*client.Client).Services().Elasticsearchservice
+
+	var arn *string
+	switch typed := resource.Item.(type) {
+	case *types.ElasticsearchDomainStatus:
+		arn = typed.ARN
+	default:
+		return fmt.Errorf("unsupported type for resolveTags: %T", typed)
+	}
+
+	tagsOutput, err := svc.ListTags(ctx, &elasticsearchservice.ListTagsInput{
+		ARN: arn,
+	}, func(o *elasticsearchservice.Options) {
+		o.Region = region
+	})
+	if err != nil {
+		return err
+	}
+
+	return resource.Set(c.Name, client.TagsToMap(tagsOutput.TagList))
+}

--- a/plugins/source/aws/resources/services/elasticsearch/tags_fetch_mock_test.go
+++ b/plugins/source/aws/resources/services/elasticsearch/tags_fetch_mock_test.go
@@ -1,0 +1,18 @@
+package elasticsearch
+
+import (
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/service/elasticsearchservice"
+	"github.com/cloudquery/cloudquery/plugins/source/aws/client/mocks"
+	"github.com/cloudquery/plugin-sdk/faker"
+	"github.com/golang/mock/gomock"
+)
+
+func addTagsCall(t *testing.T, m *mocks.MockElasticsearchserviceClient) {
+	var tags elasticsearchservice.ListTagsOutput
+	if err := faker.FakeObject(&tags); err != nil {
+		t.Fatal(err)
+	}
+	m.EXPECT().ListTags(gomock.Any(), gomock.Any(), gomock.Any()).Return(&tags, nil)
+}


### PR DESCRIPTION
BEGIN_COMMIT_OVERRIDE
feat(aws): Make `arn` primary key of `aws_elasticsearch_domains`. Rename `id` column to `domain_id`

BREAKING CHANGE: Rename `id` column to `domain_id` for `aws_elasticsearch_domains`

END_COMMIT_OVERRIDE