### PR TITLE
feat(s3): Expose New Options

### DIFF
--- a/plugins/destination/s3/client/read.go
+++ b/plugins/destination/s3/client/read.go
@@ -45,11 +45,26 @@ func (c *Client) Read(ctx context.Context, table *schema.Table, sourceName strin
 
 	switch c.pluginSpec.Format {
 	case FormatTypeCSV:
-		if err := csv.Read(r, table, sourceName, res); err != nil {
+		opts := []csv.Options{
+			csv.WithDelimiter(c.pluginSpec.Delimiter),
+		}
+		if c.pluginSpec.IncludeHeaders {
+			opts = append(opts, csv.WithHeader())
+		}
+
+		client, err := csv.NewClient(opts...)
+		if err != nil {
+			return err
+		}
+		if err = client.Read(r, table, sourceName, res); err != nil {
 			return err
 		}
 	case FormatTypeJSON:
-		if err := json.Read(r, table, sourceName, res); err != nil {
+		client, err := json.NewClient()
+		if err != nil {
+			return err
+		}
+		if err := client.Read(r, table, sourceName, res); err != nil {
 			return err
 		}
 	default:

--- a/plugins/destination/s3/client/spec.go
+++ b/plugins/destination/s3/client/spec.go
@@ -12,13 +12,19 @@ const (
 )
 
 type Spec struct {
-	Bucket   string     `json:"bucket,omitempty"`
-	Path     string     `json:"path,omitempty"`
-	Format   FormatType `json:"format,omitempty"`
-	NoRotate bool       `json:"no_rotate,omitempty"`
+	Bucket         string     `json:"bucket,omitempty"`
+	Path           string     `json:"path,omitempty"`
+	Format         FormatType `json:"format,omitempty"`
+	IncludeHeaders bool       `json:"include_headers,omitempty"`
+	Delimiter      rune       `json:"delimiter,omitempty"`
+	NoRotate       bool       `json:"no_rotate,omitempty"`
 }
 
-func (*Spec) SetDefaults() {}
+func (s *Spec) SetDefaults() {
+	if s.Delimiter == 0 {
+		s.Delimiter = ','
+	}
+}
 
 func (s *Spec) Validate() error {
 	if s.Bucket == "" {

--- a/plugins/destination/s3/client/write.go
+++ b/plugins/destination/s3/client/write.go
@@ -23,11 +23,19 @@ func (c *Client) WriteTableBatch(ctx context.Context, table *schema.Table, data 
 	w := io.Writer(&b)
 	switch c.pluginSpec.Format {
 	case FormatTypeCSV:
-		if err := csv.WriteTableBatch(w, table, data); err != nil {
+		client, err := csv.NewClient()
+		if err != nil {
+			return err
+		}
+		if err := client.WriteTableBatch(w, table, data); err != nil {
 			return err
 		}
 	case FormatTypeJSON:
-		if err := json.WriteTableBatch(w, table, data); err != nil {
+		client, err := json.NewClient()
+		if err != nil {
+			return err
+		}
+		if err := client.WriteTableBatch(w, table, data); err != nil {
 			return err
 		}
 	default:

--- a/plugins/destination/s3/go.mod
+++ b/plugins/destination/s3/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/config v1.18.8
 	github.com/aws/aws-sdk-go-v2/feature/s3/manager v1.11.47
 	github.com/aws/aws-sdk-go-v2/service/s3 v1.30.0
-	github.com/cloudquery/filetypes v1.0.6
+	github.com/cloudquery/filetypes v1.1.0
 	github.com/cloudquery/plugin-sdk v1.27.0
 	github.com/google/uuid v1.3.0
 	github.com/rs/zerolog v1.28.0

--- a/plugins/destination/s3/go.sum
+++ b/plugins/destination/s3/go.sum
@@ -78,8 +78,8 @@ github.com/chzyer/logex v1.1.10/go.mod h1:+Ywpsq7O8HXn0nuIou7OrIPyXbp3wmkHB+jjWR
 github.com/chzyer/readline v0.0.0-20180603132655-2972be24d48e/go.mod h1:nSuG5e5PlCu98SY8svDHJxuZscDgtXS6KTTbou5AhLI=
 github.com/chzyer/test v0.0.0-20180213035817-a1ea475d72b1/go.mod h1:Q3SI9o4m/ZMnBNeIyt5eFwwo7qiLfzFZmjNmxjkiQlU=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
-github.com/cloudquery/filetypes v1.0.6 h1:Jy93/hrSS7FEIQnAl9DSS18dh8xCeP7bUS/Ufrm27j0=
-github.com/cloudquery/filetypes v1.0.6/go.mod h1:J+aAJCqYnBsD0s5R350GORkL2od8rilOYu6vKBD5l8M=
+github.com/cloudquery/filetypes v1.1.0 h1:6OOogHzaBXPy0Lmxue0FZEYFI0ouY9EwzwIQPYSg95s=
+github.com/cloudquery/filetypes v1.1.0/go.mod h1:J+aAJCqYnBsD0s5R350GORkL2od8rilOYu6vKBD5l8M=
 github.com/cloudquery/plugin-sdk v1.27.0 h1:DXuvnBt1gOB98umBZU6jltZEV6oxfsdEBIAbQXFcIx4=
 github.com/cloudquery/plugin-sdk v1.27.0/go.mod h1:teMPyCON3uPdMsHvzpSiOg+IK2sOR5Tf9dYLreoURzI=
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=


### PR DESCRIPTION
<!-- 🎉 Thank you for making CloudQuery awesome by submitting a PR 🎉 -->

#### Summary

Users can now use the following options to change the destination behavior:
1. `include_header`: default is `false` when set to true first row will be the column headers
2. `delimiter`: default value is `,` but user can specify any single character


<!--
Use the following steps to ensure your PR is ready to be reviewed

- [ ] Read the [contribution guidelines](../blob/main/CONTRIBUTING.md) 🧑‍🎓
- [ ] Test locally on your own infrastructure
- [ ] Run `go fmt` to format your code 🖊
- [ ] Lint your changes via `golangci-lint run` 🚨 (install golangci-lint [here](https://golangci-lint.run/usage/install/#local-installation))
- [ ] Update or add tests 🧪
- [ ] Ensure the status checks below are successful ✅
--->
