### PR TITLE
feat(aws-resources): Add EC2 EBS Volume Statuses

### DIFF
--- a/plugins/source/aws/docs/tables/README.md
+++ b/plugins/source/aws/docs/tables/README.md
@@ -132,6 +132,7 @@
 - [aws_ec2_byoip_cidrs](aws_ec2_byoip_cidrs.md)
 - [aws_ec2_customer_gateways](aws_ec2_customer_gateways.md)
 - [aws_ec2_ebs_snapshots](aws_ec2_ebs_snapshots.md)
+- [aws_ec2_ebs_volume_statuses](aws_ec2_ebs_volume_statuses.md)
 - [aws_ec2_ebs_volumes](aws_ec2_ebs_volumes.md)
 - [aws_ec2_egress_only_internet_gateways](aws_ec2_egress_only_internet_gateways.md)
 - [aws_ec2_eips](aws_ec2_eips.md)

--- a/plugins/source/aws/docs/tables/aws_ec2_ebs_volume_statuses.md
+++ b/plugins/source/aws/docs/tables/aws_ec2_ebs_volume_statuses.md
@@ -1,0 +1,24 @@
+# Table: aws_ec2_ebs_volume_statuses
+
+https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_VolumeStatusItem.html
+
+The primary key for this table is **volume_arn**.
+
+## Columns
+
+| Name          | Type          |
+| ------------- | ------------- |
+|_cq_source_name|String|
+|_cq_sync_time|Timestamp|
+|_cq_id|UUID|
+|_cq_parent_id|UUID|
+|account_id|String|
+|region|String|
+|volume_arn (PK)|String|
+|actions|JSON|
+|attachment_statuses|JSON|
+|availability_zone|String|
+|events|JSON|
+|outpost_arn|String|
+|volume_id|String|
+|volume_status|JSON|

