### PR TITLE
fix: Snowflake migration

### DIFF
--- a/plugins/destination/snowflake/client/migrate.go
+++ b/plugins/destination/snowflake/client/migrate.go
@@ -9,9 +9,9 @@ import (
 )
 
 const (
-	isTableExistSQL = "SELECT count(*) FROM information_schema.tables WHERE table_name='?';"
-
-	sqlTableInfo = "select column_name, data_type, is_nullable from information_schema.columns where table_name='?';"
+	// Use ILIKE for case insensitivity.
+	isTableExistSQL = "SELECT count(*) FROM information_schema.tables WHERE table_name ILIKE '?';"
+	sqlTableInfo    = "select column_name, data_type, is_nullable from information_schema.columns where table_name ILIKE '?';"
 )
 
 type columnInfo struct {


### PR DESCRIPTION
IsTableExist was always false, because of case-sensitivity issues. Use ILIKE to fix this.

<!-- 🎉 Thank you for making CloudQuery awesome by submitting a PR 🎉 -->

#### Summary

<!--
Explain what problem this PR addresses
-->

<!--
Use the following steps to ensure your PR is ready to be reviewed

- [ ] Read the [contribution guidelines](../blob/main/CONTRIBUTING.md) 🧑‍🎓
- [ ] Test locally on your own infrastructure
- [ ] Run `go fmt` to format your code 🖊
- [ ] Lint your changes via `golangci-lint run` 🚨 (install golangci-lint [here](https://golangci-lint.run/usage/install/#local-installation))
- [ ] Update or add tests 🧪
- [ ] Ensure the status checks below are successful ✅
--->
