### PR TITLE
chore(ci-lint): Only enable lint caching

### DIFF
--- a/.github/workflows/cli.yml
+++ b/.github/workflows/cli.yml
@@ -59,6 +59,8 @@ jobs:
         with:
           version: v1.50.1
           working-directory: cli
+          skip-pkg-cache: true
+          skip-build-cache: true
       - name: Get dependencies
         run: go get -t -d ./...
       - name: Build

--- a/.github/workflows/dest_azblob.yml
+++ b/.github/workflows/dest_azblob.yml
@@ -36,6 +36,8 @@ jobs:
           version: v1.50.1
           working-directory: plugins/destination/azblob
           args: "--config ../../.golangci.yml"
+          skip-pkg-cache: true
+          skip-build-cache: true
       - name: Get dependencies
         run: go get -t -d ./...
       - name: Build

--- a/.github/workflows/dest_bigquery.yml
+++ b/.github/workflows/dest_bigquery.yml
@@ -47,6 +47,8 @@ jobs:
           version: v1.50.1
           working-directory: plugins/destination/bigquery
           args: "--config ../../.golangci.yml"
+          skip-pkg-cache: true
+          skip-build-cache: true
       - name: Get dependencies
         run: go get -t -d ./...
       - name: Build

--- a/.github/workflows/dest_csv.yml
+++ b/.github/workflows/dest_csv.yml
@@ -36,6 +36,8 @@ jobs:
           version: v1.50.1
           working-directory: plugins/destination/csv
           args: "--config ../../.golangci.yml"
+          skip-pkg-cache: true
+          skip-build-cache: true
       - name: Get dependencies
         run: go get -t -d ./...
       - name: Build

--- a/.github/workflows/dest_file.yml
+++ b/.github/workflows/dest_file.yml
@@ -38,6 +38,8 @@ jobs:
           version: v1.50.1
           working-directory: plugins/destination/file
           args: "--config ../../.golangci.yml"
+          skip-pkg-cache: true
+          skip-build-cache: true
       - name: Get dependencies
         run: go get -t -d ./...
       - name: Build

--- a/.github/workflows/dest_gcs.yml
+++ b/.github/workflows/dest_gcs.yml
@@ -44,6 +44,8 @@ jobs:
           version: v1.50.1
           working-directory: plugins/destination/gcs
           args: "--config ../../.golangci.yml"
+          skip-pkg-cache: true
+          skip-build-cache: true
       - name: Get dependencies
         run: go get -t -d ./...
       - name: Build

--- a/.github/workflows/dest_kafka.yml
+++ b/.github/workflows/dest_kafka.yml
@@ -36,6 +36,8 @@ jobs:
           version: v1.50.1
           working-directory: plugins/destination/kafka
           args: "--config ../../.golangci.yml"
+          skip-pkg-cache: true
+          skip-build-cache: true
       - name: Get dependencies
         run: go get -t -d ./...
       - name: Build

--- a/.github/workflows/dest_mongodb.yml
+++ b/.github/workflows/dest_mongodb.yml
@@ -36,6 +36,8 @@ jobs:
           version: v1.50.1
           working-directory: plugins/destination/mongodb
           args: "--config ../../.golangci.yml"
+          skip-pkg-cache: true
+          skip-build-cache: true
       - name: Get dependencies
         run: go get -t -d ./...
       - name: Build

--- a/.github/workflows/dest_neo4j.yml
+++ b/.github/workflows/dest_neo4j.yml
@@ -56,6 +56,8 @@ jobs:
           version: v1.50.1
           working-directory: plugins/destination/neo4j
           args: "--config ../../.golangci.yml"
+          skip-pkg-cache: true
+          skip-build-cache: true
       - name: Get dependencies
         run: go get -t -d ./...
       - name: Build

--- a/.github/workflows/dest_postgresql.yml
+++ b/.github/workflows/dest_postgresql.yml
@@ -52,6 +52,8 @@ jobs:
           version: v1.50.1
           working-directory: plugins/destination/postgresql
           args: "--config ../../.golangci.yml"
+          skip-pkg-cache: true
+          skip-build-cache: true
       - name: Get dependencies
         run: go get -t -d ./...
       - name: Build

