### PR TITLE
fix(gcp_run_locations): Use correct description link

### DIFF
--- a/plugins/source/gcp/codegen/recipes/run.go
+++ b/plugins/source/gcp/codegen/recipes/run.go
@@ -12,7 +12,7 @@ func init() {
 			Struct:      &runv1.Location{},
 			SkipFetch:   true,
 			SkipMock:    true,
-			Description: "https://cloud.google.com/api-gateway/docs/reference/rest/v1/projects.locations#Location",
+			Description: "https://cloud.google.com/run/docs/reference/rest/v1/projects.locations#Location",
 			Relations:   []string{"Services()"},
 		},
 		{

--- a/plugins/source/gcp/docs/tables/gcp_run_locations.md
+++ b/plugins/source/gcp/docs/tables/gcp_run_locations.md
@@ -1,6 +1,6 @@
 # Table: gcp_run_locations
 
-https://cloud.google.com/api-gateway/docs/reference/rest/v1/projects.locations#Location
+https://cloud.google.com/run/docs/reference/rest/v1/projects.locations#Location
 
 The primary key for this table is **_cq_id**.
 

--- a/plugins/source/gcp/resources/services/run/locations.go
+++ b/plugins/source/gcp/resources/services/run/locations.go
@@ -10,7 +10,7 @@ import (
 func Locations() *schema.Table {
 	return &schema.Table{
 		Name:        "gcp_run_locations",
-		Description: `https://cloud.google.com/api-gateway/docs/reference/rest/v1/projects.locations#Location`,
+		Description: `https://cloud.google.com/run/docs/reference/rest/v1/projects.locations#Location`,
 		Resolver:    fetchLocations,
 		Multiplex:   client.ProjectMultiplexEnabledServices("run.googleapis.com"),
 		Columns: []schema.Column{


### PR DESCRIPTION
<!-- 🎉 Thank you for making CloudQuery awesome by submitting a PR 🎉 -->

#### Summary

Follow up to https://github.com/cloudquery/cloudquery/pull/5919. Fixes the description link for the `run_locations` table

<!--
Use the following steps to ensure your PR is ready to be reviewed

- [ ] Read the [contribution guidelines](../blob/main/CONTRIBUTING.md) 🧑‍🎓
- [ ] Test locally on your own infrastructure
- [ ] Run `go fmt` to format your code 🖊
- [ ] Lint your changes via `golangci-lint run` 🚨 (install golangci-lint [here](https://golangci-lint.run/usage/install/#local-installation))
- [ ] Update or add tests 🧪
- [ ] Ensure the status checks below are successful ✅
--->
