### PR TITLE
fix(website): Fix vale comments

### DIFF
--- a/website/pages/docs/reference/destination-spec.md
+++ b/website/pages/docs/reference/destination-spec.md
@@ -61,17 +61,17 @@ Specifies the update method to use when inserting rows. The exact semantics depe
 - `overwrite`: Same as `overwrite-delete-stale`, but doesn't delete stale rows from previous `sync`s.
 - `append`: Rows are never overwritten or deleted, only appended.
 
-{/*<!-- vale off -->*/}
+<!-- vale off -->
 ### batch_size
-{/*<!-- vale on -->*/}
+<!-- vale on -->
 
 (`int`, optional)
 
 The number of resources to insert in a single batch. Only applies to plugins that utilize batching. This setting works in conjunction with `batch_size_bytes`, and batches are written whenever either `batch_size` or `batch_size_bytes` is reached. Every plugin has its own default value for `batch_size`.
 
-{/*<!-- vale off -->*/}
+<!-- vale off -->
 ### batch_size_bytes
-{/*<!-- vale on -->*/}
+<!-- vale on -->
 
 (`int`, optional)
 

--- a/website/pages/docs/reference/source-spec.md
+++ b/website/pages/docs/reference/source-spec.md
@@ -66,9 +66,9 @@ Tables to sync from the source plugin. It accepts wildcards. For example, to mat
 
 Specify which tables to skip when syncing the source plugin. It accepts wildcards. This config is useful when using wildcards in `tables`, or when you wish to skip dependent tables. Note that if a table with dependencies is skipped, all its dependant tables will also be skipped.
 
-{/*<!-- vale off -->*/}
+<!-- vale off -->
 ### skip_dependent_tables
-{/*<!-- vale on -->*/}
+<!-- vale on -->
 
 (`bool`, optional, default: `false`, introduced in CLI `v2.3.7`)
 


### PR DESCRIPTION
<!-- 🎉 Thank you for making CloudQuery awesome by submitting a PR 🎉 -->

#### Summary

`{/*<!-- vale off -->*/}` is only needed for MDX files as that how comments work for that format.
For markdown files we need only `<!-- vale off -->`

<!--
Use the following steps to ensure your PR is ready to be reviewed

- [ ] Read the [contribution guidelines](../blob/main/CONTRIBUTING.md) 🧑‍🎓
- [ ] Test locally on your own infrastructure
- [ ] Run `go fmt` to format your code 🖊
- [ ] Lint your changes via `golangci-lint run` 🚨 (install golangci-lint [here](https://golangci-lint.run/usage/install/#local-installation))
- [ ] Update or add tests 🧪
- [ ] Ensure the status checks below are successful ✅
--->
