### PR TITLE
fix(azure): Fix detecting logic for CIS Azure Benchmark v1.3.0 - 2.12

### DIFF
--- a/plugins/source/azure/policies/queries/security/default_policy_disabled.sql
+++ b/plugins/source/azure/policies/queries/security/default_policy_disabled.sql
@@ -5,7 +5,7 @@ SELECT
   :'check_id' as check_id,
   'Ensure any of the ASC Default policy setting is not set to "Disabled" (Automated)' as title,
   subscription_id,
-  id,
+  concat(id, '/', param),
   case
     when value = 'Disabled'
     then 'fail' else 'pass'

--- a/plugins/source/azure/policies/views/policy_assignment_parameters.sql
+++ b/plugins/source/azure/policies/views/policy_assignment_parameters.sql
@@ -4,8 +4,8 @@ SELECT
     azure_policy_assignments.subscription_id,
     azure_policy_assignments."name",
     parameters.*,
-    azure_policy_assignments.properties -> parameters.param ->> 'value' AS value
+    azure_policy_assignments.properties -> 'parameters' -> parameters.param ->> 'value' AS value
 FROM
     azure_policy_assignments,
-    jsonb_object_keys(azure_policy_assignments.properties) AS parameters ("param")
+    jsonb_object_keys(azure_policy_assignments.properties -> 'parameters') AS parameters ("param")
 WHERE azure_policy_assignments."name" = 'SecurityCenterBuiltIn';


### PR DESCRIPTION
#### Summary
I found a bug in the logic of CIS Azure Benchmark v1.3.0 Section 2.12 (`policy_assignment_parameters.sql` and `default_policy_disabled.sql`).

The current query takes json keys in the `property` column of the `azure_policy_assignments` table to make a view. But, an actual value of the column is below.

```json
{
    "scope": "/subscriptions/cc9a41f6-4e32-4f28-8326-a3c49e7036a3",
    "metadata": {
        "createdBy": "ae1999e6-b000-4f94-8e1c-ece7b864e35b",
        "createdOn": "2022-08-19T01:36:48.5129096Z",
        "updatedBy": "64fd25ee-36e3-44e9-bf7a-96e411ae909f",
        "updatedOn": "2023-02-08T03:00:27.2551198Z",
        "assignedBy": "Security Center",
        "parameterScopes": {},
        "excludedOutOfTheBoxStandards": [
            "PCI DSS 3.2.1",
            "ISO 27001",
            "SOC TSP"
        ]
    },
    "notScopes": [],
    "parameters": {
        "sqlServerAuditingMonitoringEffect": {
            "value": "Disabled"
        },
        "adaptiveApplicationControlsUpdateMonitoringEffect": {
            "value": "Disabled"
        }
    },
    "description": "This is the default set of policies monitored by Azure Security Center. It was automatically assigned as part of onboarding to Security Center. The default assignment contains only audit policies. For more information please visit https://aka.ms/ascpolicies",
    "displayName": "ASC Default (subscription: cc9a41f6-4e32-4f28-8326-a3c49e7036a3)",
    "enforcementMode": "Default",
    "policyDefinitionId": "/providers/Microsoft.Authorization/policySetDefinitions/1f3afdf9-d0c9-4c3d-847f-89da613e70a8",
    "nonComplianceMessages": []
}
```

Therefore, the result of taking keys is always the array `[scope, metadata, notStopes, parameters, description, displayName, enforcementMode, policyDefinitionId]`. It is useless for checking the condition in the rule. The correct logic is taking json keys in the `parameters` field.

And then, when the policy sql writes in the result table, it only saves the `id` column on the table. But the `id` is always same among the result. We cannot identify which policies are disabled. That's way, I concated `id` and `param` filed with `/` to do that.