### PR TITLE
fix(website): Set Id for Hacker News source plugin in overview table

### DIFF
--- a/website/pages/docs/plugins/sources/overview.mdx
+++ b/website/pages/docs/plugins/sources/overview.mdx
@@ -23,7 +23,7 @@ Official source plugins follow [release stages](#source-plugin-release-stages).
             { name: "Fastly", stage:"Preview" },
             { name: "GitHub", stage:"GA" },
             { name: "GitLab", stage:"Preview" },
-            { name: "Hacker News", stage:"Preview" },
+            { name: "Hacker News", stage:"Preview", id: `hackernews` },
             { name: "Heroku", stage:"Preview" },
             { name: "k8s", stage:"Preview" },
             { name: "Okta", stage:"Preview" },


### PR DESCRIPTION
<!-- 🎉 Thank you for making CloudQuery awesome by submitting a PR 🎉 -->

#### Summary

We need to set the id where we can't easily use the name to link to the overview.
Another option is to update the login in https://github.com/cloudquery/cloudquery/blob/d089745836f4d6a3e862ea7a98e57fd5054fa970/website/components/PluginsTable.tsx#L65
to strip whitespaces when defaulting to `name`

<!--
Use the following steps to ensure your PR is ready to be reviewed

- [ ] Read the [contribution guidelines](../blob/main/CONTRIBUTING.md) 🧑‍🎓
- [ ] Test locally on your own infrastructure
- [ ] Run `go fmt` to format your code 🖊
- [ ] Lint your changes via `golangci-lint run` 🚨 (install golangci-lint [here](https://golangci-lint.run/usage/install/#local-installation))
- [ ] Update or add tests 🧪
- [ ] Ensure the status checks below are successful ✅
--->
