### PR TITLE
fix: Revert "fix(gcp-resources): Add `organization_id` and `name` as PK of `gcp_resourcemanager_folders`

### DIFF
--- a/plugins/source/gcp/docs/tables/gcp_resourcemanager_folders.md
+++ b/plugins/source/gcp/docs/tables/gcp_resourcemanager_folders.md
@@ -2,7 +2,7 @@
 
 https://cloud.google.com/resource-manager/reference/rest/v3/folders#Folder
 
-The composite primary key for this table is (**organization_id**, **name**).
+The primary key for this table is **_cq_id**.
 
 ## Columns
 
@@ -10,10 +10,10 @@ The composite primary key for this table is (**organization_id**, **name**).
 | ------------- | ------------- |
 |_cq_source_name|String|
 |_cq_sync_time|Timestamp|
-|_cq_id|UUID|
+|_cq_id (PK)|UUID|
 |_cq_parent_id|UUID|
-|organization_id (PK)|String|
-|name (PK)|String|
+|organization_id|String|
+|name|String|
 |parent|String|
 |display_name|String|
 |state|String|

--- a/plugins/source/gcp/resources/services/resourcemanager/folders.go
+++ b/plugins/source/gcp/resources/services/resourcemanager/folders.go
@@ -19,17 +19,6 @@ func Folders() *schema.Table {
 				Name:     "organization_id",
 				Type:     schema.TypeString,
 				Resolver: resolveOrganizationId,
-				CreationOptions: schema.ColumnCreationOptions{
-					PrimaryKey: true,
-				},
-			},
-			{
-				Name:     "name",
-				Type:     schema.TypeString,
-				Resolver: schema.PathResolver("Name"),
-				CreationOptions: schema.ColumnCreationOptions{
-					PrimaryKey: true,
-				},
 			},
 		},
 	}


### PR DESCRIPTION
<!-- 🎉 Thank you for making CloudQuery awesome by submitting a PR 🎉 -->

#### Summary

Looks like `organization_id` can be `nil`. `name` should be good enough:
https://github.com/cloudquery/cloudquery/blob/d90410764f8d3e3c0bed82db0a143885e0c90190/plugins/source/gcp/resources/services/resourcemanager/folders_fetch.go#L44

<!--
Use the following steps to ensure your PR is ready to be reviewed

- [ ] Read the [contribution guidelines](../blob/main/CONTRIBUTING.md) 🧑‍🎓
- [ ] Test locally on your own infrastructure
- [ ] Run `go fmt` to format your code 🖊
- [ ] Lint your changes via `golangci-lint run` 🚨 (install golangci-lint [here](https://golangci-lint.run/usage/install/#local-installation))
- [ ] Update or add tests 🧪
- [ ] Ensure the status checks below are successful ✅
--->
