### PR TITLE
fix(website): Add Plausible Analytics to meta.json

### DIFF
--- a/website/pages/docs/plugins/sources/_meta.json
+++ b/website/pages/docs/plugins/sources/_meta.json
@@ -23,6 +23,7 @@
   "snyk": "Snyk",
   "stripe": "Stripe",
   "pagerduty": "PagerDuty",
+  "plausible": "Plausible",
   "tailscale": "Tailscale",
   "terraform": "Terraform",
   "vercel": "Vercel"

--- a/website/pages/docs/plugins/sources/overview.mdx
+++ b/website/pages/docs/plugins/sources/overview.mdx
@@ -42,6 +42,7 @@ Official source plugins follow [release stages](#source-plugin-release-stages).
             { name: "Vercel", stage: "Preview" },
             { name: "Snyk", stage: "Preview" },
             { name: "Azure DevOps", stage: "Preview", id: `azuredevops` },
+            { name: "Plausible Analytics", stage: "Preview", id: `plausible` },
         ]
     }
 />
@@ -49,7 +50,7 @@ Official source plugins follow [release stages](#source-plugin-release-stages).
 ## Community
 
 | **Name**                                                     |
-|--------------------------------------------------------------|
+| ------------------------------------------------------------ |
 | [Yandex](https://github.com/yandex-cloud/cq-provider-yandex) |
 
 ## Source Plugin Release Stages
@@ -70,4 +71,3 @@ For version `Major.Minor.Patch`:
 - `Major` is incremented when there are breaking changes (e.g. breaking configuration spec structure, column type changes).
 - `Minor` is incremented when we add features in a backwards compatible way.
 - `Patch` is incremented when we fix bugs in a backwards compatible way.
-


### PR DESCRIPTION
<!-- 🎉 Thank you for making CloudQuery awesome by submitting a PR 🎉 -->

#### Summary

I think the plugin needs to be in the `meta.json` as a route, otherwise our versions find replace logic doesn't work

<!--
Use the following steps to ensure your PR is ready to be reviewed

- [ ] Read the [contribution guidelines](../blob/main/CONTRIBUTING.md) 🧑‍🎓
- [ ] Test locally on your own infrastructure
- [ ] Run `go fmt` to format your code 🖊
- [ ] Lint your changes via `golangci-lint run` 🚨 (install golangci-lint [here](https://golangci-lint.run/usage/install/#local-installation))
- [ ] Update or add tests 🧪
- [ ] Ensure the status checks below are successful ✅
--->