--- a/.github/workflows/dest_s3.yml
+++ b/.github/workflows/dest_s3.yml
@@ -46,6 +46,8 @@ jobs:
           version: v1.50.1
           working-directory: plugins/destination/s3
           args: "--config ../../.golangci.yml"
+          skip-pkg-cache: true
+          skip-build-cache: true
       - name: Get dependencies
         run: go get -t -d ./...
       - name: Build

--- a/.github/workflows/dest_snowflake.yml
+++ b/.github/workflows/dest_snowflake.yml
@@ -36,6 +36,8 @@ jobs:
           version: v1.50.1
           working-directory: plugins/destination/snowflake
           args: "--config ../../.golangci.yml"
+          skip-pkg-cache: true
+          skip-build-cache: true
       - name: Get dependencies
         run: go get -t -d ./...
       - name: Build

--- a/.github/workflows/dest_sqlite.yml
+++ b/.github/workflows/dest_sqlite.yml
@@ -36,6 +36,8 @@ jobs:
           version: v1.50.1
           working-directory: plugins/destination/sqlite
           args: "--config ../../.golangci.yml"
+          skip-pkg-cache: true
+          skip-build-cache: true
       - name: Get dependencies
         run: go get -t -d ./...
       - name: Build

--- a/.github/workflows/dest_test.yml
+++ b/.github/workflows/dest_test.yml
@@ -36,6 +36,8 @@ jobs:
           version: v1.50.1
           working-directory: plugins/destination/test
           args: "--config ../../.golangci.yml"
+          skip-pkg-cache: true
+          skip-build-cache: true
       - name: Get dependencies
         run: go get -t -d ./...
       - name: Build

--- a/.github/workflows/source_aws.yml
+++ b/.github/workflows/source_aws.yml
@@ -59,6 +59,8 @@ jobs:
           version: v1.50.1
           working-directory: plugins/source/aws
           args: "--config ../../.golangci.yml"
+          skip-pkg-cache: true
+          skip-build-cache: true
       - name: Get dependencies
         run: go get -t -d ./...
       - name: Build

--- a/.github/workflows/source_azure.yml
+++ b/.github/workflows/source_azure.yml
@@ -56,6 +56,8 @@ jobs:
           version: v1.50.1
           working-directory: plugins/source/azure
           args: "--config ../../.golangci.yml"
+          skip-pkg-cache: true
+          skip-build-cache: true
       - name: Get dependencies
         run: go get -t -d ./...
       - name: Build

--- a/.github/workflows/source_azuredevops.yml
+++ b/.github/workflows/source_azuredevops.yml
@@ -36,6 +36,8 @@ jobs:
           version: v1.50.1
           working-directory: plugins/source/azuredevops
           args: "--config ../../.golangci.yml"
+          skip-pkg-cache: true
+          skip-build-cache: true
       - name: Get dependencies
         run: go get -t -d ./...
       - name: Build

--- a/.github/workflows/source_cloudflare.yml
+++ b/.github/workflows/source_cloudflare.yml
@@ -36,6 +36,8 @@ jobs:
           version: v1.50.1
           working-directory: plugins/source/cloudflare
           args: "--config ../../.golangci.yml"
+          skip-pkg-cache: true
+          skip-build-cache: true
       - name: Get dependencies
         run: go get -t -d ./...
       - name: Build

--- a/.github/workflows/source_crowdstrike.yml
+++ b/.github/workflows/source_crowdstrike.yml
@@ -36,6 +36,8 @@ jobs:
           version: v1.50.1
           working-directory: plugins/source/crowdstrike
           args: "--config ../../.golangci.yml"
+          skip-pkg-cache: true
+          skip-build-cache: true
       - name: Get dependencies
         run: go get -t -d ./...
       - name: Build

--- a/.github/workflows/source_datadog.yml
+++ b/.github/workflows/source_datadog.yml
@@ -36,6 +36,8 @@ jobs:
           version: v1.50.1
           working-directory: plugins/source/datadog
           args: "--config ../../.golangci.yml"
+          skip-pkg-cache: true
+          skip-build-cache: true
       - name: Get dependencies
         run: go get -t -d ./...
       - name: Build

