### PR TITLE
Revert "fix: Error if after the migration there are `not null` columns that are not part of the new schema"

### DIFF
--- a/plugins/destination/postgresql/client/client_test.go
+++ b/plugins/destination/postgresql/client/client_test.go
@@ -1,18 +1,10 @@
 package client
 
 import (
-	"context"
-	"fmt"
-	"math/rand"
 	"os"
 	"testing"
 
 	"github.com/cloudquery/plugin-sdk/plugins/destination"
-	"github.com/cloudquery/plugin-sdk/schema"
-	"github.com/cloudquery/plugin-sdk/specs"
-	"github.com/cloudquery/plugin-sdk/testdata"
-	"github.com/rs/zerolog"
-	"github.com/stretchr/testify/require"
 )
 
 func getTestConnection() string {
@@ -31,41 +23,4 @@ func TestPgPlugin(t *testing.T) {
 			PgxLogLevel:      LogLevelTrace,
 		},
 		destination.PluginTestSuiteTests{})
-}
-
-func TestPgPluginPrimaryKeyRename(t *testing.T) {
-	tableName := fmt.Sprintf("cq_test_pk_rename_%d", rand.Intn(100))
-	tableWithStalePk := testdata.TestTable(tableName)
-	// We simulate that a primary column was renamed
-	tableWithStalePk.Columns = append(tableWithStalePk.Columns, schema.Column{Name: "stale_pk_1", Type: schema.TypeUUID, CreationOptions: schema.ColumnCreationOptions{PrimaryKey: true}})
-	tableWithStalePk.Columns = append(tableWithStalePk.Columns, schema.Column{Name: "stale_pk_2", Type: schema.TypeUUID, CreationOptions: schema.ColumnCreationOptions{PrimaryKey: true}})
-	p := destination.NewPlugin("postgresql", "development", New)
-	ctx := context.Background()
-
-	spec := Spec{
-		ConnectionString: getTestConnection(),
-		PgxLogLevel:      LogLevelTrace,
-	}
-
-	// Init the plugin so we can call migrate
-	if err := p.Init(ctx, zerolog.Logger{}, specs.Destination{Name: "stale_pk", Spec: spec}); err != nil {
-		t.Fatal(err)
-	}
-
-	// Call migrate so the `stale_pk_1` and `stale_pk_2` columns are created
-	if err := p.Migrate(ctx, []*schema.Table{tableWithStalePk}); err != nil {
-		t.Fatal(err)
-	}
-
-	// Migrate the table again without the `stale_pk_1` and `stale_pk_2` columns
-	table := testdata.TestTable(tableName)
-	err := p.Migrate(ctx, []*schema.Table{table})
-	expected := `the following primary keys were removed from the schema ["stale_pk_1" "stale_pk_2"] for table "%s".
-You can migrate the table manually by running:
------------------------------------------------------------------------------------------
-alter table "%s" drop constraint if exists "%s_cqpk";
-alter table "%s" alter column "stale_pk_1" drop not null;
-alter table "%s" alter column "stale_pk_2" drop not null;
------------------------------------------------------------------------------------------`
-	require.ErrorContains(t, err, fmt.Sprintf(expected, tableName, tableName, tableName, tableName, tableName))
 }

--- a/plugins/destination/postgresql/client/migrate.go
+++ b/plugins/destination/postgresql/client/migrate.go
@@ -61,26 +61,6 @@ func (c *Client) isTableExistSQL(ctx context.Context, table string) (bool, error
 	return tableExist == 1, nil
 }
 
