### PR TITLE
fix(table-diff): Mark type changes as breaking

### DIFF
--- a/scripts/table_diff/changes/changes.go
+++ b/scripts/table_diff/changes/changes.go
@@ -101,7 +101,7 @@ func getColumnChanges(file *gitdiff.File, table string) (changes []change) {
 			if addedColumn.dataType != deletedColumn.dataType {
 				changes = append(changes, change{
 					Text:     fmt.Sprintf("Table %s: column type changed from %s to %s for %s", backtickStrings(table, deletedColumn.dataType, addedColumn.dataType, deletedName)...),
-					Breaking: false,
+					Breaking: true,
 				})
 			}
 


### PR DESCRIPTION
<!-- 🎉 Thank you for making CloudQuery awesome by submitting a PR 🎉 -->

#### Summary

While we [auto migrate type changes](https://github.com/cloudquery/cloudquery/blob/a4987ae191b9f5e660d29ca4a99f1469dd9e1fe7/plugins/destination/postgresql/client/migrate.go#LL110C8-L110C8) I believe those should still be considered breaking as they can impact how the data is queried

<!--
Use the following steps to ensure your PR is ready to be reviewed

- [ ] Read the [contribution guidelines](../blob/main/CONTRIBUTING.md) 🧑‍🎓
- [ ] Test locally on your own infrastructure
- [ ] Run `go fmt` to format your code 🖊
- [ ] Lint your changes via `golangci-lint run` 🚨 (install golangci-lint [here](https://golangci-lint.run/usage/install/#local-installation))
- [ ] Update or add tests 🧪
- [ ] Ensure the status checks below are successful ✅
--->
