### PR TITLE
fix(bigquery): Migrations: ignore extra columns in the table

### DIFF
--- a/plugins/destination/bigquery/client/migrate.go
+++ b/plugins/destination/bigquery/client/migrate.go
@@ -147,10 +147,8 @@ func schemasMatch(haveSchema, wantSchema bigquery.Schema) bool {
 	for _, wf := range wantSchema {
 		if hf, ok := haveMap[wf.Name]; !ok {
 			return false
-		} else {
-			if hf.Type != wf.Type {
-				return false
-			}
+		} else if hf.Type != wf.Type {
+			return false
 		}
 	}
 	return true

--- a/plugins/destination/bigquery/client/migrate.go
+++ b/plugins/destination/bigquery/client/migrate.go
@@ -96,21 +96,14 @@ func (c *Client) waitForTableToExist(ctx context.Context, client *bigquery.Clien
 func (c *Client) waitForSchemaToMatch(ctx context.Context, client *bigquery.Client, table *schema.Table) error {
 	c.logger.Debug().Str("table", table.Name).Msg("Waiting for schemas to match")
 	wantSchema := c.bigQuerySchemaForTable(table)
-	want, err := wantSchema.ToJSONFields()
-	if err != nil {
-		return fmt.Errorf("failed to convert schema to JSON: %v", err)
-	}
 	for i := 0; i < maxTableChecks; i++ {
 		md, err := client.Dataset(c.pluginSpec.DatasetID).Table(table.Name).Metadata(ctx)
 		if err != nil {
 			return err
 		}
-		got, err := md.Schema.ToJSONFields()
-		if err != nil {
-			return fmt.Errorf("failed to convert schema to JSON: %v", err)
-		}
-		if string(got) == string(want) {
-			c.logger.Debug().Str("table", table.Name).Msg("Schemas matched")
+		haveSchema := md.Schema
+		if schemasMatch(haveSchema, wantSchema) {
+			c.logger.Debug().Str("table", table.Name).Msg("Schemas match")
 			return nil
 		}
 		c.logger.Debug().Str("table", table.Name).Int("i", i).Msg("Waiting for schemas to match")
@@ -120,14 +113,80 @@ func (c *Client) waitForSchemaToMatch(ctx context.Context, client *bigquery.Clie
 }
 
 func (c *Client) autoMigrateTable(ctx context.Context, client *bigquery.Client, table *schema.Table) error {
-	bqSchema := c.bigQuerySchemaForTable(table)
+	bqTable := client.Dataset(c.pluginSpec.DatasetID).Table(table.Name)
+	md, err := bqTable.Metadata(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to get table metadata: %w", err)
+	}
+	haveSchema := md.Schema
+	wantSchema := c.bigQuerySchemaForTable(table)
+	wantSchema, err = mergeSchemas(haveSchema, wantSchema)
+	if err != nil {
+		return fmt.Errorf("failed to migrate table schema: %w", err)
+	}
 	tm := bigquery.TableMetadataToUpdate{
 		Name:        table.Name,
 		Description: table.Description,
-		Schema:      bqSchema,
+		Schema:      wantSchema,
 	}
-	_, err := client.Dataset(c.pluginSpec.DatasetID).Table(table.Name).Update(ctx, tm, "")
-	return err
+	_, err = bqTable.Update(ctx, tm, "")
+	if err != nil {
+		return fmt.Errorf("failed to update table schema: %w", err)
+	}
+	return nil
+}
+
+func schemasMatch(haveSchema, wantSchema bigquery.Schema) bool {
+	// Schemas are considered a match if everything in the want schema is in the have schema,
+	// and they have the same types.
+	// We don't mind if there are extra fields in the have schema.
+	haveMap := make(map[string]*bigquery.FieldSchema)
+	for _, f := range haveSchema {
+		haveMap[f.Name] = f
+	}
+	for _, wf := range wantSchema {
+		if hf, ok := haveMap[wf.Name]; !ok {
+			return false
+		} else {
+			if hf.Type != wf.Type {
+				return false
+			}
+		}
+	}
+	return true
+}
+
+// mergeSchemas merges the schema we want with the schema we have, to avoid
+// losing any existing data
+func mergeSchemas(haveSchema, wantSchema bigquery.Schema) (bigquery.Schema, error) {
+	haveMap := make(map[string]*bigquery.FieldSchema)
+	for _, f := range haveSchema {
+		haveMap[f.Name] = f
+	}
+	wantMap := make(map[string]*bigquery.FieldSchema)
+	for _, f := range wantSchema {
+		wantMap[f.Name] = f
+	}
+	merged := make(bigquery.Schema, 0, len(wantSchema))
+	// keep everything in the schema we have, as long as the types didn't change
+	// or an unknown column isn't required
+	for _, f := range haveSchema {
+		if want, ok := wantMap[f.Name]; ok {
+			if want.Type != f.Type {
+				return nil, fmt.Errorf("field %v changed type from %v to %v", f.Name, f.Type, want.Type)
+			}
+		} else if f.Required {
+			return nil, fmt.Errorf("field %v is required but not in new schema", f.Name)
+		}
+		merged = append(merged, f)
+	}
+	// add anything new
+	for _, f := range wantSchema {
+		if _, ok := haveMap[f.Name]; !ok {
+			merged = append(merged, f)
+		}
+	}
+	return merged, nil
 }
 
 func (c *Client) createTable(ctx context.Context, client *bigquery.Client, table *schema.Table) error {

--- a/plugins/destination/bigquery/client/read.go
+++ b/plugins/destination/bigquery/client/read.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
+	"strings"
 	"time"
 
 	"cloud.google.com/go/bigquery"
@@ -12,7 +13,7 @@ import (
 )
 
 const (
-	readSQL = "SELECT * FROM `%s.%s.%s` WHERE `_cq_source_name` = @cq_source_name order by _cq_sync_time asc"
+	readSQL = "SELECT %s FROM `%s.%s.%s` WHERE `_cq_source_name` = @cq_source_name order by _cq_sync_time asc"
 )
 
 func (*Client) createResultsArray(table *schema.Table) []bigquery.Value {
@@ -78,7 +79,12 @@ func (*Client) createResultsArray(table *schema.Table) []bigquery.Value {
 }
 
 func (c *Client) Read(ctx context.Context, table *schema.Table, sourceName string, res chan<- []any) error {
-	stmt := fmt.Sprintf(readSQL, c.pluginSpec.ProjectID, c.pluginSpec.DatasetID, table.Name)
+	colNames := make([]string, 0, len(table.Columns))
+	for _, col := range table.Columns {
+		colNames = append(colNames, col.Name)
+	}
+	cols := "`" + strings.Join(colNames, "`, `") + "`"
+	stmt := fmt.Sprintf(readSQL, cols, c.pluginSpec.ProjectID, c.pluginSpec.DatasetID, table.Name)
 	q := c.client.Query(stmt)
 	q.Parameters = []bigquery.QueryParameter{
 		{


### PR DESCRIPTION
BigQuery migrations should not fail if there are extra columns present in the table. As long as the columns are not required, it should ignore those columns and add any extra ones required by CloudQuery table schemas. This allows users to add additional columns of their own, and it means that you can upgrade to a new minor version of a source plugin and roll back later without issues.

This is tested in the new tests added in https://github.com/cloudquery/plugin-sdk/pull/574

- Fixes https://github.com/cloudquery/cloudquery/issues/6364