-func (c *Client) getStalePks(pgPKs map[string]bool, table *schema.Table) []string {
-	stalePks := []string{}
-	if c.enabledPks() {
-		for pk := range pgPKs {
-			stalePk := true
-			for _, col := range table.Columns {
-				if col.Name == pk && col.CreationOptions.PrimaryKey {
-					stalePk = false
-					break
-				}
-			}
-			if stalePk {
-				c.logger.Info().Str("table", table.Name).Str("column", pk).Msg("Column exists with primary key but is not in the schema")
-				stalePks = append(stalePks, pk)
-			}
-		}
-	}
-	return stalePks
-}
-
 func (c *Client) autoMigrateTable(ctx context.Context, table *schema.Table) error {
 	var err error
 	var pgColumns *pgTableColumns
@@ -94,16 +74,6 @@ func (c *Client) autoMigrateTable(ctx context.Context, table *schema.Table) erro
 
 	if pgPKs, err = c.getPgTablePrimaryKeys(ctx, table.Name); err != nil {
 		return fmt.Errorf("failed to get table %s primary key columns: %w", table.Name, err)
-	}
-
-	stalePks := c.getStalePks(pgPKs, table)
-	constraintName := pgx.Identifier{table.Name + "_cqpk"}.Sanitize()
-	dropConstraintSQL := "alter table " + tableName + " drop constraint if exists " + constraintName
-	if len(stalePks) > 0 {
-		message := "the following primary keys were removed from the schema %q for table %q.\nYou can migrate the table manually by running:\n%s"
-		sep := strings.Repeat("-", len(dropConstraintSQL)+1)
-		query := fmt.Sprintf("%s\n%s;\n%s\n%s", sep, dropConstraintSQL, getDropNotNullQuery(table, stalePks), sep)
-		return fmt.Errorf(message, stalePks, table.Name, query)
 	}
 
 	reCreatePrimaryKeys := false
@@ -153,10 +123,9 @@ func (c *Client) autoMigrateTable(ctx context.Context, table *schema.Table) erro
 			reCreatePrimaryKeys = true
 		}
 	}
