### PR TITLE
fix(azure)!: Drop `subscription_id` from `azure_policy_data_policy_manifests`

### DIFF
--- a/plugins/source/azure/docs/tables/azure_policy_data_policy_manifests.md
+++ b/plugins/source/azure/docs/tables/azure_policy_data_policy_manifests.md
@@ -2,7 +2,7 @@
 
 https://pkg.go.dev/github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resources/armpolicy@v0.6.0#DataPolicyManifest
 
-The composite primary key for this table is (**subscription_id**, **id**).
+The primary key for this table is **id**.
 
 ## Columns
 
@@ -12,7 +12,6 @@ The composite primary key for this table is (**subscription_id**, **id**).
 |_cq_sync_time|Timestamp|
 |_cq_id|UUID|
 |_cq_parent_id|UUID|
-|subscription_id (PK)|String|
 |properties|JSON|
 |id (PK)|String|
 |name|String|

--- a/plugins/source/azure/resources/services/policy/data_policy_manifests.go
+++ b/plugins/source/azure/resources/services/policy/data_policy_manifests.go
@@ -14,9 +14,7 @@ func DataPolicyManifests() *schema.Table {
 		Name:        "azure_policy_data_policy_manifests",
 		Resolver:    fetchDataPolicyManifests,
 		Description: "https://pkg.go.dev/github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resources/armpolicy@v0.6.0#DataPolicyManifest",
-		Multiplex:   client.SubscriptionMultiplexRegisteredNamespace("azure_policy_data_policy_manifests", client.Namespacemicrosoft_authorization),
 		Transform:   transformers.TransformWithStruct(&armpolicy.DataPolicyManifest{}, transformers.WithPrimaryKeys("ID")),
-		Columns:     schema.ColumnList{client.SubscriptionIDPK},
 	}
 }
 


### PR DESCRIPTION
Fixes #7251.
Related to #7263.