### PR TITLE
doc: Athena Resource View Standalone SQL Script

### DIFF
--- a/plugins/source/aws/views/athena/README.md
+++ b/plugins/source/aws/views/athena/README.md
@@ -1,12 +1,23 @@
 # Athena Resources View
 
-You can create and `aws_resources` view for Athena, similar to the equivalent [Postgres version](../resources.sql). This allows you to query resources across all tables by tag or ARN.
+You can create an `aws_resources` view for Athena, similar to the [equivalent Postgres version](../resources.sql). This allows you to query resources across all tables by tag or ARN.
 
-There are currently two methods to create this view as follows
+There are currently two methods to create this view:
 
-## **Athena Resources View Creation Tool**
+1. a query that that outputs a `CREATE VIEW` statement you can run in the Athena console (easiest, lowest effort)
+2. a Go script that will create the view for you. This can be run as a binary or as a Lambda function (can be automated to run periodically)
+
+## Option 1: Standalone SQL script
+
+### Usage
+
+Execute the [`resources.sql`](./resources.sql) script in Athena. The output of this execution will be a `CREATE OR REPLACE VIEW` statement.
+
+Copy the full `CREATE OR REPLACE VIEW` output statement and execute it in Athena.
+
+## Option 2: **Athena Resources View Creation Tool**
    
-## Usage
+### Usage
 
 The script can be run as a standalone script or as an AWS Lambda function. In either case, you will need a working installation of Go.
 
@@ -139,12 +150,3 @@ $ ./athena_resources_view -database athena-example -output 's3://cloudquery-athe
   If any query errors occur, you should be able to see them in the "Recent Queries" tab in the Athena console. Also check the logs for the function itself for any clues.
 
 With the Lambda created, you are free to then schedule it to run on a regular basis, or after a CloudQuery run.
-
-## **Standalone SQL script**
-
-## Usage
-
-Execute the `resources.sql` script in Athena. The output of this exection will be the `create view` statement.
-
-Copy the full `create view` output statement and execute it in Athena
-

--- a/plugins/source/aws/views/athena/README.md
+++ b/plugins/source/aws/views/athena/README.md
@@ -1,7 +1,11 @@
-# Athena Resources View Creation Tool
+# Athena Resources View
 
-This script can be used to create an `aws_resources` view for Athena. This allows you to query resources across all tables by tag or ARN in Athena, similar to the equivalent [Postgres version](../resources.sql).
+You can create and `aws_resources` view for Athena, similar to the equivalent [Postgres version](../resources.sql). This allows you to query resources across all tables by tag or ARN.
 
+There are currently two methods to create this view as follows
+
+## **Athena Resources View Creation Tool**
+   
 ## Usage
 
 The script can be run as a standalone script or as an AWS Lambda function. In either case, you will need a working installation of Go.
@@ -20,15 +24,15 @@ Show the help options:
 $ ./athena_resources_view --help
 Usage of ./athena_resources_view:
   -catalog string
-    	Catalog name (default "awsdatacatalog")
+      Catalog name (default "awsdatacatalog")
   -database string
-    	Database name
+      Database name
   -output string
