### PR TITLE
fix(aws)!: Add `account_id` and `region` to `aws_quicksight_*` resources

### DIFF
--- a/plugins/source/aws/docs/tables/aws_quicksight_analyses.md
+++ b/plugins/source/aws/docs/tables/aws_quicksight_analyses.md
@@ -2,7 +2,7 @@
 
 https://docs.aws.amazon.com/quicksight/latest/APIReference/API_Analysis.html
 
-The primary key for this table is **arn**.
+The composite primary key for this table is (**account_id**, **region**, **arn**).
 
 ## Columns
 
@@ -12,8 +12,8 @@ The primary key for this table is **arn**.
 |_cq_sync_time|Timestamp|
 |_cq_id|UUID|
 |_cq_parent_id|UUID|
-|account_id|String|
-|region|String|
+|account_id (PK)|String|
+|region (PK)|String|
 |tags|JSON|
 |analysis_id|String|
 |arn (PK)|String|

--- a/plugins/source/aws/docs/tables/aws_quicksight_analyses.md
+++ b/plugins/source/aws/docs/tables/aws_quicksight_analyses.md
@@ -15,8 +15,8 @@ The primary key for this table is **arn**.
 |account_id|String|
 |region|String|
 |tags|JSON|
-|arn (PK)|String|
 |analysis_id|String|
+|arn (PK)|String|
 |created_time|Timestamp|
 |data_set_arns|StringArray|
 |errors|JSON|

--- a/plugins/source/aws/docs/tables/aws_quicksight_dashboards.md
+++ b/plugins/source/aws/docs/tables/aws_quicksight_dashboards.md
@@ -2,7 +2,7 @@
 
 https://docs.aws.amazon.com/quicksight/latest/APIReference/API_DashboardSummary.html
 
-The primary key for this table is **arn**.
+The composite primary key for this table is (**account_id**, **region**, **arn**).
 
 ## Columns
 
@@ -12,8 +12,8 @@ The primary key for this table is **arn**.
 |_cq_sync_time|Timestamp|
 |_cq_id|UUID|
 |_cq_parent_id|UUID|
-|account_id|String|
-|region|String|
+|account_id (PK)|String|
+|region (PK)|String|
 |tags|JSON|
 |arn (PK)|String|
 |created_time|Timestamp|

--- a/plugins/source/aws/docs/tables/aws_quicksight_data_sets.md
+++ b/plugins/source/aws/docs/tables/aws_quicksight_data_sets.md
@@ -2,7 +2,7 @@
 
 https://docs.aws.amazon.com/quicksight/latest/APIReference/API_DataSetSummary.html
 
-The primary key for this table is **arn**.
+The composite primary key for this table is (**account_id**, **region**, **arn**).
 
 ## Relations
 
@@ -17,8 +17,8 @@ The following tables depend on aws_quicksight_data_sets:
 |_cq_sync_time|Timestamp|
 |_cq_id|UUID|
 |_cq_parent_id|UUID|
-|account_id|String|
-|region|String|
+|account_id (PK)|String|
+|region (PK)|String|
 |tags|JSON|
 |arn (PK)|String|
 |column_level_permission_rules_applied|Bool|

--- a/plugins/source/aws/docs/tables/aws_quicksight_data_sources.md
+++ b/plugins/source/aws/docs/tables/aws_quicksight_data_sources.md
@@ -2,7 +2,7 @@
 
 https://docs.aws.amazon.com/quicksight/latest/APIReference/API_DataSource.html
 
-The primary key for this table is **arn**.
+The composite primary key for this table is (**account_id**, **region**, **arn**).
 
 ## Columns
 
@@ -12,8 +12,8 @@ The primary key for this table is **arn**.
 |_cq_sync_time|Timestamp|
 |_cq_id|UUID|
 |_cq_parent_id|UUID|
-|account_id|String|
-|region|String|
+|account_id (PK)|String|
+|region (PK)|String|
 |tags|JSON|
 |arn (PK)|String|
 |created_time|Timestamp|

--- a/plugins/source/aws/docs/tables/aws_quicksight_folders.md
+++ b/plugins/source/aws/docs/tables/aws_quicksight_folders.md
@@ -2,7 +2,7 @@
 
 https://docs.aws.amazon.com/quicksight/latest/APIReference/API_Folder.html
 
-The primary key for this table is **arn**.
+The composite primary key for this table is (**account_id**, **region**, **arn**).
 
 ## Columns
 
