### PR TITLE
fix(github): Fix PK order in `github_hook_deliveries`, `github_team_members`, `github_team_repositories`

### DIFF
--- a/plugins/source/github/codegen/recipes/actions.go
+++ b/plugins/source/github/codegen/recipes/actions.go
@@ -9,19 +9,20 @@ import (
 func Actions() []*Resource {
 	return []*Resource{
 		{
+			TableName:  "workflows",
 			Service:    "actions",
 			SubService: "workflows",
-			Multiplex:  orgMultiplex,
 			Struct:     new(github.Workflow),
-			TableName:  "workflows",
-			SkipFields: skipID,
-			ExtraColumns: append(orgColumns, idColumn,
-				codegen.ColumnDefinition{
+			PKColumns:  []string{"id"},
+			ExtraColumns: codegen.ColumnDefinitions{
+				orgColumn,
+				{
 					Name:     "contents",
 					Type:     schema.TypeString,
 					Resolver: `resolveContents`,
 				},
-			),
+			},
+			Multiplex: orgMultiplex,
 		},
 	}
 }

--- a/plugins/source/github/codegen/recipes/base.go
+++ b/plugins/source/github/codegen/recipes/base.go
@@ -23,6 +23,7 @@ type Resource struct {
 	SubService           string
 	Struct               any
 	SkipFields           []string
+	PKColumns            []string
 	ExtraColumns         []codegen.ColumnDefinition
 	Table                *codegen.TableDefinition
 	TableName            string
@@ -59,6 +60,7 @@ func (r *Resource) Generate() error {
 	r.TableName = `github_` + r.TableName
 	r.Table, err = codegen.NewTableFromStruct(r.TableName, r.Struct,
 		codegen.WithSkipFields(r.SkipFields),
+		codegen.WithPKColumns(r.PKColumns...),
 		codegen.WithExtraColumns(r.ExtraColumns),
 		codegen.WithTypeTransformer(timestampTransformer),
 	)

--- a/plugins/source/github/codegen/recipes/billing.go
+++ b/plugins/source/github/codegen/recipes/billing.go
@@ -1,6 +1,7 @@
 package recipes
 
 import (
+	"github.com/cloudquery/plugin-sdk/codegen"
 	"github.com/google/go-github/v48/github"
 )
 
@@ -9,23 +10,23 @@ func Billing() []*Resource {
 		{
 			Service:      "billing",
 			SubService:   "action",
-			Multiplex:    orgMultiplex,
 			Struct:       new(github.ActionBilling),
-			ExtraColumns: orgColumns,
+			ExtraColumns: codegen.ColumnDefinitions{orgColumn},
+			Multiplex:    orgMultiplex,
 		},
 		{
 			Service:      "billing",
 			SubService:   "package",
-			Multiplex:    orgMultiplex,
 			Struct:       new(github.PackageBilling),
-			ExtraColumns: orgColumns,
+			ExtraColumns: codegen.ColumnDefinitions{orgColumn},
+			Multiplex:    orgMultiplex,
 		},
 		{
 			Service:      "billing",
 			SubService:   "storage",
-			Multiplex:    orgMultiplex,
 			Struct:       new(github.StorageBilling),
-			ExtraColumns: orgColumns,
+			ExtraColumns: codegen.ColumnDefinitions{orgColumn},
+			Multiplex:    orgMultiplex,
 		},
 	}
 }

--- a/plugins/source/github/codegen/recipes/columns.go
+++ b/plugins/source/github/codegen/recipes/columns.go
@@ -6,32 +6,11 @@ import (
 )
 
 var (
-	orgColumns = []codegen.ColumnDefinition{
-		{
-			Name:        "org",
-			Description: "The Github Organization of the resource.",
-			Type:        schema.TypeString,
-			Resolver:    `client.ResolveOrg`,
-			Options:     schema.ColumnCreationOptions{PrimaryKey: true},
-		},
+	orgColumn = codegen.ColumnDefinition{
+		Name:        "org",
+		Description: "The Github Organization of the resource.",
+		Type:        schema.TypeString,
+		Resolver:    `client.ResolveOrg`,
+		Options:     schema.ColumnCreationOptions{PrimaryKey: true},
 	}
-	idColumn = pkColumn("id", "ID")
-	skipID   = []string{"ID"}
 )
-
-func timestampField(name, path string) codegen.ColumnDefinition {
-	return codegen.ColumnDefinition{
-		Name:     name,
-		Type:     schema.TypeTimestamp,
-		Resolver: `schema.PathResolver("` + path + `.Time")`,
-	}
-}
-
-func pkColumn(name, path string) codegen.ColumnDefinition {
-	return codegen.ColumnDefinition{
-		Name:     name,
-		Type:     schema.TypeInt,
-		Resolver: `schema.PathResolver("` + path + `")`,
-		Options:  schema.ColumnCreationOptions{PrimaryKey: true},
-	}
-}

--- a/plugins/source/github/codegen/recipes/external.go
+++ b/plugins/source/github/codegen/recipes/external.go
@@ -1,25 +1,19 @@
 package recipes
 
 import (
+	"github.com/cloudquery/plugin-sdk/codegen"
 	"github.com/google/go-github/v48/github"
 )
 
 func External() []*Resource {
-	const (
-		groupID   = "GroupID"
-		updatedAt = "UpdatedAt"
-	)
 	return []*Resource{
 		{
-			Service:    "external",
-			SubService: "groups",
-			Multiplex:  orgMultiplex,
-			Struct:     new(github.ExternalGroup),
-			SkipFields: append(skipID, groupID, updatedAt),
-			ExtraColumns: append(orgColumns,
-				pkColumn("group_id", groupID),
-				timestampField("updated_at", updatedAt),
-			),
+			Service:      "external",
+			SubService:   "groups",
+			Struct:       new(github.ExternalGroup),
+			PKColumns:    []string{"group_id"},
+			ExtraColumns: codegen.ColumnDefinitions{orgColumn},
+			Multiplex:    orgMultiplex,
 		},
 	}
 }

--- a/plugins/source/github/codegen/recipes/hooks.go
+++ b/plugins/source/github/codegen/recipes/hooks.go
@@ -7,47 +7,45 @@ import (
 )
 
 func Hooks() []*Resource {
-	const (
-		deliveredAt = "DeliveredAt"
-	)
-
 	return []*Resource{
 		{
+			TableName:    "hooks",
 			Service:      "hooks",
 			SubService:   "hooks",
-			Multiplex:    orgMultiplex,
 			Struct:       new(github.Hook),
-			TableName:    "hooks",
-			SkipFields:   skipID,
-			ExtraColumns: append(orgColumns, idColumn),
+			PKColumns:    []string{"id"},
+			ExtraColumns: codegen.ColumnDefinitions{orgColumn},
+			Multiplex:    orgMultiplex,
 			Relations:    []string{"Deliveries()"},
 		},
 		{
+			TableName:  "hook_deliveries",
 			Service:    "hooks",
 			SubService: "deliveries",
-			Multiplex:  "", // we skip multiplexing here as it's a relation
 			Struct:     new(github.HookDelivery),
-			TableName:  "hook_deliveries",
-			SkipFields: append(skipID, deliveredAt, "Request", "Response"),
-			ExtraColumns: append(orgColumns, idColumn,
-				codegen.ColumnDefinition{
+			PKColumns:  []string{"id"},
+			SkipFields: []string{"Request", "Response"},
+			ExtraColumns: codegen.ColumnDefinitions{
+				orgColumn,
+				{
 					Name:        "hook_id",
 					Type:        schema.TypeInt,
 					Resolver:    `client.ResolveParentColumn("ID")`,
 					Description: "Hook ID",
 					Options:     schema.ColumnCreationOptions{PrimaryKey: true},
 				},
-				codegen.ColumnDefinition{
+				{
 					Name:     "request",
 					Type:     schema.TypeString,
 					Resolver: `resolveRequest`,
 				},
-				codegen.ColumnDefinition{
+				{
 					Name:     "response",
 					Type:     schema.TypeString,
 					Resolver: `resolveResponse`,
 				},
-				timestampField("delivered_at", deliveredAt)),
+			},
+			Multiplex: "", // we skip multiplexing here as it's a relation
 		},
 	}
 }

--- a/plugins/source/github/codegen/recipes/installations.go
+++ b/plugins/source/github/codegen/recipes/installations.go
@@ -1,19 +1,20 @@
 package recipes
 
 import (
+	"github.com/cloudquery/plugin-sdk/codegen"
 	"github.com/google/go-github/v48/github"
 )
 
 func Installations() []*Resource {
 	return []*Resource{
 		{
+			TableName:    "installations",
 			Service:      "installations",
 			SubService:   "installations",
-			Multiplex:    orgMultiplex,
 			Struct:       new(github.Installation),
-			TableName:    "installations",
-			SkipFields:   skipID,
-			ExtraColumns: append(orgColumns, idColumn),
+			PKColumns:    []string{"id"},
+			ExtraColumns: codegen.ColumnDefinitions{orgColumn},
+			Multiplex:    orgMultiplex,
 		},
 	}
 }

--- a/plugins/source/github/codegen/recipes/issues.go
+++ b/plugins/source/github/codegen/recipes/issues.go
@@ -1,19 +1,20 @@
 package recipes
 
 import (
+	"github.com/cloudquery/plugin-sdk/codegen"
 	"github.com/google/go-github/v48/github"
 )
 
 func Issues() []*Resource {
 	return []*Resource{
 		{
+			TableName:    "issues",
 			Service:      "issues",
 			SubService:   "issues",
-			Multiplex:    orgMultiplex,
 			Struct:       new(github.Issue),
-			TableName:    "issues",
-			SkipFields:   skipID,
-			ExtraColumns: append(orgColumns, idColumn),
+			PKColumns:    []string{"id"},
+			ExtraColumns: codegen.ColumnDefinitions{orgColumn},
+			Multiplex:    orgMultiplex,
 		},
 	}
 }

--- a/plugins/source/github/codegen/recipes/organizations.go
+++ b/plugins/source/github/codegen/recipes/organizations.go
@@ -11,27 +11,28 @@ func Organizations() []*Resource {
 		{
 			Service:      "organizations",
 			SubService:   "organizations",
-			Multiplex:    orgMultiplex,
 			Struct:       new(github.Organization),
 			TableName:    "organizations",
-			SkipFields:   skipID,
-			ExtraColumns: append(orgColumns, idColumn),
+			PKColumns:    []string{"id"},
+			ExtraColumns: codegen.ColumnDefinitions{orgColumn},
+			Multiplex:    orgMultiplex,
 			Relations:    []string{"Members()"},
 		},
 		{
 			Service:    "organizations",
 			SubService: "members",
-			Multiplex:  "", // we skip multiplexing here as it's a relation
 			Struct:     new(github.User),
 			TableName:  "organization_members",
-			SkipFields: skipID,
-			ExtraColumns: append(orgColumns, idColumn, // we can use orgColumns here
-				codegen.ColumnDefinition{
+			PKColumns:  []string{"id"},
+			ExtraColumns: codegen.ColumnDefinitions{
+				orgColumn, // we can use orgColumn here
+				{
 					Name:     "membership",
 					Type:     schema.TypeJSON,
 					Resolver: "resolveMembership",
 				},
-			),
+			},
+			Multiplex: "", // we skip multiplexing here as it's a relation
 		},
 	}
 }

--- a/plugins/source/github/codegen/recipes/repositories.go
+++ b/plugins/source/github/codegen/recipes/repositories.go
@@ -1,6 +1,7 @@
 package recipes
 
 import (
+	"github.com/cloudquery/plugin-sdk/codegen"
 	"github.com/google/go-github/v48/github"
 )
 
@@ -14,22 +15,10 @@ func Repositories() []*Resource {
 }
 
 func repository() *Resource {
-	const (
-		createdAt = "CreatedAt"
-		pushedAt  = "PushedAt"
-		updatedAt = "UpdatedAt"
-	)
-
 	return &Resource{
-		SubService: "repositories",
-		Struct:     new(github.Repository),
-		SkipFields: append(skipID,
-			createdAt, pushedAt, updatedAt,
-		),
-		ExtraColumns: append(orgColumns, idColumn,
-			timestampField("created_at", createdAt),
-			timestampField("pushed_at", pushedAt),
-			timestampField("updated_at", updatedAt),
-		),
+		SubService:   "repositories",
+		Struct:       new(github.Repository),
+		PKColumns:    []string{"id"},
+		ExtraColumns: codegen.ColumnDefinitions{orgColumn},
 	}
 }

--- a/plugins/source/github/codegen/recipes/teams.go
+++ b/plugins/source/github/codegen/recipes/teams.go
@@ -22,29 +22,31 @@ func Teams() []*Resource {
 
 	return []*Resource{
 		{
+			TableName:    "teams",
 			Service:      "teams",
 			SubService:   "teams",
-			Multiplex:    orgMultiplex,
 			Struct:       new(github.Team),
-			TableName:    "teams",
-			SkipFields:   skipID,
-			ExtraColumns: append(orgColumns, idColumn),
+			PKColumns:    []string{"id"},
+			ExtraColumns: codegen.ColumnDefinitions{orgColumn},
+			Multiplex:    orgMultiplex,
 			Relations:    []string{"Members()", "Repositories()"},
 		},
 		{
+			TableName:  "team_members",
 			Service:    "teams",
 			SubService: "members",
-			Multiplex:  "", // we skip multiplexing here as it's a relation
 			Struct:     new(github.User),
-			TableName:  "team_members",
-			SkipFields: skipID,
-			ExtraColumns: append(orgColumns, idColumn, teamID,
+			PKColumns:  []string{"id"},
+			ExtraColumns: codegen.ColumnDefinitions{
+				orgColumn,
+				teamID,
 				codegen.ColumnDefinition{
 					Name:     "membership",
 					Type:     schema.TypeJSON,
 					Resolver: "resolveMembership",
 				},
-			),
+			},
+			Multiplex: "", // we skip multiplexing here as it's a relation
 		},
 		repos,
 	}

--- a/plugins/source/github/docs/tables/github_external_groups.md
+++ b/plugins/source/github/docs/tables/github_external_groups.md
@@ -12,7 +12,7 @@ The composite primary key for this table is (**org**, **group_id**).
 |_cq_parent_id|UUID|
 |org (PK)|String|
 |group_id (PK)|Int|
-|updated_at|Timestamp|
 |group_name|String|
+|updated_at|Timestamp|
 |teams|JSON|
 |members|JSON|

--- a/plugins/source/github/docs/tables/github_hook_deliveries.md
+++ b/plugins/source/github/docs/tables/github_hook_deliveries.md
@@ -1,6 +1,6 @@
 # Table: github_hook_deliveries
 
-The composite primary key for this table is (**org**, **id**, **hook_id**).
+The composite primary key for this table is (**org**, **hook_id**, **id**).
 
 ## Relations
 
@@ -15,12 +15,12 @@ This table depends on [github_hooks](github_hooks.md).
 |_cq_id|UUID|
 |_cq_parent_id|UUID|
 |org (PK)|String|
-|id (PK)|Int|
 |hook_id (PK)|Int|
 |request|String|
 |response|String|
-|delivered_at|Timestamp|
+|id (PK)|Int|
 |guid|String|
+|delivered_at|Timestamp|
 |redelivery|Bool|
 |duration|Float|
 |status|String|

--- a/plugins/source/github/docs/tables/github_hooks.md
+++ b/plugins/source/github/docs/tables/github_hooks.md
@@ -16,10 +16,10 @@ The following tables depend on github_hooks:
 |_cq_id|UUID|
 |_cq_parent_id|UUID|
 |org (PK)|String|
-|id (PK)|Int|
 |created_at|Timestamp|
 |updated_at|Timestamp|
 |url|String|
+|id (PK)|Int|
 |type|String|
 |name|String|
 |test_url|String|

--- a/plugins/source/github/docs/tables/github_issues.md
+++ b/plugins/source/github/docs/tables/github_issues.md
@@ -14,6 +14,7 @@ The composite primary key for this table is (**org**, **id**).
 |id (PK)|Int|
 |number|Int|
 |state|String|
+|state_reason|String|
 |locked|Bool|
 |title|String|
 |body|String|

--- a/plugins/source/github/docs/tables/github_organization_members.md
+++ b/plugins/source/github/docs/tables/github_organization_members.md
@@ -15,9 +15,9 @@ This table depends on [github_organizations](github_organizations.md).
 |_cq_id|UUID|
 |_cq_parent_id|UUID|
 |org (PK)|String|
-|id (PK)|Int|
 |membership|JSON|
 |login|String|
+|id (PK)|Int|
 |node_id|String|
 |avatar_url|String|
 |html_url|String|

--- a/plugins/source/github/docs/tables/github_organizations.md
+++ b/plugins/source/github/docs/tables/github_organizations.md
@@ -16,8 +16,8 @@ The following tables depend on github_organizations:
 |_cq_id|UUID|
 |_cq_parent_id|UUID|
 |org (PK)|String|
-|id (PK)|Int|
 |login|String|
+|id (PK)|Int|
 |node_id|String|
 |avatar_url|String|
 |html_url|String|

--- a/plugins/source/github/docs/tables/github_repositories.md
+++ b/plugins/source/github/docs/tables/github_repositories.md
@@ -12,9 +12,6 @@ The composite primary key for this table is (**org**, **id**).
 |_cq_parent_id|UUID|
 |org (PK)|String|
 |id (PK)|Int|
-|created_at|Timestamp|
-|pushed_at|Timestamp|
-|updated_at|Timestamp|
 |node_id|String|
 |owner|JSON|
 |name|String|
@@ -24,6 +21,9 @@ The composite primary key for this table is (**org**, **id**).
 |code_of_conduct|JSON|
 |default_branch|String|
 |master_branch|String|
+|created_at|Timestamp|
+|pushed_at|Timestamp|
+|updated_at|Timestamp|
 |html_url|String|
 |clone_url|String|
 |git_url|String|
@@ -69,6 +69,7 @@ The composite primary key for this table is (**org**, **id**).
 |has_pages|Bool|
 |has_projects|Bool|
 |has_downloads|Bool|
+|has_discussions|Bool|
 |is_template|Bool|
 |license_template|String|
 |gitignore_template|String|

--- a/plugins/source/github/docs/tables/github_team_members.md
+++ b/plugins/source/github/docs/tables/github_team_members.md
@@ -1,6 +1,6 @@
 # Table: github_team_members
 
-The composite primary key for this table is (**org**, **id**, **team_id**).
+The composite primary key for this table is (**org**, **team_id**, **id**).
 
 ## Relations
 
@@ -15,10 +15,10 @@ This table depends on [github_teams](github_teams.md).
 |_cq_id|UUID|
 |_cq_parent_id|UUID|
 |org (PK)|String|
-|id (PK)|Int|
 |team_id (PK)|Int|
 |membership|JSON|
 |login|String|
+|id (PK)|Int|
 |node_id|String|
 |avatar_url|String|
 |html_url|String|

--- a/plugins/source/github/docs/tables/github_team_repositories.md
+++ b/plugins/source/github/docs/tables/github_team_repositories.md
@@ -1,6 +1,6 @@
 # Table: github_team_repositories
 
-The composite primary key for this table is (**org**, **id**, **team_id**).
+The composite primary key for this table is (**org**, **team_id**, **id**).
 
 ## Relations
 
@@ -15,11 +15,8 @@ This table depends on [github_teams](github_teams.md).
 |_cq_id|UUID|
 |_cq_parent_id|UUID|
 |org (PK)|String|
-|id (PK)|Int|
-|created_at|Timestamp|
-|pushed_at|Timestamp|
-|updated_at|Timestamp|
 |team_id (PK)|Int|
+|id (PK)|Int|
 |node_id|String|
 |owner|JSON|
 |name|String|
@@ -29,6 +26,9 @@ This table depends on [github_teams](github_teams.md).
 |code_of_conduct|JSON|
 |default_branch|String|
 |master_branch|String|
+|created_at|Timestamp|
+|pushed_at|Timestamp|
+|updated_at|Timestamp|
 |html_url|String|
 |clone_url|String|
 |git_url|String|
@@ -74,6 +74,7 @@ This table depends on [github_teams](github_teams.md).
 |has_pages|Bool|
 |has_projects|Bool|
 |has_downloads|Bool|
+|has_discussions|Bool|
 |is_template|Bool|
 |license_template|String|
 |gitignore_template|String|

--- a/plugins/source/github/docs/tables/github_workflows.md
+++ b/plugins/source/github/docs/tables/github_workflows.md
@@ -11,8 +11,8 @@ The composite primary key for this table is (**org**, **id**).
 |_cq_id|UUID|
 |_cq_parent_id|UUID|
 |org (PK)|String|
-|id (PK)|Int|
 |contents|String|
+|id (PK)|Int|
 |node_id|String|
 |name|String|
 |path|String|

--- a/plugins/source/github/go.mod
+++ b/plugins/source/github/go.mod
@@ -5,7 +5,7 @@ go 1.19
 require (
 	github.com/cloudquery/plugin-sdk v1.13.1
 	github.com/golang/mock v1.6.0
-	github.com/google/go-github/v48 v48.1.0
+	github.com/google/go-github/v48 v48.2.0
 	github.com/iancoleman/strcase v0.2.0
 	github.com/rs/zerolog v1.28.0
 	github.com/thoas/go-funk v0.9.3-0.20221027085339-5573bc209e28

--- a/plugins/source/github/go.sum
+++ b/plugins/source/github/go.sum
@@ -106,8 +106,8 @@ github.com/google/go-cmp v0.5.1/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/
 github.com/google/go-cmp v0.5.2/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.5/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.9 h1:O2Tfq5qg4qc4AmwVlvv0oLiVAGB7enBSJ2x2DqQFi38=
-github.com/google/go-github/v48 v48.1.0 h1:nqPqq+0oRY2AMR/SRskGrrP4nnewPB7e/m2+kbT/UvM=
-github.com/google/go-github/v48 v48.1.0/go.mod h1:dDlehKBDo850ZPvCTK0sEqTCVWcrGl2LcDiajkYi89Y=
+github.com/google/go-github/v48 v48.2.0 h1:68puzySE6WqUY9KWmpOsDEQfDZsso98rT6pZcz9HqcE=
+github.com/google/go-github/v48 v48.2.0/go.mod h1:dDlehKBDo850ZPvCTK0sEqTCVWcrGl2LcDiajkYi89Y=
 github.com/google/go-querystring v1.1.0 h1:AnCroh3fv4ZBgVIf1Iwtovgjaw/GiKJo8M8yD/fhyJ8=
 github.com/google/go-querystring v1.1.0/go.mod h1:Kcdr2DB4koayq7X8pmAG4sNG59So17icRSOU623lUBU=
 github.com/google/martian v2.1.0+incompatible/go.mod h1:9I4somxYTbIHy5NJKHRl3wXiIaQGbYVAs8BPL6v8lEs=

--- a/plugins/source/github/resources/services/actions/workflows.go
+++ b/plugins/source/github/resources/services/actions/workflows.go
@@ -23,17 +23,17 @@ func Workflows() *schema.Table {
 				},
 			},
 			{
+				Name:     "contents",
+				Type:     schema.TypeString,
+				Resolver: resolveContents,
+			},
+			{
 				Name:     "id",
 				Type:     schema.TypeInt,
 				Resolver: schema.PathResolver("ID"),
 				CreationOptions: schema.ColumnCreationOptions{
 					PrimaryKey: true,
 				},
-			},
-			{
-				Name:     "contents",
-				Type:     schema.TypeString,
-				Resolver: resolveContents,
 			},
 			{
 				Name:     "node_id",

--- a/plugins/source/github/resources/services/external/groups.go
+++ b/plugins/source/github/resources/services/external/groups.go
@@ -31,14 +31,14 @@ func Groups() *schema.Table {
 				},
 			},
 			{
-				Name:     "updated_at",
-				Type:     schema.TypeTimestamp,
-				Resolver: schema.PathResolver("UpdatedAt.Time"),
-			},
-			{
 				Name:     "group_name",
 				Type:     schema.TypeString,
 				Resolver: schema.PathResolver("GroupName"),
+			},
+			{
+				Name:     "updated_at",
+				Type:     schema.TypeTimestamp,
+				Resolver: schema.PathResolver("UpdatedAt"),
 			},
 			{
 				Name:     "teams",

--- a/plugins/source/github/resources/services/hooks/deliveries.go
+++ b/plugins/source/github/resources/services/hooks/deliveries.go
@@ -22,14 +22,6 @@ func Deliveries() *schema.Table {
 				},
 			},
 			{
-				Name:     "id",
-				Type:     schema.TypeInt,
-				Resolver: schema.PathResolver("ID"),
-				CreationOptions: schema.ColumnCreationOptions{
-					PrimaryKey: true,
-				},
-			},
-			{
 				Name:        "hook_id",
 				Type:        schema.TypeInt,
 				Resolver:    client.ResolveParentColumn("ID"),
@@ -49,14 +41,22 @@ func Deliveries() *schema.Table {
 				Resolver: resolveResponse,
 			},
 			{
-				Name:     "delivered_at",
-				Type:     schema.TypeTimestamp,
-				Resolver: schema.PathResolver("DeliveredAt.Time"),
+				Name:     "id",
+				Type:     schema.TypeInt,
+				Resolver: schema.PathResolver("ID"),
+				CreationOptions: schema.ColumnCreationOptions{
+					PrimaryKey: true,
+				},
 			},
 			{
 				Name:     "guid",
 				Type:     schema.TypeString,
 				Resolver: schema.PathResolver("GUID"),
+			},
+			{
+				Name:     "delivered_at",
+				Type:     schema.TypeTimestamp,
+				Resolver: schema.PathResolver("DeliveredAt"),
 			},
 			{
 				Name:     "redelivery",

--- a/plugins/source/github/resources/services/hooks/hooks.go
+++ b/plugins/source/github/resources/services/hooks/hooks.go
@@ -23,14 +23,6 @@ func Hooks() *schema.Table {
 				},
 			},
 			{
-				Name:     "id",
-				Type:     schema.TypeInt,
-				Resolver: schema.PathResolver("ID"),
-				CreationOptions: schema.ColumnCreationOptions{
-					PrimaryKey: true,
-				},
-			},
-			{
 				Name:     "created_at",
 				Type:     schema.TypeTimestamp,
 				Resolver: schema.PathResolver("CreatedAt"),
@@ -44,6 +36,14 @@ func Hooks() *schema.Table {
 				Name:     "url",
 				Type:     schema.TypeString,
 				Resolver: schema.PathResolver("URL"),
+			},
+			{
+				Name:     "id",
+				Type:     schema.TypeInt,
+				Resolver: schema.PathResolver("ID"),
+				CreationOptions: schema.ColumnCreationOptions{
+					PrimaryKey: true,
+				},
 			},
 			{
 				Name:     "type",

--- a/plugins/source/github/resources/services/issues/issues.go
+++ b/plugins/source/github/resources/services/issues/issues.go
@@ -41,6 +41,11 @@ func Issues() *schema.Table {
 				Resolver: schema.PathResolver("State"),
 			},
 			{
+				Name:     "state_reason",
+				Type:     schema.TypeString,
+				Resolver: schema.PathResolver("StateReason"),
+			},
+			{
 				Name:     "locked",
 				Type:     schema.TypeBool,
 				Resolver: schema.PathResolver("Locked"),

--- a/plugins/source/github/resources/services/organizations/members.go
+++ b/plugins/source/github/resources/services/organizations/members.go
@@ -22,14 +22,6 @@ func Members() *schema.Table {
 				},
 			},
 			{
-				Name:     "id",
-				Type:     schema.TypeInt,
-				Resolver: schema.PathResolver("ID"),
-				CreationOptions: schema.ColumnCreationOptions{
-					PrimaryKey: true,
-				},
-			},
-			{
 				Name:     "membership",
 				Type:     schema.TypeJSON,
 				Resolver: resolveMembership,
@@ -38,6 +30,14 @@ func Members() *schema.Table {
 				Name:     "login",
 				Type:     schema.TypeString,
 				Resolver: schema.PathResolver("Login"),
+			},
+			{
+				Name:     "id",
+				Type:     schema.TypeInt,
+				Resolver: schema.PathResolver("ID"),
+				CreationOptions: schema.ColumnCreationOptions{
+					PrimaryKey: true,
+				},
 			},
 			{
 				Name:     "node_id",

--- a/plugins/source/github/resources/services/organizations/organizations.go
+++ b/plugins/source/github/resources/services/organizations/organizations.go
@@ -23,17 +23,17 @@ func Organizations() *schema.Table {
 				},
 			},
 			{
+				Name:     "login",
+				Type:     schema.TypeString,
+				Resolver: schema.PathResolver("Login"),
+			},
+			{
 				Name:     "id",
 				Type:     schema.TypeInt,
 				Resolver: schema.PathResolver("ID"),
 				CreationOptions: schema.ColumnCreationOptions{
 					PrimaryKey: true,
 				},
-			},
-			{
-				Name:     "login",
-				Type:     schema.TypeString,
-				Resolver: schema.PathResolver("Login"),
 			},
 			{
 				Name:     "node_id",

--- a/plugins/source/github/resources/services/repositories/repositories.go
+++ b/plugins/source/github/resources/services/repositories/repositories.go
@@ -31,21 +31,6 @@ func Repositories() *schema.Table {
 				},
 			},
 			{
-				Name:     "created_at",
-				Type:     schema.TypeTimestamp,
-				Resolver: schema.PathResolver("CreatedAt.Time"),
-			},
-			{
-				Name:     "pushed_at",
-				Type:     schema.TypeTimestamp,
-				Resolver: schema.PathResolver("PushedAt.Time"),
-			},
-			{
-				Name:     "updated_at",
-				Type:     schema.TypeTimestamp,
-				Resolver: schema.PathResolver("UpdatedAt.Time"),
-			},
-			{
 				Name:     "node_id",
 				Type:     schema.TypeString,
 				Resolver: schema.PathResolver("NodeID"),
@@ -89,6 +74,21 @@ func Repositories() *schema.Table {
 				Name:     "master_branch",
 				Type:     schema.TypeString,
 				Resolver: schema.PathResolver("MasterBranch"),
+			},
+			{
+				Name:     "created_at",
+				Type:     schema.TypeTimestamp,
+				Resolver: schema.PathResolver("CreatedAt"),
+			},
+			{
+				Name:     "pushed_at",
+				Type:     schema.TypeTimestamp,
+				Resolver: schema.PathResolver("PushedAt"),
+			},
+			{
+				Name:     "updated_at",
+				Type:     schema.TypeTimestamp,
+				Resolver: schema.PathResolver("UpdatedAt"),
 			},
 			{
 				Name:     "html_url",
@@ -314,6 +314,11 @@ func Repositories() *schema.Table {
 				Name:     "has_downloads",
 				Type:     schema.TypeBool,
 				Resolver: schema.PathResolver("HasDownloads"),
+			},
+			{
+				Name:     "has_discussions",
+				Type:     schema.TypeBool,
+				Resolver: schema.PathResolver("HasDiscussions"),
 			},
 			{
 				Name:     "is_template",

--- a/plugins/source/github/resources/services/teams/members.go
+++ b/plugins/source/github/resources/services/teams/members.go
@@ -22,14 +22,6 @@ func Members() *schema.Table {
 				},
 			},
 			{
-				Name:     "id",
-				Type:     schema.TypeInt,
-				Resolver: schema.PathResolver("ID"),
-				CreationOptions: schema.ColumnCreationOptions{
-					PrimaryKey: true,
-				},
-			},
-			{
 				Name:     "team_id",
 				Type:     schema.TypeInt,
 				Resolver: client.ResolveParentColumn("ID"),
@@ -46,6 +38,14 @@ func Members() *schema.Table {
 				Name:     "login",
 				Type:     schema.TypeString,
 				Resolver: schema.PathResolver("Login"),
+			},
+			{
+				Name:     "id",
+				Type:     schema.TypeInt,
+				Resolver: schema.PathResolver("ID"),
+				CreationOptions: schema.ColumnCreationOptions{
+					PrimaryKey: true,
+				},
 			},
 			{
 				Name:     "node_id",

--- a/plugins/source/github/resources/services/teams/repositories.go
+++ b/plugins/source/github/resources/services/teams/repositories.go
@@ -22,32 +22,17 @@ func Repositories() *schema.Table {
 				},
 			},
 			{
-				Name:     "id",
+				Name:     "team_id",
 				Type:     schema.TypeInt,
-				Resolver: schema.PathResolver("ID"),
+				Resolver: client.ResolveParentColumn("ID"),
 				CreationOptions: schema.ColumnCreationOptions{
 					PrimaryKey: true,
 				},
 			},
 			{
-				Name:     "created_at",
-				Type:     schema.TypeTimestamp,
-				Resolver: schema.PathResolver("CreatedAt.Time"),
-			},
-			{
-				Name:     "pushed_at",
-				Type:     schema.TypeTimestamp,
-				Resolver: schema.PathResolver("PushedAt.Time"),
-			},
-			{
-				Name:     "updated_at",
-				Type:     schema.TypeTimestamp,
-				Resolver: schema.PathResolver("UpdatedAt.Time"),
-			},
-			{
-				Name:     "team_id",
+				Name:     "id",
 				Type:     schema.TypeInt,
-				Resolver: client.ResolveParentColumn("ID"),
+				Resolver: schema.PathResolver("ID"),
 				CreationOptions: schema.ColumnCreationOptions{
 					PrimaryKey: true,
 				},
@@ -96,6 +81,21 @@ func Repositories() *schema.Table {
 				Name:     "master_branch",
 				Type:     schema.TypeString,
 				Resolver: schema.PathResolver("MasterBranch"),
+			},
+			{
+				Name:     "created_at",
+				Type:     schema.TypeTimestamp,
+				Resolver: schema.PathResolver("CreatedAt"),
+			},
+			{
+				Name:     "pushed_at",
+				Type:     schema.TypeTimestamp,
+				Resolver: schema.PathResolver("PushedAt"),
+			},
+			{
+				Name:     "updated_at",
+				Type:     schema.TypeTimestamp,
+				Resolver: schema.PathResolver("UpdatedAt"),
 			},
 			{
 				Name:     "html_url",
@@ -321,6 +321,11 @@ func Repositories() *schema.Table {
 				Name:     "has_downloads",
 				Type:     schema.TypeBool,
 				Resolver: schema.PathResolver("HasDownloads"),
+			},
+			{
+				Name:     "has_discussions",
+				Type:     schema.TypeBool,
+				Resolver: schema.PathResolver("HasDiscussions"),
 			},
 			{
 				Name:     "is_template",


### PR DESCRIPTION
Change PK columns order for some resources

BEGIN_COMMIT_OVERRIDE
fix(github): Change PK columns order for some resources
  BREAKING-CHANGE: Reorder PK columns in for `github_hook_deliveries`, `github_team_members` and `github_team_repositories`

feat(github): Update GitHub client

chore(github): Simplify codegen recipes
END_COMMIT_OVERRIDE