### PR TITLE
fix(ci-broken-links): Update `wait-for-vercel` to latest commit sha

### DIFF
--- a/.github/workflows/broken_links.yml
+++ b/.github/workflows/broken_links.yml
@@ -27,7 +27,7 @@ jobs:
 
       - name: Waiting for Vercel Preview
         if: github.event_name == 'pull_request'
-        uses: patrickedqvist/wait-for-vercel-preview@v1.2.0
+        uses: patrickedqvist/wait-for-vercel-preview@1d4a973cb668249d5fb0e34d04be05634e396a8b
         id: preview-deployment
         with:
           token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
<!-- 🎉 Thank you for making CloudQuery awesome by submitting a PR 🎉 -->

#### Summary

This uses the latest version of `wait-for-vercel`, specifically with:
1. New deps https://github.com/patrickedqvist/wait-for-vercel-preview/pull/44
2. Better error messages on network errors https://github.com/patrickedqvist/wait-for-vercel-preview/pull/36

I'm hoping 2. will help us debug the failing broken links CI failures

<!--
Use the following steps to ensure your PR is ready to be reviewed

- [ ] Read the [contribution guidelines](../blob/main/CONTRIBUTING.md) 🧑‍🎓
- [ ] Test locally on your own infrastructure
- [ ] Run `go fmt` to format your code 🖊
- [ ] Lint your changes via `golangci-lint run` 🚨 (install golangci-lint [here](https://golangci-lint.run/usage/install/#local-installation))
- [ ] Update or add tests 🧪
- [ ] Ensure the status checks below are successful ✅
--->
