### PR TITLE
chore(website): Add plausible analytics

### DIFF
--- a/website/pages/_app.tsx
+++ b/website/pages/_app.tsx
@@ -39,6 +39,7 @@ export default function Nextra({ Component, pageProps }) {
                 : (window.sa_event.q = [a]);
             })}
       </Script>
+      <Script defer data-domain="cloudquery.io" src="https://plausible.io/js/script.js"></Script>
       <Script src="https://scripts.simpleanalyticscdn.com/latest.js" />
       <noscript>
         {/* eslint-disable @next/next/no-img-element */}


### PR DESCRIPTION
Add plausible analytics for two reasons:

1) I need that to work on the plausible plugin
2) we can check this out and we can keep it if we like it or remove later on if simple analytics is good enough for us (we don't need to add cookie consent to this analytics as well).