### PR TITLE
fix(azure)!: Drop `subscription_id` from `azure_authorization_provider_operations_metadata`

### DIFF
--- a/plugins/source/azure/docs/tables/azure_authorization_provider_operations_metadata.md
+++ b/plugins/source/azure/docs/tables/azure_authorization_provider_operations_metadata.md
@@ -2,7 +2,7 @@
 
 https://learn.microsoft.com/en-us/rest/api/authorization/provider-operations-metadata/list?tabs=HTTP#provideroperationsmetadata
 
-The composite primary key for this table is (**subscription_id**, **id**).
+The primary key for this table is **id**.
 
 ## Columns
 
@@ -12,7 +12,6 @@ The composite primary key for this table is (**subscription_id**, **id**).
 |_cq_sync_time|Timestamp|
 |_cq_id|UUID|
 |_cq_parent_id|UUID|
-|subscription_id (PK)|String|
 |display_name|String|
 |id (PK)|String|
 |name|String|

--- a/plugins/source/azure/resources/services/authorization/provider_operations_metadata.go
+++ b/plugins/source/azure/resources/services/authorization/provider_operations_metadata.go
@@ -14,13 +14,11 @@ func ProviderOperationsMetadata() *schema.Table {
 		Name:        "azure_authorization_provider_operations_metadata",
 		Resolver:    fetchProviderOperationsMetadata,
 		Description: "https://learn.microsoft.com/en-us/rest/api/authorization/provider-operations-metadata/list?tabs=HTTP#provideroperationsmetadata",
-		Multiplex:   client.SubscriptionMultiplexRegisteredNamespace("azure_authorization_provider_operations_metadata", client.Namespacemicrosoft_authorization),
 		Transform:   transformers.TransformWithStruct(&armauthorization.ProviderOperationsMetadata{}, transformers.WithPrimaryKeys("ID")),
-		Columns:     schema.ColumnList{client.SubscriptionIDPK},
 	}
 }
 
-func fetchProviderOperationsMetadata(ctx context.Context, meta schema.ClientMeta, parent *schema.Resource, res chan<- any) error {
+func fetchProviderOperationsMetadata(ctx context.Context, meta schema.ClientMeta, _ *schema.Resource, res chan<- any) error {
 	cl := meta.(*client.Client)
 	svc, err := armauthorization.NewProviderOperationsMetadataClient(cl.Creds, cl.Options)
 	if err != nil {


### PR DESCRIPTION
Related to #7269.
Fixes #7241.