### PR TITLE
fix(gcp-resources): Add `project_id, instance_name, name` as PKs for gcp_bigtableadmin_tables`

### DIFF
--- a/plugins/source/gcp/docs/tables/gcp_bigtableadmin_tables.md
+++ b/plugins/source/gcp/docs/tables/gcp_bigtableadmin_tables.md
@@ -2,7 +2,7 @@
 
 https://cloud.google.com/bigtable/docs/reference/admin/rest/v2/projects.instances.tables#Table
 
-The primary key for this table is **project_id**.
+The composite primary key for this table is (**project_id**, **instance_name**, **name**).
 
 ## Relations
 
@@ -17,6 +17,8 @@ This table depends on [gcp_bigtableadmin_instances](gcp_bigtableadmin_instances.
 |_cq_id|UUID|
 |_cq_parent_id|UUID|
 |project_id (PK)|String|
+|instance_name (PK)|String|
+|name (PK)|String|
 |families|StringArray|
 |family_infos|JSON|
 |deletion_protection|Int|

--- a/plugins/source/gcp/resources/services/bigtableadmin/tables.go
+++ b/plugins/source/gcp/resources/services/bigtableadmin/tables.go
@@ -24,6 +24,22 @@ func Tables() *schema.Table {
 					PrimaryKey: true,
 				},
 			},
+			{
+				Name:     "instance_name",
+				Type:     schema.TypeString,
+				Resolver: schema.ParentColumnResolver("name"),
+				CreationOptions: schema.ColumnCreationOptions{
+					PrimaryKey: true,
+				},
+			},
+			{
+				Name:     "name",
+				Type:     schema.TypeString,
+				Resolver: schema.PathResolver("Name"),
+				CreationOptions: schema.ColumnCreationOptions{
+					PrimaryKey: true,
+				},
+			},
 		},
 	}
 }


### PR DESCRIPTION
<!-- 🎉 Thank you for making CloudQuery awesome by submitting a PR 🎉 -->

#### Summary

`gcp_bigtableadmin_tables` had only `project_id` as PK which means we can only get 1 per project in `overwrite*` modes.
Since the API doesn't provide an Id we need to use the parent `instance_name` and table name.
The code to get the table name already exists:
https://github.com/cloudquery/cloudquery/blob/60c0f145577881c4850eb82f546da47a1d57ed5c/plugins/source/gcp/resources/services/bigtableadmin/tables_fetch.go#L28
I added it accidentally in https://github.com/cloudquery/cloudquery/pull/6384

<!--
Use the following steps to ensure your PR is ready to be reviewed

- [ ] Read the [contribution guidelines](../blob/main/CONTRIBUTING.md) 🧑‍🎓
- [ ] Test locally on your own infrastructure
- [ ] Run `go fmt` to format your code 🖊
- [ ] Lint your changes via `golangci-lint run` 🚨 (install golangci-lint [here](https://golangci-lint.run/usage/install/#local-installation))
- [ ] Update or add tests 🧪
- [ ] Ensure the status checks below are successful ✅
--->
