### PR TITLE
fix(website): Fix aws config

### DIFF
--- a/website/pages/docs/plugins/sources/aws/configuration.md
+++ b/website/pages/docs/plugins/sources/aws/configuration.md
@@ -104,7 +104,7 @@ This is the (nested) spec used by the AWS source plugin.
 
   Defines the maximum number of times an API request will be retried 
 
-- `max_retries` (int) (max_backoff: 30)
+- `max_backoff` (int) (default: 30)
   
   Defines the duration between retry attempts
 


### PR DESCRIPTION
Fix a typo introduced in https://github.com/cloudquery/cloudquery/pull/5942
