### PR TITLE
fix(github-resources)!: Resolver Org Hooks request/response using GetHookDelivery

### DIFF
--- a/plugins/source/github/client/mocks/mock_orgs.go
+++ b/plugins/source/github/client/mocks/mock_orgs.go
@@ -51,6 +51,22 @@ func (mr *MockOrganizationsServiceMockRecorder) Get(arg0, arg1 interface{}) *gom
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Get", reflect.TypeOf((*MockOrganizationsService)(nil).Get), arg0, arg1)
 }
 
+// GetHookDelivery mocks base method.
+func (m *MockOrganizationsService) GetHookDelivery(arg0 context.Context, arg1 string, arg2, arg3 int64) (*github.HookDelivery, *github.Response, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetHookDelivery", arg0, arg1, arg2, arg3)
+	ret0, _ := ret[0].(*github.HookDelivery)
+	ret1, _ := ret[1].(*github.Response)
+	ret2, _ := ret[2].(error)
+	return ret0, ret1, ret2
+}
+
+// GetHookDelivery indicates an expected call of GetHookDelivery.
+func (mr *MockOrganizationsServiceMockRecorder) GetHookDelivery(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetHookDelivery", reflect.TypeOf((*MockOrganizationsService)(nil).GetHookDelivery), arg0, arg1, arg2, arg3)
+}
+
 // GetOrgMembership mocks base method.
 func (m *MockOrganizationsService) GetOrgMembership(arg0 context.Context, arg1, arg2 string) (*github.Membership, *github.Response, error) {
 	m.ctrl.T.Helper()

--- a/plugins/source/github/client/services.go
+++ b/plugins/source/github/client/services.go
@@ -45,6 +45,7 @@ type OrganizationsService interface {
 	Get(ctx context.Context, org string) (*github.Organization, *github.Response, error)
 	GetOrgMembership(ctx context.Context, user, org string) (*github.Membership, *github.Response, error)
 	ListHookDeliveries(ctx context.Context, org string, id int64, opts *github.ListCursorOptions) ([]*github.HookDelivery, *github.Response, error)
+	GetHookDelivery(ctx context.Context, owner string, hookID, deliveryID int64) (*github.HookDelivery, *github.Response, error)
 	ListHooks(ctx context.Context, org string, opts *github.ListOptions) ([]*github.Hook, *github.Response, error)
 	ListInstallations(ctx context.Context, org string, opts *github.ListOptions) (*github.OrganizationInstallations, *github.Response, error)
 	ListMembers(ctx context.Context, org string, opts *github.ListMembersOptions) ([]*github.User, *github.Response, error)

--- a/plugins/source/github/docs/tables/github_hook_deliveries.md
+++ b/plugins/source/github/docs/tables/github_hook_deliveries.md
@@ -16,8 +16,6 @@ This table depends on [github_hooks](github_hooks.md).
 |_cq_parent_id|UUID|
 |org (PK)|String|
 |hook_id (PK)|Int|
-|request|String|
-|response|String|
 |id (PK)|Int|
 |guid|String|
 |delivered_at|Timestamp|
@@ -29,3 +27,5 @@ This table depends on [github_hooks](github_hooks.md).
 |action|String|
 |installation_id|Int|
 |repository_id|Int|
+|request|JSON|
+|response|JSON|

--- a/plugins/source/github/resources/services/hooks/deliveries.go
+++ b/plugins/source/github/resources/services/hooks/deliveries.go
@@ -9,9 +9,10 @@ import (
 
 func Deliveries() *schema.Table {
 	return &schema.Table{
-		Name:      "github_hook_deliveries",
-		Resolver:  fetchDeliveries,
-		Transform: transformers.TransformWithStruct(&github.HookDelivery{}, client.SharedTransformers()...),
+		Name:                "github_hook_deliveries",
+		Resolver:            fetchDeliveries,
+		PreResourceResolver: hooksGet,
+		Transform:           transformers.TransformWithStruct(&github.HookDelivery{}, client.SharedTransformers()...),
 		Columns: []schema.Column{
 			{
 				Name:        "org",
@@ -30,16 +31,6 @@ func Deliveries() *schema.Table {
 				CreationOptions: schema.ColumnCreationOptions{
 					PrimaryKey: true,
 				},
-			},
-			{
-				Name:     "request",
-				Type:     schema.TypeString,
-				Resolver: resolveRequest,
-			},
-			{
-				Name:     "response",
-				Type:     schema.TypeString,
-				Resolver: resolveResponse,
 			},
 			{
 				Name:     "id",

--- a/plugins/source/github/resources/services/hooks/deliveries_fetch.go
+++ b/plugins/source/github/resources/services/hooks/deliveries_fetch.go
@@ -28,12 +28,16 @@ func fetchDeliveries(ctx context.Context, meta schema.ClientMeta, parent *schema
 	}
 }
 
-func resolveRequest(ctx context.Context, meta schema.ClientMeta, resource *schema.Resource, c schema.Column) error {
-	delivery := resource.Item.(*github.HookDelivery)
-	return resource.Set(c.Name, delivery.Request.String())
-}
+func hooksGet(ctx context.Context, meta schema.ClientMeta, r *schema.Resource) error {
+	hook := *r.Parent.Item.(*github.Hook)
+	delivery := r.Item.(*github.HookDelivery)
+	c := meta.(*client.Client)
 
-func resolveResponse(ctx context.Context, meta schema.ClientMeta, resource *schema.Resource, c schema.Column) error {
-	delivery := resource.Item.(*github.HookDelivery)
-	return resource.Set(c.Name, delivery.Response.String())
+	deliveryWithRequestResponse, _, err := c.Github.Organizations.GetHookDelivery(ctx, c.Org, *hook.ID, *delivery.ID)
+	if err != nil {
+		return err
+	}
+
+	r.SetItem(deliveryWithRequestResponse)
+	return nil
 }

--- a/plugins/source/github/resources/services/hooks/hooks_test.go
+++ b/plugins/source/github/resources/services/hooks/hooks_test.go
@@ -1,6 +1,7 @@
 package hooks
 
 import (
+	"encoding/json"
 	"testing"
 
 	"github.com/cloudquery/cloudquery/plugins/source/github/client"
@@ -25,7 +26,20 @@ func buildHooks(t *testing.T, ctrl *gomock.Controller) client.GithubServices {
 	if err := faker.FakeObject(&hd); err != nil {
 		t.Fatal(err)
 	}
+	hd.Request = nil
+	hd.Response = nil
 	mock.EXPECT().ListHookDeliveries(gomock.Any(), "testorg", *cs.ID, gomock.Any()).Return([]*github.HookDelivery{hd}, &github.Response{}, nil)
+
+	var hdGet *github.HookDelivery
+	if err := faker.FakeObject(&hdGet); err != nil {
+		t.Fatal(err)
+	}
+	rawRequest := json.RawMessage("{}")
+	rawResponse := json.RawMessage("{}")
+	hdGet.Request = &github.HookRequest{Headers: make(map[string]string), RawPayload: &rawRequest}
+	hdGet.Response = &github.HookResponse{Headers: make(map[string]string), RawPayload: &rawResponse}
+	mock.EXPECT().GetHookDelivery(gomock.Any(), "testorg", *cs.ID, *hd.ID).Return(hdGet, &github.Response{}, nil)
+
 	return client.GithubServices{Organizations: mock}
 }
 


### PR DESCRIPTION
<!-- 🎉 Thank you for making CloudQuery awesome by submitting a PR 🎉 -->

#### Summary

Fixes https://github.com/cloudquery/cloudquery-issues/issues/468.
We need to `Get` the hook to resolve the request and response

BEGIN_COMMIT_OVERRIDE
fix(github-resources): Resolver Org Hooks request/response using GetHookDelivery

BREAKING-CHANGE: The `request` and `response` columns for `github_hook_deliveries` are now of type `JSON` instead of `String`.
END_COMMIT_OVERRIDE

<!--
Use the following steps to ensure your PR is ready to be reviewed

- [ ] Read the [contribution guidelines](../blob/main/CONTRIBUTING.md) 🧑‍🎓
- [ ] Test locally on your own infrastructure
- [ ] Run `go fmt` to format your code 🖊
- [ ] Lint your changes via `golangci-lint run` 🚨 (install golangci-lint [here](https://golangci-lint.run/usage/install/#local-installation))
- [ ] Update or add tests 🧪
- [ ] Ensure the status checks below are successful ✅
--->
