### PR TITLE
fix: Fix discovery error check

### DIFF
--- a/cli/cmd/migrate.go
+++ b/cli/cmd/migrate.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"strings"
 
-	discovery "github.com/cloudquery/plugin-sdk/clients/discovery/v0"
+	"github.com/cloudquery/plugin-sdk/clients/discovery/v0"
 	"github.com/cloudquery/plugin-sdk/registry"
 	"github.com/cloudquery/plugin-sdk/specs"
 	"github.com/rs/zerolog/log"
@@ -65,7 +65,7 @@ func migrate(cmd *cobra.Command, args []string) error {
 		}
 		versions, err := discoveryClient.GetVersions(ctx)
 		if err != nil {
-			if discoveryErr := discoveryClient.Terminate(); err != nil {
+			if discoveryErr := discoveryClient.Terminate(); discoveryErr != nil {
 				log.Error().Err(discoveryErr).Msg("failed to terminate discovery client")
 				fmt.Println("failed to terminate discovery client:", discoveryErr)
 			}

--- a/cli/cmd/sync.go
+++ b/cli/cmd/sync.go
@@ -7,7 +7,7 @@ import (
 	"github.com/google/uuid"
 	"golang.org/x/exp/slices"
 
-	discovery "github.com/cloudquery/plugin-sdk/clients/discovery/v0"
+	"github.com/cloudquery/plugin-sdk/clients/discovery/v0"
 	"github.com/cloudquery/plugin-sdk/registry"
 	"github.com/cloudquery/plugin-sdk/specs"
 	"github.com/rs/zerolog/log"
@@ -80,7 +80,7 @@ func sync(cmd *cobra.Command, args []string) error {
 
 		versions, err := discoveryClient.GetVersions(ctx)
 		if err != nil {
-			if discoveryErr := discoveryClient.Terminate(); err != nil {
+			if discoveryErr := discoveryClient.Terminate(); discoveryErr != nil {
 				log.Error().Err(discoveryErr).Msg("failed to terminate discovery client")
 				fmt.Println("failed to terminate discovery client:", discoveryErr)
 			}


### PR DESCRIPTION
The error conditions were checking the wrong `err` variable, which can be an issue for v0 plugins.