@@ -12,8 +12,8 @@ The primary key for this table is **arn**.
 |_cq_sync_time|Timestamp|
 |_cq_id|UUID|
 |_cq_parent_id|UUID|
-|account_id|String|
-|region|String|
+|account_id (PK)|String|
+|region (PK)|String|
 |tags|JSON|
 |arn (PK)|String|
 |created_time|Timestamp|

--- a/plugins/source/aws/docs/tables/aws_quicksight_group_members.md
+++ b/plugins/source/aws/docs/tables/aws_quicksight_group_members.md
@@ -2,7 +2,7 @@
 
 https://docs.aws.amazon.com/quicksight/latest/APIReference/API_GroupMember.html
 
-The composite primary key for this table is (**user_arn**, **group_arn**).
+The composite primary key for this table is (**group_arn**, **arn**).
 
 ## Relations
 
@@ -18,7 +18,6 @@ This table depends on [aws_quicksight_groups](aws_quicksight_groups.md).
 |_cq_parent_id|UUID|
 |account_id|String|
 |region|String|
-|user_arn (PK)|String|
 |group_arn (PK)|String|
-|arn|String|
+|arn (PK)|String|
 |member_name|String|

--- a/plugins/source/aws/docs/tables/aws_quicksight_group_members.md
+++ b/plugins/source/aws/docs/tables/aws_quicksight_group_members.md
@@ -2,7 +2,7 @@
 
 https://docs.aws.amazon.com/quicksight/latest/APIReference/API_GroupMember.html
 
-The composite primary key for this table is (**group_arn**, **arn**).
+The composite primary key for this table is (**account_id**, **region**, **group_arn**, **arn**).
 
 ## Relations
 
@@ -16,8 +16,8 @@ This table depends on [aws_quicksight_groups](aws_quicksight_groups.md).
 |_cq_sync_time|Timestamp|
 |_cq_id|UUID|
 |_cq_parent_id|UUID|
-|account_id|String|
-|region|String|
+|account_id (PK)|String|
+|region (PK)|String|
 |group_arn (PK)|String|
 |arn (PK)|String|
 |member_name|String|

--- a/plugins/source/aws/docs/tables/aws_quicksight_groups.md
+++ b/plugins/source/aws/docs/tables/aws_quicksight_groups.md
@@ -2,7 +2,7 @@
 
 https://docs.aws.amazon.com/quicksight/latest/APIReference/API_Group.html
 
-The primary key for this table is **arn**.
+The composite primary key for this table is (**account_id**, **region**, **arn**).
 
 ## Relations
 
@@ -17,8 +17,8 @@ The following tables depend on aws_quicksight_groups:
 |_cq_sync_time|Timestamp|
 |_cq_id|UUID|
 |_cq_parent_id|UUID|
-|account_id|String|
-|region|String|
+|account_id (PK)|String|
+|region (PK)|String|
 |tags|JSON|
 |arn (PK)|String|
 |description|String|

--- a/plugins/source/aws/docs/tables/aws_quicksight_ingestions.md
+++ b/plugins/source/aws/docs/tables/aws_quicksight_ingestions.md
@@ -2,7 +2,7 @@
 
 https://docs.aws.amazon.com/quicksight/latest/APIReference/API_Ingestion.html
 
-The composite primary key for this table is (**data_set_arn**, **arn**).
+The composite primary key for this table is (**account_id**, **region**, **data_set_arn**, **arn**).
 
 ## Relations
 
@@ -16,8 +16,8 @@ This table depends on [aws_quicksight_data_sets](aws_quicksight_data_sets.md).
 |_cq_sync_time|Timestamp|
 |_cq_id|UUID|
 |_cq_parent_id|UUID|
-|account_id|String|
-|region|String|
+|account_id (PK)|String|
+|region (PK)|String|
 |tags|JSON|
 |data_set_arn (PK)|String|
 |arn (PK)|String|

--- a/plugins/source/aws/docs/tables/aws_quicksight_ingestions.md
+++ b/plugins/source/aws/docs/tables/aws_quicksight_ingestions.md
@@ -2,7 +2,7 @@
 
 https://docs.aws.amazon.com/quicksight/latest/APIReference/API_Ingestion.html
 
-The composite primary key for this table is (**arn**, **data_set_arn**).
+The composite primary key for this table is (**data_set_arn**, **arn**).
 
 ## Relations
 
