### PR TITLE
fix(deps): Update plugin-sdk to v1.21.0 for destinations

### DIFF
--- a/plugins/destination/azblob/client/client_test.go
+++ b/plugins/destination/azblob/client/client_test.go
@@ -21,9 +21,10 @@ func TestPluginCSV(t *testing.T) {
 			NoRotate:       true,
 		},
 		destination.PluginTestSuiteTests{
-			SkipOverwrite:    true,
-			SkipDeleteStale:  true,
-			SkipSecondAppend: true,
+			SkipOverwrite:     true,
+			SkipDeleteStale:   true,
+			SkipSecondAppend:  true,
+			SkipMigrateAppend: true,
 		},
 	)
 }

--- a/plugins/destination/azblob/client/client_test.go
+++ b/plugins/destination/azblob/client/client_test.go
@@ -41,9 +41,10 @@ func TestPluginJSON(t *testing.T) {
 			NoRotate:       true,
 		},
 		destination.PluginTestSuiteTests{
-			SkipOverwrite:    true,
-			SkipDeleteStale:  true,
-			SkipSecondAppend: true,
+			SkipOverwrite:     true,
+			SkipDeleteStale:   true,
+			SkipSecondAppend:  true,
+			SkipMigrateAppend: true,
 		},
 	)
 }

--- a/plugins/destination/azblob/go.mod
+++ b/plugins/destination/azblob/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/Azure/azure-sdk-for-go/sdk/azidentity v1.2.0
 	github.com/Azure/azure-sdk-for-go/sdk/storage/azblob v0.6.1
 	github.com/cloudquery/filetypes v1.0.2
-	github.com/cloudquery/plugin-sdk v1.19.0
+	github.com/cloudquery/plugin-sdk v1.21.0
 	github.com/google/uuid v1.3.0
 	github.com/rs/zerolog v1.28.0
 )

--- a/plugins/destination/azblob/go.sum
+++ b/plugins/destination/azblob/go.sum
@@ -54,6 +54,8 @@ github.com/cloudquery/filetypes v1.0.2 h1:UxZ6aoZld2EQZzPgE8JIzmn98V6Px0cmK7rsJy
 github.com/cloudquery/filetypes v1.0.2/go.mod h1:d9YllN+dlQNrT/+fFLwdjeXXE3a2Mj9kffO9aMwzOrg=
 github.com/cloudquery/plugin-sdk v1.19.0 h1:rA2FHLgon5J+VB6tK+w3LLJyegsL/vAkj3Xi9N1Xk1c=
 github.com/cloudquery/plugin-sdk v1.19.0/go.mod h1:teMPyCON3uPdMsHvzpSiOg+IK2sOR5Tf9dYLreoURzI=
+github.com/cloudquery/plugin-sdk v1.21.0 h1:Oon4fFeUpc/QNkSwLPaoHcv9EVzcXK/6Y3ZaAcg7VOk=
+github.com/cloudquery/plugin-sdk v1.21.0/go.mod h1:teMPyCON3uPdMsHvzpSiOg+IK2sOR5Tf9dYLreoURzI=
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
 github.com/cncf/udpa/go v0.0.0-20201120205902-5459f2c99403/go.mod h1:WmhPx2Nbnhtbo57+VJT5O0JRkEi1Wbu0z5j0R8u5Hbk=
 github.com/coreos/go-systemd v0.0.0-20190321100706-95778dfbb74e/go.mod h1:F5haX7vjVVG0kc13fIWeqUViNPyEJxv/OmvnBo0Yme4=

