### PR TITLE
fix: Return error if read is called when `no_rotate` is false

### DIFF
--- a/plugins/destination/azblob/client/read.go
+++ b/plugins/destination/azblob/client/read.go
@@ -7,7 +7,6 @@ import (
 	"github.com/cloudquery/filetypes/csv"
 	"github.com/cloudquery/filetypes/json"
 	"github.com/cloudquery/plugin-sdk/schema"
-	"github.com/google/uuid"
 )
 
 func (c *Client) ReverseTransformValues(table *schema.Table, values []any) (schema.CQTypes, error) {
@@ -22,10 +21,11 @@ func (c *Client) ReverseTransformValues(table *schema.Table, values []any) (sche
 }
 
 func (c *Client) Read(ctx context.Context, table *schema.Table, sourceName string, res chan<- []any) error {
-	name := fmt.Sprintf("%s/%s.%s.%s", c.pluginSpec.Path, table.Name, c.pluginSpec.Format, uuid.NewString())
-	if c.pluginSpec.NoRotate {
-		name = fmt.Sprintf("%s/%s.%s", c.pluginSpec.Path, table.Name, c.pluginSpec.Format)
+	if !c.pluginSpec.NoRotate {
+		return fmt.Errorf("reading is not supported when no_rotate is false. Table: %q; Source: %q", table.Name, sourceName)
 	}
+	name := fmt.Sprintf("%s/%s.%s", c.pluginSpec.Path, table.Name, c.pluginSpec.Format)
+
 	response, err := c.storageClient.DownloadStream(ctx, c.pluginSpec.Container, name, nil)
 	if err != nil {
 		return err

--- a/plugins/destination/file/client/read.go
+++ b/plugins/destination/file/client/read.go
@@ -8,7 +8,6 @@ import (
 	"github.com/cloudquery/filetypes/csv"
 	"github.com/cloudquery/filetypes/json"
 	"github.com/cloudquery/plugin-sdk/schema"
-	"github.com/google/uuid"
 )
 
 func (c *Client) ReverseTransformValues(table *schema.Table, values []any) (schema.CQTypes, error) {
@@ -23,10 +22,10 @@ func (c *Client) ReverseTransformValues(table *schema.Table, values []any) (sche
 }
 
 func (c *Client) Read(ctx context.Context, table *schema.Table, sourceName string, res chan<- []any) error {
-	name := fmt.Sprintf("%s/%s.%s.%s", c.pluginSpec.Directory, table.Name, c.pluginSpec.Format, uuid.NewString())
-	if c.pluginSpec.NoRotate {
-		name = fmt.Sprintf("%s/%s.%s", c.pluginSpec.Directory, table.Name, c.pluginSpec.Format)
+	if !c.pluginSpec.NoRotate {
+		return fmt.Errorf("reading is not supported when no_rotate is false. Table: %q; Source: %q", table.Name, sourceName)
 	}
+	name := fmt.Sprintf("%s/%s.%s", c.pluginSpec.Path, table.Name, c.pluginSpec.Format)
 	f, err := os.Open(name)
 	if err != nil {
 		return err

--- a/plugins/destination/gcs/client/read.go
+++ b/plugins/destination/gcs/client/read.go
@@ -7,7 +7,6 @@ import (
 	"github.com/cloudquery/filetypes/csv"
 	"github.com/cloudquery/filetypes/json"
 	"github.com/cloudquery/plugin-sdk/schema"
-	"github.com/google/uuid"
 )
 
 func (c *Client) ReverseTransformValues(table *schema.Table, values []any) (schema.CQTypes, error) {
@@ -22,10 +21,10 @@ func (c *Client) ReverseTransformValues(table *schema.Table, values []any) (sche
 }
 
 func (c *Client) Read(ctx context.Context, table *schema.Table, sourceName string, res chan<- []any) error {
-	name := fmt.Sprintf("%s/%s.%s.%s", c.pluginSpec.Path, table.Name, c.pluginSpec.Format, uuid.NewString())
-	if c.pluginSpec.NoRotate {
-		name = fmt.Sprintf("%s/%s.%s", c.pluginSpec.Path, table.Name, c.pluginSpec.Format)
+	if !c.pluginSpec.NoRotate {
+		return fmt.Errorf("reading is not supported when no_rotate is false. Table: %q; Source: %q", table.Name, sourceName)
 	}
+	name := fmt.Sprintf("%s/%s.%s", c.pluginSpec.Path, table.Name, c.pluginSpec.Format)
 	r, err := c.bucket.Object(name).NewReader(ctx)
 	if err != nil {
 		return err

--- a/plugins/destination/s3/client/read.go
+++ b/plugins/destination/s3/client/read.go
@@ -11,7 +11,6 @@ import (
 	"github.com/cloudquery/filetypes/csv"
 	"github.com/cloudquery/filetypes/json"
 	"github.com/cloudquery/plugin-sdk/schema"
-	"github.com/google/uuid"
 )
 
 const maxFileSize = 1024 * 1024 * 20
@@ -28,10 +27,10 @@ func (c *Client) ReverseTransformValues(table *schema.Table, values []any) (sche
 }
 
 func (c *Client) Read(ctx context.Context, table *schema.Table, sourceName string, res chan<- []any) error {
-	name := fmt.Sprintf("%s/%s.%s.%s", c.pluginSpec.Path, table.Name, c.pluginSpec.Format, uuid.NewString())
-	if c.pluginSpec.NoRotate {
-		name = fmt.Sprintf("%s/%s.%s", c.pluginSpec.Path, table.Name, c.pluginSpec.Format)
+	if !c.pluginSpec.NoRotate {
+		return fmt.Errorf("reading is not supported when no_rotate is false. Table: %q; Source: %q", table.Name, sourceName)
 	}
+	name := fmt.Sprintf("%s/%s.%s", c.pluginSpec.Path, table.Name, c.pluginSpec.Format)
 	writerAtBuffer := manager.NewWriteAtBuffer(make([]byte, 0, maxFileSize))
 	_, err := c.downloader.Download(ctx,
 		writerAtBuffer,


### PR DESCRIPTION
<!-- 🎉 Thank you for making CloudQuery awesome by submitting a PR 🎉 -->

#### Summary

We should return an error when trying to read if `no_rotate` is `false` as we can't read a randomly generated name

<!--
Use the following steps to ensure your PR is ready to be reviewed

- [ ] Read the [contribution guidelines](../blob/main/CONTRIBUTING.md) 🧑‍🎓
- [ ] Test locally on your own infrastructure
- [ ] Run `go fmt` to format your code 🖊
- [ ] Lint your changes via `golangci-lint run` 🚨 (install golangci-lint [here](https://golangci-lint.run/usage/install/#local-installation))
- [ ] Update or add tests 🧪
- [ ] Ensure the status checks below are successful ✅
--->
