### PR TITLE
feat(k8s): Support running cloudquery k8s plugin in k8s cluster using serviceaccount

### DIFF
--- a/website/pages/docs/plugins/sources/k8s/overview.mdx
+++ b/website/pages/docs/plugins/sources/k8s/overview.mdx
@@ -19,3 +19,29 @@ file (`~/.kube/config`). You can also specify a different configuration by setti
 ```bash
 export KUBECONFIG=<PATH_TO_YOUR_CONFIG_FILE>
 ```
+
+If `cloudquery` is running in a pod of the Kubernetes cluster whose information will be synced, the k8s serviceaccount can be used for authentication directly.
+First, create a cluster role named cloudquery-cluster-read with all get and list privliages of all resources.
+And then create a cluster role binding for the cluster role and the service acccount the `cloudquery` pod use.
+```
+$ kubectl apply -f - <<EOF
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: cloudquery-cluster-read
+rules:
+- apiGroups:
+  - '*'
+  resources:
+  - '*'
+  verbs:
+  - get
+  - list
+- nonResourceURLs:
+  - '*'
+  verbs:
+  - get
+  - list
+EOF
+$ kubectl create clusterrolebinding cloudquery-cluster-read-$service_account-binding --clusterrole=cloudquery-cluster-read --serviceaccount=$service_account
+```


### PR DESCRIPTION

<!-- 🎉 Thank you for making CloudQuery awesome by submitting a PR 🎉 -->

#### Summary

Support running cloudquery k8s plugin in k8s cluster using serviceaccount.

We are using argo workflow(https://argoproj.github.io/argo-workflows/) to schedule the cloudquery k8s resource syncing every day in the k8s pod.  Currently the client in k8s plugin only support kubeconfig env,  so we need the pack the kubeconfig into the docker image or put it in a configmap, which is not the k8s-way. 

So we want to add the support to create the client  in k8s plugin  using k8s serviceaccount.


The changes in the PR is a little hack. Suggestions are welcomed. Thanks~

<!--
Use the following steps to ensure your PR is ready to be reviewed

- [ - ] Read the [contribution guidelines](../blob/main/CONTRIBUTING.md) 🧑‍🎓
- [ - ] Test locally on your own infrastructure
- [ - ] Run `go fmt` to format your code 🖊
- [ - ] Lint your changes via `golangci-lint run` 🚨 (install golangci-lint [here](https://golangci-lint.run/usage/install/#local-installation))
- [ - ] Update or add tests 🧪
- [ - ] Ensure the status checks below are successful ✅
--->
