### PR TITLE
test(azblob): Ensure container exists before tests

### DIFF
--- a/plugins/destination/azblob/client/client_test.go
+++ b/plugins/destination/azblob/client/client_test.go
@@ -1,20 +1,64 @@
 package client
 
 import (
+	"context"
 	"testing"
 
+	"github.com/Azure/azure-sdk-for-go/sdk/azidentity"
+	"github.com/Azure/azure-sdk-for-go/sdk/storage/azblob"
 	"github.com/cloudquery/plugin-sdk/plugins/destination"
+	"github.com/google/uuid"
 )
 
-const storage_account = "cqdestinationazblob"
-const container = "test"
+const storageAccount = "cqdestinationazblob"
+
+func getClient(t *testing.T) *azblob.Client {
+	t.Helper()
+
+	cred, err := azidentity.NewDefaultAzureCredential(nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	storageClient, err := azblob.NewClient("https://"+storageAccount+".blob.core.windows.net", cred, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	return storageClient
+}
+
+func createContainer(t *testing.T, container string) {
+	t.Helper()
+
+	storageClient := getClient(t)
+
+	_, err := storageClient.CreateContainer(context.Background(), container, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
+func deleteContainer(t *testing.T, container string) {
+	t.Helper()
+
+	storageClient := getClient(t)
+
+	_, err := storageClient.DeleteContainer(context.Background(), container, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+}
 
 func TestPluginCSV(t *testing.T) {
+	container := "test-csv-" + uuid.New().String()
+	createContainer(t, container)
+	defer deleteContainer(t, container)
 	p := destination.NewPlugin("azblob", "development", New, destination.WithManagedWriter())
 
 	destination.PluginTestSuiteRunner(t, p,
 		Spec{
-			StorageAccount: storage_account,
+			StorageAccount: storageAccount,
 			Container:      container,
 			Path:           t.TempDir(),
 			Format:         FormatTypeCSV,
@@ -29,11 +73,14 @@ func TestPluginCSV(t *testing.T) {
 }
 
 func TestPluginJSON(t *testing.T) {
+	container := "test-json-" + uuid.New().String()
+	createContainer(t, container)
+	defer deleteContainer(t, container)
 	p := destination.NewPlugin("azblob", "development", New, destination.WithManagedWriter())
 
 	destination.PluginTestSuiteRunner(t, p,
 		Spec{
-			StorageAccount: storage_account,
+			StorageAccount: storageAccount,
 			Container:      container,
 			Path:           t.TempDir(),
 			Format:         FormatTypeJSON,


### PR DESCRIPTION
<!-- 🎉 Thank you for making CloudQuery awesome by submitting a PR 🎉 -->

#### Summary

Azure playground account resources get nuked, so we can't rely on them existing. [I re-created the storage account](https://portal.azure.com/#@ypcloudquery.onmicrosoft.com/resource/subscriptions/21e0d134-5da8-4754-8587-c58425d93de5/resourceGroups/cloudquery-ci/providers/Microsoft.Storage/storageAccounts/cqdestinationazblob/overview) and excluded it via https://github.com/cloudquery/deployments/pull/48/files (internal link).

This is still missing the required permissions for the storage account, as I'm not sure which user I should set them on

<!--
Use the following steps to ensure your PR is ready to be reviewed

- [ ] Read the [contribution guidelines](../blob/main/CONTRIBUTING.md) 🧑‍🎓
- [ ] Test locally on your own infrastructure
- [ ] Run `go fmt` to format your code 🖊
- [ ] Lint your changes via `golangci-lint run` 🚨 (install golangci-lint [here](https://golangci-lint.run/usage/install/#local-installation))
- [ ] Update or add tests 🧪
- [ ] Ensure the status checks below are successful ✅
--->
