### PR TITLE
fix(aws)!: PK for `aws_cloudtrail_trails`

### DIFF
--- a/plugins/source/aws/docs/tables/aws_cloudtrail_trails.md
+++ b/plugins/source/aws/docs/tables/aws_cloudtrail_trails.md
@@ -2,7 +2,7 @@
 
 https://docs.aws.amazon.com/awscloudtrail/latest/APIReference/API_Trail.html
 
-The composite primary key for this table is (**region**, **arn**).
+The composite primary key for this table is (**account_id**, **region**, **arn**).
 
 ## Relations
 
@@ -17,7 +17,7 @@ The following tables depend on aws_cloudtrail_trails:
 |_cq_sync_time|Timestamp|
 |_cq_id|UUID|
 |_cq_parent_id|UUID|
-|account_id|String|
+|account_id (PK)|String|
 |region (PK)|String|
 |cloudwatch_logs_log_group_name|String|
 |arn (PK)|String|

--- a/plugins/source/aws/resources/services/cloudtrail/trails.go
+++ b/plugins/source/aws/resources/services/cloudtrail/trails.go
@@ -19,6 +19,9 @@ func Trails() *schema.Table {
 				Name:     "account_id",
 				Type:     schema.TypeString,
 				Resolver: client.ResolveAWSAccount,
+				CreationOptions: schema.ColumnCreationOptions{
+					PrimaryKey: true,
+				},
 			},
 			{
 				Name:     "region",


### PR DESCRIPTION
<!-- 🎉 Thank you for making CloudQuery awesome by submitting a PR 🎉 -->

#### Summary

Org wide Cloudtrails can span an account. ARN + region isn't enough for uniqueness as each trail would only show up once per region, rather than once per account per region...



<!--
Use the following steps to ensure your PR is ready to be reviewed

- [ ] Read the [contribution guidelines](../blob/main/CONTRIBUTING.md) 🧑‍🎓
- [ ] Test locally on your own infrastructure
- [ ] Run `go fmt` to format your code 🖊
- [ ] Lint your changes via `golangci-lint run` 🚨 (install golangci-lint [here](https://golangci-lint.run/usage/install/#local-installation))
- [ ] Update or add tests 🧪
- [ ] Ensure the status checks below are successful ✅
--->