@@ -19,8 +19,8 @@ This table depends on [aws_quicksight_data_sets](aws_quicksight_data_sets.md).
 |account_id|String|
 |region|String|
 |tags|JSON|
-|arn (PK)|String|
 |data_set_arn (PK)|String|
+|arn (PK)|String|
 |created_time|Timestamp|
 |ingestion_status|String|
 |error_info|JSON|

--- a/plugins/source/aws/docs/tables/aws_quicksight_templates.md
+++ b/plugins/source/aws/docs/tables/aws_quicksight_templates.md
@@ -2,7 +2,7 @@
 
 https://docs.aws.amazon.com/quicksight/latest/APIReference/API_TemplateSummary.html
 
-The primary key for this table is **arn**.
+The composite primary key for this table is (**account_id**, **region**, **arn**).
 
 ## Columns
 
@@ -12,8 +12,8 @@ The primary key for this table is **arn**.
 |_cq_sync_time|Timestamp|
 |_cq_id|UUID|
 |_cq_parent_id|UUID|
-|account_id|String|
-|region|String|
+|account_id (PK)|String|
+|region (PK)|String|
 |tags|JSON|
 |arn (PK)|String|
 |created_time|Timestamp|

--- a/plugins/source/aws/docs/tables/aws_quicksight_users.md
+++ b/plugins/source/aws/docs/tables/aws_quicksight_users.md
@@ -2,7 +2,7 @@
 
 https://docs.aws.amazon.com/quicksight/latest/APIReference/API_User.html
 
-The primary key for this table is **arn**.
+The composite primary key for this table is (**account_id**, **region**, **arn**).
 
 ## Columns
 
@@ -12,8 +12,8 @@ The primary key for this table is **arn**.
 |_cq_sync_time|Timestamp|
 |_cq_id|UUID|
 |_cq_parent_id|UUID|
-|account_id|String|
-|region|String|
+|account_id (PK)|String|
+|region (PK)|String|
 |tags|JSON|
 |active|Bool|
 |arn (PK)|String|

--- a/plugins/source/aws/docs/tables/aws_quicksight_users.md
+++ b/plugins/source/aws/docs/tables/aws_quicksight_users.md
@@ -15,8 +15,8 @@ The primary key for this table is **arn**.
 |account_id|String|
 |region|String|
 |tags|JSON|
-|arn (PK)|String|
 |active|Bool|
+|arn (PK)|String|
 |custom_permissions_name|String|
 |email|String|
 |external_login_federation_provider_type|String|

--- a/plugins/source/aws/resources/services/quicksight/analyses.go
+++ b/plugins/source/aws/resources/services/quicksight/analyses.go
@@ -15,6 +15,6 @@ func Analyses() *schema.Table {
 		PreResourceResolver: getAnalysis,
 		Transform:           transformers.TransformWithStruct(&types.Analysis{}, transformers.WithPrimaryKeys("Arn")),
 		Multiplex:           client.ServiceAccountRegionMultiplexer("quicksight"),
-		Columns:             []schema.Column{client.DefaultAccountIDColumn(false), client.DefaultRegionColumn(false), tagsCol},
+		Columns:             []schema.Column{client.DefaultAccountIDColumn(true), client.DefaultRegionColumn(true), tagsCol},
 	}
 }

--- a/plugins/source/aws/resources/services/quicksight/analyses.go
+++ b/plugins/source/aws/resources/services/quicksight/analyses.go
@@ -13,24 +13,8 @@ func Analyses() *schema.Table {
 		Description:         "https://docs.aws.amazon.com/quicksight/latest/APIReference/API_Analysis.html",
 		Resolver:            fetchQuicksightAnalyses,
 		PreResourceResolver: getAnalysis,
-		Transform:           transformers.TransformWithStruct(&types.Analysis{}),
+		Transform:           transformers.TransformWithStruct(&types.Analysis{}, transformers.WithPrimaryKeys("Arn")),
 		Multiplex:           client.ServiceAccountRegionMultiplexer("quicksight"),
-		Columns: []schema.Column{
-			client.DefaultAccountIDColumn(false),
-			client.DefaultRegionColumn(false),
-			{
-				Name:     "tags",
-				Type:     schema.TypeJSON,
-				Resolver: resolveTags(),
-			},
-			{
-				Name:     "arn",
-				Type:     schema.TypeString,
-				Resolver: schema.PathResolver("Arn"),
-				CreationOptions: schema.ColumnCreationOptions{
-					PrimaryKey: true,
-				},
-			},
-		},
+		Columns:             []schema.Column{client.DefaultAccountIDColumn(false), client.DefaultRegionColumn(false), tagsCol},
 	}
 }

