### PR TITLE
doc: Reorder the points on the performance tuning page

### DIFF
--- a/website/pages/docs/advanced-topics/performance-tuning.mdx
+++ b/website/pages/docs/advanced-topics/performance-tuning.mdx
@@ -6,31 +6,6 @@ title: Performance Tuning
 
 This page contains a number of tips and tricks for improving the performance of `cloudquery sync` for large cloud estates.
 
-## Tune Concurrency
-
-The `concurrency` setting, available for all source plugins as part of the [source spec](/docs/reference/source-spec#concurrency), controls the approximate number of concurrent requests that will be made while performing a sync. Setting this to a low number will reduce the number of concurrent requests, reducing the memory used and making the sync less likely to hit rate limits. The trade-off is that syncs will take longer to complete.
-
-## Use a Different Scheduler
-
-By default, CloudQuery syncs will fetch all tables in parallel, writing data to the destination(s) as they come in. However, the `concurrency` setting, mentioned above, places a limit on how many **table-clients** can be synced at a time. What "table-client" means depends on the source plugin and the table. In AWS, for example, a client is usually a combination of account and region. Get all the combinations of accounts and regions for all tables, and you have all the table-clients for a sync. For the GCP source plugin, clients generally map to projects.
-
-The default CloudQuery scheduler, known as `dfs`, will sync up to `concurrency / 100` table-clients at a time (we are ignoring child relations for the purposes of this discussion). Let's take an example GCP cloud estate with 5000 projects, syncing 100 tables. This makes for approximately 500,000 table-client pairs, and a concurrency of 10,000 will allow 100 table-client pairs to be synced at a time. The `dfs` scheduler will start with the first table and its first 100 projects, and then move on to finish all projects for that table before moving on to the next table. This means, in practice, only one table is really being synced at a time!
-
-Usually this works out fine, as long as the cloud platform's rate limits are aligned with the clients. But if rate limits are applied per-table, rather than per-project, `dfs` can be suboptimal. A better strategy in this case would be to choose the first client for every table before moving on to the next client. This is what the `round-robin` scheduler does. Note that this scheduler is currently **experimental**. 
-
-The following example config enables `round-robin` scheduling for the GCP source plugin, with a concurrency of 100000:
-
-```yaml
-kind: source
-spec:
-  name: "gcp"
-  path: "cloudquery/gcp"
-  version: "VERSION_SOURCE_GCP"
-  destinations: ["postgresql"]
-  concurrency: 100000
-  scheduler: "round-robin"  # experimental
-```
-
 ## Use Wildcard Matching
 
 import { Callout } from 'nextra-theme-docs'
@@ -81,3 +56,29 @@ skip_tables:
 ```
 
 By skipping table `B`, we are automatically skipping its dependant table `C` as well. Likewise, by including table `A`, we are automatically including its dependant tables `B` and `C` as well, unless they are explicitly skipped in the `skip_tables` section (like in the example above).
+
+## Tune Concurrency
+
+The `concurrency` setting, available for all source plugins as part of the [source spec](/docs/reference/source-spec#concurrency), controls the approximate number of concurrent requests that will be made while performing a sync. Setting this to a low number will reduce the number of concurrent requests, reducing the memory used and making the sync less likely to hit rate limits. The trade-off is that syncs will take longer to complete.
+
+## Use a Different Scheduler
+
+By default, CloudQuery syncs will fetch all tables in parallel, writing data to the destination(s) as they come in. However, the `concurrency` setting, mentioned above, places a limit on how many **table-clients** can be synced at a time. What "table-client" means depends on the source plugin and the table. In AWS, for example, a client is usually a combination of account and region. Get all the combinations of accounts and regions for all tables, and you have all the table-clients for a sync. For the GCP source plugin, clients generally map to projects.
+
+The default CloudQuery scheduler, known as `dfs`, will sync up to `concurrency / 100` table-clients at a time (we are ignoring child relations for the purposes of this discussion). Let's take an example GCP cloud estate with 5000 projects, syncing 100 tables. This makes for approximately 500,000 table-client pairs, and a concurrency of 10,000 will allow 100 table-client pairs to be synced at a time. The `dfs` scheduler will start with the first table and its first 100 projects, and then move on to finish all projects for that table before moving on to the next table. This means, in practice, only one table is really being synced at a time!
+
+Usually this works out fine, as long as the cloud platform's rate limits are aligned with the clients. But if rate limits are applied per-table, rather than per-project, `dfs` can be suboptimal. A better strategy in this case would be to choose the first client for every table before moving on to the next client. This is what the `round-robin` scheduler does. Note that this scheduler is currently **experimental**. 
+
+The following example config enables `round-robin` scheduling for the GCP source plugin, with a concurrency of 100000:
+
+```yaml
+kind: source
+spec:
+  name: "gcp"
+  path: "cloudquery/gcp"
+  version: "VERSION_SOURCE_GCP"
+  destinations: ["postgresql"]
+  concurrency: 100000
+  scheduler: "round-robin"  # experimental
+```
+


### PR DESCRIPTION
Absolutely a nit, but using wildcard-matching to limit tables synced may be more effective than tuning concurrency settings.

<!-- 🎉 Thank you for making CloudQuery awesome by submitting a PR 🎉 -->

#### Summary

<!--
Explain what problem this PR addresses
-->

<!--
Use the following steps to ensure your PR is ready to be reviewed

- [ ] Read the [contribution guidelines](../blob/main/CONTRIBUTING.md) 🧑‍🎓
- [ ] Test locally on your own infrastructure
- [ ] Run `go fmt` to format your code 🖊
- [ ] Lint your changes via `golangci-lint run` 🚨 (install golangci-lint [here](https://golangci-lint.run/usage/install/#local-installation))
- [ ] Update or add tests 🧪
- [ ] Ensure the status checks below are successful ✅
--->