--- a/.github/workflows/source_digitalocean.yml
+++ b/.github/workflows/source_digitalocean.yml
@@ -36,6 +36,8 @@ jobs:
           version: v1.50.1
           working-directory: plugins/source/digitalocean
           args: "--config ../../.golangci.yml"
+          skip-pkg-cache: true
+          skip-build-cache: true
       - name: Get dependencies
         run: go get -t -d ./...
       - name: Build

--- a/.github/workflows/source_fastly.yml
+++ b/.github/workflows/source_fastly.yml
@@ -36,6 +36,8 @@ jobs:
           version: v1.50.1
           working-directory: plugins/source/fastly
           args: "--config ../../.golangci.yml"
+          skip-pkg-cache: true
+          skip-build-cache: true
       - name: Get dependencies
         run: go get -t -d ./...
       - name: Build

--- a/.github/workflows/source_gandi.yml
+++ b/.github/workflows/source_gandi.yml
@@ -36,6 +36,8 @@ jobs:
           version: v1.50.1
           working-directory: plugins/source/gandi
           args: "--config ../../.golangci.yml"
+          skip-pkg-cache: true
+          skip-build-cache: true
       - name: Get dependencies
         run: go get -t -d ./...
       - name: Build

--- a/.github/workflows/source_gcp.yml
+++ b/.github/workflows/source_gcp.yml
@@ -56,6 +56,8 @@ jobs:
           version: v1.50.1
           working-directory: plugins/source/gcp
           args: "--config ../../.golangci.yml"
+          skip-pkg-cache: true
+          skip-build-cache: true
       - name: Get dependencies
         run: go get -t -d ./...
       - name: Build

--- a/.github/workflows/source_github.yml
+++ b/.github/workflows/source_github.yml
@@ -36,6 +36,8 @@ jobs:
           version: v1.50.1
           working-directory: plugins/source/github
           args: "--config ../../.golangci.yml"
+          skip-pkg-cache: true
+          skip-build-cache: true
       - name: Get dependencies
         run: go get -t -d ./...
       - name: Build

--- a/.github/workflows/source_gitlab.yml
+++ b/.github/workflows/source_gitlab.yml
@@ -36,6 +36,8 @@ jobs:
           version: v1.50.1
           working-directory: plugins/source/gitlab
           args: "--config ../../.golangci.yml"
+          skip-pkg-cache: true
+          skip-build-cache: true
       - name: Get dependencies
         run: go get -t -d ./...
       - name: Build

--- a/.github/workflows/source_heroku.yml
+++ b/.github/workflows/source_heroku.yml
@@ -36,6 +36,8 @@ jobs:
           version: v1.50.1
           working-directory: plugins/source/heroku
           args: "--config ../../.golangci.yml"
+          skip-pkg-cache: true
+          skip-build-cache: true
       - name: Get dependencies
         run: go get -t -d ./...
       - name: Build

--- a/.github/workflows/source_k8s.yml
+++ b/.github/workflows/source_k8s.yml
@@ -56,6 +56,8 @@ jobs:
           version: v1.50.1
           working-directory: plugins/source/k8s
           args: "--config ../../.golangci.yml"
+          skip-pkg-cache: true
+          skip-build-cache: true
       - name: Get dependencies
         run: go get -t -d ./...
       - name: Build

--- a/.github/workflows/source_okta.yml
+++ b/.github/workflows/source_okta.yml
@@ -36,6 +36,8 @@ jobs:
           version: v1.50.1
           working-directory: plugins/source/k8s
           args: "--config ../../.golangci.yml"
+          skip-pkg-cache: true
+          skip-build-cache: true
       - name: Get dependencies
         run: go get -t -d ./...
       - name: Build

--- a/.github/workflows/source_pagerduty.yml
+++ b/.github/workflows/source_pagerduty.yml
@@ -36,6 +36,8 @@ jobs:
           version: v1.50.1
           working-directory: plugins/source/pagerduty
           args: "--config ../../.golangci.yml"
+          skip-pkg-cache: true
+          skip-build-cache: true
       - name: Get dependencies
         run: go get -t -d ./...
       - name: Build