--- a/plugins/source/aws/resources/services/quicksight/dashboards.go
+++ b/plugins/source/aws/resources/services/quicksight/dashboards.go
@@ -14,6 +14,6 @@ func Dashboards() *schema.Table {
 		Resolver:    fetchQuicksightDashboards,
 		Transform:   transformers.TransformWithStruct(&types.DashboardSummary{}, transformers.WithPrimaryKeys("Arn")),
 		Multiplex:   client.ServiceAccountRegionMultiplexer("quicksight"),
-		Columns:     []schema.Column{client.DefaultAccountIDColumn(false), client.DefaultRegionColumn(false), tagsCol},
+		Columns:     []schema.Column{client.DefaultAccountIDColumn(true), client.DefaultRegionColumn(true), tagsCol},
 	}
 }

--- a/plugins/source/aws/resources/services/quicksight/dashboards.go
+++ b/plugins/source/aws/resources/services/quicksight/dashboards.go
@@ -12,24 +12,8 @@ func Dashboards() *schema.Table {
 		Name:        "aws_quicksight_dashboards",
 		Description: "https://docs.aws.amazon.com/quicksight/latest/APIReference/API_DashboardSummary.html",
 		Resolver:    fetchQuicksightDashboards,
-		Transform:   transformers.TransformWithStruct(&types.DashboardSummary{}),
+		Transform:   transformers.TransformWithStruct(&types.DashboardSummary{}, transformers.WithPrimaryKeys("Arn")),
 		Multiplex:   client.ServiceAccountRegionMultiplexer("quicksight"),
-		Columns: []schema.Column{
-			client.DefaultAccountIDColumn(false),
-			client.DefaultRegionColumn(false),
-			{
-				Name:     "tags",
-				Type:     schema.TypeJSON,
-				Resolver: resolveTags(),
-			},
-			{
-				Name:     "arn",
-				Type:     schema.TypeString,
-				Resolver: schema.PathResolver("Arn"),
-				CreationOptions: schema.ColumnCreationOptions{
-					PrimaryKey: true,
-				},
-			},
-		},
+		Columns:     []schema.Column{client.DefaultAccountIDColumn(false), client.DefaultRegionColumn(false), tagsCol},
 	}
 }

--- a/plugins/source/aws/resources/services/quicksight/data_sets.go
+++ b/plugins/source/aws/resources/services/quicksight/data_sets.go
@@ -12,29 +12,9 @@ func DataSets() *schema.Table {
 		Name:        "aws_quicksight_data_sets",
 		Description: "https://docs.aws.amazon.com/quicksight/latest/APIReference/API_DataSetSummary.html",
 		Resolver:    fetchQuicksightDataSets,
-		Transform:   transformers.TransformWithStruct(&types.DataSetSummary{}),
-
-		Multiplex: client.ServiceAccountRegionMultiplexer("quicksight"),
-		Columns: []schema.Column{
-			client.DefaultAccountIDColumn(false),
-			client.DefaultRegionColumn(false),
-			{
-				Name:     "tags",
-				Type:     schema.TypeJSON,
-				Resolver: resolveTags(),
-			},
-			{
-				Name:     "arn",
-				Type:     schema.TypeString,
-				Resolver: schema.PathResolver("Arn"),
-				CreationOptions: schema.ColumnCreationOptions{
-					PrimaryKey: true,
-				},
-			},
-		},
-
-		Relations: []*schema.Table{
-			Ingestions(),
-		},
+		Transform:   transformers.TransformWithStruct(&types.DataSetSummary{}, transformers.WithPrimaryKeys("Arn")),
+		Multiplex:   client.ServiceAccountRegionMultiplexer("quicksight"),
+		Columns:     []schema.Column{client.DefaultAccountIDColumn(false), client.DefaultRegionColumn(false), tagsCol},
+		Relations:   []*schema.Table{ingestions()},
 	}
 }