--- a/plugins/destination/bigquery/client/migrate.go
+++ b/plugins/destination/bigquery/client/migrate.go
@@ -96,21 +96,14 @@ func (c *Client) waitForTableToExist(ctx context.Context, client *bigquery.Clien
 func (c *Client) waitForSchemaToMatch(ctx context.Context, client *bigquery.Client, table *schema.Table) error {
 	c.logger.Debug().Str("table", table.Name).Msg("Waiting for schemas to match")
 	wantSchema := c.bigQuerySchemaForTable(table)
-	want, err := wantSchema.ToJSONFields()
-	if err != nil {
-		return fmt.Errorf("failed to convert schema to JSON: %v", err)
-	}
 	for i := 0; i < maxTableChecks; i++ {
 		md, err := client.Dataset(c.pluginSpec.DatasetID).Table(table.Name).Metadata(ctx)
 		if err != nil {
 			return err
 		}
-		got, err := md.Schema.ToJSONFields()
-		if err != nil {
-			return fmt.Errorf("failed to convert schema to JSON: %v", err)
-		}
-		if string(got) == string(want) {
-			c.logger.Debug().Str("table", table.Name).Msg("Schemas matched")
+		haveSchema := md.Schema
+		if schemasMatch(haveSchema, wantSchema) {
+			c.logger.Debug().Str("table", table.Name).Msg("Schemas match")
 			return nil
 		}
 		c.logger.Debug().Str("table", table.Name).Int("i", i).Msg("Waiting for schemas to match")
@@ -120,14 +113,78 @@ func (c *Client) waitForSchemaToMatch(ctx context.Context, client *bigquery.Clie
 }
 
 func (c *Client) autoMigrateTable(ctx context.Context, client *bigquery.Client, table *schema.Table) error {
-	bqSchema := c.bigQuerySchemaForTable(table)
+	bqTable := client.Dataset(c.pluginSpec.DatasetID).Table(table.Name)
+	md, err := bqTable.Metadata(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to get table metadata: %w", err)
+	}
+	haveSchema := md.Schema
+	wantSchema := c.bigQuerySchemaForTable(table)
+	wantSchema, err = mergeSchemas(haveSchema, wantSchema)
+	if err != nil {
+		return fmt.Errorf("failed to migrate table schema: %w", err)
+	}
 	tm := bigquery.TableMetadataToUpdate{
 		Name:        table.Name,
 		Description: table.Description,
-		Schema:      bqSchema,
+		Schema:      wantSchema,
 	}
-	_, err := client.Dataset(c.pluginSpec.DatasetID).Table(table.Name).Update(ctx, tm, "")
-	return err
+	_, err = bqTable.Update(ctx, tm, "")
+	if err != nil {
+		return fmt.Errorf("failed to update table schema: %w", err)
+	}
+	return nil
+}
+
+func schemasMatch(haveSchema, wantSchema bigquery.Schema) bool {
+	// Schemas are considered a match if everything in the want schema is in the have schema,
+	// and they have the same types.
+	// We don't mind if there are extra fields in the have schema.
+	haveMap := make(map[string]*bigquery.FieldSchema)
+	for _, f := range haveSchema {
+		haveMap[f.Name] = f
+	}
+	for _, wf := range wantSchema {
+		if hf, ok := haveMap[wf.Name]; !ok {
+			return false
+		} else if hf.Type != wf.Type {
+			return false
+		}
+	}
+	return true
+}
+
+// mergeSchemas merges the schema we want with the schema we have, to avoid
+// losing any existing data
+func mergeSchemas(haveSchema, wantSchema bigquery.Schema) (bigquery.Schema, error) {
+	haveMap := make(map[string]*bigquery.FieldSchema)
+	for _, f := range haveSchema {
+		haveMap[f.Name] = f
+	}
+	wantMap := make(map[string]*bigquery.FieldSchema)
+	for _, f := range wantSchema {
+		wantMap[f.Name] = f
+	}
+	merged := make(bigquery.Schema, 0, len(wantSchema))
+	// keep everything in the schema we have, as long as the types didn't change
+	// or an unknown column isn't required
+	for _, f := range haveSchema {
+		if want, ok := wantMap[f.Name]; ok {
+			if want.Type != f.Type {
+				return nil, fmt.Errorf("field %v changed type from %v to %v", f.Name, f.Type, want.Type)
+			}
+		} else if f.Required {
+			return nil, fmt.Errorf("field %v is required but not in new schema", f.Name)
+		}
+		merged = append(merged, f)
+	}
+	// add anything new
+	for _, f := range wantSchema {
+		if _, ok := haveMap[f.Name]; !ok {
+			merged = append(merged, f)
+		}
+	}
+	return merged, nil
 }
 
 func (c *Client) createTable(ctx context.Context, client *bigquery.Client, table *schema.Table) error {

--- a/plugins/destination/bigquery/client/read.go
+++ b/plugins/destination/bigquery/client/read.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
+	"strings"
 	"time"
 
 	"cloud.google.com/go/bigquery"
@@ -12,7 +13,7 @@ import (
 )
 
 const (
-	readSQL = "SELECT * FROM `%s.%s.%s` WHERE `_cq_source_name` = @cq_source_name order by _cq_sync_time asc"
+	readSQL = "SELECT %s FROM `%s.%s.%s` WHERE `_cq_source_name` = @cq_source_name order by _cq_sync_time asc"
 )
 
 func (*Client) createResultsArray(table *schema.Table) []bigquery.Value {
@@ -78,7 +79,12 @@ func (*Client) createResultsArray(table *schema.Table) []bigquery.Value {
 }
 
 func (c *Client) Read(ctx context.Context, table *schema.Table, sourceName string, res chan<- []any) error {
-	stmt := fmt.Sprintf(readSQL, c.pluginSpec.ProjectID, c.pluginSpec.DatasetID, table.Name)
+	colNames := make([]string, 0, len(table.Columns))
+	for _, col := range table.Columns {
+		colNames = append(colNames, col.Name)
+	}
+	cols := "`" + strings.Join(colNames, "`, `") + "`"
+	stmt := fmt.Sprintf(readSQL, cols, c.pluginSpec.ProjectID, c.pluginSpec.DatasetID, table.Name)
 	q := c.client.Query(stmt)
 	q.Parameters = []bigquery.QueryParameter{
 		{

--- a/plugins/destination/bigquery/go.mod
+++ b/plugins/destination/bigquery/go.mod
@@ -4,7 +4,7 @@ go 1.19
 
 require (
 	cloud.google.com/go/bigquery v1.44.0
-	github.com/cloudquery/plugin-sdk v1.19.0
+	github.com/cloudquery/plugin-sdk v1.21.0
 	github.com/rs/zerolog v1.28.0
 	golang.org/x/sync v0.1.0
 	google.golang.org/api v0.103.0

--- a/plugins/destination/bigquery/go.sum
+++ b/plugins/destination/bigquery/go.sum
@@ -55,6 +55,8 @@ github.com/chzyer/test v0.0.0-20180213035817-a1ea475d72b1/go.mod h1:Q3SI9o4m/ZMn
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
 github.com/cloudquery/plugin-sdk v1.19.0 h1:rA2FHLgon5J+VB6tK+w3LLJyegsL/vAkj3Xi9N1Xk1c=
 github.com/cloudquery/plugin-sdk v1.19.0/go.mod h1:teMPyCON3uPdMsHvzpSiOg+IK2sOR5Tf9dYLreoURzI=
+github.com/cloudquery/plugin-sdk v1.21.0 h1:Oon4fFeUpc/QNkSwLPaoHcv9EVzcXK/6Y3ZaAcg7VOk=
+github.com/cloudquery/plugin-sdk v1.21.0/go.mod h1:teMPyCON3uPdMsHvzpSiOg+IK2sOR5Tf9dYLreoURzI=
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
 github.com/cncf/udpa/go v0.0.0-20201120205902-5459f2c99403/go.mod h1:WmhPx2Nbnhtbo57+VJT5O0JRkEi1Wbu0z5j0R8u5Hbk=
 github.com/coreos/go-systemd v0.0.0-20190321100706-95778dfbb74e/go.mod h1:F5haX7vjVVG0kc13fIWeqUViNPyEJxv/OmvnBo0Yme4=

--- a/plugins/destination/csv/client/client_test.go
+++ b/plugins/destination/csv/client/client_test.go
@@ -49,8 +49,9 @@ func TestPlugin(t *testing.T) {
 			Directory: t.TempDir(),
 		},
 		destination.PluginTestSuiteTests{
-			SkipOverwrite:   true,
-			SkipDeleteStale: true,
+			SkipOverwrite:     true,
+			SkipDeleteStale:   true,
+			SkipMigrateAppend: true,
 		},
 	)
 }

--- a/plugins/destination/csv/go.mod
+++ b/plugins/destination/csv/go.mod
@@ -3,7 +3,7 @@ module github.com/cloudquery/cloudquery/plugins/destination/csv
 go 1.19
 
 require (
-	github.com/cloudquery/plugin-sdk v1.16.1
+	github.com/cloudquery/plugin-sdk v1.21.0
 	github.com/rs/zerolog v1.28.0
 )
 

--- a/plugins/destination/csv/go.sum
+++ b/plugins/destination/csv/go.sum
@@ -42,6 +42,8 @@ github.com/chzyer/test v0.0.0-20180213035817-a1ea475d72b1/go.mod h1:Q3SI9o4m/ZMn
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
 github.com/cloudquery/plugin-sdk v1.16.1 h1:FstBNQkdAFZRh5F3Y0ugL/pLTg/tPAzljxnpjNda4po=
 github.com/cloudquery/plugin-sdk v1.16.1/go.mod h1:teMPyCON3uPdMsHvzpSiOg+IK2sOR5Tf9dYLreoURzI=
+github.com/cloudquery/plugin-sdk v1.21.0 h1:Oon4fFeUpc/QNkSwLPaoHcv9EVzcXK/6Y3ZaAcg7VOk=
+github.com/cloudquery/plugin-sdk v1.21.0/go.mod h1:teMPyCON3uPdMsHvzpSiOg+IK2sOR5Tf9dYLreoURzI=
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
 github.com/cncf/udpa/go v0.0.0-20201120205902-5459f2c99403/go.mod h1:WmhPx2Nbnhtbo57+VJT5O0JRkEi1Wbu0z5j0R8u5Hbk=
 github.com/coreos/go-systemd v0.0.0-20190321100706-95778dfbb74e/go.mod h1:F5haX7vjVVG0kc13fIWeqUViNPyEJxv/OmvnBo0Yme4=

--- a/plugins/destination/file/client/client_test.go
+++ b/plugins/destination/file/client/client_test.go
@@ -16,8 +16,9 @@ func TestPluginCSV(t *testing.T) {
 			NoRotate:  true,
 		},
 		destination.PluginTestSuiteTests{
-			SkipOverwrite:   true,
-			SkipDeleteStale: true,
+			SkipOverwrite:     true,
+			SkipDeleteStale:   true,
+			SkipMigrateAppend: true,
 		},
 	)
 }

--- a/plugins/destination/file/go.mod
+++ b/plugins/destination/file/go.mod
@@ -4,7 +4,7 @@ go 1.19
 
 require (
 	github.com/cloudquery/filetypes v1.0.2
-	github.com/cloudquery/plugin-sdk v1.19.0
+	github.com/cloudquery/plugin-sdk v1.21.0
 	github.com/google/uuid v1.3.0
 	github.com/rs/zerolog v1.28.0
 )

--- a/plugins/destination/file/go.sum
+++ b/plugins/destination/file/go.sum
@@ -44,6 +44,8 @@ github.com/cloudquery/filetypes v1.0.2 h1:UxZ6aoZld2EQZzPgE8JIzmn98V6Px0cmK7rsJy
 github.com/cloudquery/filetypes v1.0.2/go.mod h1:d9YllN+dlQNrT/+fFLwdjeXXE3a2Mj9kffO9aMwzOrg=
 github.com/cloudquery/plugin-sdk v1.19.0 h1:rA2FHLgon5J+VB6tK+w3LLJyegsL/vAkj3Xi9N1Xk1c=
 github.com/cloudquery/plugin-sdk v1.19.0/go.mod h1:teMPyCON3uPdMsHvzpSiOg+IK2sOR5Tf9dYLreoURzI=
+github.com/cloudquery/plugin-sdk v1.21.0 h1:Oon4fFeUpc/QNkSwLPaoHcv9EVzcXK/6Y3ZaAcg7VOk=
+github.com/cloudquery/plugin-sdk v1.21.0/go.mod h1:teMPyCON3uPdMsHvzpSiOg+IK2sOR5Tf9dYLreoURzI=
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
 github.com/cncf/udpa/go v0.0.0-20201120205902-5459f2c99403/go.mod h1:WmhPx2Nbnhtbo57+VJT5O0JRkEi1Wbu0z5j0R8u5Hbk=
 github.com/coreos/go-systemd v0.0.0-20190321100706-95778dfbb74e/go.mod h1:F5haX7vjVVG0kc13fIWeqUViNPyEJxv/OmvnBo0Yme4=

--- a/plugins/destination/gcs/client/client_test.go
+++ b/plugins/destination/gcs/client/client_test.go
@@ -19,9 +19,10 @@ func TestPluginCSV(t *testing.T) {
 			NoRotate: true,
 		},
 		destination.PluginTestSuiteTests{
-			SkipOverwrite:    true,
-			SkipDeleteStale:  true,
-			SkipSecondAppend: true,
+			SkipOverwrite:     true,
+			SkipDeleteStale:   true,
+			SkipSecondAppend:  true,
+			SkipMigrateAppend: true,
 		},
 	)
 }

--- a/plugins/destination/gcs/client/client_test.go
+++ b/plugins/destination/gcs/client/client_test.go
@@ -38,9 +38,10 @@ func TestPluginJSON(t *testing.T) {
 			NoRotate: true,
 		},
 		destination.PluginTestSuiteTests{
-			SkipOverwrite:    true,
-			SkipDeleteStale:  true,
-			SkipSecondAppend: true,
+			SkipOverwrite:     true,
+			SkipDeleteStale:   true,
+			SkipSecondAppend:  true,
+			SkipMigrateAppend: true,
 		},
 	)
 }

--- a/plugins/destination/gcs/go.mod
+++ b/plugins/destination/gcs/go.mod
@@ -5,7 +5,7 @@ go 1.19
 require (
 	cloud.google.com/go/storage v1.27.0
 	github.com/cloudquery/filetypes v1.0.2
-	github.com/cloudquery/plugin-sdk v1.19.0
+	github.com/cloudquery/plugin-sdk v1.21.0
 	github.com/google/uuid v1.3.0
 	github.com/rs/zerolog v1.28.0
 )

--- a/plugins/destination/gcs/go.sum
+++ b/plugins/destination/gcs/go.sum
@@ -55,6 +55,8 @@ github.com/cloudquery/filetypes v1.0.2 h1:UxZ6aoZld2EQZzPgE8JIzmn98V6Px0cmK7rsJy
 github.com/cloudquery/filetypes v1.0.2/go.mod h1:d9YllN+dlQNrT/+fFLwdjeXXE3a2Mj9kffO9aMwzOrg=
 github.com/cloudquery/plugin-sdk v1.19.0 h1:rA2FHLgon5J+VB6tK+w3LLJyegsL/vAkj3Xi9N1Xk1c=
 github.com/cloudquery/plugin-sdk v1.19.0/go.mod h1:teMPyCON3uPdMsHvzpSiOg+IK2sOR5Tf9dYLreoURzI=
+github.com/cloudquery/plugin-sdk v1.21.0 h1:Oon4fFeUpc/QNkSwLPaoHcv9EVzcXK/6Y3ZaAcg7VOk=
+github.com/cloudquery/plugin-sdk v1.21.0/go.mod h1:teMPyCON3uPdMsHvzpSiOg+IK2sOR5Tf9dYLreoURzI=
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
 github.com/cncf/udpa/go v0.0.0-20201120205902-5459f2c99403/go.mod h1:WmhPx2Nbnhtbo57+VJT5O0JRkEi1Wbu0z5j0R8u5Hbk=
 github.com/coreos/go-systemd v0.0.0-20190321100706-95778dfbb74e/go.mod h1:F5haX7vjVVG0kc13fIWeqUViNPyEJxv/OmvnBo0Yme4=

--- a/plugins/destination/kafka/client/client_test.go
+++ b/plugins/destination/kafka/client/client_test.go
@@ -32,6 +32,7 @@ func TestPgPlugin(t *testing.T) {
 			MaxMetadataRetries: 15,
 		},
 		destination.PluginTestSuiteTests{
-			SkipOverwrite: true,
+			SkipOverwrite:     true,
+			SkipMigrateAppend: true,
 		})
 }