--- a/.github/workflows/source_salesforce.yml
+++ b/.github/workflows/source_salesforce.yml
@@ -36,6 +36,8 @@ jobs:
           version: v1.50.1
           working-directory: plugins/source/salesforce
           args: "--config ../../.golangci.yml"
+          skip-pkg-cache: true
+          skip-build-cache: true
       - name: Get dependencies
         run: go get -t -d ./...
       - name: Build

--- a/.github/workflows/source_shopify.yml
+++ b/.github/workflows/source_shopify.yml
@@ -36,6 +36,8 @@ jobs:
           version: v1.50.1
           working-directory: plugins/source/shopify
           args: "--config ../../.golangci.yml"
+          skip-pkg-cache: true
+          skip-build-cache: true
       - name: Get dependencies
         run: go get -t -d ./...
       - name: Build

--- a/.github/workflows/source_slack.yml
+++ b/.github/workflows/source_slack.yml
@@ -36,6 +36,8 @@ jobs:
           version: v1.50.1
           working-directory: plugins/source/slack
           args: "--config ../../.golangci.yml"
+          skip-pkg-cache: true
+          skip-build-cache: true
       - name: Get dependencies
         run: go get -t -d ./...
       - name: Build

--- a/.github/workflows/source_tailscale.yml
+++ b/.github/workflows/source_tailscale.yml
@@ -36,6 +36,8 @@ jobs:
           version: v1.50.1
           working-directory: plugins/source/tailscale
           args: "--config ../../.golangci.yml"
+          skip-pkg-cache: true
+          skip-build-cache: true
       - name: Get dependencies
         run: go get -t -d ./...
       - name: Build

--- a/.github/workflows/source_terraform.yml
+++ b/.github/workflows/source_terraform.yml
@@ -36,6 +36,8 @@ jobs:
           version: v1.50.1
           working-directory: plugins/source/terraform
           args: "--config ../../.golangci.yml"
+          skip-pkg-cache: true
+          skip-build-cache: true
       - name: Get dependencies
         run: go get -t -d ./...
       - name: Build

--- a/.github/workflows/source_test.yml
+++ b/.github/workflows/source_test.yml
@@ -36,6 +36,8 @@ jobs:
           version: v1.50.1
           working-directory: plugins/source/test
           args: "--config ../../.golangci.yml"
+          skip-pkg-cache: true
+          skip-build-cache: true
       - name: Get dependencies
         run: go get -t -d ./...
       - name: Build

--- a/.github/workflows/source_vercel.yml
+++ b/.github/workflows/source_vercel.yml
@@ -36,6 +36,8 @@ jobs:
           version: v1.50.1
           working-directory: plugins/source/vercel
           args: "--config ../../.golangci.yml"
+          skip-pkg-cache: true
+          skip-build-cache: true
       - name: Get dependencies
         run: go get -t -d ./...
       - name: Build


### PR DESCRIPTION
<!-- 🎉 Thank you for making CloudQuery awesome by submitting a PR 🎉 -->

#### Summary

Our linter caches are huge and also exceed the limits so impact other workflows based on caching:
![image](https://user-images.githubusercontent.com/26760571/210755335-bc29778f-43ed-458b-9238-24c29605606d.png)

On AWS it takes ~60 seconds to just download the cache:
![image](https://user-images.githubusercontent.com/26760571/210755674-76082732-5bde-4e52-80de-ca699e8282d1.png)

This PR tries to improve the situation by only keeping the lint cache, and disabling the build+dependencies cache.
If this doesn't work, I'll revert to the original action and disable caching altogether

<!--
Use the following steps to ensure your PR is ready to be reviewed

- [ ] Read the [contribution guidelines](../blob/main/CONTRIBUTING.md) 🧑‍🎓
- [ ] Test locally on your own infrastructure
- [ ] Run `go fmt` to format your code 🖊
- [ ] Lint your changes via `golangci-lint run` 🚨 (install golangci-lint [here](https://golangci-lint.run/usage/install/#local-installation))
- [ ] Update or add tests 🧪
- [ ] Ensure the status checks below are successful ✅
--->