--- a/plugins/source/aws/resources/services/quicksight/data_sets.go
+++ b/plugins/source/aws/resources/services/quicksight/data_sets.go
@@ -14,7 +14,7 @@ func DataSets() *schema.Table {
 		Resolver:    fetchQuicksightDataSets,
 		Transform:   transformers.TransformWithStruct(&types.DataSetSummary{}, transformers.WithPrimaryKeys("Arn")),
 		Multiplex:   client.ServiceAccountRegionMultiplexer("quicksight"),
-		Columns:     []schema.Column{client.DefaultAccountIDColumn(false), client.DefaultRegionColumn(false), tagsCol},
+		Columns:     []schema.Column{client.DefaultAccountIDColumn(true), client.DefaultRegionColumn(true), tagsCol},
 		Relations:   []*schema.Table{ingestions()},
 	}
 }

--- a/plugins/source/aws/resources/services/quicksight/data_sources.go
+++ b/plugins/source/aws/resources/services/quicksight/data_sources.go
@@ -12,24 +12,11 @@ func DataSources() *schema.Table {
 		Name:        "aws_quicksight_data_sources",
 		Description: "https://docs.aws.amazon.com/quicksight/latest/APIReference/API_DataSource.html",
 		Resolver:    fetchQuicksightDataSources,
-		Transform:   transformers.TransformWithStruct(&types.DataSource{}, transformers.WithSkipFields("AlternateDataSourceParameters")),
-		Multiplex:   client.ServiceAccountRegionMultiplexer("quicksight"),
-		Columns: []schema.Column{
-			client.DefaultAccountIDColumn(false),
-			client.DefaultRegionColumn(false),
-			{
-				Name:     "tags",
-				Type:     schema.TypeJSON,
-				Resolver: resolveTags(),
-			},
-			{
-				Name:     "arn",
-				Type:     schema.TypeString,
-				Resolver: schema.PathResolver("Arn"),
-				CreationOptions: schema.ColumnCreationOptions{
-					PrimaryKey: true,
-				},
-			},
-		},
+		Transform: transformers.TransformWithStruct(&types.DataSource{},
+			transformers.WithPrimaryKeys("Arn"),
+			transformers.WithSkipFields("AlternateDataSourceParameters"),
+		),
+		Multiplex: client.ServiceAccountRegionMultiplexer("quicksight"),
+		Columns:   []schema.Column{client.DefaultAccountIDColumn(false), client.DefaultRegionColumn(false), tagsCol},
 	}
 }

--- a/plugins/source/aws/resources/services/quicksight/data_sources.go
+++ b/plugins/source/aws/resources/services/quicksight/data_sources.go
@@ -17,6 +17,6 @@ func DataSources() *schema.Table {
 			transformers.WithSkipFields("AlternateDataSourceParameters"),
 		),
 		Multiplex: client.ServiceAccountRegionMultiplexer("quicksight"),
-		Columns:   []schema.Column{client.DefaultAccountIDColumn(false), client.DefaultRegionColumn(false), tagsCol},
+		Columns:   []schema.Column{client.DefaultAccountIDColumn(true), client.DefaultRegionColumn(true), tagsCol},
 	}
 }

--- a/plugins/source/aws/resources/services/quicksight/folders.go
+++ b/plugins/source/aws/resources/services/quicksight/folders.go
@@ -13,24 +13,8 @@ func Folders() *schema.Table {
 		Description:         "https://docs.aws.amazon.com/quicksight/latest/APIReference/API_Folder.html",
 		Resolver:            fetchQuicksightFolders,
 		PreResourceResolver: getFolder,
-		Transform:           transformers.TransformWithStruct(&types.Folder{}),
+		Transform:           transformers.TransformWithStruct(&types.Folder{}, transformers.WithPrimaryKeys("Arn")),
 		Multiplex:           client.ServiceAccountRegionMultiplexer("quicksight"),
-		Columns: []schema.Column{
-			client.DefaultAccountIDColumn(false),
-			client.DefaultRegionColumn(false),
-			{
-				Name:     "tags",
-				Type:     schema.TypeJSON,
-				Resolver: resolveTags(),
-			},
-			{
-				Name:     "arn",
-				Type:     schema.TypeString,
-				Resolver: schema.PathResolver("Arn"),
-				CreationOptions: schema.ColumnCreationOptions{
-					PrimaryKey: true,
-				},
-			},
-		},
+		Columns:             []schema.Column{client.DefaultAccountIDColumn(false), client.DefaultRegionColumn(false), tagsCol},
 	}
 }

