### PR TITLE
fix(azure)!: Drop `subscription_id` from `azure_cdn_edge_nodes`

### DIFF
--- a/plugins/source/azure/docs/tables/azure_cdn_edge_nodes.md
+++ b/plugins/source/azure/docs/tables/azure_cdn_edge_nodes.md
@@ -2,7 +2,7 @@
 
 https://learn.microsoft.com/en-us/rest/api/cdn/edge-nodes/list?tabs=HTTP#edgenode
 
-The composite primary key for this table is (**subscription_id**, **id**).
+The primary key for this table is **id**.
 
 ## Columns
 
@@ -12,7 +12,6 @@ The composite primary key for this table is (**subscription_id**, **id**).
 |_cq_sync_time|Timestamp|
 |_cq_id|UUID|
 |_cq_parent_id|UUID|
-|subscription_id (PK)|String|
 |properties|JSON|
 |id (PK)|String|
 |name|String|

--- a/plugins/source/azure/resources/services/cdn/edge_nodes.go
+++ b/plugins/source/azure/resources/services/cdn/edge_nodes.go
@@ -14,9 +14,7 @@ func EdgeNodes() *schema.Table {
 		Name:        "azure_cdn_edge_nodes",
 		Resolver:    fetchEdgeNodes,
 		Description: "https://learn.microsoft.com/en-us/rest/api/cdn/edge-nodes/list?tabs=HTTP#edgenode",
-		Multiplex:   client.SubscriptionMultiplexRegisteredNamespace("azure_cdn_edge_nodes", client.Namespacemicrosoft_cdn),
 		Transform:   transformers.TransformWithStruct(&armcdn.EdgeNode{}, transformers.WithPrimaryKeys("ID")),
-		Columns:     schema.ColumnList{client.SubscriptionIDPK},
 	}
 }
 


### PR DESCRIPTION
Fixes #7243
Related to #7271