### PR TITLE
fix(snowflake): Strip nulls

### DIFF
--- a/plugins/destination/snowflake/client/transformer.go
+++ b/plugins/destination/snowflake/client/transformer.go
@@ -3,6 +3,7 @@ package client
 import (
 	"encoding/hex"
 	"encoding/json"
+	"strings"
 
 	"github.com/cloudquery/plugin-sdk/schema"
 )
@@ -43,13 +44,13 @@ func (*Client) TransformJSON(v *schema.JSON) any {
 }
 
 func (*Client) TransformText(v *schema.Text) any {
-	return v.String()
+	return stripNulls(v.String())
 }
 
 func (*Client) TransformTextArray(v *schema.TextArray) any {
 	res := make([]string, len(v.Elements))
 	for i, e := range v.Elements {
-		res[i] = e.String()
+		res[i] = stripNulls(e.String())
 	}
 	return res
 }
@@ -107,4 +108,8 @@ func (*Client) TransformMacaddrArray(v *schema.MacaddrArray) any {
 		res[i] = e.String()
 	}
 	return res
+}
+
+func stripNulls(s string) string {
+	return strings.ReplaceAll(s, "\x00", "")
 }


### PR DESCRIPTION
Because of the way writing to snowflake works (i.e. via a JSON file), for text arrays, strings with nulls become screwed up a little (which fails our tests..).

["abc", "def\x00"] becomes, in snowflake, [`abc`, `def\u0000`] i.e. a string of length 4 becomes a string of length 9).

This fix does exactly the same thing we do in postgresql.