--- a/plugins/source/aws/resources/services/quicksight/folders.go
+++ b/plugins/source/aws/resources/services/quicksight/folders.go
@@ -15,6 +15,6 @@ func Folders() *schema.Table {
 		PreResourceResolver: getFolder,
 		Transform:           transformers.TransformWithStruct(&types.Folder{}, transformers.WithPrimaryKeys("Arn")),
 		Multiplex:           client.ServiceAccountRegionMultiplexer("quicksight"),
-		Columns:             []schema.Column{client.DefaultAccountIDColumn(false), client.DefaultRegionColumn(false), tagsCol},
+		Columns:             []schema.Column{client.DefaultAccountIDColumn(true), client.DefaultRegionColumn(true), tagsCol},
 	}
 }

--- a/plugins/source/aws/resources/services/quicksight/group_members.go
+++ b/plugins/source/aws/resources/services/quicksight/group_members.go
@@ -7,31 +7,21 @@ import (
 	"github.com/cloudquery/plugin-sdk/transformers"
 )
 
-func GroupMembers() *schema.Table {
+func groupMembers() *schema.Table {
 	return &schema.Table{
 		Name:        "aws_quicksight_group_members",
 		Description: "https://docs.aws.amazon.com/quicksight/latest/APIReference/API_GroupMember.html",
 		Resolver:    fetchQuicksightGroupMembers,
-		Transform:   transformers.TransformWithStruct(&types.GroupMember{}),
+		Transform:   transformers.TransformWithStruct(&types.GroupMember{}, transformers.WithPrimaryKeys("Arn")),
 		Multiplex:   client.ServiceAccountRegionMultiplexer("quicksight"),
 		Columns: []schema.Column{
 			client.DefaultAccountIDColumn(false),
 			client.DefaultRegionColumn(false),
 			{
-				Name:     "user_arn",
-				Type:     schema.TypeString,
-				Resolver: schema.PathResolver("Arn"),
-				CreationOptions: schema.ColumnCreationOptions{
-					PrimaryKey: true,
-				},
-			},
-			{
-				Name:     "group_arn",
-				Type:     schema.TypeString,
-				Resolver: schema.ParentColumnResolver("arn"),
-				CreationOptions: schema.ColumnCreationOptions{
-					PrimaryKey: true,
-				},
+				Name:            "group_arn",
+				Type:            schema.TypeString,
+				Resolver:        schema.ParentColumnResolver("arn"),
+				CreationOptions: schema.ColumnCreationOptions{PrimaryKey: true},
 			},
 		},
 	}

--- a/plugins/source/aws/resources/services/quicksight/group_members.go
+++ b/plugins/source/aws/resources/services/quicksight/group_members.go
@@ -15,8 +15,8 @@ func groupMembers() *schema.Table {
 		Transform:   transformers.TransformWithStruct(&types.GroupMember{}, transformers.WithPrimaryKeys("Arn")),
 		Multiplex:   client.ServiceAccountRegionMultiplexer("quicksight"),
 		Columns: []schema.Column{
-			client.DefaultAccountIDColumn(false),
-			client.DefaultRegionColumn(false),
+			client.DefaultAccountIDColumn(true),
+			client.DefaultRegionColumn(true),
 			{
 				Name:            "group_arn",
 				Type:            schema.TypeString,

--- a/plugins/source/aws/resources/services/quicksight/groups.go
+++ b/plugins/source/aws/resources/services/quicksight/groups.go
@@ -14,7 +14,7 @@ func Groups() *schema.Table {
 		Resolver:    fetchQuicksightGroups,
 		Transform:   transformers.TransformWithStruct(&types.Group{}, transformers.WithPrimaryKeys("Arn")),
 		Multiplex:   client.ServiceAccountRegionMultiplexer("quicksight"),
-		Columns:     []schema.Column{client.DefaultAccountIDColumn(false), client.DefaultRegionColumn(false), tagsCol},
+		Columns:     []schema.Column{client.DefaultAccountIDColumn(true), client.DefaultRegionColumn(true), tagsCol},
 		Relations:   []*schema.Table{groupMembers()},
 	}
 }

--- a/plugins/source/aws/resources/services/quicksight/groups.go
+++ b/plugins/source/aws/resources/services/quicksight/groups.go
@@ -12,28 +12,9 @@ func Groups() *schema.Table {
 		Name:        "aws_quicksight_groups",
 		Description: "https://docs.aws.amazon.com/quicksight/latest/APIReference/API_Group.html",
 		Resolver:    fetchQuicksightGroups,
-		Transform:   transformers.TransformWithStruct(&types.Group{}),
+		Transform:   transformers.TransformWithStruct(&types.Group{}, transformers.WithPrimaryKeys("Arn")),
 		Multiplex:   client.ServiceAccountRegionMultiplexer("quicksight"),
-		Columns: []schema.Column{
-			client.DefaultAccountIDColumn(false),
-			client.DefaultRegionColumn(false),
-			{
-				Name:     "tags",
-				Type:     schema.TypeJSON,
-				Resolver: resolveTags(),
-			},
-			{
-				Name:     "arn",
-				Type:     schema.TypeString,
-				Resolver: schema.PathResolver("Arn"),
-				CreationOptions: schema.ColumnCreationOptions{
-					PrimaryKey: true,
-				},
-			},
-		},
-
-		Relations: []*schema.Table{
-			GroupMembers(),
-		},
+		Columns:     []schema.Column{client.DefaultAccountIDColumn(false), client.DefaultRegionColumn(false), tagsCol},
+		Relations:   []*schema.Table{groupMembers()},
 	}
 }

--- a/plugins/source/aws/resources/services/quicksight/ingestions.go
+++ b/plugins/source/aws/resources/services/quicksight/ingestions.go
@@ -7,36 +7,22 @@ import (
 	"github.com/cloudquery/plugin-sdk/transformers"
 )
 
-func Ingestions() *schema.Table {
+func ingestions() *schema.Table {
 	return &schema.Table{
 		Name:        "aws_quicksight_ingestions",
 		Description: "https://docs.aws.amazon.com/quicksight/latest/APIReference/API_Ingestion.html",
 		Resolver:    fetchQuicksightIngestions,
-		Transform:   transformers.TransformWithStruct(&types.Ingestion{}),
+		Transform:   transformers.TransformWithStruct(&types.Ingestion{}, transformers.WithPrimaryKeys("Arn")),
 		Multiplex:   client.ServiceAccountRegionMultiplexer("quicksight"),
 		Columns: []schema.Column{
 			client.DefaultAccountIDColumn(false),
 			client.DefaultRegionColumn(false),
+			tagsCol,
 			{
-				Name:     "tags",
-				Type:     schema.TypeJSON,
-				Resolver: resolveTags(),
-			},
-			{
-				Name:     "arn",
-				Type:     schema.TypeString,
-				Resolver: schema.PathResolver("Arn"),
-				CreationOptions: schema.ColumnCreationOptions{
-					PrimaryKey: true,
-				},
-			},
-			{
-				Name:     "data_set_arn",
-				Type:     schema.TypeString,
-				Resolver: schema.ParentColumnResolver("arn"),
-				CreationOptions: schema.ColumnCreationOptions{
-					PrimaryKey: true,
-				},
+				Name:            "data_set_arn",
+				Type:            schema.TypeString,
+				Resolver:        schema.ParentColumnResolver("arn"),
+				CreationOptions: schema.ColumnCreationOptions{PrimaryKey: true},
 			},
 		},
 	}

--- a/plugins/source/aws/resources/services/quicksight/ingestions.go
+++ b/plugins/source/aws/resources/services/quicksight/ingestions.go
@@ -15,8 +15,8 @@ func ingestions() *schema.Table {
 		Transform:   transformers.TransformWithStruct(&types.Ingestion{}, transformers.WithPrimaryKeys("Arn")),
 		Multiplex:   client.ServiceAccountRegionMultiplexer("quicksight"),
 		Columns: []schema.Column{
-			client.DefaultAccountIDColumn(false),
-			client.DefaultRegionColumn(false),
+			client.DefaultAccountIDColumn(true),
+			client.DefaultRegionColumn(true),
 			tagsCol,
 			{
 				Name:            "data_set_arn",

--- a/plugins/source/aws/resources/services/quicksight/templates.go
+++ b/plugins/source/aws/resources/services/quicksight/templates.go
@@ -12,24 +12,8 @@ func Templates() *schema.Table {
 		Name:        "aws_quicksight_templates",
 		Description: "https://docs.aws.amazon.com/quicksight/latest/APIReference/API_TemplateSummary.html",
 		Resolver:    fetchQuicksightTemplates,
-		Transform:   transformers.TransformWithStruct(&types.TemplateSummary{}),
+		Transform:   transformers.TransformWithStruct(&types.TemplateSummary{}, transformers.WithPrimaryKeys("Arn")),
 		Multiplex:   client.ServiceAccountRegionMultiplexer("quicksight"),
-		Columns: []schema.Column{
-			client.DefaultAccountIDColumn(false),
-			client.DefaultRegionColumn(false),
-			{
-				Name:     "tags",
-				Type:     schema.TypeJSON,
-				Resolver: resolveTags(),
-			},
-			{
-				Name:     "arn",
-				Type:     schema.TypeString,
-				Resolver: schema.PathResolver("Arn"),
-				CreationOptions: schema.ColumnCreationOptions{
-					PrimaryKey: true,
-				},
-			},
-		},
+		Columns:     []schema.Column{client.DefaultAccountIDColumn(false), client.DefaultRegionColumn(false), tagsCol},
 	}
 }

--- a/plugins/source/aws/resources/services/quicksight/templates.go
+++ b/plugins/source/aws/resources/services/quicksight/templates.go
@@ -14,6 +14,6 @@ func Templates() *schema.Table {
 		Resolver:    fetchQuicksightTemplates,
 		Transform:   transformers.TransformWithStruct(&types.TemplateSummary{}, transformers.WithPrimaryKeys("Arn")),
 		Multiplex:   client.ServiceAccountRegionMultiplexer("quicksight"),
-		Columns:     []schema.Column{client.DefaultAccountIDColumn(false), client.DefaultRegionColumn(false), tagsCol},
+		Columns:     []schema.Column{client.DefaultAccountIDColumn(true), client.DefaultRegionColumn(true), tagsCol},
 	}
 }

--- a/plugins/source/aws/resources/services/quicksight/users.go
+++ b/plugins/source/aws/resources/services/quicksight/users.go
@@ -12,24 +12,8 @@ func Users() *schema.Table {
 		Name:        "aws_quicksight_users",
 		Description: "https://docs.aws.amazon.com/quicksight/latest/APIReference/API_User.html",
 		Resolver:    fetchQuicksightUsers,
-		Transform:   transformers.TransformWithStruct(&types.User{}),
+		Transform:   transformers.TransformWithStruct(&types.User{}, transformers.WithPrimaryKeys("Arn")),
 		Multiplex:   client.ServiceAccountRegionMultiplexer("quicksight"),
-		Columns: []schema.Column{
-			client.DefaultAccountIDColumn(false),
-			client.DefaultRegionColumn(false),
-			{
-				Name:     "tags",
-				Type:     schema.TypeJSON,
-				Resolver: resolveTags(),
-			},
-			{
-				Name:     "arn",
-				Type:     schema.TypeString,
-				Resolver: schema.PathResolver("Arn"),
-				CreationOptions: schema.ColumnCreationOptions{
-					PrimaryKey: true,
-				},
-			},
-		},
+		Columns:     []schema.Column{client.DefaultAccountIDColumn(false), client.DefaultRegionColumn(false), tagsCol},
 	}
 }

--- a/plugins/source/aws/resources/services/quicksight/users.go
+++ b/plugins/source/aws/resources/services/quicksight/users.go
@@ -14,6 +14,6 @@ func Users() *schema.Table {
 		Resolver:    fetchQuicksightUsers,
 		Transform:   transformers.TransformWithStruct(&types.User{}, transformers.WithPrimaryKeys("Arn")),
 		Multiplex:   client.ServiceAccountRegionMultiplexer("quicksight"),
-		Columns:     []schema.Column{client.DefaultAccountIDColumn(false), client.DefaultRegionColumn(false), tagsCol},
+		Columns:     []schema.Column{client.DefaultAccountIDColumn(true), client.DefaultRegionColumn(true), tagsCol},
 	}
 }


### PR DESCRIPTION
closes https://github.com/cloudquery/cloudquery-issues/issues/488

BEGIN_COMMIT_OVERRIDE
fix(aws): Add `account_id` and region to `aws_quicksight_*` resources
  BREAKING-CHANGE: fix(aws): Add `account_id` and region to `aws_quicksight_*` resources

fix(aws): Rename `user_arn` field to `arn` in `aws_quicksight_group_members`
  BREAKING-CHANGE: Rename `user_arn` field to `arn` in `aws_quicksight_group_members`
END_COMMIT_OVERRIDE