-    	Query output path (e.g. s3://bucket/path)
+      Query output path (e.g. s3://bucket/path)
   -region string
-    	View name (default: aws_resources) (default "us-east-1")
+      View name (default: aws_resources) (default "us-east-1")
   -view-name string
-    	View name (default: aws_resources) (default "aws_resources")
+      View name (default: aws_resources) (default "aws_resources")
 ```
 
 Run the script (it will use the AWS credentials from your environment):
@@ -37,102 +41,110 @@ Run the script (it will use the AWS credentials from your environment):
 $ ./athena_resources_view -database athena-example -output 's3://cloudquery-athena-example/output/'
 ```
 
-## Lambda function
+### Lambda function
 
 1. Build the binary:
 
-   ```shell
-   GOOS=linux GOARCH=amd64 go build -o main main.go
-   ```
+  ```shell
+  GOOS=linux GOARCH=amd64 go build -o main main.go
+  ```
 
 2. Zip the binary. On Linux or Mac, you can use the `zip` command:
 
-   ```shell
-   zip main.zip main
-   ```
-   
-   On Windows, follow the instructions [here](https://docs.aws.amazon.com/lambda/latest/dg/golang-package.html#golang-package-windows) to create a zip file using the `build-lambda-zip` tool.
+  ```shell
+  zip main.zip main
+  ```
+  
+  On Windows, follow the instructions [here](https://docs.aws.amazon.com/lambda/latest/dg/golang-package.html#golang-package-windows) to create a zip file using the `build-lambda-zip` tool.
 
 3. Create the execution role:
 
-   ```shell
-   aws iam create-role --role-name lambda-ex --assume-role-policy-document file://trust-policy.json
-   ```
+  ```shell
+  aws iam create-role --role-name lambda-ex --assume-role-policy-document file://trust-policy.json
+  ```
 
-   Make a note of your role ARN. You will need this to create your function.
+  Make a note of your role ARN. You will need this to create your function.
 
 4. Add permissions to the role to allow it to execute Athena queries. You can use the following policy document as a template:
 
-   ```json
-   {
-       "Version": "2012-10-17",
-       "Statement": [
-         {
-           "Effect": "Allow",
-           "Action": [
-             "athena:StartQueryExecution",
-             "athena:GetQueryExecution",
-             "athena:GetQueryResults",
-             "glue:GetDatabases",
-             "glue:GetTables",
-             "glue:GetTable",
-             "glue:UpdateTable"
-           ],
-           "Resource": "*"
-         },
-         {
-           "Effect": "Allow",
-           "Action": [
-             "s3:GetObject",
-             "s3:ListBucket",
-             "s3:PutObject",
-             "s3:GetBucketLocation"
-           ],
-           "Resource": [
-             "arn:aws:s3:::cloudquery-athena-example",
-             "arn:aws:s3:::cloudquery-athena-example/output/*"
-           ]
-         }
-       ]
-   }
-   ```
+  ```json
+  {
+      "Version": "2012-10-17",
+      "Statement": [
+        {
+          "Effect": "Allow",
+          "Action": [
+            "athena:StartQueryExecution",
+            "athena:GetQueryExecution",
+            "athena:GetQueryResults",
+            "glue:GetDatabases",
+            "glue:GetTables",
+            "glue:GetTable",
+            "glue:UpdateTable"
+          ],
+          "Resource": "*"
+        },
+        {
+          "Effect": "Allow",
+          "Action": [
+            "s3:GetObject",
+            "s3:ListBucket",
+            "s3:PutObject",
+            "s3:GetBucketLocation"
+          ],
+          "Resource": [
+            "arn:aws:s3:::cloudquery-athena-example",
+            "arn:aws:s3:::cloudquery-athena-example/output/*"
+          ]
+        }
+      ]
+  }
+  ```
 
-   Save this as `athena-policy.json`, make appropriate edits for your environment (e.g. replacing `cloudquery-athena-example/output` with the bucket and directory where query results should be written), and then run:
+  Save this as `athena-policy.json`, make appropriate edits for your environment (e.g. replacing `cloudquery-athena-example/output` with the bucket and directory where query results should be written), and then run:
 
-   ```shell
-   aws iam put-role-policy --role-name lambda-ex --policy-name athena-policy --policy-document file://athena-policy.json
-   ```
+  ```shell
+  aws iam put-role-policy --role-name lambda-ex --policy-name athena-policy --policy-document file://athena-policy.json
+  ```
 
 5. Create the function (replace `<your-role-arn>` with the ARN of the role you created in step 2):
 
-   ```shell
-   aws lambda create-function --function-name athena-resources-view --zip-file fileb://main.zip --handler main --runtime go1.x --role <your-role-arn>
-   ```
-   
-   Athena queries can take a while to run, so we should increase the timeout. The default is 3 seconds, but we can increase this to 5 minutes:
+  ```shell
+  aws lambda create-function --function-name athena-resources-view --zip-file fileb://main.zip --handler main --runtime go1.x --role <your-role-arn>
+  ```
+  
+  Athena queries can take a while to run, so we should increase the timeout. The default is 3 seconds, but we can increase this to 5 minutes:
 
-   ```shell
-   aws lambda update-function-configuration --function-name athena-resources-view --timeout 300
-   ```
-   
+  ```shell
+  aws lambda update-function-configuration --function-name athena-resources-view --timeout 300
+  ```
+  
 6. Finally, run the function. This might be easier from the console, but here is an example of how to do it from the command line (you will need to modify the values in the payload for your environment):
 
-   ```shell
-   aws lambda invoke --cli-binary-format raw-in-base64-out --function-name athena-resources-view --invocation-type Event --payload '{"catalog": "awsdatacatalog", "database": "athena-example", "output": "s3://cloudquery-athena-example/output", "view": "aws_resources", "region": "us-east-1"}' response.json
-   ```
-   
-   The above command uses the following JSON payload, which you should adapt for your environment:
-   ```json
-   {
-       "catalog": "awsdatacatalog",
-       "database": "athena-example",
-       "output": "s3://cloudquery-athena-example/output",
-       "view": "aws_resources",
-       "region": "us-east-1"
-   }
-   ```
-   
-   If any query errors occur, you should be able to see them in the "Recent Queries" tab in the Athena console. Also check the logs for the function itself for any clues.
+  ```shell
+  aws lambda invoke --cli-binary-format raw-in-base64-out --function-name athena-resources-view --invocation-type Event --payload '{"catalog": "awsdatacatalog", "database": "athena-example", "output": "s3://cloudquery-athena-example/output", "view": "aws_resources", "region": "us-east-1"}' response.json
+  ```
+  
+  The above command uses the following JSON payload, which you should adapt for your environment:
+  ```json
+  {
+      "catalog": "awsdatacatalog",
+      "database": "athena-example",
+      "output": "s3://cloudquery-athena-example/output",
+      "view": "aws_resources",
+      "region": "us-east-1"
+  }
+  ```
+  
+  If any query errors occur, you should be able to see them in the "Recent Queries" tab in the Athena console. Also check the logs for the function itself for any clues.
 
 With the Lambda created, you are free to then schedule it to run on a regular basis, or after a CloudQuery run.
+
+## **Standalone SQL script**
+
+## Usage
+
+Execute the `resources.sql` script in Athena. The output of this exection will be the `create view` statement.
+
+Copy the full `create view` output statement and execute it in Athena
 

--- a/plugins/source/aws/views/athena/resources.sql
+++ b/plugins/source/aws/views/athena/resources.sql
@@ -47,7 +47,7 @@ select_statements as (
     from aws_tables
 )
 
-select concat('create view aws_resources as (',
+select concat('create or replace view aws_resources as (',
     array_join(array_agg(select_statement), ' union all '),
     ');') as create_view_statement
 from select_statements;

--- a/plugins/source/aws/views/athena/resources.sql
+++ b/plugins/source/aws/views/athena/resources.sql
@@ -1,0 +1,53 @@
+with aws_tables as (
+    select table_name
+    from information_schema.columns
+    where table_name like 'aws_%s'
+        and column_name = 'account_id'
+    intersect
+    select table_name
+    from information_schema.columns
+    where table_name like 'aws_%s'
+        and column_name = 'arn'
+),
+
+select_statements as (
+    select concat('select _cq_id, _cq_source_name, _cq_sync_time, ',
+        '''',
+        table_name,
+        '''',
+        ' as _cq_table, account_id, ',
+        case
+            when
+                exists (
+                    select 1
+                    from
+                        information_schema.columns
+                    where
+                        information_schema.columns.column_name = 'region'
+                        and information_schema.columns.table_name = aws_tables.table_name
+                ) then 'region'
+            else concat('''', 'unavailable', '''')
+        end,
+        ' as region, arn, ',
+        case
+            when
+                exists (
+                    select 1
+                    from
+                        information_schema.columns
+                    where
+                        information_schema.columns.column_name = 'tags'
+                        and information_schema.columns.table_name = aws_tables.table_name
+                ) then 'tags'
+            else concat('''', '{}', '''')
+        end,
+        ' as tags from ',
+        table_name
+    ) as select_statement
+    from aws_tables
+)
+
+select concat('create view aws_resources as (',
+    array_join(array_agg(select_statement), ' union all '),
+    ');') as create_view_statement
+from select_statements;


### PR DESCRIPTION
This adds a standalone SQL script that can be used to create an aws_resources view in Athena, similar to the Postgres one.

Provides an alternative option for https://github.com/cloudquery/cloudquery/issues/4383