### PR TITLE
fix(azure)!: Add `subscription_id` to `azure_security_secure_score_control_definitions` PK

### DIFF
--- a/plugins/source/azure/docs/tables/azure_security_secure_score_control_definitions.md
+++ b/plugins/source/azure/docs/tables/azure_security_secure_score_control_definitions.md
@@ -2,7 +2,7 @@
 
 https://learn.microsoft.com/en-us/rest/api/defenderforcloud/secure-score-control-definitions/list?tabs=HTTP#securescorecontroldefinitionitem
 
-The primary key for this table is **id**.
+The composite primary key for this table is (**subscription_id**, **id**).
 
 ## Columns
 
@@ -12,7 +12,7 @@ The primary key for this table is **id**.
 |_cq_sync_time|Timestamp|
 |_cq_id|UUID|
 |_cq_parent_id|UUID|
-|subscription_id|String|
+|subscription_id (PK)|String|
 |properties|JSON|
 |id (PK)|String|
 |name|String|

--- a/plugins/source/azure/resources/services/security/secure_score_control_definitions.go
+++ b/plugins/source/azure/resources/services/security/secure_score_control_definitions.go
@@ -16,7 +16,7 @@ func SecureScoreControlDefinitions() *schema.Table {
 		Description: "https://learn.microsoft.com/en-us/rest/api/defenderforcloud/secure-score-control-definitions/list?tabs=HTTP#securescorecontroldefinitionitem",
 		Multiplex:   client.SubscriptionMultiplexRegisteredNamespace("azure_security_secure_score_control_definitions", client.Namespacemicrosoft_security),
 		Transform:   transformers.TransformWithStruct(&armsecurity.SecureScoreControlDefinitionItem{}, transformers.WithPrimaryKeys("ID")),
-		Columns:     schema.ColumnList{client.SubscriptionID},
+		Columns:     schema.ColumnList{client.SubscriptionIDPK},
 	}
 }
 


### PR DESCRIPTION
Fixes #7256