### PR TITLE
fix(k8s): Fix a typo in source/k8s/views/resource.sql: cq_table -> _cq_table

### DIFF
--- a/plugins/source/k8s/views/resource.sql
+++ b/plugins/source/k8s/views/resource.sql
@@ -19,7 +19,7 @@ BEGIN
             strSQL = strSQL || ' UNION ALL ';
         END IF;
         -- create an SQL query to select from table and transform it into our resources view schema
-        strSQL = strSQL || format('SELECT _cq_id, _cq_source_name, _cq_sync_time, %L AS cq_table, context, uid FROM %s', tbl, tbl);
+        strSQL = strSQL || format('SELECT _cq_id, _cq_source_name, _cq_sync_time, %L AS _cq_table, context, uid FROM %s', tbl, tbl);
     END LOOP;
     IF strSQL = ''::TEXT THEN
         RAISE EXCEPTION 'No tables found with UID and CONTEXT columns. Run a sync first and try again.';


### PR DESCRIPTION
<!-- 🎉 Thank you for making CloudQuery awesome by submitting a PR 🎉 -->

#### Summary

The column name "cq_table" of k8s_resources view created by source/k8s/views/resource.sql 
is inconsistent with the dashboard config in source/k8s/grafana/asset_inventory.json which use column "_cq_table"

Fix a typo by change: cq_table -> _cq_table in source/k8s/views/resource.sql

<!--
Use the following steps to ensure your PR is ready to be reviewed

- [-] Read the [contribution guidelines](../blob/main/CONTRIBUTING.md) 🧑‍🎓
- [-] Test locally on your own infrastructure
- [-] Run `go fmt` to format your code 🖊
- [-] Lint your changes via `golangci-lint run` 🚨 (install golangci-lint [here](https://golangci-lint.run/usage/install/#local-installation))
- [-] Update or add tests 🧪
- [-] Ensure the status checks below are successful ✅
--->
