### PR TITLE
fix(tests): Postgresql: Read only columns defined in the schema

### DIFF
--- a/plugins/destination/postgresql/client/read.go
+++ b/plugins/destination/postgresql/client/read.go
@@ -3,17 +3,23 @@ package client
 import (
 	"context"
 	"fmt"
+	"strings"
 
 	"github.com/cloudquery/plugin-sdk/schema"
 	"github.com/jackc/pgx/v5"
 )
 
 const (
-	readSQL = "SELECT * FROM %s WHERE _cq_source_name = $1 order by _cq_sync_time asc"
+	readSQL = "SELECT %s FROM %s WHERE _cq_source_name = $1 order by _cq_sync_time asc"
 )
 
 func (c *Client) Read(ctx context.Context, table *schema.Table, sourceName string, res chan<- []any) error {
-	sql := fmt.Sprintf(readSQL, pgx.Identifier{table.Name}.Sanitize())
+	colNames := make([]string, 0, len(table.Columns))
+	for _, col := range table.Columns {
+		colNames = append(colNames, pgx.Identifier{col.Name}.Sanitize())
+	}
+	cols := strings.Join(colNames, ",")
+	sql := fmt.Sprintf(readSQL, cols, pgx.Identifier{table.Name}.Sanitize())
 	rows, err := c.conn.Query(ctx, sql, sourceName)
 	if err != nil {
 		return err


### PR DESCRIPTION
The PostgreSQL read test should only read and return the columns defined in our schema. This will allow https://github.com/cloudquery/plugin-sdk/pull/574/files to pass.