### PR TITLE
fix(azure)!: Drop `subscription_id` from `azure_eventgrid_topic_types`

### DIFF
--- a/plugins/source/azure/docs/tables/azure_eventgrid_topic_types.md
+++ b/plugins/source/azure/docs/tables/azure_eventgrid_topic_types.md
@@ -2,7 +2,7 @@
 
 https://learn.microsoft.com/en-us/rest/api/eventgrid/controlplane-version2022-06-15/topic-types/list?tabs=HTTP#topictypeinfo
 
-The composite primary key for this table is (**subscription_id**, **id**).
+The primary key for this table is **id**.
 
 ## Columns
 
@@ -12,7 +12,6 @@ The composite primary key for this table is (**subscription_id**, **id**).
 |_cq_sync_time|Timestamp|
 |_cq_id|UUID|
 |_cq_parent_id|UUID|
-|subscription_id (PK)|String|
 |properties|JSON|
 |id (PK)|String|
 |name|String|

--- a/plugins/source/azure/resources/services/eventgrid/topic_types.go
+++ b/plugins/source/azure/resources/services/eventgrid/topic_types.go
@@ -14,9 +14,7 @@ func TopicTypes() *schema.Table {
 		Name:        "azure_eventgrid_topic_types",
 		Resolver:    fetchTopicTypes,
 		Description: "https://learn.microsoft.com/en-us/rest/api/eventgrid/controlplane-version2022-06-15/topic-types/list?tabs=HTTP#topictypeinfo",
-		Multiplex:   client.SubscriptionMultiplexRegisteredNamespace("azure_eventgrid_topic_types", client.Namespacemicrosoft_eventgrid),
 		Transform:   transformers.TransformWithStruct(&armeventgrid.TopicTypeInfo{}, transformers.WithPrimaryKeys("ID")),
-		Columns:     schema.ColumnList{client.SubscriptionIDPK},
 	}
 }
 


### PR DESCRIPTION
Fixes #7246.
Related to #7275.