### PR TITLE
fix(bigquery-spec)!: Move `batch_size` from the plugin spec to the top level spec

### DIFF
--- a/plugins/destination/bigquery/client/client.go
+++ b/plugins/destination/bigquery/client/client.go
@@ -17,7 +17,6 @@ type Client struct {
 	logger     zerolog.Logger
 	spec       specs.Destination
 	metrics    destination.Metrics
-	batchSize  int
 	pluginSpec Spec
 	client     *bigquery.Client
 }
@@ -41,7 +40,6 @@ func New(ctx context.Context, logger zerolog.Logger, destSpec specs.Destination)
 	}
 
 	c.pluginSpec = spec
-	c.batchSize = spec.BatchSize
 
 	// the context here is used for token refresh so this is workaround as suggested
 	// https://github.com/googleapis/google-cloud-go/issues/946

--- a/plugins/destination/bigquery/client/spec.go
+++ b/plugins/destination/bigquery/client/spec.go
@@ -34,7 +34,6 @@ type Spec struct {
 	DatasetLocation       string                 `json:"dataset_location"`
 	TimePartitioning      TimePartitioningOption `json:"time_partitioning"`
 	ServiceAccountKeyJSON string                 `json:"service_account_key_json"`
-	BatchSize             int                    `json:"batch_size,omitempty"`
 }
 
 const defaultBatchSize = 1000
@@ -42,9 +41,6 @@ const defaultBatchSize = 1000
 func (s *Spec) SetDefaults() {
 	if s.TimePartitioning == "" {
 		s.TimePartitioning = TimePartitioningOptionNone
-	}
-	if s.BatchSize <= 0 {
-		s.BatchSize = defaultBatchSize
 	}
 }
 

--- a/plugins/destination/bigquery/client/write.go
+++ b/plugins/destination/bigquery/client/write.go
@@ -10,7 +10,6 @@ import (
 )
 
 const (
-	batchSize    = 1000
 	writeTimeout = 5 * time.Minute
 )
 

--- a/website/pages/docs/plugins/destinations/bigquery/overview.md
+++ b/website/pages/docs/plugins/destinations/bigquery/overview.md
@@ -90,10 +90,6 @@ This is the top-level spec used by the BigQuery destination plugin.
 
   GCP service account key content. This allows for using different service accounts for the GCP source and BigQuery destination. If using service account keys, it is best to use [environment or file variable substitution](/docs/advanced-topics/environment-variable-substitution).
 
-- `batch_size` (int, optional. Default: 1000)
-
-  Number of rows to insert in a single batch.
-
 ## Underlying library
 
 We use the official [cloud.google.com/go/bigquery](https://pkg.go.dev/cloud.google.com/go/bigquery) package for database connection.

--- a/website/pages/docs/reference/destination-spec.md
+++ b/website/pages/docs/reference/destination-spec.md
@@ -61,6 +61,14 @@ Specifies the update method to use when inserting rows. The exact semantics depe
 - `overwrite`: Same as `overwrite-delete-stale`, but doesn't delete stale rows from previous `sync`s.
 - `append`: Rows are never overwritten or deleted, only appended.
 
+<!-- vale off -->
+### batch_size
+<!-- vale on -->
+
+(`int`, optional, default: `10000`)
+
+The number of resources to insert in a single batch. Only relevant for plugins that utilize batching.
+
 ### spec
 
 (`object`, optional)


### PR DESCRIPTION
<!-- 🎉 Thank you for making CloudQuery awesome by submitting a PR 🎉 -->

#### Summary

Related to https://github.com/cloudquery/cloudquery/issues/6070#issuecomment-1366626946.

With the SDK level batching the configuration that "takes" is now at the top spec level. Setting `batch_size` at the plugin level has no impact

<!--
Use the following steps to ensure your PR is ready to be reviewed

- [ ] Read the [contribution guidelines](../blob/main/CONTRIBUTING.md) 🧑‍🎓
- [ ] Test locally on your own infrastructure
- [ ] Run `go fmt` to format your code 🖊
- [ ] Lint your changes via `golangci-lint run` 🚨 (install golangci-lint [here](https://golangci-lint.run/usage/install/#local-installation))
- [ ] Update or add tests 🧪
- [ ] Ensure the status checks below are successful ✅
--->
