### PR TITLE
fix(cli): Fix brew latest

### DIFF
--- a/cli/cmd/analytics.go
+++ b/cli/cmd/analytics.go
@@ -14,6 +14,7 @@ import (
 )
 
 const (
+	// default analytics host
 	analyticsHost = "analyticsv1.cloudquery.io:443"
 )
 


### PR DESCRIPTION
This should fix so `brew install cloudquery` will install latest version and not a hotfix to a year old version 😆 