--- a/plugins/destination/kafka/go.mod
+++ b/plugins/destination/kafka/go.mod
@@ -5,7 +5,7 @@ go 1.19
 require (
 	github.com/Shopify/sarama v1.37.2
 	github.com/cloudquery/filetypes v1.0.2
-	github.com/cloudquery/plugin-sdk v1.19.0
+	github.com/cloudquery/plugin-sdk v1.21.0
 	github.com/rs/zerolog v1.28.0
 )
 

--- a/plugins/destination/kafka/go.sum
+++ b/plugins/destination/kafka/go.sum
@@ -47,6 +47,8 @@ github.com/cloudquery/filetypes v1.0.2 h1:UxZ6aoZld2EQZzPgE8JIzmn98V6Px0cmK7rsJy
 github.com/cloudquery/filetypes v1.0.2/go.mod h1:d9YllN+dlQNrT/+fFLwdjeXXE3a2Mj9kffO9aMwzOrg=
 github.com/cloudquery/plugin-sdk v1.19.0 h1:rA2FHLgon5J+VB6tK+w3LLJyegsL/vAkj3Xi9N1Xk1c=
 github.com/cloudquery/plugin-sdk v1.19.0/go.mod h1:teMPyCON3uPdMsHvzpSiOg+IK2sOR5Tf9dYLreoURzI=
