### PR TITLE
fix(postgres): Error on new PK column

### DIFF
--- a/plugins/destination/postgresql/client/migrate.go
+++ b/plugins/destination/postgresql/client/migrate.go
@@ -123,7 +123,7 @@ func (c *Client) autoMigrateTable(ctx context.Context, table *schema.Table) erro
 
 			sql := "alter table " + tableName + " add column " + columnName + " " + columnType
 			if col.CreationOptions.PrimaryKey {
-				reCreatePrimaryKeys = true
+				return fmt.Errorf("failed to auto-migrate table %s: adding the new column %s as a primary key to an existing table is not supported. Please drop the table and re-run", table.Name, col.Name)
 			}
 			if _, err := c.conn.Exec(ctx, sql); err != nil {
 				return fmt.Errorf("failed to add column %s on table %s: %w", col.Name, table.Name, err)


### PR DESCRIPTION
<!-- 🎉 Thank you for making CloudQuery awesome by submitting a PR 🎉 -->

#### Summary

Related to https://github.com/cloudquery/cloudquery/issues/6600.

This changes the Postgres migration logic to fail when a new column is added and it's a PK.
This is the same as the SQLite plugin:
https://github.com/cloudquery/cloudquery/blob/bfd1494fa464f2cafa4b1d04bfd54ac4726319ad/plugins/destination/sqlite/client/migrate.go#L93

I think we can improve this as only error if the table exists and is not empty as for empty tables this shouldn't be an issue 

<!--
Use the following steps to ensure your PR is ready to be reviewed

- [ ] Read the [contribution guidelines](../blob/main/CONTRIBUTING.md) 🧑‍🎓
- [ ] Test locally on your own infrastructure
- [ ] Run `go fmt` to format your code 🖊
- [ ] Lint your changes via `golangci-lint run` 🚨 (install golangci-lint [here](https://golangci-lint.run/usage/install/#local-installation))
- [ ] Update or add tests 🧪
- [ ] Ensure the status checks below are successful ✅
--->
