### PR TITLE
fix: Fix SQLite migration logic

### DIFF
--- a/plugins/destination/sqlite/client/migrate.go
+++ b/plugins/destination/sqlite/client/migrate.go
@@ -10,7 +10,7 @@ import (
 )
 
 const (
-	isTableExistSQL = "SELECT count(name) FROM sqlite_master WHERE type='table' AND name='?';"
+	isTableExistSQL = "SELECT count(name) FROM sqlite_master WHERE type='table' AND name=?;"
 
 	// https://wiki.postgresql.org/wiki/Retrieve_primary_key_columns
 	sqlTableInfo = "PRAGMA table_info('%s');"


### PR DESCRIPTION
There was a bug in the query that checks whether a table exists - it always found the table to not exist because `?` was being quoted. We also now select only the columns defined in the table schema, rather than all columns.

This will allow https://github.com/cloudquery/plugin-sdk/pull/574/files to pass.