### PR TITLE
fix: Postgresql timestamps

### DIFF
--- a/plugins/destination/postgresql/client/transformer.go
+++ b/plugins/destination/postgresql/client/transformer.go
@@ -68,8 +68,10 @@ func (*Client) TransformTextArray(v *schema.TextArray) any {
 }
 
 func (*Client) TransformTimestamptz(v *schema.Timestamptz) any {
+	// In postgresql, our underlyting type for timestamps is 'timestamp without timezone', so we have to
+	// convert it to UTC here (to avoid stripping the timezone information on INSERT).
 	return &pgtype.Timestamptz{
-		Time:  v.Time,
+		Time:  v.Time.UTC(),
 		Valid: v.Status == schema.Present,
 	}
 }


### PR DESCRIPTION
because underlyting postgresql type is `timestamp without timezone`, we need to change it to UTC (otherwise we jsut strip TZ information, making the data bad).

<!-- 🎉 Thank you for making CloudQuery awesome by submitting a PR 🎉 -->

#### Summary

<!--
Explain what problem this PR addresses
-->

<!--
Use the following steps to ensure your PR is ready to be reviewed

- [ ] Read the [contribution guidelines](../blob/main/CONTRIBUTING.md) 🧑‍🎓
- [ ] Test locally on your own infrastructure
- [ ] Run `go fmt` to format your code 🖊
- [ ] Lint your changes via `golangci-lint run` 🚨 (install golangci-lint [here](https://golangci-lint.run/usage/install/#local-installation))
- [ ] Update or add tests 🧪
- [ ] Ensure the status checks below are successful ✅
--->
