### PR TITLE
fix(ci): Skip broken links checks if build is ignored on Vercel

### DIFF
--- a/.github/workflows/broken_links.yml
+++ b/.github/workflows/broken_links.yml
@@ -20,13 +20,32 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
+      - uses: actions/checkout@v3
+        if: github.event_name == 'pull_request'
+        with:
+          fetch-depth: 2
+
+      - name: Should run broken links check
+        if: github.event_name == 'pull_request'
+        id: broken-links
+        run: |
+          # The paths here match the build ignore setting on Vercel
+          git diff --quiet HEAD^ HEAD website .github/workflows/broken_links.yml
+          has_changes=$?
+          if [ ${has_changes} = 1 ] ; then \
+              echo "check=true" >> $GITHUB_OUTPUT \
+          else \
+              echo "check=false" >> $GITHUB_OUTPUT \
+          fi
+
       - name: Setup node
+        if: steps.broken-links.outputs.check != 'false'
         uses: actions/setup-node@v3
         with:
           node-version: "lts/*"
 
       - name: Waiting for Vercel Preview
-        if: github.event_name == 'pull_request'
+        if: github.event_name == 'pull_request' && steps.broken-links.outputs.check != 'false'
         uses: patrickedqvist/wait-for-vercel-preview@1d4a973cb668249d5fb0e34d04be05634e396a8b
         id: preview-deployment
         with:
@@ -38,12 +57,14 @@ jobs:
           allow_inactive: true
 
       - name: Set Vercel URL output
+        if: steps.broken-links.outputs.check != 'false'
         id: vercel
         run: |
           DEPLOY_URL=${{ steps.preview-deployment.outputs.url }}
           echo "url=${DEPLOY_URL:-"https://www.cloudquery.io/"}" >> $GITHUB_OUTPUT
 
       - name: Check for broken links
+        if: steps.broken-links.outputs.check != 'false'
         # We need to exclude some hosts that protect against bots
         run: |
           set -o pipefail


### PR DESCRIPTION
<!-- 🎉 Thank you for making CloudQuery awesome by submitting a PR 🎉 -->

#### Summary

A workaround to https://github.com/patrickedqvist/wait-for-vercel-preview/issues/45.
This should fix the broken links CI workflow when a build is ignored on Vercel.
I'm using negated logic `!= false` as we also run this check on a schedule and manually. Otherwise we need to set multiple outputs (`skip-for-pr`, `skip-for-schedule`)

<!--
Use the following steps to ensure your PR is ready to be reviewed

- [ ] Read the [contribution guidelines](../blob/main/CONTRIBUTING.md) 🧑‍🎓
- [ ] Test locally on your own infrastructure
- [ ] Run `go fmt` to format your code 🖊
- [ ] Lint your changes via `golangci-lint run` 🚨 (install golangci-lint [here](https://golangci-lint.run/usage/install/#local-installation))
- [ ] Update or add tests 🧪
- [ ] Ensure the status checks below are successful ✅
--->
