### PR TITLE
feat(website): Bring back code block titles

### DIFF
--- a/website/pages/docs/core-concepts/configuration.md
+++ b/website/pages/docs/core-concepts/configuration.md
@@ -10,7 +10,7 @@ One option is to maintain configuration for your source and destination plugins 
 
 Here is a simple example with only one source and one destination plugin:
 
-```yaml copy
+```yaml copy filename="aws.yml"
 kind: source
 spec:
   name: aws
@@ -20,7 +20,7 @@ spec:
   destinations: ["postgresql"]
 ```
 
-```yaml copy
+```yaml copy filename="postgresql.yml"
 kind: destination
 spec:
   name: postgresql
@@ -40,7 +40,7 @@ cloudquery sync aws.yml postgresql.yml
 
 Let's imagine we now wanted to add a `gcp` source as well. We can add its configuration in a new file:
 
-```yaml copy
+```yaml copy filename="gcp.yml"
 kind: source
 spec:
   name: gcp
@@ -60,7 +60,7 @@ cloudquery sync aws.yml gcp.yml postgresql.yml
 
 You can also combine sources and destinations into a single file by separating the sections with `---`:
 
-```yaml copy
+```yaml copy filename="config.yml"
 kind: source
 spec:
   name: aws

--- a/website/pages/docs/plugins/sources/aws/overview.mdx
+++ b/website/pages/docs/plugins/sources/aws/overview.mdx
@@ -50,7 +50,7 @@ For information about obtaining credentials, see the
 
 Here are example contents for a `credentials` file:
 
-```toml copy
+```toml copy filename="~/.aws/credentials"
 [default]
 aws_access_key_id = YOUR_ACCESS_KEY_ID
 aws_secret_access_key = YOUR_SECRET_ACCESS_KEY
@@ -60,7 +60,7 @@ You can also specify credentials for a different profile, and instruct CloudQuer
 
 For example:
 
-```toml copy
+```toml copy filename="~/.aws/credentials"
 [myprofile]
 aws_access_key_id = YOUR_ACCESS_KEY_ID
 aws_secret_access_key = YOUR_SECRET_ACCESS_KEY
@@ -74,7 +74,7 @@ export AWS_PROFILE=myprofile
 
 or, configure your desired profile in the `local_profile` field:
 
-```yaml copy
+```yaml copy filename="aws.yml"
 accounts:
   id: <account_alias>
   local_profile: myprofile

--- a/website/pages/how-to-guides/how-to-load-infrastructure-data-into-athena.mdx
+++ b/website/pages/how-to-guides/how-to-load-infrastructure-data-into-athena.mdx
@@ -56,7 +56,7 @@ Open source data integration at scale.
 
 We will configure the CloudQuery AWS source plugin to sync data from your AWS account(s). To do so, we'll create a file called `aws.yml` with the following config:
 
-```yaml copy
+```yaml copy filename="aws.yml"
 kind: source
 spec:
   name: aws
@@ -72,7 +72,7 @@ This is the most basic configuration of the AWS source plugin. It will work as l
 
 Similar to the config we created for the AWS plugin, we also need a destination config that is configured to write the AWS data to JSON files in S3. We'll call this file `s3.yml`:
 
-```yaml copy
+```yaml copy filename="s3.yml"
 kind: destination
 spec:
   name: "s3"
@@ -104,7 +104,7 @@ Athena can query data in S3, but it needs to know the schema of the data in orde
 
 First we'll create a role for the crawler to use. It will need access to the S3 bucket we created in the previous step. The following trust policy will give the role what it needs:
 
-```json copy
+```json copy filename="crawler-trust-policy.json"
 {
     "Version": "2012-10-17",
     "Statement": [
@@ -129,7 +129,7 @@ aws iam create-role \
 
 We should also attach a policy to the role that gives it access to the S3 bucket we created in the previous step. The following policy will give the crawler access to the S3 bucket. Make sure to update the bucket name to the value of `BUCKET_NAME` you chose earlier (in our example, `cloudquery-athena-example`):
 
-```json copy
+```json copy filename="crawler-policy-s3-access.json"
 {
     "Version": "2012-10-17",
     "Statement": [
@@ -158,7 +158,7 @@ aws iam put-role-policy \
 
 The crawler will also need additional permissions to perform all its tasks, such as writing CloudWatch logs. We attach another policy to the role to give it these permissions. This is a simplified version of the default policy created by AWS when creating a crawler through the console. You should review these permissions to ensure they are appropriate for your use case:
 
-```json copy
+```json copy filename="crawler-policy.json"
 {
     "Version": "2012-10-17",
     "Statement": [


### PR DESCRIPTION
<!-- 🎉 Thank you for making CloudQuery awesome by submitting a PR 🎉 -->

#### Summary

Fixes https://github.com/cloudquery/cloudquery/issues/7302

Brings back https://github.com/cloudquery/cloudquery/pull/7236 and https://github.com/cloudquery/cloudquery/pull/7238.
We need to use `filename` see https://github.com/cloudquery/cloudquery/issues/7302#issuecomment-1427051349

<!--
Use the following steps to ensure your PR is ready to be reviewed

- [ ] Read the [contribution guidelines](../blob/main/CONTRIBUTING.md) 🧑‍🎓
- [ ] Test locally on your own infrastructure
- [ ] Run `go fmt` to format your code 🖊
- [ ] Lint your changes via `golangci-lint run` 🚨 (install golangci-lint [here](https://golangci-lint.run/usage/install/#local-installation))
- [ ] Update or add tests 🧪
- [ ] Ensure the status checks below are successful ✅
--->