-
 	if reCreatePrimaryKeys {
 		c.logger.Info().Str("table", table.Name).Msg("Recreating primary keys")
-		if err := c.setNotNullOnPks(ctx, table); err != nil {
+		if err := c.setNullOnPks(ctx, table); err != nil {
 			return fmt.Errorf("failed to enforce not null on primary keys: %w", err)
 		}
 
@@ -164,14 +133,16 @@ func (c *Client) autoMigrateTable(ctx context.Context, table *schema.Table) erro
 		if err != nil {
 			return fmt.Errorf("failed to begin transaction to recreate primary keys: %w", err)
 		}
-		if _, err := tx.Exec(ctx, dropConstraintSQL); err != nil {
+		constraintName := pgx.Identifier{table.Name + "_cqpk"}.Sanitize()
+		sql := "alter table " + tableName + " drop constraint if exists " + constraintName
+		if _, err := tx.Exec(ctx, sql); err != nil {
 			if err := tx.Rollback(ctx); err != nil {
 				c.logger.Error().Err(err).Msg("failed to rollback transaction")
 			}
 			return fmt.Errorf("failed to drop primary key constraint on table %s: %w", table.Name, err)
 		}
 
-		sql := "alter table " + tableName + " add constraint " + constraintName + " primary key (" + strings.Join(table.PrimaryKeys(), ",") + ")"
+		sql = "alter table " + tableName + " add constraint " + constraintName + " primary key (" + strings.Join(table.PrimaryKeys(), ",") + ")"
 		if _, err := tx.Exec(ctx, sql); err != nil {
 			if err := tx.Rollback(ctx); err != nil {
 				c.logger.Error().Err(err).Msg("failed to rollback transaction")
@@ -182,11 +153,10 @@ func (c *Client) autoMigrateTable(ctx context.Context, table *schema.Table) erro
 			return fmt.Errorf("failed to commit transaction to recreate primary keys: %w", err)
 		}
 	}
-
 	return nil
 }
 
-func (c *Client) setNotNullOnPks(ctx context.Context, table *schema.Table) error {
+func (c *Client) setNullOnPks(ctx context.Context, table *schema.Table) error {
 	for _, col := range table.PrimaryKeys() {
 		sql := "alter table " + pgx.Identifier{table.Name}.Sanitize() + " alter column " + pgx.Identifier{col}.Sanitize() + " set not null"
 		if _, err := c.conn.Exec(ctx, sql); err != nil {
@@ -194,15 +164,6 @@ func (c *Client) setNotNullOnPks(ctx context.Context, table *schema.Table) error
 		}
 	}
 	return nil
-}
-
-func getDropNotNullQuery(table *schema.Table, stalePks []string) string {
-	queries := []string{}
-	for _, col := range stalePks {
-		queries = append(queries, "alter table "+pgx.Identifier{table.Name}.Sanitize()+" alter column "+pgx.Identifier{col}.Sanitize()+" drop not null;")
-	}
-
-	return strings.Join(queries, "\n")
 }
 
 func (c *Client) createTableIfNotExist(ctx context.Context, table *schema.Table) error {

--- a/plugins/destination/postgresql/go.mod
+++ b/plugins/destination/postgresql/go.mod
@@ -7,13 +7,6 @@ require (
 	github.com/jackc/pgx-zerolog v0.0.0-20220923130014-7856b90a65ae
 	github.com/jackc/pgx/v5 v5.2.0
 	github.com/rs/zerolog v1.28.0
-	github.com/stretchr/testify v1.8.1
-)
-
-require (
-	github.com/davecgh/go-spew v1.1.1 // indirect
-	github.com/pmezard/go-difflib v1.0.0 // indirect
-	gopkg.in/yaml.v3 v3.0.1 // indirect
 )
 
 require (

--- a/plugins/destination/postgresql/go.sum
+++ b/plugins/destination/postgresql/go.sum
@@ -51,7 +51,6 @@ github.com/coreos/go-systemd/v22 v22.3.3-0.20220203105225-a9a7ef127534/go.mod h1
 github.com/cpuguy83/go-md2man/v2 v2.0.2/go.mod h1:tgQtvFlXSQOSOSIRvRPT7W67SCa46tRHOmNcaadrF8o=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
-github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/envoyproxy/go-control-plane v0.9.0/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
 github.com/envoyproxy/go-control-plane v0.9.1-0.20191026205805-5f8ba28d4473/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
 github.com/envoyproxy/go-control-plane v0.9.4/go.mod h1:6rpuAdCZL397s3pYoYcLgu1mIlRU8Am5FuJP05cCM98=
@@ -185,16 +184,11 @@ github.com/spf13/cobra v1.6.1/go.mod h1:IOw/AERYS7UzyrGinqmz6HLUo219MORXGxhbaJUq
 github.com/spf13/pflag v1.0.5 h1:iy+VFUOCP1a+8yFto/drg2CJ5u0yRoB7fZw3DKv/JXA=
 github.com/spf13/pflag v1.0.5/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
-github.com/stretchr/objx v0.4.0/go.mod h1:YvHI0jy2hoMjB+UWwv71VJQ9isScKT/TqJzVSSt89Yw=
-github.com/stretchr/objx v0.5.0/go.mod h1:Yh+to48EsGEfYuaHDzXPcE3xhTkx73EhmCGUpEOglKo=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
 github.com/stretchr/testify v1.5.1/go.mod h1:5W2xD1RspED5o8YsWQXVCued0rvSQ+mT+I5cxcmMvtA=
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
-github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
-github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
 github.com/stretchr/testify v1.8.1 h1:w7B6lhMri9wdJUVmEZPGGhZzrYTPvgJArz7wNPgYKsk=
-github.com/stretchr/testify v1.8.1/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
 github.com/thoas/go-funk v0.9.3 h1:7+nAEx3kn5ZJcnDm2Bh23N2yOtweO14bi//dvRtgLpw=
 github.com/thoas/go-funk v0.9.3/go.mod h1:+IWnUfUmFO1+WVYQWQtIJHeRRdaIyyYglZN7xzUPe4Q=
 github.com/yuin/goldmark v1.1.25/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=


### PR DESCRIPTION
I think this should be given additional take, potentially not doing any drops as we should avoid those like fire especially when running those in distributed mode and so on. 