### PR TITLE
fix(cli): Continue to next source after successful sync/migrate

### DIFF
--- a/cli/cmd/migrate.go
+++ b/cli/cmd/migrate.go
@@ -72,7 +72,7 @@ func migrate(cmd *cobra.Command, args []string) error {
 			if err := migrateConnectionV0(ctx, cqDir, *sourceSpec, destinationsSpecs); err != nil {
 				return fmt.Errorf("failed to migrate source %s: %w", sourceSpec.Name, err)
 			}
-			return nil
+			continue
 		}
 
 		if err := discoveryClient.Terminate(); err != nil {
@@ -83,14 +83,14 @@ func migrate(cmd *cobra.Command, args []string) error {
 			if err := migrateConnectionV1(ctx, cqDir, *sourceSpec, destinationsSpecs); err != nil {
 				return fmt.Errorf("failed to migrate source %s: %w", sourceSpec.Name, err)
 			}
-			return nil
+			continue
 		}
 
 		if slices.Index(versions, "v0") != -1 {
 			if err := migrateConnectionV0(ctx, cqDir, *sourceSpec, destinationsSpecs); err != nil {
 				return fmt.Errorf("failed to migrate source %s: %w", sourceSpec.Name, err)
 			}
-			return nil
+			continue
 		}
 
 		return fmt.Errorf("failed to migrate source %s, unknown versions %v", sourceSpec.Name, versions)

--- a/cli/cmd/sync.go
+++ b/cli/cmd/sync.go
@@ -88,7 +88,7 @@ func sync(cmd *cobra.Command, args []string) error {
 			if err := syncConnectionV0(ctx, cqDir, *sourceSpec, destinationsSpecs, invocationUUID.String(), noMigrate); err != nil {
 				return fmt.Errorf("failed to sync source %s: %w", sourceSpec.Name, err)
 			}
-			return nil
+			continue
 		}
 		if err := discoveryClient.Terminate(); err != nil {
 			return fmt.Errorf("failed to terminate discovery client: %w", err)
@@ -98,14 +98,14 @@ func sync(cmd *cobra.Command, args []string) error {
 			if err := syncConnectionV1(ctx, cqDir, *sourceSpec, destinationsSpecs, invocationUUID.String(), noMigrate); err != nil {
 				return fmt.Errorf("failed to sync v1 source %s: %w", sourceSpec.Name, err)
 			}
-			return nil
+			continue
 		}
 
 		if slices.Index(versions, "v0") != -1 {
 			if err := syncConnectionV1(ctx, cqDir, *sourceSpec, destinationsSpecs, invocationUUID.String(), noMigrate); err != nil {
 				return fmt.Errorf("failed to sync v0 source %s: %w", sourceSpec.Name, err)
 			}
-			return nil
+			continue
 		}
 
 		return fmt.Errorf("failed to sync source %s, unknown versions %v", sourceSpec.Name, versions)


### PR DESCRIPTION
<!-- 🎉 Thank you for making CloudQuery awesome by submitting a PR 🎉 -->

#### Summary

Multiple sources support is broken in the new CLI. This should fix it

<!--
Use the following steps to ensure your PR is ready to be reviewed

- [ ] Read the [contribution guidelines](../blob/main/CONTRIBUTING.md) 🧑‍🎓
- [ ] Test locally on your own infrastructure
- [ ] Run `go fmt` to format your code 🖊
- [ ] Lint your changes via `golangci-lint run` 🚨 (install golangci-lint [here](https://golangci-lint.run/usage/install/#local-installation))
- [ ] Update or add tests 🧪
- [ ] Ensure the status checks below are successful ✅
--->
