### PR TITLE
fix(aws)!: Fix PK  for `aws_rds_certificates`

### DIFF
--- a/plugins/source/aws/docs/tables/aws_rds_certificates.md
+++ b/plugins/source/aws/docs/tables/aws_rds_certificates.md
@@ -2,7 +2,7 @@
 
 https://docs.aws.amazon.com/AmazonRDS/latest/APIReference/API_Certificate.html
 
-The primary key for this table is **arn**.
+The composite primary key for this table is (**account_id**, **arn**).
 
 ## Columns
 
@@ -12,7 +12,7 @@ The primary key for this table is **arn**.
 |_cq_sync_time|Timestamp|
 |_cq_id|UUID|
 |_cq_parent_id|UUID|
-|account_id|String|
+|account_id (PK)|String|
 |region|String|
 |arn (PK)|String|
 |certificate_arn|String|

--- a/plugins/source/aws/resources/services/rds/certificates.go
+++ b/plugins/source/aws/resources/services/rds/certificates.go
@@ -19,6 +19,9 @@ func Certificates() *schema.Table {
 				Name:     "account_id",
 				Type:     schema.TypeString,
 				Resolver: client.ResolveAWSAccount,
+				CreationOptions: schema.ColumnCreationOptions{
+					PrimaryKey: true,
+				},
 			},
 			{
 				Name:     "region",


### PR DESCRIPTION
<!-- 🎉 Thank you for making CloudQuery awesome by submitting a PR 🎉 -->

#### Summary

CLI Docs show that `arn` has no account in it:
```
{
    "Certificates": [
        {
            "Thumbprint": "34478a908a83ae45dcb61676d235ece975c62c63",
            "ValidFrom": "2015-02-05T21:54:04Z",
            "CertificateIdentifier": "rds-ca-2015",
            "ValidTill": "2020-03-05T21:54:04Z",
            "CertificateType": "CA",
            "CertificateArn": "arn:aws:rds:us-east-1::cert:rds-ca-2015"
        }
    ]
}
```
<!--
Use the following steps to ensure your PR is ready to be reviewed

- [ ] Read the [contribution guidelines](../blob/main/CONTRIBUTING.md) 🧑‍🎓
- [ ] Test locally on your own infrastructure
- [ ] Run `go fmt` to format your code 🖊
- [ ] Lint your changes via `golangci-lint run` 🚨 (install golangci-lint [here](https://golangci-lint.run/usage/install/#local-installation))
- [ ] Update or add tests 🧪
- [ ] Ensure the status checks below are successful ✅
--->