--- a/plugins/source/aws/resources/plugin/tables.go
+++ b/plugins/source/aws/resources/plugin/tables.go
@@ -177,6 +177,7 @@ func tables() []*schema.Table {
 		ec2.CustomerGateways(),
 		ec2.EbsSnapshots(),
 		ec2.EbsVolumes(),
+		ec2.EbsVolumesStatuses(),
 		ec2.EgressOnlyInternetGateways(),
 		ec2.Eips(),
 		ec2.FlowLogs(),

--- a/plugins/source/aws/resources/services/ec2/ebs_volume_statuses.go
+++ b/plugins/source/aws/resources/services/ec2/ebs_volume_statuses.go
@@ -1,0 +1,38 @@
+package ec2
+
+import (
+	"github.com/aws/aws-sdk-go-v2/service/ec2/types"
+	"github.com/cloudquery/cloudquery/plugins/source/aws/client"
+	"github.com/cloudquery/plugin-sdk/schema"
+	"github.com/cloudquery/plugin-sdk/transformers"
+)
+
+func EbsVolumesStatuses() *schema.Table {
+	return &schema.Table{
+		Name:        "aws_ec2_ebs_volume_statuses",
+		Description: `https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_VolumeStatusItem.html`,
+		Resolver:    fetchEc2EbsVolumeStatuses,
+		Multiplex:   client.ServiceAccountRegionMultiplexer("ec2"),
+		Transform:   transformers.TransformWithStruct(&types.VolumeStatusItem{}),
+		Columns: []schema.Column{
+			{
+				Name:     "account_id",
+				Type:     schema.TypeString,
+				Resolver: client.ResolveAWSAccount,
+			},
+			{
+				Name:     "region",
+				Type:     schema.TypeString,
+				Resolver: client.ResolveAWSRegion,
+			},
+			{
+				Name:     "volume_arn",
+				Type:     schema.TypeString,
+				Resolver: resolveEbsVolumeStatusArn,
+				CreationOptions: schema.ColumnCreationOptions{
+					PrimaryKey: true,
+				},
+			},
+		},
+	}
+}

--- a/plugins/source/aws/resources/services/ec2/ebs_volume_statuses_fetch.go
+++ b/plugins/source/aws/resources/services/ec2/ebs_volume_statuses_fetch.go
@@ -1,0 +1,36 @@
+package ec2
+
+import (
+	"context"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/ec2"
+	"github.com/aws/aws-sdk-go-v2/service/ec2/types"
+	"github.com/cloudquery/cloudquery/plugins/source/aws/client"
+	"github.com/cloudquery/plugin-sdk/schema"
+)
+
+func fetchEc2EbsVolumeStatuses(ctx context.Context, meta schema.ClientMeta, _ *schema.Resource, res chan<- any) error {
+	c := meta.(*client.Client)
+	svc := c.Services().Ec2
+	config := ec2.DescribeVolumeStatusInput{MaxResults: aws.Int32(1000)}
+	for {
+		response, err := svc.DescribeVolumeStatus(ctx, &config)
+		if err != nil {
+			return err
+		}
+		res <- response.VolumeStatuses
+		if aws.ToString(response.NextToken) == "" {
+			break
+		}
+		config.NextToken = response.NextToken
+	}
+	return nil
+}
+
+func resolveEbsVolumeStatusArn(_ context.Context, meta schema.ClientMeta, resource *schema.Resource, c schema.Column) error {
+	cl := meta.(*client.Client)
+	volume := resource.Item.(types.VolumeStatusItem)
+	a := resolveVolumeARN(cl.Partition, cl.Region, cl.AccountID, aws.ToString(volume.VolumeId))
+	return resource.Set(c.Name, a)
+}

--- a/plugins/source/aws/resources/services/ec2/ebs_volume_statuses_mock_test.go
+++ b/plugins/source/aws/resources/services/ec2/ebs_volume_statuses_mock_test.go
@@ -1,0 +1,30 @@
+package ec2
+
+import (
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/service/ec2"
+	"github.com/cloudquery/cloudquery/plugins/source/aws/client"
+	"github.com/cloudquery/cloudquery/plugins/source/aws/client/mocks"
+	"github.com/cloudquery/plugin-sdk/faker"
+	"github.com/golang/mock/gomock"
+)
+
+func buildEc2EbsVolumeStatuses(t *testing.T, ctrl *gomock.Controller) client.Services {
+	m := mocks.NewMockEc2Client(ctrl)
+	statusOutput := ec2.DescribeVolumeStatusOutput{}
+	err := faker.FakeObject(&statusOutput)
+	if err != nil {
+		t.Fatal(err)
+	}
+	statusOutput.NextToken = nil
+	m.EXPECT().DescribeVolumeStatus(gomock.Any(), gomock.Any(), gomock.Any()).Return(
+		&statusOutput, nil)
+	return client.Services{
+		Ec2: m,
+	}
+}
+
+func TestEc2EbsVolumeStatues(t *testing.T) {
+	client.AwsMockTestHelper(t, EbsVolumesStatuses(), buildEc2EbsVolumeStatuses, client.TestOptions{})
+}

--- a/plugins/source/aws/resources/services/ec2/ebs_volumes_fetch.go
+++ b/plugins/source/aws/resources/services/ec2/ebs_volumes_fetch.go
@@ -29,15 +29,20 @@ func fetchEc2EbsVolumes(ctx context.Context, meta schema.ClientMeta, _ *schema.R
 	return nil
 }
 
+func resolveVolumeARN(partition string, region string, accountID string, volumeId string) string {
+	a := arn.ARN{
+		Partition: partition,
+		Service:   "ec2",
+		Region:    region,
+		AccountID: accountID,
+		Resource:  "volume/" + volumeId,
+	}
+	return a.String()
+}
+
 func resolveEbsVolumeArn(_ context.Context, meta schema.ClientMeta, resource *schema.Resource, c schema.Column) error {
 	cl := meta.(*client.Client)
 	volume := resource.Item.(types.Volume)
-	a := arn.ARN{
-		Partition: cl.Partition,
-		Service:   "ec2",
-		Region:    cl.Region,
-		AccountID: cl.AccountID,
-		Resource:  "volume/" + aws.ToString(volume.VolumeId),
-	}
-	return resource.Set(c.Name, a.String())
+	a := resolveVolumeARN(cl.Partition, cl.Region, cl.AccountID, aws.ToString(volume.VolumeId))
+	return resource.Set(c.Name, a)
 }

--- a/website/pages/docs/plugins/sources/aws/tables.md
+++ b/website/pages/docs/plugins/sources/aws/tables.md
@@ -132,6 +132,7 @@
 - [aws_ec2_byoip_cidrs](https://github.com/cloudquery/cloudquery/blob/main/plugins/source/aws/docs/tables/aws_ec2_byoip_cidrs.md)
 - [aws_ec2_customer_gateways](https://github.com/cloudquery/cloudquery/blob/main/plugins/source/aws/docs/tables/aws_ec2_customer_gateways.md)
 - [aws_ec2_ebs_snapshots](https://github.com/cloudquery/cloudquery/blob/main/plugins/source/aws/docs/tables/aws_ec2_ebs_snapshots.md)
+- [aws_ec2_ebs_volume_statuses](https://github.com/cloudquery/cloudquery/blob/main/plugins/source/aws/docs/tables/aws_ec2_ebs_volume_statuses.md)
 - [aws_ec2_ebs_volumes](https://github.com/cloudquery/cloudquery/blob/main/plugins/source/aws/docs/tables/aws_ec2_ebs_volumes.md)
 - [aws_ec2_egress_only_internet_gateways](https://github.com/cloudquery/cloudquery/blob/main/plugins/source/aws/docs/tables/aws_ec2_egress_only_internet_gateways.md)
 - [aws_ec2_eips](https://github.com/cloudquery/cloudquery/blob/main/plugins/source/aws/docs/tables/aws_ec2_eips.md)


### PR DESCRIPTION
<!-- 🎉 Thank you for making CloudQuery awesome by submitting a PR 🎉 -->

#### Summary

Fixes https://github.com/cloudquery/cloudquery/issues/7637.
To get status events, we need `DescribeVolumeStatus`.

I tested syncing statues, but events is a bit hard as those are created by AWS, see https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/monitoring-volume-status.html?icmpid=docs_ec2_console#monitoring-vol-events

<!--
Use the following steps to ensure your PR is ready to be reviewed

- [ ] Read the [contribution guidelines](../blob/main/CONTRIBUTING.md) 🧑‍🎓
- [ ] Test locally on your own infrastructure
- [ ] Run `go fmt` to format your code 🖊
- [ ] Lint your changes via `golangci-lint run` 🚨 (install golangci-lint [here](https://golangci-lint.run/usage/install/#local-installation))
- [ ] Update or add tests 🧪
- [ ] Ensure the status checks below are successful ✅
--->
