### PR TITLE
fix(tests): Fix Snowflake read test

### DIFF
--- a/plugins/destination/snowflake/client/read.go
+++ b/plugins/destination/snowflake/client/read.go
@@ -10,7 +10,7 @@ import (
 )
 
 const (
-	readSQL = "SELECT * FROM %s WHERE \"_cq_source_name\" = ?"
+	readSQL = "SELECT %s FROM %s WHERE \"_cq_source_name\" = ?"
 )
 
 // https://github.com/snowflakedb/gosnowflake/issues/674
@@ -98,7 +98,12 @@ func (*Client) createResultsArray(values []any, table *schema.Table) []any {
 }
 
 func (c *Client) Read(ctx context.Context, table *schema.Table, sourceName string, res chan<- []any) error {
-	stmt := fmt.Sprintf(readSQL, table.Name)
+	colNames := make([]string, 0, len(table.Columns))
+	for _, col := range table.Columns {
+		colNames = append(colNames, `"`+col.Name+`"`)
+	}
+	cols := strings.Join(colNames, ", ")
+	stmt := fmt.Sprintf(readSQL, cols, table.Name)
 	rows, err := c.db.Query(stmt, sourceName)
 	if err != nil {
 		return err


### PR DESCRIPTION
This changes the Read query to only select the columns defined in the table schema, so that user-defined columns are ignored. Since Read is only used in tests, this only affects testing right now.

This change should allow the new test in https://github.com/cloudquery/plugin-sdk/pull/574 to pass