### PR TITLE
fix(aws): Turn tags into maps

### DIFF
--- a/plugins/source/aws/docs/tables/aws_cloudformation_stacks.md
+++ b/plugins/source/aws/docs/tables/aws_cloudformation_stacks.md
@@ -21,6 +21,7 @@ The following tables depend on aws_cloudformation_stacks:
 |region|String|
 |id|String|
 |arn (PK)|String|
+|tags|JSON|
 |creation_time|Timestamp|
 |stack_name|String|
 |stack_status|String|
@@ -41,5 +42,4 @@ The following tables depend on aws_cloudformation_stacks:
 |root_id|String|
 |stack_id|String|
 |stack_status_reason|String|
-|tags|JSON|
 |timeout_in_minutes|Int|

--- a/plugins/source/aws/docs/tables/aws_codebuild_projects.md
+++ b/plugins/source/aws/docs/tables/aws_codebuild_projects.md
@@ -15,6 +15,7 @@ The primary key for this table is **arn**.
 |account_id|String|
 |region|String|
 |arn (PK)|String|
+|tags|JSON|
 |artifacts|JSON|
 |badge|JSON|
 |build_batch_config|JSON|
@@ -38,7 +39,6 @@ The primary key for this table is **arn**.
 |service_role|String|
 |source|JSON|
 |source_version|String|
-|tags|JSON|
 |timeout_in_minutes|Int|
 |vpc_config|JSON|
 |webhook|JSON|

--- a/plugins/source/aws/docs/tables/aws_directconnect_connections.md
+++ b/plugins/source/aws/docs/tables/aws_directconnect_connections.md
@@ -16,6 +16,7 @@ The composite primary key for this table is (**arn**, **id**).
 |region|String|
 |arn (PK)|String|
 |id (PK)|String|
+|tags|JSON|
 |aws_device|String|
 |aws_device_v2|String|
 |aws_logical_device_id|String|
@@ -35,5 +36,4 @@ The composite primary key for this table is (**arn**, **id**).
 |partner_name|String|
 |port_encryption_status|String|
 |provider_name|String|
-|tags|JSON|
 |vlan|Int|

--- a/plugins/source/aws/docs/tables/aws_ec2_customer_gateways.md
+++ b/plugins/source/aws/docs/tables/aws_ec2_customer_gateways.md
@@ -15,11 +15,11 @@ The primary key for this table is **arn**.
 |account_id|String|
 |region|String|
 |arn (PK)|String|
+|tags|JSON|
 |bgp_asn|String|
 |certificate_arn|String|
 |customer_gateway_id|String|
 |device_name|String|
 |ip_address|String|
 |state|String|
-|tags|JSON|
 |type|String|

--- a/plugins/source/aws/docs/tables/aws_redshift_clusters.md
+++ b/plugins/source/aws/docs/tables/aws_redshift_clusters.md
@@ -22,6 +22,7 @@ The following tables depend on aws_redshift_clusters:
 |region|String|
 |arn (PK)|String|
 |logging_status|JSON|
+|tags|JSON|
 |allow_version_upgrade|Bool|
 |aqua_configuration|JSON|
 |automated_snapshot_retention_period|Int|
@@ -69,7 +70,6 @@ The following tables depend on aws_redshift_clusters:
 |restore_status|JSON|
 |snapshot_schedule_identifier|String|
 |snapshot_schedule_state|String|
-|tags|JSON|
 |total_storage_capacity_in_mega_bytes|Int|
 |vpc_id|String|
 |vpc_security_groups|JSON|

--- a/plugins/source/aws/resources/services/cloudformation/stacks.go
+++ b/plugins/source/aws/resources/services/cloudformation/stacks.go
@@ -38,6 +38,11 @@ func Stacks() *schema.Table {
 					PrimaryKey: true,
 				},
 			},
+			{
+				Name:     "tags",
+				Type:     schema.TypeJSON,
+				Resolver: client.ResolveTags,
+			},
 		},
 
 		Relations: []*schema.Table{

--- a/plugins/source/aws/resources/services/codebuild/projects.go
+++ b/plugins/source/aws/resources/services/codebuild/projects.go
@@ -33,6 +33,11 @@ func Projects() *schema.Table {
 					PrimaryKey: true,
 				},
 			},
+			{
+				Name:     "tags",
+				Type:     schema.TypeJSON,
+				Resolver: client.ResolveTags,
+			},
 		},
 	}
 }

--- a/plugins/source/aws/resources/services/directconnect/connections.go
+++ b/plugins/source/aws/resources/services/directconnect/connections.go
@@ -41,6 +41,11 @@ func Connections() *schema.Table {
 					PrimaryKey: true,
 				},
 			},
+			{
+				Name:     "tags",
+				Type:     schema.TypeJSON,
+				Resolver: client.ResolveTags,
+			},
 		},
 	}
 }

--- a/plugins/source/aws/resources/services/ec2/customer_gateways.go
+++ b/plugins/source/aws/resources/services/ec2/customer_gateways.go
@@ -33,6 +33,11 @@ func CustomerGateways() *schema.Table {
 					PrimaryKey: true,
 				},
 			},
+			{
+				Name:     "tags",
+				Type:     schema.TypeJSON,
+				Resolver: client.ResolveTags,
+			},
 		},
 	}
 }

--- a/plugins/source/aws/resources/services/redshift/clusters.go
+++ b/plugins/source/aws/resources/services/redshift/clusters.go
@@ -40,6 +40,11 @@ func Clusters() *schema.Table {
 				Resolver:    resolveRedshiftClusterLoggingStatus,
 				Description: `Describes the status of logging for a cluster.`,
 			},
+			{
+				Name:     "tags",
+				Type:     schema.TypeJSON,
+				Resolver: client.ResolveTags,
+			},
 		},
 
 		Relations: []*schema.Table{


### PR DESCRIPTION
Copied from https://github.com/cloudquery/cloudquery/pull/7651

These resources use a list instead of our convention of map[string] for tags:
 - aws_cloudformation_stacks
 - aws_codebuild_projects
 - aws_ec2_customer_gateways
 - aws_redshift_clusters

This update fixes it. 