### PR TITLE
fix(destinations): Handle nulls in JSONs

### DIFF
--- a/plugins/destination/mongodb/client/transformer.go
+++ b/plugins/destination/mongodb/client/transformer.go
@@ -7,19 +7,31 @@ import (
 )
 
 func (*Client) TransformBool(v *schema.Bool) any {
-	return v.Bool
+	if v.Status == schema.Present {
+		return v.Bool
+	}
+	return nil
 }
 
 func (*Client) TransformBytea(v *schema.Bytea) any {
-	return v.Bytes
+	if v.Status == schema.Present {
+		return v.Bytes
+	}
+	return nil
 }
 
 func (*Client) TransformFloat8(v *schema.Float8) any {
-	return v.Float
+	if v.Status == schema.Present {
+		return v.Float
+	}
+	return nil
 }
 
 func (*Client) TransformInt8(v *schema.Int8) any {
-	return v.Int
+	if v.Status == schema.Present {
+		return v.Int
+	}
+	return nil
 }
 
 func (*Client) TransformInt8Array(v *schema.Int8Array) any {
@@ -42,7 +54,10 @@ func (*Client) TransformJSON(v *schema.JSON) any {
 }
 
 func (*Client) TransformText(v *schema.Text) any {
-	return v.String()
+	if v.Status == schema.Present {
+		return v.String()
+	}
+	return nil
 }
 
 func (*Client) TransformTextArray(v *schema.TextArray) any {
@@ -54,14 +69,17 @@ func (*Client) TransformTextArray(v *schema.TextArray) any {
 }
 
 func (*Client) TransformTimestamptz(v *schema.Timestamptz) any {
-	if v.Status != schema.Present {
-		return nil
+	if v.Status == schema.Present {
+		return v.Time
 	}
-	return v.Time
+	return nil
 }
 
 func (*Client) TransformUUID(v *schema.UUID) any {
-	return v.String()
+	if v.Status == schema.Present {
+		return v.String()
+	}
+	return nil
 }
 
 func (*Client) TransformUUIDArray(v *schema.UUIDArray) any {
@@ -73,7 +91,10 @@ func (*Client) TransformUUIDArray(v *schema.UUIDArray) any {
 }
 
 func (*Client) TransformCIDR(v *schema.CIDR) any {
-	return v.String()
+	if v.Status == schema.Present {
+		return v.String()
+	}
+	return nil
 }
 
 func (*Client) TransformCIDRArray(v *schema.CIDRArray) any {
@@ -85,7 +106,10 @@ func (*Client) TransformCIDRArray(v *schema.CIDRArray) any {
 }
 
 func (*Client) TransformInet(v *schema.Inet) any {
-	return v.String()
+	if v.Status == schema.Present {
+		return v.String()
+	}
+	return nil
 }
 
 func (*Client) TransformInetArray(v *schema.InetArray) any {
@@ -97,7 +121,10 @@ func (*Client) TransformInetArray(v *schema.InetArray) any {
 }
 
 func (*Client) TransformMacaddr(v *schema.Macaddr) any {
-	return v.String()
+	if v.Status == schema.Present {
+		return v.String()
+	}
+	return nil
 }
 
 func (*Client) TransformMacaddrArray(v *schema.MacaddrArray) any {

--- a/plugins/destination/neo4j/client/transformer.go
+++ b/plugins/destination/neo4j/client/transformer.go
@@ -5,19 +5,31 @@ import (
 )
 
 func (*Client) TransformBool(v *schema.Bool) any {
-	return v.Bool
+	if v.Status == schema.Present {
+		return v.Bool
+	}
+	return nil
 }
 
 func (*Client) TransformBytea(v *schema.Bytea) any {
-	return v.Bytes
+	if v.Status == schema.Present {
+		return v.Bytes
+	}
+	return nil
 }
 
 func (*Client) TransformFloat8(v *schema.Float8) any {
-	return v.Float
+	if v.Status == schema.Present {
+		return v.Float
+	}
+	return nil
 }
 
 func (*Client) TransformInt8(v *schema.Int8) any {
-	return v.Int
+	if v.Status == schema.Present {
+		return v.Int
+	}
+	return nil
 }
 
 func (*Client) TransformInt8Array(v *schema.Int8Array) any {
@@ -29,14 +41,17 @@ func (*Client) TransformInt8Array(v *schema.Int8Array) any {
 }
 
 func (*Client) TransformJSON(v *schema.JSON) any {
-	if v.Status != schema.Present {
-		return nil
+	if v.Status == schema.Present {
+		return string(v.Bytes)
 	}
-	return string(v.Bytes)
+	return nil
 }
 
 func (*Client) TransformText(v *schema.Text) any {
-	return v.String()
+	if v.Status == schema.Present {
+		return v.String()
+	}
+	return nil
 }
 
 func (*Client) TransformTextArray(v *schema.TextArray) any {
@@ -48,14 +63,17 @@ func (*Client) TransformTextArray(v *schema.TextArray) any {
 }
 
 func (*Client) TransformTimestamptz(v *schema.Timestamptz) any {
-	if v.Status != schema.Present {
-		return nil
+	if v.Status == schema.Present {
+		return v.Time
 	}
-	return v.Time
+	return nil
 }
 
 func (*Client) TransformUUID(v *schema.UUID) any {
-	return v.String()
+	if v.Status == schema.Present {
+		return v.String()
+	}
+	return nil
 }
 
 func (*Client) TransformUUIDArray(v *schema.UUIDArray) any {
@@ -67,7 +85,10 @@ func (*Client) TransformUUIDArray(v *schema.UUIDArray) any {
 }
 
 func (*Client) TransformCIDR(v *schema.CIDR) any {
-	return v.String()
+	if v.Status == schema.Present {
+		return v.String()
+	}
+	return nil
 }
 
 func (*Client) TransformCIDRArray(v *schema.CIDRArray) any {
@@ -79,7 +100,10 @@ func (*Client) TransformCIDRArray(v *schema.CIDRArray) any {
 }
 
 func (*Client) TransformInet(v *schema.Inet) any {
-	return v.String()
+	if v.Status == schema.Present {
+		return v.String()
+	}
+	return nil
 }
 
 func (*Client) TransformInetArray(v *schema.InetArray) any {
@@ -91,7 +115,10 @@ func (*Client) TransformInetArray(v *schema.InetArray) any {
 }
 
 func (*Client) TransformMacaddr(v *schema.Macaddr) any {
-	return v.String()
+	if v.Status == schema.Present {
+		return v.String()
+	}
+	return nil
 }
 
 func (*Client) TransformMacaddrArray(v *schema.MacaddrArray) any {

--- a/plugins/destination/postgresql/client/transformer.go
+++ b/plugins/destination/postgresql/client/transformer.go
@@ -16,7 +16,11 @@ func (*Client) TransformBool(v *schema.Bool) any {
 }
 
 func (*Client) TransformBytea(v *schema.Bytea) any {
-	return v.Bytes
+	if v.Status == schema.Present {
+		return v.Bytes
+	} else {
+		return nil
+	}
 }
 
 func (*Client) TransformFloat8(v *schema.Float8) any {
@@ -42,7 +46,11 @@ func (*Client) TransformInt8Array(v *schema.Int8Array) any {
 }
 
 func (*Client) TransformJSON(v *schema.JSON) any {
-	return v.Bytes
+	if v.Status == schema.Present {
+		return v.Bytes
+	} else {
+		return nil
+	}
 }
 
 func (*Client) TransformText(v *schema.Text) any {
@@ -83,7 +91,11 @@ func (*Client) TransformUUIDArray(v *schema.UUIDArray) any {
 }
 
 func (*Client) TransformCIDR(v *schema.CIDR) any {
-	return v.IPNet
+	if v.Status == schema.Present {
+		return v.IPNet
+	} else {
+		return nil
+	}
 }
 
 func (*Client) TransformCIDRArray(v *schema.CIDRArray) any {
@@ -95,7 +107,11 @@ func (*Client) TransformCIDRArray(v *schema.CIDRArray) any {
 }
 
 func (*Client) TransformInet(v *schema.Inet) any {
-	return v.IPNet
+	if v.Status == schema.Present {
+		return v.IPNet
+	} else {
+		return nil
+	}
 }
 
 func (*Client) TransformInetArray(v *schema.InetArray) any {
@@ -107,7 +123,11 @@ func (*Client) TransformInetArray(v *schema.InetArray) any {
 }
 
 func (*Client) TransformMacaddr(v *schema.Macaddr) any {
-	return v.Addr
+	if v.Status == schema.Present {
+		return v.Addr
+	} else {
+		return nil
+	}
 }
 
 func (c *Client) TransformMacaddrArray(v *schema.MacaddrArray) any {

--- a/plugins/destination/postgresql/client/transformer.go
+++ b/plugins/destination/postgresql/client/transformer.go
@@ -18,9 +18,8 @@ func (*Client) TransformBool(v *schema.Bool) any {
 func (*Client) TransformBytea(v *schema.Bytea) any {
 	if v.Status == schema.Present {
 		return v.Bytes
-	} else {
-		return nil
 	}
+	return nil
 }
 
 func (*Client) TransformFloat8(v *schema.Float8) any {
@@ -48,9 +47,8 @@ func (*Client) TransformInt8Array(v *schema.Int8Array) any {
 func (*Client) TransformJSON(v *schema.JSON) any {
 	if v.Status == schema.Present {
 		return v.Bytes
-	} else {
-		return nil
 	}
+	return nil
 }
 
 func (*Client) TransformText(v *schema.Text) any {
@@ -93,9 +91,8 @@ func (*Client) TransformUUIDArray(v *schema.UUIDArray) any {
 func (*Client) TransformCIDR(v *schema.CIDR) any {
 	if v.Status == schema.Present {
 		return v.IPNet
-	} else {
-		return nil
 	}
+	return nil
 }
 
 func (*Client) TransformCIDRArray(v *schema.CIDRArray) any {
@@ -109,9 +106,8 @@ func (*Client) TransformCIDRArray(v *schema.CIDRArray) any {
 func (*Client) TransformInet(v *schema.Inet) any {
 	if v.Status == schema.Present {
 		return v.IPNet
-	} else {
-		return nil
 	}
+	return nil
 }
 
 func (*Client) TransformInetArray(v *schema.InetArray) any {
@@ -125,9 +121,8 @@ func (*Client) TransformInetArray(v *schema.InetArray) any {
 func (*Client) TransformMacaddr(v *schema.Macaddr) any {
 	if v.Status == schema.Present {
 		return v.Addr
-	} else {
-		return nil
 	}
+	return nil
 }
 
 func (c *Client) TransformMacaddrArray(v *schema.MacaddrArray) any {


### PR DESCRIPTION
Looks like we didn't handle `nulls` well in all cases.

This should close https://github.com/cloudquery/cloudquery/issues/6333 and also the recent pg report that we got.

Side note: There is some boilerplate code here but I don't think there is a way to avoid it because we do want to give destinations an opportunity to decide what to do on `null` value which might not always be just send null as it can be empty `string` like in CSV or some other value.