### PR TITLE
feat(gcp):  Improve Error messages for Rate Limited

### DIFF
--- a/plugins/source/gcp/client/client.go
+++ b/plugins/source/gcp/client/client.go
@@ -26,6 +26,7 @@ import (
 
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 )
 
 const maxProjectIdsToLog int = 100
@@ -201,7 +202,12 @@ func New(ctx context.Context, logger zerolog.Logger, s specs.Source) (schema.Cli
 	}
 	if gcpSpec.EnabledServicesOnly {
 		if err := c.configureEnabledServices(ctx, s.Concurrency); err != nil {
-			c.logger.Err(err).Msg("failed to list enabled services")
+
+			if status.Code(err) == codes.ResourceExhausted {
+				c.logger.Err(err).Msg("failed to list enabled services because of rate limiting. Consider setting larger values for `backoff_retries` and `backoff_delay`")
+			} else {
+				c.logger.Err(err).Msg("failed to list enabled services")
+			}
 			return nil, err
 		}
 	}

--- a/website/pages/docs/plugins/sources/gcp/configuration.md
+++ b/website/pages/docs/plugins/sources/gcp/configuration.md
@@ -55,7 +55,7 @@ This is the (nested) spec used by GCP Source Plugin
   If specified APIs will be retried with exponential backoff if they are rate limited. This is the max number of retries.
 
 - `enabled_services_only` (bool) (default: false).
-If enabled CloudQuery will skip any resources that belong to a service that has been disabled or not been enabled. 
+If enabled CloudQuery will skip any resources that belong to a service that has been disabled or not been enabled. If you use this option on a large organization (greater than 500 projects) you should also set the `backoff_retries` to a value greater than `0` otherwise the sync could fail because of rate limiting.
 
 ## GCP + Kubernetes (GKE)
 


### PR DESCRIPTION
<!-- 🎉 Thank you for making CloudQuery awesome by submitting a PR 🎉 -->

#### Summary

When large orgs use `enabled_services` they may well hit rate limits. This pr helps with documentation and gives the user a specific error message when it occurs

<!--
Use the following steps to ensure your PR is ready to be reviewed

- [ ] Read the [contribution guidelines](../blob/main/CONTRIBUTING.md) 🧑‍🎓
- [ ] Test locally on your own infrastructure
- [ ] Run `go fmt` to format your code 🖊
- [ ] Lint your changes via `golangci-lint run` 🚨 (install golangci-lint [here](https://golangci-lint.run/usage/install/#local-installation))
- [ ] Update or add tests 🧪
- [ ] Ensure the status checks below are successful ✅
--->
