### PR TITLE
fix(crowdstrike): Change timestamp column type and add documentation

### DIFF
--- a/plugins/source/crowdstrike/README.md
+++ b/plugins/source/crowdstrike/README.md
@@ -4,35 +4,4 @@ This plugin pulls information from CrowdStrike and loads it into any supported C
 
 ## Links
 
-- [Tables](./docs/tables/README.md)
-
-## Authentication
-
-In order to fetch information from CrowdStrike, `cloudquery` needs to be authenticated. A client id and secret is required for authentication. Follow [these steps](https://www.crowdstrike.com/blog/tech-center/get-access-falcon-apis/) to set these up. Note that you will also need to enlist the client to have the appropriate scope for what you want to query.
-
-## Configuration
-
-To configure CloudQuery to extract from CrowdStrike, create a `.yml` file in your CloudQuery configuration directory.
-For example, the following configuration will extract information from CrowdStrike, and connect it to a `postgresql` destination plugin
-
-```yaml
-kind: source
-spec:
-  # Source spec section
-  name: crowdstrike
-  path: cloudquery/crowdstrike
-  version: "0.0.1" # latest version of crowdstrike plugin
-  tables: ["*"]
-  destinations: ["postgresql"]
-  spec:
-    client_id: <CLIENT_ID>
-    client_secret: <CLIENT_SECRET>
-```
-
-## Example
-
-You can reduce alert fatigue by narrowing alerts down from CrowdStrike using fuzzy matching.
-
-```sql
-select * from crowdstrike_alerts_query where resources like ('%filter_here%');
-```
+- [User Guide](https://docs.cloudquery.io/docs/plugins/sources/crowdstrike/overview)

--- a/plugins/source/crowdstrike/codegen/recipes/incidents.go
+++ b/plugins/source/crowdstrike/codegen/recipes/incidents.go
@@ -1,6 +1,8 @@
 package recipes
 
 import (
+	"github.com/cloudquery/plugin-sdk/codegen"
+	"github.com/cloudquery/plugin-sdk/schema"
 	"github.com/crowdstrike/gofalcon/falcon/models"
 )
 
@@ -11,6 +13,14 @@ func CrowdScore() []*Resource {
 			SubService: "crowdscore",
 			Struct:     &models.DomainEnvironmentScore{},
 			PKColumns:  []string{"id"},
+			SkipFields: []string{"Timestamp"},
+			ExtraColumns: []codegen.ColumnDefinition{
+				{
+					Name:     "timestamp",
+					Type:     schema.TypeTimestamp,
+					Resolver: `schema.PathResolver("Timestamp")`,
+				},
+			},
 		},
 	}
 	return resources

--- a/plugins/source/crowdstrike/docs/tables/crowdstrike_incidents_crowdscore.md
+++ b/plugins/source/crowdstrike/docs/tables/crowdstrike_incidents_crowdscore.md
@@ -10,6 +10,6 @@ The primary key for this table is **id**.
 |_cq_sync_time|Timestamp|
 |_cq_id|UUID|
 |_cq_parent_id|UUID|
+|timestamp|Timestamp|
 |id (PK)|String|
 |score|Int|
-|timestamp|JSON|

--- a/plugins/source/crowdstrike/resources/services/incidents/crowdscore.go
+++ b/plugins/source/crowdstrike/resources/services/incidents/crowdscore.go
@@ -12,6 +12,11 @@ func Crowdscore() *schema.Table {
 		Resolver: fetchCrowdscore,
 		Columns: []schema.Column{
 			{
+				Name:     "timestamp",
+				Type:     schema.TypeTimestamp,
+				Resolver: schema.PathResolver("Timestamp"),
+			},
+			{
 				Name:     "id",
 				Type:     schema.TypeString,
 				Resolver: schema.PathResolver("ID"),
@@ -23,11 +28,6 @@ func Crowdscore() *schema.Table {
 				Name:     "score",
 				Type:     schema.TypeInt,
 				Resolver: schema.PathResolver("Score"),
-			},
-			{
-				Name:     "timestamp",
-				Type:     schema.TypeJSON,
-				Resolver: schema.PathResolver("Timestamp"),
 			},
 		},
 	}

--- a/website/pages/docs/plugins/sources/_meta.json
+++ b/website/pages/docs/plugins/sources/_meta.json
@@ -3,6 +3,7 @@
   "aws": "AWS",
   "azure": "Azure",
   "cloudflare": "Cloudflare",
+  "crowdstrike": "CrowdStrike",
   "datadog": "Datadog",
   "digitalocean": "DigitalOcean",
   "gandi": "Gandi",

--- a/website/pages/docs/plugins/sources/crowdstrike/_meta.json
+++ b/website/pages/docs/plugins/sources/crowdstrike/_meta.json
@@ -1,0 +1,4 @@
+{
+  "overview": "Overview",
+  "tables": "Tables"
+}

--- a/website/pages/docs/plugins/sources/crowdstrike/overview.md
+++ b/website/pages/docs/plugins/sources/crowdstrike/overview.md
@@ -1,0 +1,35 @@
+# CrowdStrike Plugin
+
+This plugin pulls information from CrowdStrike and loads it into any supported CloudQuery destination (e.g. PostgreSQL).
+
+## Authentication
+
+In order to fetch information from CrowdStrike, `cloudquery` needs to be authenticated. A client id and secret is required for authentication. Follow [these steps](https://www.crowdstrike.com/blog/tech-center/get-access-falcon-apis/) to set these up. Note that you will also need to enlist the client to have the appropriate scope for what you want to query.
+
+## Configuration
+
+To configure CloudQuery to extract from CrowdStrike, create a `.yml` file in your CloudQuery configuration directory.
+For example, the following configuration will extract information from CrowdStrike, and connect it to a `postgresql` destination plugin
+
+```yaml
+kind: source
+spec:
+  # Source spec section
+  name: crowdstrike
+  path: cloudquery/crowdstrike
+  version: "VERSION_SOURCE_CROWDSTRIKE"
+  tables: ["*"]
+  destinations: ["postgresql"]
+  spec:
+    client_id: <CLIENT_ID>
+    client_secret: <CLIENT_SECRET>
+```
+
+## Example
+
+See all CrowdStrike alerts that match a pattern:
+
+```sql
+select * from crowdstrike_alerts_query where resources like ('%filter_here%');
+```
+

--- a/website/pages/docs/plugins/sources/crowdstrike/tables.md
+++ b/website/pages/docs/plugins/sources/crowdstrike/tables.md
@@ -1,0 +1,6 @@
+# Source Plugin: crowdstrike
+## Tables
+| Name          |
+| ------------- |
+| [crowdstrike_incidents_crowdscore](https://github.com/cloudquery/cloudquery/blob/main/plugins/source/crowdstrike/docs/tables/crowdstrike_incidents_crowdscore.md) |
+| [crowdstrike_alerts_query](https://github.com/cloudquery/cloudquery/blob/main/plugins/source/crowdstrike/docs/tables/crowdstrike_alerts_query.md) |


### PR DESCRIPTION
This:
 - changes the timestamp column to be of timestamp type (it's actually an aliased Go timestamp type)
 - adds back the Crowdstrike documentation removed before

Leaving in draft because I'd like to understand some potential use cases first (maybe by checking some example data)--it looks like `errors` and `metadata` may be part of the API response metadata and should be excluded, and maybe then we need a few more tables / columns before releasing. But I'm not familiar with CrowdStrike, so could be missing something