### PR TITLE
fix(gcp-resources): Add `project_id` and `id` as PKs of `gcp_bigquery_tables`

### DIFF
--- a/plugins/source/gcp/docs/tables/gcp_bigquery_tables.md
+++ b/plugins/source/gcp/docs/tables/gcp_bigquery_tables.md
@@ -2,7 +2,7 @@
 
 https://cloud.google.com/bigquery/docs/reference/rest/v2/tables#Table
 
-The primary key for this table is **_cq_id**.
+The composite primary key for this table is (**project_id**, **id**).
 
 ## Relations
 
@@ -14,9 +14,10 @@ This table depends on [gcp_bigquery_datasets](gcp_bigquery_datasets.md).
 | ------------- | ------------- |
 |_cq_source_name|String|
 |_cq_sync_time|Timestamp|
-|_cq_id (PK)|UUID|
+|_cq_id|UUID|
 |_cq_parent_id|UUID|
-|project_id|String|
+|project_id (PK)|String|
+|id (PK)|String|
 |clone_definition|JSON|
 |clustering|JSON|
 |creation_time|Int|
@@ -27,7 +28,6 @@ This table depends on [gcp_bigquery_datasets](gcp_bigquery_datasets.md).
 |expiration_time|Int|
 |external_data_configuration|JSON|
 |friendly_name|String|
-|id|String|
 |kind|String|
 |labels|JSON|
 |last_modified_time|Int|

--- a/plugins/source/gcp/resources/services/bigquery/tables.go
+++ b/plugins/source/gcp/resources/services/bigquery/tables.go
@@ -20,6 +20,17 @@ func Tables() *schema.Table {
 				Name:     "project_id",
 				Type:     schema.TypeString,
 				Resolver: client.ResolveProject,
+				CreationOptions: schema.ColumnCreationOptions{
+					PrimaryKey: true,
+				},
+			},
+			{
+				Name:     "id",
+				Type:     schema.TypeString,
+				Resolver: schema.PathResolver("Id"),
+				CreationOptions: schema.ColumnCreationOptions{
+					PrimaryKey: true,
+				},
 			},
 		},
 	}


### PR DESCRIPTION
<!-- 🎉 Thank you for making CloudQuery awesome by submitting a PR 🎉 -->

#### Summary

Same as https://github.com/cloudquery/cloudquery/pull/6532 for tables

<!--
Use the following steps to ensure your PR is ready to be reviewed

- [ ] Read the [contribution guidelines](../blob/main/CONTRIBUTING.md) 🧑‍🎓
- [ ] Test locally on your own infrastructure
- [ ] Run `go fmt` to format your code 🖊
- [ ] Lint your changes via `golangci-lint run` 🚨 (install golangci-lint [here](https://golangci-lint.run/usage/install/#local-installation))
- [ ] Update or add tests 🧪
- [ ] Ensure the status checks below are successful ✅
--->
