### PR TITLE
fix: Update destinations to use new Read API

### DIFF
--- a/plugins/destination/csv/client/client.go
+++ b/plugins/destination/csv/client/client.go
@@ -31,6 +31,7 @@ type migrateMsg struct {
 type readMsg struct {
 	table     *schema.Table
 	source    string
+	options   destination.ReadOptions
 	err       chan error
 	resources chan []any
 }
@@ -130,7 +131,7 @@ func (c *Client) listen() {
 		case msg := <-c.migrateChan:
 			msg.err <- c.migrate(msg.tables)
 		case msg := <-c.readChan:
-			msg.err <- c.read(msg.table, msg.source, msg.resources)
+			msg.err <- c.read(msg.table, msg.source, msg.resources, msg.options)
 		case msg := <-c.closeChan:
 			c.close()
 			msg.err <- nil

--- a/plugins/destination/csv/client/client_test.go
+++ b/plugins/destination/csv/client/client_test.go
@@ -20,10 +20,13 @@ func getTestLogger(t *testing.T) zerolog.Logger {
 }
 
 func TestClient(t *testing.T) {
+	d := t.TempDir()
 	ctx := context.Background()
 	client, err := New(ctx, getTestLogger(t), specs.Destination{
 		WriteMode: specs.WriteModeAppend,
-		Spec:      Spec{},
+		Spec: Spec{
+			Directory: d,
+		},
 	})
 	if err != nil {
 		t.Fatal(err)

--- a/plugins/destination/csv/go.mod
+++ b/plugins/destination/csv/go.mod
@@ -30,3 +30,5 @@ require (
 	google.golang.org/protobuf v1.28.1 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect
 )
+
+replace github.com/cloudquery/plugin-sdk v1.13.1 => ../../../../plugin-sdk

--- a/plugins/destination/csv/internal/priorityqueue/priority_queue.go
+++ b/plugins/destination/csv/internal/priorityqueue/priority_queue.go
@@ -43,9 +43,9 @@ func (pq PriorityQueue) Less(i, j int) bool {
 		if !pq.items[i].Cols[col].Equal(pq.items[j].Cols[col]) {
 			less := pq.items[i].Cols[col].LessThan(pq.items[j].Cols[col])
 			if orderBy.Desc {
-				return less
+				return !less
 			}
-			return !less
+			return less
 		}
 	}
 	return false

--- a/plugins/destination/csv/internal/priorityqueue/priority_queue.go
+++ b/plugins/destination/csv/internal/priorityqueue/priority_queue.go
@@ -1,0 +1,70 @@
+package priorityqueue
+
+import (
+	"github.com/cloudquery/plugin-sdk/plugins/destination"
+	"github.com/cloudquery/plugin-sdk/schema"
+)
+
+type Item struct {
+	Cols []schema.CQType // All columns of the row
+}
+
+// NewItem creates a new Item to be used with PriorityQueue
+func NewItem(cols []schema.CQType) *Item {
+	return &Item{
+		Cols: cols,
+	}
+}
+
+// A PriorityQueue implements heap.Interface and holds Items.
+type PriorityQueue struct {
+	table   *schema.Table
+	orderBy []destination.OrderByColumn
+	items   []*Item
+}
+
+func New(table *schema.Table, orderBy []destination.OrderByColumn) *PriorityQueue {
+	pq := &PriorityQueue{
+		table:   table,
+		orderBy: orderBy,
+		items:   make([]*Item, 0),
+	}
+	return pq
+}
+
+func (pq PriorityQueue) Len() int { return len(pq.items) }
+
+func (pq PriorityQueue) Less(i, j int) bool {
+	for _, orderBy := range pq.orderBy {
+		col := pq.table.Columns.Index(orderBy.Name)
+		if col == -1 {
+			return false
+		}
+		if !pq.items[i].Cols[col].Equal(pq.items[j].Cols[col]) {
+			less := pq.items[i].Cols[col].LessThan(pq.items[j].Cols[col])
+			if orderBy.Desc {
+				return less
+			}
+			return !less
+		}
+	}
+	return false
+}
+
+func (pq PriorityQueue) Swap(i, j int) {
+	pq.items[i], pq.items[j] = pq.items[j], pq.items[i]
+}
+
+func (pq *PriorityQueue) Push(x any) {
+	item := x.(*Item)
+	pq.items = append(pq.items, item)
+}
+
+func (pq *PriorityQueue) Pop() any {
+	old := *pq
+	n := len(old.items)
+	item := old.items[n-1]
+	old.items[n-1] = nil // avoid memory leak
+	pq.items = old.items[0 : n-1]
+	return item
+}

--- a/plugins/destination/csv/internal/priorityqueue/priority_queue_test.go
+++ b/plugins/destination/csv/internal/priorityqueue/priority_queue_test.go
@@ -2,7 +2,6 @@ package priorityqueue
 
 import (
 	"container/heap"
-	"sort"
 	"testing"
 
 	"github.com/cloudquery/plugin-sdk/plugins/destination"
@@ -66,8 +65,6 @@ func TestPriorityQueue(t *testing.T) {
 		heap.Pop(pq).(*Item),
 		heap.Pop(pq).(*Item),
 	}
-	// items will be popped in reverse priority order, so we reverse the slice
-	reverseSlice(items)
 
 	if items[0].Cols[0].(*schema.Int8).Int != 1 {
 		t.Fatalf("after pop, items[0] id = %d, want 1", items[0].Cols[0].(*schema.Int8).Int)
@@ -84,10 +81,8 @@ func TestPriorityQueue(t *testing.T) {
 	if items[2].Cols[1].(*schema.Int8).Int != 1 {
 		t.Fatalf("after pop, items[2] version = %d, want 1", items[2].Cols[1].(*schema.Int8).Int)
 	}
-}
 
-func reverseSlice[T comparable](s []T) {
-	sort.SliceStable(s, func(i, j int) bool {
-		return i > j
-	})
+	if pq.Len() != 0 {
+		t.Fatalf("after pop, pq.Len() = %d, want 0", pq.Len())
+	}
 }

--- a/plugins/destination/csv/internal/priorityqueue/priority_queue_test.go
+++ b/plugins/destination/csv/internal/priorityqueue/priority_queue_test.go
@@ -1,0 +1,93 @@
+package priorityqueue
+
+import (
+	"container/heap"
+	"sort"
+	"testing"
+
+	"github.com/cloudquery/plugin-sdk/plugins/destination"
+	"github.com/cloudquery/plugin-sdk/schema"
+)
+
+func TestPriorityQueue(t *testing.T) {
+	table := &schema.Table{
+		Name: "test",
+		Columns: []schema.Column{
+			{
+				Name: "id",
+				Type: schema.TypeInt,
+			},
+			{
+				Name: "version",
+				Type: schema.TypeInt,
+			},
+		},
+	}
+	orderBy := []destination.OrderByColumn{
+		{
+			Name: "id",
+			Desc: false,
+		},
+		{
+			Name: "version",
+			Desc: true,
+		},
+	}
+	pq := New(table, orderBy)
+	heap.Push(pq, NewItem([]schema.CQType{
+		&schema.Int8{Int: 1},
+		&schema.Int8{Int: 1},
+	}))
+	if pq.Len() != 1 {
+		t.Fatalf("after first push, pq.Len() = %d, want 1", pq.Len())
+	}
+	if pq.items[0].Cols[0].(*schema.Int8).Int != 1 {
+		t.Fatalf("after first push, pq.items[0].Cols[0].(*schema.Int8).Int = %d, want 1", pq.items[0].Cols[0].(*schema.Int8).Int)
+	}
+
+	heap.Push(pq, NewItem([]schema.CQType{
+		&schema.Int8{Int: 2},
+		&schema.Int8{Int: 1},
+	}))
+	if pq.Len() != 2 {
+		t.Fatalf("after second push, pq.Len() = %d, want 2", pq.Len())
+	}
+
+	heap.Push(pq, NewItem([]schema.CQType{
+		&schema.Int8{Int: 2},
+		&schema.Int8{Int: 2},
+	}))
+	if pq.Len() != 3 {
+		t.Fatalf("after third push, pq.Len() = %d, want 3", pq.Len())
+	}
+
+	items := []*Item{
+		heap.Pop(pq).(*Item),
+		heap.Pop(pq).(*Item),
+		heap.Pop(pq).(*Item),
+	}
+	// items will be popped in reverse priority order, so we reverse the slice
+	reverseSlice(items)
+
+	if items[0].Cols[0].(*schema.Int8).Int != 1 {
+		t.Fatalf("after pop, items[0] id = %d, want 1", items[0].Cols[0].(*schema.Int8).Int)
+	}
+	if items[1].Cols[0].(*schema.Int8).Int != 2 {
+		t.Fatalf("after pop, items[1] id = %d, want 2", items[1].Cols[0].(*schema.Int8).Int)
+	}
+	if items[1].Cols[1].(*schema.Int8).Int != 2 {
+		t.Fatalf("after pop, items[1] version = %d, want 2", items[1].Cols[1].(*schema.Int8).Int)
+	}
+	if items[2].Cols[0].(*schema.Int8).Int != 2 {
+		t.Fatalf("after pop, items[2] id = %d, want 2", items[2].Cols[0].(*schema.Int8).Int)
+	}
+	if items[2].Cols[1].(*schema.Int8).Int != 1 {
+		t.Fatalf("after pop, items[2] version = %d, want 1", items[2].Cols[1].(*schema.Int8).Int)
+	}
+}
+
+func reverseSlice[T comparable](s []T) {
+	sort.SliceStable(s, func(i, j int) bool {
+		return i > j
+	})
+}

--- a/plugins/destination/postgresql/client/read.go
+++ b/plugins/destination/postgresql/client/read.go
@@ -3,17 +3,57 @@ package client
 import (
 	"context"
 	"fmt"
+	"strings"
 
+	"github.com/cloudquery/plugin-sdk/plugins/destination"
 	"github.com/cloudquery/plugin-sdk/schema"
 	"github.com/jackc/pgx/v5"
 )
 
-const (
-	readSQL = "SELECT * FROM %s WHERE _cq_source_name = $1 order by _cq_sync_time asc"
-)
+func (c *Client) Read(ctx context.Context, table *schema.Table, sourceName string, res chan<- []any, opts destination.ReadOptions) error {
+	readSQL := []string{"SELECT"}
 
-func (c *Client) Read(ctx context.Context, table *schema.Table, sourceName string, res chan<- []any) error {
-	sql := fmt.Sprintf(readSQL, pgx.Identifier{table.Name}.Sanitize())
+	// add columns
+	if len(opts.Columns) == 0 {
+		readSQL = append(readSQL, "*")
+	} else {
+		for i, col := range opts.Columns {
+			if i > 0 {
+				readSQL = append(readSQL, ",")
+			}
+			readSQL = append(readSQL, pgx.Identifier{col}.Sanitize())
+		}
+	}
+
+	// add table name
+	readSQL = append(readSQL, fmt.Sprintf("FROM %s", pgx.Identifier{table.Name}.Sanitize()))
+
+	// add source name
+	readSQL = append(readSQL, fmt.Sprintf("WHERE %s = $1", pgx.Identifier{schema.CqSourceNameColumn.Name}.Sanitize()))
+
+	// add order by
+	if len(opts.OrderBy) == 0 {
+		readSQL = append(readSQL, "ORDER BY _cq_sync_time ASC")
+	} else {
+		readSQL = append(readSQL, "ORDER BY")
+		for i, col := range opts.OrderBy {
+			if i > 0 {
+				readSQL = append(readSQL, ",")
+			}
+			order := "ASC"
+			if col.Desc {
+				order = "DESC"
+			}
+			readSQL = append(readSQL, fmt.Sprintf("%s %s", pgx.Identifier{col.Name}.Sanitize(), order))
+		}
+	}
+
+	// add limit
+	if opts.Limit > 0 {
+		readSQL = append(readSQL, fmt.Sprintf("LIMIT %d", opts.Limit))
+	}
+
+	sql := strings.Join(readSQL, " ")
 	rows, err := c.conn.Query(ctx, sql, sourceName)
 	if err != nil {
 		return err

--- a/plugins/destination/postgresql/go.mod
+++ b/plugins/destination/postgresql/go.mod
@@ -37,3 +37,5 @@ require (
 	google.golang.org/protobuf v1.28.1 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect
 )
+
+replace github.com/cloudquery/plugin-sdk v1.13.1 => ../../../../plugin-sdk

--- a/plugins/destination/snowflake/client/client.go
+++ b/plugins/destination/snowflake/client/client.go
@@ -2,13 +2,12 @@ package client
 
 import (
 	"context"
+	"database/sql"
 	"fmt"
 
 	"github.com/cloudquery/plugin-sdk/plugins/destination"
 	"github.com/cloudquery/plugin-sdk/specs"
 	"github.com/rs/zerolog"
-
-	"database/sql"
 
 	"github.com/snowflakedb/gosnowflake"
 )

--- a/plugins/destination/snowflake/go.mod
+++ b/plugins/destination/snowflake/go.mod
@@ -66,3 +66,5 @@ require (
 	google.golang.org/protobuf v1.28.1 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect
 )
+
+replace github.com/cloudquery/plugin-sdk v1.13.1 => ../../../../plugin-sdk

--- a/plugins/destination/sqlite/client/read.go
+++ b/plugins/destination/sqlite/client/read.go
@@ -4,12 +4,10 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
+	"strings"
 
+	"github.com/cloudquery/plugin-sdk/plugins/destination"
 	"github.com/cloudquery/plugin-sdk/schema"
-)
-
-const (
-	readSQL = `SELECT * FROM "%s" WHERE _cq_source_name = $1 order by _cq_sync_time asc`
 )
 
 func (*Client) createResultsArray(table *schema.Table) []any {
@@ -72,8 +70,50 @@ func (*Client) createResultsArray(table *schema.Table) []any {
 	return results
 }
 
-func (c *Client) Read(ctx context.Context, table *schema.Table, sourceName string, res chan<- []any) error {
-	rows, err := c.db.Query(fmt.Sprintf(readSQL, table.Name), sourceName)
+func (c *Client) Read(ctx context.Context, table *schema.Table, sourceName string, res chan<- []any, opts destination.ReadOptions) error {
+	readSQL := []string{"SELECT"}
+
+	// add columns
+	if len(opts.Columns) == 0 {
+		readSQL = append(readSQL, "*")
+	} else {
+		for i, col := range opts.Columns {
+			if i > 0 {
+				readSQL = append(readSQL, ",")
+			}
+			readSQL = append(readSQL, col)
+		}
+	}
+
+	// add table name
+	readSQL = append(readSQL, fmt.Sprintf("FROM %s", sanitizeName(table.Name)))
+
+	// add source name
+	readSQL = append(readSQL, fmt.Sprintf("WHERE %s = $1", sanitizeName(schema.CqSourceNameColumn.Name)))
+
+	// add order by
+	if len(opts.OrderBy) == 0 {
+		readSQL = append(readSQL, "ORDER BY _cq_sync_time ASC")
+	} else {
+		readSQL = append(readSQL, "ORDER BY")
+		for i, col := range opts.OrderBy {
+			if i > 0 {
+				readSQL = append(readSQL, ",")
+			}
+			order := "ASC"
+			if col.Desc {
+				order = "DESC"
+			}
+			readSQL = append(readSQL, fmt.Sprintf("%s %s", sanitizeName(col.Name), order))
+		}
+	}
+
+	// add limit
+	if opts.Limit > 0 {
+		readSQL = append(readSQL, fmt.Sprintf("LIMIT %d", opts.Limit))
+	}
+
+	rows, err := c.db.Query(strings.Join(readSQL, " "), sourceName)
 	if err != nil {
 		return err
 	}
@@ -86,4 +126,10 @@ func (c *Client) Read(ctx context.Context, table *schema.Table, sourceName strin
 	}
 	rows.Close()
 	return nil
+}
+
+func sanitizeName(s string) string {
+	s = strings.ReplaceAll(s, string([]byte{0}), "")
+	s = `"` + strings.ReplaceAll(s, `"`, `""`) + `"`
+	return s
 }

--- a/plugins/destination/sqlite/go.mod
+++ b/plugins/destination/sqlite/go.mod
@@ -31,3 +31,5 @@ require (
 	google.golang.org/protobuf v1.28.1 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect
 )
+
+replace github.com/cloudquery/plugin-sdk v1.13.1 => ../../../../plugin-sdk


### PR DESCRIPTION
Draft to show what usage of the new Read API in https://github.com/cloudquery/plugin-sdk/pull/542 will look like in practice.

It's easy to implement for databases, but not so trivial for files. However, this shows that it can be done for files without loading the entire file into memory (as long as there is a limit on the number of results returned). Most of the code is around implementing a priority queue to limit memory usage while sorting results for CSV.