+github.com/cloudquery/plugin-sdk v1.21.0 h1:Oon4fFeUpc/QNkSwLPaoHcv9EVzcXK/6Y3ZaAcg7VOk=
+github.com/cloudquery/plugin-sdk v1.21.0/go.mod h1:teMPyCON3uPdMsHvzpSiOg+IK2sOR5Tf9dYLreoURzI=
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
 github.com/cncf/udpa/go v0.0.0-20201120205902-5459f2c99403/go.mod h1:WmhPx2Nbnhtbo57+VJT5O0JRkEi1Wbu0z5j0R8u5Hbk=
 github.com/coreos/go-systemd v0.0.0-20190321100706-95778dfbb74e/go.mod h1:F5haX7vjVVG0kc13fIWeqUViNPyEJxv/OmvnBo0Yme4=

--- a/plugins/destination/mongodb/client/read.go
+++ b/plugins/destination/mongodb/client/read.go
@@ -14,6 +14,10 @@ func (*Client) createResultsArray(res bson.M, table *schema.Table) []any {
 	results := make([]any, 0, len(table.Columns))
 	for _, col := range table.Columns {
 		val := res[col.Name]
+		if val == nil {
+			results = append(results, nil)
+			continue
+		}
 		switch col.Type {
 		case schema.TypeBool:
 			r := (val).(bool)

--- a/plugins/destination/mongodb/go.mod
+++ b/plugins/destination/mongodb/go.mod
@@ -3,7 +3,7 @@ module github.com/cloudquery/cloudquery/plugins/destination/mongodb
 go 1.19
 
 require (
-	github.com/cloudquery/plugin-sdk v1.19.0
+	github.com/cloudquery/plugin-sdk v1.21.0
 	github.com/rs/zerolog v1.28.0
 	go.mongodb.org/mongo-driver v1.11.1
 )

--- a/plugins/destination/mongodb/go.sum
+++ b/plugins/destination/mongodb/go.sum
@@ -42,6 +42,8 @@ github.com/chzyer/test v0.0.0-20180213035817-a1ea475d72b1/go.mod h1:Q3SI9o4m/ZMn
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
 github.com/cloudquery/plugin-sdk v1.19.0 h1:rA2FHLgon5J+VB6tK+w3LLJyegsL/vAkj3Xi9N1Xk1c=
 github.com/cloudquery/plugin-sdk v1.19.0/go.mod h1:teMPyCON3uPdMsHvzpSiOg+IK2sOR5Tf9dYLreoURzI=
+github.com/cloudquery/plugin-sdk v1.21.0 h1:Oon4fFeUpc/QNkSwLPaoHcv9EVzcXK/6Y3ZaAcg7VOk=
+github.com/cloudquery/plugin-sdk v1.21.0/go.mod h1:teMPyCON3uPdMsHvzpSiOg+IK2sOR5Tf9dYLreoURzI=
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
 github.com/cncf/udpa/go v0.0.0-20201120205902-5459f2c99403/go.mod h1:WmhPx2Nbnhtbo57+VJT5O0JRkEi1Wbu0z5j0R8u5Hbk=
 github.com/coreos/go-systemd v0.0.0-20190321100706-95778dfbb74e/go.mod h1:F5haX7vjVVG0kc13fIWeqUViNPyEJxv/OmvnBo0Yme4=

--- a/plugins/destination/neo4j/client/read.go
+++ b/plugins/destination/neo4j/client/read.go
@@ -17,6 +17,10 @@ const (
 func (*Client) createResultsArray(table *schema.Table, node *neo4j.Node) []any {
 	results := make([]any, 0, len(table.Columns))
 	for _, col := range table.Columns {
+		if node.Props[col.Name] == nil {
+			results = append(results, nil)
+			continue
+		}
 		switch col.Type {
 		case schema.TypeBool:
 			r := node.Props[col.Name].(bool)

--- a/plugins/destination/neo4j/go.mod
+++ b/plugins/destination/neo4j/go.mod
@@ -3,7 +3,7 @@ module github.com/cloudquery/cloudquery/plugins/destination/neo4j
 go 1.19
 
 require (
-	github.com/cloudquery/plugin-sdk v1.19.0
+	github.com/cloudquery/plugin-sdk v1.21.0
 	github.com/neo4j/neo4j-go-driver/v5 v5.3.0
 	github.com/rs/zerolog v1.28.0
 )

--- a/plugins/destination/neo4j/go.sum
+++ b/plugins/destination/neo4j/go.sum
@@ -42,6 +42,8 @@ github.com/chzyer/test v0.0.0-20180213035817-a1ea475d72b1/go.mod h1:Q3SI9o4m/ZMn
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
 github.com/cloudquery/plugin-sdk v1.19.0 h1:rA2FHLgon5J+VB6tK+w3LLJyegsL/vAkj3Xi9N1Xk1c=
 github.com/cloudquery/plugin-sdk v1.19.0/go.mod h1:teMPyCON3uPdMsHvzpSiOg+IK2sOR5Tf9dYLreoURzI=
+github.com/cloudquery/plugin-sdk v1.21.0 h1:Oon4fFeUpc/QNkSwLPaoHcv9EVzcXK/6Y3ZaAcg7VOk=
+github.com/cloudquery/plugin-sdk v1.21.0/go.mod h1:teMPyCON3uPdMsHvzpSiOg+IK2sOR5Tf9dYLreoURzI=
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
 github.com/cncf/udpa/go v0.0.0-20201120205902-5459f2c99403/go.mod h1:WmhPx2Nbnhtbo57+VJT5O0JRkEi1Wbu0z5j0R8u5Hbk=
 github.com/coreos/go-systemd v0.0.0-20190321100706-95778dfbb74e/go.mod h1:F5haX7vjVVG0kc13fIWeqUViNPyEJxv/OmvnBo0Yme4=

--- a/plugins/destination/postgresql/client/read.go
+++ b/plugins/destination/postgresql/client/read.go
@@ -3,17 +3,23 @@ package client
 import (
 	"context"
 	"fmt"
+	"strings"
 
 	"github.com/cloudquery/plugin-sdk/schema"
 	"github.com/jackc/pgx/v5"
 )
 
 const (
-	readSQL = "SELECT * FROM %s WHERE _cq_source_name = $1 order by _cq_sync_time asc"
+	readSQL = "SELECT %s FROM %s WHERE _cq_source_name = $1 order by _cq_sync_time asc"
 )
 
 func (c *Client) Read(ctx context.Context, table *schema.Table, sourceName string, res chan<- []any) error {
-	sql := fmt.Sprintf(readSQL, pgx.Identifier{table.Name}.Sanitize())
+	colNames := make([]string, 0, len(table.Columns))
+	for _, col := range table.Columns {
+		colNames = append(colNames, pgx.Identifier{col.Name}.Sanitize())
+	}
+	cols := strings.Join(colNames, ",")
+	sql := fmt.Sprintf(readSQL, cols, pgx.Identifier{table.Name}.Sanitize())
 	rows, err := c.conn.Query(ctx, sql, sourceName)
 	if err != nil {
 		return err

--- a/plugins/destination/postgresql/go.mod
+++ b/plugins/destination/postgresql/go.mod
@@ -3,7 +3,7 @@ module github.com/cloudquery/cloudquery/plugins/destination/postgresql
 go 1.19
 
 require (
-	github.com/cloudquery/plugin-sdk v1.18.0
+	github.com/cloudquery/plugin-sdk v1.21.0
 	github.com/jackc/pgx-zerolog v0.0.0-20220923130014-7856b90a65ae
 	github.com/jackc/pgx/v5 v5.2.0
 	github.com/rs/zerolog v1.28.0

--- a/plugins/destination/postgresql/go.sum
+++ b/plugins/destination/postgresql/go.sum
@@ -42,6 +42,8 @@ github.com/chzyer/test v0.0.0-20180213035817-a1ea475d72b1/go.mod h1:Q3SI9o4m/ZMn
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
 github.com/cloudquery/plugin-sdk v1.18.0 h1:8n78JWjqeunEaIT2WNTE/jMbAFvDxhX4f8TnwgUX48I=
 github.com/cloudquery/plugin-sdk v1.18.0/go.mod h1:teMPyCON3uPdMsHvzpSiOg+IK2sOR5Tf9dYLreoURzI=
+github.com/cloudquery/plugin-sdk v1.21.0 h1:Oon4fFeUpc/QNkSwLPaoHcv9EVzcXK/6Y3ZaAcg7VOk=
+github.com/cloudquery/plugin-sdk v1.21.0/go.mod h1:teMPyCON3uPdMsHvzpSiOg+IK2sOR5Tf9dYLreoURzI=
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
 github.com/cncf/udpa/go v0.0.0-20201120205902-5459f2c99403/go.mod h1:WmhPx2Nbnhtbo57+VJT5O0JRkEi1Wbu0z5j0R8u5Hbk=
 github.com/coreos/go-systemd v0.0.0-20190321100706-95778dfbb74e/go.mod h1:F5haX7vjVVG0kc13fIWeqUViNPyEJxv/OmvnBo0Yme4=

--- a/plugins/destination/s3/client/client_test.go
+++ b/plugins/destination/s3/client/client_test.go
@@ -19,9 +19,9 @@ func TestPluginCSV(t *testing.T) {
 			NoRotate: true,
 		},
 		destination.PluginTestSuiteTests{
-			SkipOverwrite:    true,
-			SkipDeleteStale:  true,
-			SkipSecondAppend: true,
+			SkipOverwrite:     true,
+			SkipDeleteStale:   true,
+			SkipSecondAppend:  true,
 			SkipMigrateAppend: true,
 		},
 	)
@@ -38,9 +38,10 @@ func TestPluginJSON(t *testing.T) {
 			NoRotate: true,
 		},
 		destination.PluginTestSuiteTests{
-			SkipOverwrite:    true,
-			SkipDeleteStale:  true,
-			SkipSecondAppend: true,
+			SkipOverwrite:     true,
+			SkipDeleteStale:   true,
+			SkipSecondAppend:  true,
+			SkipMigrateAppend: true,
 		},
 	)
 }

--- a/plugins/destination/s3/client/client_test.go
+++ b/plugins/destination/s3/client/client_test.go
@@ -22,6 +22,7 @@ func TestPluginCSV(t *testing.T) {
 			SkipOverwrite:    true,
 			SkipDeleteStale:  true,
 			SkipSecondAppend: true,
+			SkipMigrateAppend: true,
 		},
 	)
 }

--- a/plugins/destination/s3/go.mod
+++ b/plugins/destination/s3/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/feature/s3/manager v1.11.47
 	github.com/aws/aws-sdk-go-v2/service/s3 v1.30.0
 	github.com/cloudquery/filetypes v1.0.2
-	github.com/cloudquery/plugin-sdk v1.19.0
+	github.com/cloudquery/plugin-sdk v1.21.0
 	github.com/google/uuid v1.3.0
 	github.com/rs/zerolog v1.28.0
 )

--- a/plugins/destination/s3/go.sum
+++ b/plugins/destination/s3/go.sum
@@ -82,6 +82,8 @@ github.com/cloudquery/filetypes v1.0.2 h1:UxZ6aoZld2EQZzPgE8JIzmn98V6Px0cmK7rsJy
 github.com/cloudquery/filetypes v1.0.2/go.mod h1:d9YllN+dlQNrT/+fFLwdjeXXE3a2Mj9kffO9aMwzOrg=
 github.com/cloudquery/plugin-sdk v1.19.0 h1:rA2FHLgon5J+VB6tK+w3LLJyegsL/vAkj3Xi9N1Xk1c=
 github.com/cloudquery/plugin-sdk v1.19.0/go.mod h1:teMPyCON3uPdMsHvzpSiOg+IK2sOR5Tf9dYLreoURzI=
+github.com/cloudquery/plugin-sdk v1.21.0 h1:Oon4fFeUpc/QNkSwLPaoHcv9EVzcXK/6Y3ZaAcg7VOk=
+github.com/cloudquery/plugin-sdk v1.21.0/go.mod h1:teMPyCON3uPdMsHvzpSiOg+IK2sOR5Tf9dYLreoURzI=
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
 github.com/cncf/udpa/go v0.0.0-20201120205902-5459f2c99403/go.mod h1:WmhPx2Nbnhtbo57+VJT5O0JRkEi1Wbu0z5j0R8u5Hbk=
 github.com/coreos/go-systemd v0.0.0-20190321100706-95778dfbb74e/go.mod h1:F5haX7vjVVG0kc13fIWeqUViNPyEJxv/OmvnBo0Yme4=

--- a/plugins/destination/snowflake/client/client_test.go
+++ b/plugins/destination/snowflake/client/client_test.go
@@ -14,6 +14,7 @@ func TestPlugin(t *testing.T) {
 			ConnectionString: os.Getenv("SNOW_TEST_DSN"),
 		},
 		destination.PluginTestSuiteTests{
-			SkipOverwrite: true,
+			SkipOverwrite:     true,
+			SkipMigrateAppend: true, // fails with `invalid identifier '"new_column"'`, maybe because delays in schema propagation?
 		})
 }

--- a/plugins/destination/snowflake/client/read.go
+++ b/plugins/destination/snowflake/client/read.go
@@ -10,7 +10,7 @@ import (
 )
 
 const (
-	readSQL = "SELECT * FROM %s WHERE \"_cq_source_name\" = ?"
+	readSQL = "SELECT %s FROM %s WHERE \"_cq_source_name\" = ?"
 )
 
 // https://github.com/snowflakedb/gosnowflake/issues/674
@@ -40,6 +40,10 @@ func snowflakeStrToArray(val string) []string {
 func (*Client) createResultsArray(values []any, table *schema.Table) []any {
 	results := make([]any, 0, len(table.Columns))
 	for i, col := range table.Columns {
+		if values[i] == nil {
+			results = append(results, nil)
+			continue
+		}
 		switch col.Type {
 		case schema.TypeBool:
 			r := (*values[i].(*any)).(bool)
@@ -98,7 +102,12 @@ func (*Client) createResultsArray(values []any, table *schema.Table) []any {
 }
 
 func (c *Client) Read(ctx context.Context, table *schema.Table, sourceName string, res chan<- []any) error {
-	stmt := fmt.Sprintf(readSQL, table.Name)
+	colNames := make([]string, 0, len(table.Columns))
+	for _, col := range table.Columns {
+		colNames = append(colNames, `"`+col.Name+`"`)
+	}
+	cols := strings.Join(colNames, ", ")
+	stmt := fmt.Sprintf(readSQL, cols, table.Name)
 	rows, err := c.db.Query(stmt, sourceName)
 	if err != nil {
 		return err

--- a/plugins/destination/snowflake/go.mod
+++ b/plugins/destination/snowflake/go.mod
@@ -3,7 +3,7 @@ module github.com/cloudquery/cloudquery/plugins/destination/snowflake
 go 1.19
 
 require (
-	github.com/cloudquery/plugin-sdk v1.19.0
+	github.com/cloudquery/plugin-sdk v1.21.0
 	github.com/rs/zerolog v1.28.0
 	github.com/snowflakedb/gosnowflake v1.6.16
 )

--- a/plugins/destination/snowflake/go.sum
+++ b/plugins/destination/snowflake/go.sum
@@ -105,6 +105,8 @@ github.com/chzyer/test v0.0.0-20180213035817-a1ea475d72b1/go.mod h1:Q3SI9o4m/ZMn
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
 github.com/cloudquery/plugin-sdk v1.19.0 h1:rA2FHLgon5J+VB6tK+w3LLJyegsL/vAkj3Xi9N1Xk1c=
 github.com/cloudquery/plugin-sdk v1.19.0/go.mod h1:teMPyCON3uPdMsHvzpSiOg+IK2sOR5Tf9dYLreoURzI=
+github.com/cloudquery/plugin-sdk v1.21.0 h1:Oon4fFeUpc/QNkSwLPaoHcv9EVzcXK/6Y3ZaAcg7VOk=
+github.com/cloudquery/plugin-sdk v1.21.0/go.mod h1:teMPyCON3uPdMsHvzpSiOg+IK2sOR5Tf9dYLreoURzI=
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
 github.com/cncf/udpa/go v0.0.0-20201120205902-5459f2c99403/go.mod h1:WmhPx2Nbnhtbo57+VJT5O0JRkEi1Wbu0z5j0R8u5Hbk=
 github.com/cncf/xds/go v0.0.0-20210312221358-fbca930ec8ed/go.mod h1:eXthEFrGJvWHgFFCl3hGmgk+/aYT6PnTQLykKQRLhEs=

--- a/plugins/destination/sqlite/client/migrate.go
+++ b/plugins/destination/sqlite/client/migrate.go
@@ -10,7 +10,7 @@ import (
 )
 
 const (
-	isTableExistSQL = "SELECT count(name) FROM sqlite_master WHERE type='table' AND name='?';"
+	isTableExistSQL = "SELECT count(name) FROM sqlite_master WHERE type='table' AND name=?;"
 
 	// https://wiki.postgresql.org/wiki/Retrieve_primary_key_columns
 	sqlTableInfo = "PRAGMA table_info('%s');"

--- a/plugins/destination/sqlite/client/read.go
+++ b/plugins/destination/sqlite/client/read.go
@@ -18,19 +18,19 @@ func (*Client) createResultsArray(table *schema.Table) []any {
 	for _, col := range table.Columns {
 		switch col.Type {
 		case schema.TypeBool:
-			var r bool
+			var r *bool
 			results = append(results, &r)
 		case schema.TypeInt:
-			var r int
+			var r *int
 			results = append(results, &r)
 		case schema.TypeFloat:
-			var r float64
+			var r *float64
 			results = append(results, &r)
 		case schema.TypeUUID:
-			var r string
+			var r *string
 			results = append(results, &r)
 		case schema.TypeString:
-			var r string
+			var r *string
 			results = append(results, &r)
 		case schema.TypeByteArray:
 			var r sql.RawBytes
@@ -39,7 +39,7 @@ func (*Client) createResultsArray(table *schema.Table) []any {
 			var r string
 			results = append(results, &r)
 		case schema.TypeTimestamp:
-			var r string
+			var r *string
 			results = append(results, &r)
 		case schema.TypeJSON:
 			var r string
@@ -48,19 +48,19 @@ func (*Client) createResultsArray(table *schema.Table) []any {
 			var r string
 			results = append(results, &r)
 		case schema.TypeCIDR:
-			var r string
+			var r *string
 			results = append(results, &r)
 		case schema.TypeCIDRArray:
 			var r string
 			results = append(results, &r)
 		case schema.TypeMacAddr:
-			var r string
+			var r *string
 			results = append(results, &r)
 		case schema.TypeMacAddrArray:
 			var r string
 			results = append(results, &r)
 		case schema.TypeInet:
-			var r string
+			var r *string
 			results = append(results, &r)
 		case schema.TypeInetArray:
 			var r string

--- a/plugins/destination/sqlite/go.mod
+++ b/plugins/destination/sqlite/go.mod
@@ -3,7 +3,7 @@ module github.com/cloudquery/cloudquery/plugins/destination/sqlite
 go 1.19
 
 require (
-	github.com/cloudquery/plugin-sdk v1.19.0
+	github.com/cloudquery/plugin-sdk v1.21.0
 	github.com/mattn/go-sqlite3 v1.14.16
 	github.com/rs/zerolog v1.28.0
 )

--- a/plugins/destination/sqlite/go.sum
+++ b/plugins/destination/sqlite/go.sum
@@ -42,6 +42,8 @@ github.com/chzyer/test v0.0.0-20180213035817-a1ea475d72b1/go.mod h1:Q3SI9o4m/ZMn
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
 github.com/cloudquery/plugin-sdk v1.19.0 h1:rA2FHLgon5J+VB6tK+w3LLJyegsL/vAkj3Xi9N1Xk1c=
 github.com/cloudquery/plugin-sdk v1.19.0/go.mod h1:teMPyCON3uPdMsHvzpSiOg+IK2sOR5Tf9dYLreoURzI=
+github.com/cloudquery/plugin-sdk v1.21.0 h1:Oon4fFeUpc/QNkSwLPaoHcv9EVzcXK/6Y3ZaAcg7VOk=
+github.com/cloudquery/plugin-sdk v1.21.0/go.mod h1:teMPyCON3uPdMsHvzpSiOg+IK2sOR5Tf9dYLreoURzI=
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
 github.com/cncf/udpa/go v0.0.0-20201120205902-5459f2c99403/go.mod h1:WmhPx2Nbnhtbo57+VJT5O0JRkEi1Wbu0z5j0R8u5Hbk=
 github.com/coreos/go-systemd v0.0.0-20190321100706-95778dfbb74e/go.mod h1:F5haX7vjVVG0kc13fIWeqUViNPyEJxv/OmvnBo0Yme4=

--- a/plugins/destination/test/go.mod
+++ b/plugins/destination/test/go.mod
@@ -3,7 +3,7 @@ module github.com/cloudquery/cloudquery/plugins/destination/test
 go 1.19
 
 require (
-	github.com/cloudquery/plugin-sdk v1.19.0
+	github.com/cloudquery/plugin-sdk v1.21.0
 	github.com/rs/zerolog v1.28.0
 )
 

--- a/plugins/destination/test/go.sum
+++ b/plugins/destination/test/go.sum
@@ -42,6 +42,8 @@ github.com/chzyer/test v0.0.0-20180213035817-a1ea475d72b1/go.mod h1:Q3SI9o4m/ZMn
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
 github.com/cloudquery/plugin-sdk v1.19.0 h1:rA2FHLgon5J+VB6tK+w3LLJyegsL/vAkj3Xi9N1Xk1c=
 github.com/cloudquery/plugin-sdk v1.19.0/go.mod h1:teMPyCON3uPdMsHvzpSiOg+IK2sOR5Tf9dYLreoURzI=
+github.com/cloudquery/plugin-sdk v1.21.0 h1:Oon4fFeUpc/QNkSwLPaoHcv9EVzcXK/6Y3ZaAcg7VOk=
+github.com/cloudquery/plugin-sdk v1.21.0/go.mod h1:teMPyCON3uPdMsHvzpSiOg+IK2sOR5Tf9dYLreoURzI=
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
 github.com/cncf/udpa/go v0.0.0-20201120205902-5459f2c99403/go.mod h1:WmhPx2Nbnhtbo57+VJT5O0JRkEi1Wbu0z5j0R8u5Hbk=
 github.com/coreos/go-systemd v0.0.0-20190321100706-95778dfbb74e/go.mod h1:F5haX7vjVVG0kc13fIWeqUViNPyEJxv/OmvnBo0Yme4=


### PR DESCRIPTION
This updates plugin-sdk to v1.21.0 for all destinations, and ensures that the new migration test either passes or gets skipped for all of them.

This also restores some code that was accidentally removed in https://github.com/cloudquery/cloudquery/pull/6382