### PR TITLE
feat(aws): Use ServiceAccountRegion Multiplexer

### DIFF
--- a/plugins/source/aws/resources/services/account/alternate_contacts.go
+++ b/plugins/source/aws/resources/services/account/alternate_contacts.go
@@ -12,7 +12,7 @@ func AlternateContacts() *schema.Table {
 		Name:        "aws_account_alternate_contacts",
 		Description: `https://docs.aws.amazon.com/accounts/latest/reference/API_AlternateContact.html`,
 		Resolver:    fetchAccountAlternateContacts,
-		Multiplex:   client.AccountMultiplex,
+		Multiplex:   client.ServiceAccountRegionMultiplexer("account"),
 		Transform:   transformers.TransformWithStruct(&types.AlternateContact{}),
 		Columns: []schema.Column{
 			client.DefaultAccountIDColumn(true),

--- a/plugins/source/aws/resources/services/account/contacts.go
+++ b/plugins/source/aws/resources/services/account/contacts.go
@@ -12,7 +12,7 @@ func Contacts() *schema.Table {
 		Name:        "aws_account_contacts",
 		Description: `https://docs.aws.amazon.com/accounts/latest/reference/API_ContactInformation.html`,
 		Resolver:    fetchAccountContacts,
-		Multiplex:   client.AccountMultiplex,
+		Multiplex:   client.ServiceAccountRegionMultiplexer("account"),
 		Transform:   transformers.TransformWithStruct(&types.ContactInformation{}),
 		Columns: []schema.Column{
 			client.DefaultAccountIDColumn(true),

--- a/plugins/source/aws/resources/services/cloudfront/cache_policies.go
+++ b/plugins/source/aws/resources/services/cloudfront/cache_policies.go
@@ -12,7 +12,7 @@ func CachePolicies() *schema.Table {
 		Name:        "aws_cloudfront_cache_policies",
 		Description: `https://docs.aws.amazon.com/cloudfront/latest/APIReference/API_CachePolicySummary.html`,
 		Resolver:    fetchCloudfrontCachePolicies,
-		Multiplex:   client.AccountMultiplex,
+		Multiplex:   client.ServiceAccountRegionMultiplexer("cloudfront"),
 		Transform:   transformers.TransformWithStruct(&types.CachePolicySummary{}),
 		Columns: []schema.Column{
 			client.DefaultAccountIDColumn(false),

--- a/plugins/source/aws/resources/services/cloudfront/distributions.go
+++ b/plugins/source/aws/resources/services/cloudfront/distributions.go
@@ -13,7 +13,7 @@ func Distributions() *schema.Table {
 		Description:         `https://docs.aws.amazon.com/cloudfront/latest/APIReference/API_Distribution.html`,
 		Resolver:            fetchCloudfrontDistributions,
 		PreResourceResolver: getDistribution,
-		Multiplex:           client.AccountMultiplex,
+		Multiplex:           client.ServiceAccountRegionMultiplexer("cloudfront"),
 		Transform:           transformers.TransformWithStruct(&types.Distribution{}),
 		Columns: []schema.Column{
 			client.DefaultAccountIDColumn(false),

--- a/plugins/source/aws/resources/services/iam/accounts.go
+++ b/plugins/source/aws/resources/services/iam/accounts.go
@@ -12,7 +12,7 @@ func Accounts() *schema.Table {
 		Name:      "aws_iam_accounts",
 		Resolver:  fetchIamAccounts,
 		Transform: transformers.TransformWithStruct(&models.Account{}),
-		Multiplex: client.AccountMultiplex,
+		Multiplex: client.ServiceAccountRegionMultiplexer("iam"),
 		Columns: []schema.Column{
 			client.DefaultAccountIDColumn(true),
 		},

--- a/plugins/source/aws/resources/services/iam/credential_reports.go
+++ b/plugins/source/aws/resources/services/iam/credential_reports.go
@@ -22,7 +22,7 @@ func CredentialReports() *schema.Table {
 				"Cert2LastRotated",
 			),
 		),
-		Multiplex: client.AccountMultiplex,
+		Multiplex: client.ServiceAccountRegionMultiplexer("iam"),
 		Columns: []schema.Column{
 			{
 				Name:     "arn",

--- a/plugins/source/aws/resources/services/iam/group_policies.go
+++ b/plugins/source/aws/resources/services/iam/group_policies.go
@@ -14,7 +14,7 @@ func GroupPolicies() *schema.Table {
 		Resolver:            fetchIamGroupPolicies,
 		PreResourceResolver: getGroupPolicy,
 		Transform:           transformers.TransformWithStruct(&iam.GetGroupPolicyOutput{}),
-		Multiplex:           client.AccountMultiplex,
+		Multiplex:           client.ServiceAccountRegionMultiplexer("iam"),
 		Columns: []schema.Column{
 			client.DefaultAccountIDColumn(false),
 			{

--- a/plugins/source/aws/resources/services/iam/groups.go
+++ b/plugins/source/aws/resources/services/iam/groups.go
@@ -13,7 +13,7 @@ func Groups() *schema.Table {
 		Description: `https://docs.aws.amazon.com/IAM/latest/APIReference/API_Group.html`,
 		Resolver:    fetchIamGroups,
 		Transform:   transformers.TransformWithStruct(&types.Group{}),
-		Multiplex:   client.AccountMultiplex,
+		Multiplex:   client.ServiceAccountRegionMultiplexer("iam"),
 		Columns: []schema.Column{
 			client.DefaultAccountIDColumn(true),
 			{

--- a/plugins/source/aws/resources/services/iam/instance_profiles.go
+++ b/plugins/source/aws/resources/services/iam/instance_profiles.go
@@ -13,7 +13,7 @@ func InstanceProfiles() *schema.Table {
 		Description: `https://docs.aws.amazon.com/IAM/latest/APIReference/API_InstanceProfile.html`,
 		Resolver:    fetchIamInstanceProfiles,
 		Transform:   transformers.TransformWithStruct(&types.InstanceProfile{}),
-		Multiplex:   client.AccountMultiplex,
+		Multiplex:   client.ServiceAccountRegionMultiplexer("iam"),
 		Columns: []schema.Column{
 			client.DefaultAccountIDColumn(true),
 			{

--- a/plugins/source/aws/resources/services/iam/openid_connect_identity_providers.go
+++ b/plugins/source/aws/resources/services/iam/openid_connect_identity_providers.go
@@ -14,7 +14,7 @@ func OpenidConnectIdentityProviders() *schema.Table {
 		Resolver:            fetchIamOpenidConnectIdentityProviders,
 		PreResourceResolver: getOpenIdConnectIdentityProvider,
 		Transform:           transformers.TransformWithStruct(&models.IamOpenIdIdentityProviderWrapper{}, transformers.WithUnwrapAllEmbeddedStructs()),
-		Multiplex:           client.AccountMultiplex,
+		Multiplex:           client.ServiceAccountRegionMultiplexer("iam"),
 		Columns: []schema.Column{
 			client.DefaultAccountIDColumn(false),
 			{

--- a/plugins/source/aws/resources/services/iam/password_policies.go
+++ b/plugins/source/aws/resources/services/iam/password_policies.go
@@ -13,7 +13,7 @@ func PasswordPolicies() *schema.Table {
 		Description: `https://docs.aws.amazon.com/IAM/latest/APIReference/API_PasswordPolicy.html`,
 		Resolver:    fetchIamPasswordPolicies,
 		Transform:   transformers.TransformWithStruct(&models.PasswordPolicyWrapper{}, transformers.WithUnwrapAllEmbeddedStructs()),
-		Multiplex:   client.AccountMultiplex,
+		Multiplex:   client.ServiceAccountRegionMultiplexer("iam"),
 		Columns: []schema.Column{
 			client.DefaultAccountIDColumn(true),
 		},

--- a/plugins/source/aws/resources/services/iam/policies.go
+++ b/plugins/source/aws/resources/services/iam/policies.go
@@ -13,7 +13,7 @@ func Policies() *schema.Table {
 		Description: `https://docs.aws.amazon.com/IAM/latest/APIReference/API_ManagedPolicyDetail.html`,
 		Resolver:    fetchIamPolicies,
 		Transform:   transformers.TransformWithStruct(&types.ManagedPolicyDetail{}),
-		Multiplex:   client.AccountMultiplex,
+		Multiplex:   client.ServiceAccountRegionMultiplexer("iam"),
 		Columns: []schema.Column{
 			client.DefaultAccountIDColumn(true),
 			{

--- a/plugins/source/aws/resources/services/iam/role_policies.go
+++ b/plugins/source/aws/resources/services/iam/role_policies.go
@@ -14,7 +14,7 @@ func RolePolicies() *schema.Table {
 		Resolver:            fetchIamRolePolicies,
 		PreResourceResolver: getRolePolicy,
 		Transform:           transformers.TransformWithStruct(&iam.GetRolePolicyOutput{}),
-		Multiplex:           client.AccountMultiplex,
+		Multiplex:           client.ServiceAccountRegionMultiplexer("iam"),
 		Columns: []schema.Column{
 			client.DefaultAccountIDColumn(true),
 			{

--- a/plugins/source/aws/resources/services/iam/roles.go
+++ b/plugins/source/aws/resources/services/iam/roles.go
@@ -14,7 +14,7 @@ func Roles() *schema.Table {
 		Resolver:            fetchIamRoles,
 		PreResourceResolver: getRole,
 		Transform:           transformers.TransformWithStruct(&types.Role{}),
-		Multiplex:           client.AccountMultiplex,
+		Multiplex:           client.ServiceAccountRegionMultiplexer("iam"),
 		Columns: []schema.Column{
 			client.DefaultAccountIDColumn(true),
 			{

--- a/plugins/source/aws/resources/services/iam/saml_identity_providers.go
+++ b/plugins/source/aws/resources/services/iam/saml_identity_providers.go
@@ -18,7 +18,7 @@ func SamlIdentityProviders() *schema.Table {
 			transformers.WithUnwrapAllEmbeddedStructs(),
 			transformers.WithSkipFields("ResultMetadata"),
 		),
-		Multiplex: client.AccountMultiplex,
+		Multiplex: client.ServiceAccountRegionMultiplexer("iam"),
 		Columns: []schema.Column{
 			client.DefaultAccountIDColumn(false),
 			{

--- a/plugins/source/aws/resources/services/iam/server_certificates.go
+++ b/plugins/source/aws/resources/services/iam/server_certificates.go
@@ -13,7 +13,7 @@ func ServerCertificates() *schema.Table {
 		Description: `https://docs.aws.amazon.com/IAM/latest/APIReference/API_ServerCertificateMetadata.html`,
 		Resolver:    fetchIamServerCertificates,
 		Transform:   transformers.TransformWithStruct(&types.ServerCertificateMetadata{}),
-		Multiplex:   client.AccountMultiplex,
+		Multiplex:   client.ServiceAccountRegionMultiplexer("iam"),
 		Columns: []schema.Column{
 			client.DefaultAccountIDColumn(true),
 			{

--- a/plugins/source/aws/resources/services/iam/signing_certificates.go
+++ b/plugins/source/aws/resources/services/iam/signing_certificates.go
@@ -13,7 +13,7 @@ func SigningCertificates() *schema.Table {
 		Description: `https://docs.aws.amazon.com/IAM/latest/APIReference/API_SigningCertificate.html`,
 		Resolver:    fetchUserSigningCertificates,
 		Transform:   transformers.TransformWithStruct(&types.SigningCertificate{}, transformers.WithPrimaryKeys("CertificateId")),
-		Multiplex:   client.AccountMultiplex,
+		Multiplex:   client.ServiceAccountRegionMultiplexer("iam"),
 		Columns: []schema.Column{
 			client.DefaultAccountIDColumn(false),
 			{

--- a/plugins/source/aws/resources/services/iam/ssh_public_keys.go
+++ b/plugins/source/aws/resources/services/iam/ssh_public_keys.go
@@ -13,7 +13,7 @@ func SshPublicKeys() *schema.Table {
 		Description: `https://docs.aws.amazon.com/IAM/latest/APIReference/API_SSHPublicKeyMetadata.html`,
 		Resolver:    fetchIamSshPublicKeys,
 		Transform:   transformers.TransformWithStruct(&types.SSHPublicKeyMetadata{}),
-		Multiplex:   client.AccountMultiplex,
+		Multiplex:   client.ServiceAccountRegionMultiplexer("iam"),
 		Columns: []schema.Column{
 			client.DefaultAccountIDColumn(false),
 			{

--- a/plugins/source/aws/resources/services/iam/user_access_keys.go
+++ b/plugins/source/aws/resources/services/iam/user_access_keys.go
@@ -14,7 +14,7 @@ func UserAccessKeys() *schema.Table {
 		Resolver:             fetchIamUserAccessKeys,
 		PostResourceResolver: postIamUserAccessKeyResolver,
 		Transform:            transformers.TransformWithStruct(&models.AccessKeyWrapper{}, transformers.WithUnwrapAllEmbeddedStructs()),
-		Multiplex:            client.AccountMultiplex,
+		Multiplex:            client.ServiceAccountRegionMultiplexer("iam"),
 		Columns: []schema.Column{
 			client.DefaultAccountIDColumn(true),
 			{

--- a/plugins/source/aws/resources/services/iam/user_attached_policies.go
+++ b/plugins/source/aws/resources/services/iam/user_attached_policies.go
@@ -13,7 +13,7 @@ func UserAttachedPolicies() *schema.Table {
 		Description: `https://docs.aws.amazon.com/IAM/latest/APIReference/API_AttachedPolicy.html`,
 		Resolver:    fetchIamUserAttachedPolicies,
 		Transform:   transformers.TransformWithStruct(&types.AttachedPolicy{}),
-		Multiplex:   client.AccountMultiplex,
+		Multiplex:   client.ServiceAccountRegionMultiplexer("iam"),
 		Columns: []schema.Column{
 			client.DefaultAccountIDColumn(true),
 			{

--- a/plugins/source/aws/resources/services/iam/user_groups.go
+++ b/plugins/source/aws/resources/services/iam/user_groups.go
@@ -13,7 +13,7 @@ func UserGroups() *schema.Table {
 		Description: `https://docs.aws.amazon.com/IAM/latest/APIReference/API_Group.html`,
 		Resolver:    fetchIamUserGroups,
 		Transform:   transformers.TransformWithStruct(&types.Group{}, transformers.WithPrimaryKeys("Arn")),
-		Multiplex:   client.AccountMultiplex,
+		Multiplex:   client.ServiceAccountRegionMultiplexer("iam"),
 		Columns: []schema.Column{
 			client.DefaultAccountIDColumn(false),
 			{

--- a/plugins/source/aws/resources/services/iam/user_policies.go
+++ b/plugins/source/aws/resources/services/iam/user_policies.go
@@ -14,7 +14,7 @@ func UserPolicies() *schema.Table {
 		Resolver:            fetchIamUserPolicies,
 		PreResourceResolver: getUserPolicy,
 		Transform:           transformers.TransformWithStruct(&iam.GetUserPolicyOutput{}),
-		Multiplex:           client.AccountMultiplex,
+		Multiplex:           client.ServiceAccountRegionMultiplexer("iam"),
 		Columns: []schema.Column{
 			client.DefaultAccountIDColumn(false),
 			{

--- a/plugins/source/aws/resources/services/iam/users.go
+++ b/plugins/source/aws/resources/services/iam/users.go
@@ -14,7 +14,7 @@ func Users() *schema.Table {
 		Resolver:            fetchIamUsers,
 		PreResourceResolver: getUser,
 		Transform:           transformers.TransformWithStruct(&types.User{}),
-		Multiplex:           client.AccountMultiplex,
+		Multiplex:           client.ServiceAccountRegionMultiplexer("iam"),
 		Columns: []schema.Column{
 			{
 				Name:     "arn",

--- a/plugins/source/aws/resources/services/iam/virtual_mfa_devices.go
+++ b/plugins/source/aws/resources/services/iam/virtual_mfa_devices.go
@@ -13,7 +13,7 @@ func VirtualMfaDevices() *schema.Table {
 		Description: `https://docs.aws.amazon.com/IAM/latest/APIReference/API_VirtualMFADevice.html`,
 		Resolver:    fetchIamVirtualMfaDevices,
 		Transform:   transformers.TransformWithStruct(&types.VirtualMFADevice{}),
-		Multiplex:   client.AccountMultiplex,
+		Multiplex:   client.ServiceAccountRegionMultiplexer("iam"),
 		Columns: []schema.Column{
 			client.DefaultAccountIDColumn(false),
 			{

--- a/plugins/source/aws/resources/services/organizations/accounts.go
+++ b/plugins/source/aws/resources/services/organizations/accounts.go
@@ -13,7 +13,7 @@ func Accounts() *schema.Table {
 		Description: `https://docs.aws.amazon.com/organizations/latest/APIReference/API_Account.html`,
 		Resolver:    fetchOrganizationsAccounts,
 		Transform:   transformers.TransformWithStruct(&types.Account{}),
-		Multiplex:   client.AccountMultiplex,
+		Multiplex:   client.ServiceAccountRegionMultiplexer("organizations"),
 		Columns: []schema.Column{
 			client.DefaultAccountIDColumn(false),
 			{

--- a/plugins/source/aws/resources/services/organizations/organizations.go
+++ b/plugins/source/aws/resources/services/organizations/organizations.go
@@ -18,7 +18,7 @@ func Organizations() *schema.Table {
 				"AvailablePolicyTypes", // deprecated and misleading field according to docs
 			),
 		),
-		Multiplex: client.AccountMultiplex,
+		Multiplex: client.ServiceAccountRegionMultiplexer("organizations"),
 		Columns: []schema.Column{
 			client.DefaultAccountIDColumn(true),
 			{

--- a/plugins/source/aws/resources/services/organizations/resource_policies.go
+++ b/plugins/source/aws/resources/services/organizations/resource_policies.go
@@ -13,7 +13,7 @@ func ResourcePolicies() *schema.Table {
 		Description: `https://docs.aws.amazon.com/organizations/latest/APIReference/API_DescribeResourcePolicy.html`,
 		Resolver:    fetchOrganizationsResourcePolicies,
 		Transform:   transformers.TransformWithStruct(&types.ResourcePolicy{}),
-		Multiplex:   client.AccountMultiplex,
+		Multiplex:   client.ServiceAccountRegionMultiplexer("organizations"),
 		Columns: []schema.Column{
 			client.DefaultAccountIDColumn(true),
 		},

--- a/plugins/source/aws/resources/services/route53/delegation_sets.go
+++ b/plugins/source/aws/resources/services/route53/delegation_sets.go
@@ -13,7 +13,7 @@ func DelegationSets() *schema.Table {
 		Description: `https://docs.aws.amazon.com/Route53/latest/APIReference/API_DelegationSet.html`,
 		Resolver:    fetchRoute53DelegationSets,
 		Transform:   transformers.TransformWithStruct(&types.DelegationSet{}),
-		Multiplex:   client.AccountMultiplex,
+		Multiplex:   client.ServiceAccountRegionMultiplexer("route53"),
 		Columns: []schema.Column{
 			client.DefaultAccountIDColumn(false),
 			{

--- a/plugins/source/aws/resources/services/route53/domains.go
+++ b/plugins/source/aws/resources/services/route53/domains.go
@@ -14,7 +14,7 @@ func Domains() *schema.Table {
 		Resolver:            fetchRoute53Domains,
 		PreResourceResolver: getDomain,
 		Transform:           transformers.TransformWithStruct(&route53domains.GetDomainDetailOutput{}),
-		Multiplex:           client.AccountMultiplex,
+		Multiplex:           client.ServiceAccountRegionMultiplexer("route53domains"),
 		Columns: []schema.Column{
 			client.DefaultAccountIDColumn(true),
 			{

--- a/plugins/source/aws/resources/services/route53/health_checks.go
+++ b/plugins/source/aws/resources/services/route53/health_checks.go
@@ -12,7 +12,7 @@ func HealthChecks() *schema.Table {
 		Description: `https://docs.aws.amazon.com/Route53/latest/APIReference/API_HealthCheck.html`,
 		Resolver:    fetchRoute53HealthChecks,
 		Transform:   transformers.TransformWithStruct(&Route53HealthCheckWrapper{}, transformers.WithUnwrapStructFields("HealthCheck")),
-		Multiplex:   client.AccountMultiplex,
+		Multiplex:   client.ServiceAccountRegionMultiplexer("route53"),
 		Columns: []schema.Column{
 			client.DefaultAccountIDColumn(false),
 			{

--- a/plugins/source/aws/resources/services/route53/hosted_zone_query_logging_configs.go
+++ b/plugins/source/aws/resources/services/route53/hosted_zone_query_logging_configs.go
@@ -13,7 +13,7 @@ func HostedZoneQueryLoggingConfigs() *schema.Table {
 		Description: `https://docs.aws.amazon.com/Route53/latest/APIReference/API_QueryLoggingConfig.html`,
 		Resolver:    fetchRoute53HostedZoneQueryLoggingConfigs,
 		Transform:   transformers.TransformWithStruct(&types.QueryLoggingConfig{}),
-		Multiplex:   client.AccountMultiplex,
+		Multiplex:   client.ServiceAccountRegionMultiplexer("route53"),
 		Columns: []schema.Column{
 			client.DefaultAccountIDColumn(false),
 			{

--- a/plugins/source/aws/resources/services/route53/hosted_zone_resource_record_sets.go
+++ b/plugins/source/aws/resources/services/route53/hosted_zone_resource_record_sets.go
@@ -13,7 +13,7 @@ func HostedZoneResourceRecordSets() *schema.Table {
 		Description: `https://docs.aws.amazon.com/Route53/latest/APIReference/API_ResourceRecordSet.html`,
 		Resolver:    fetchRoute53HostedZoneResourceRecordSets,
 		Transform:   transformers.TransformWithStruct(&types.ResourceRecordSet{}),
-		Multiplex:   client.AccountMultiplex,
+		Multiplex:   client.ServiceAccountRegionMultiplexer("route53"),
 		Columns: []schema.Column{
 			client.DefaultAccountIDColumn(false),
 			{

--- a/plugins/source/aws/resources/services/route53/hosted_zone_traffic_policy_instances.go
+++ b/plugins/source/aws/resources/services/route53/hosted_zone_traffic_policy_instances.go
@@ -13,7 +13,7 @@ func HostedZoneTrafficPolicyInstances() *schema.Table {
 		Description: `https://docs.aws.amazon.com/Route53/latest/APIReference/API_TrafficPolicyInstance.html`,
 		Resolver:    fetchRoute53HostedZoneTrafficPolicyInstances,
 		Transform:   transformers.TransformWithStruct(&types.TrafficPolicyInstance{}),
-		Multiplex:   client.AccountMultiplex,
+		Multiplex:   client.ServiceAccountRegionMultiplexer("route53"),
 		Columns: []schema.Column{
 			client.DefaultAccountIDColumn(true),
 			{

--- a/plugins/source/aws/resources/services/route53/hosted_zones.go
+++ b/plugins/source/aws/resources/services/route53/hosted_zones.go
@@ -17,7 +17,7 @@ func HostedZones() *schema.Table {
 			transformers.WithUnwrapStructFields("HostedZone"),
 			transformers.WithNameTransformer(client.CreateReplaceTransformer(map[string]string{"vp_cs": "vpcs"})),
 		),
-		Multiplex: client.AccountMultiplex,
+		Multiplex: client.ServiceAccountRegionMultiplexer("route53"),
 		Columns: []schema.Column{
 			client.DefaultAccountIDColumn(false),
 			{

--- a/plugins/source/aws/resources/services/route53/operations.go
+++ b/plugins/source/aws/resources/services/route53/operations.go
@@ -17,7 +17,7 @@ func Operations() *schema.Table {
 		Resolver:            fetchRoute53Operations,
 		PreResourceResolver: getOperation,
 		Transform:           transformers.TransformWithStruct(&route53domains.GetOperationDetailOutput{}, transformers.WithSkipFields("ResultMetadata"), transformers.WithPrimaryKeys("OperationId", "Status", "SubmittedDate", "Type")),
-		Multiplex:           client.AccountMultiplex,
+		Multiplex:           client.ServiceAccountRegionMultiplexer("route53domains"),
 		Columns: []schema.Column{
 			client.DefaultAccountIDColumn(true),
 		},

--- a/plugins/source/aws/resources/services/route53/traffic_policies.go
+++ b/plugins/source/aws/resources/services/route53/traffic_policies.go
@@ -13,7 +13,7 @@ func TrafficPolicies() *schema.Table {
 		Description: `https://docs.aws.amazon.com/Route53/latest/APIReference/API_TrafficPolicySummary.html`,
 		Resolver:    fetchRoute53TrafficPolicies,
 		Transform:   transformers.TransformWithStruct(&types.TrafficPolicySummary{}),
-		Multiplex:   client.AccountMultiplex,
+		Multiplex:   client.ServiceAccountRegionMultiplexer("route53"),
 		Columns: []schema.Column{
 			client.DefaultAccountIDColumn(false),
 			{

--- a/plugins/source/aws/resources/services/route53/traffic_policy_versions.go
+++ b/plugins/source/aws/resources/services/route53/traffic_policy_versions.go
@@ -13,7 +13,7 @@ func TrafficPolicyVersions() *schema.Table {
 		Description: `https://docs.aws.amazon.com/Route53/latest/APIReference/API_TrafficPolicy.html`,
 		Resolver:    fetchRoute53TrafficPolicyVersions,
 		Transform:   transformers.TransformWithStruct(&types.TrafficPolicy{}),
-		Multiplex:   client.AccountMultiplex,
+		Multiplex:   client.ServiceAccountRegionMultiplexer("route53"),
 		Columns: []schema.Column{
 			client.DefaultAccountIDColumn(false),
 			{

--- a/plugins/source/aws/resources/services/savingsplans/savingsplans.go
+++ b/plugins/source/aws/resources/services/savingsplans/savingsplans.go
@@ -13,7 +13,7 @@ func Plans() *schema.Table {
 		Description: `https://docs.aws.amazon.com/savingsplans/latest/APIReference/API_SavingsPlan.html`,
 		Resolver:    fetchSavingsPlans,
 		Transform:   transformers.TransformWithStruct(&types.SavingsPlan{}),
-		Multiplex:   client.AccountMultiplex,
+		Multiplex:   client.ServiceAccountRegionMultiplexer("savingsplans"),
 		Columns: []schema.Column{
 			client.DefaultAccountIDColumn(false),
 			{

--- a/plugins/source/aws/resources/services/shield/attacks.go
+++ b/plugins/source/aws/resources/services/shield/attacks.go
@@ -14,7 +14,7 @@ func Attacks() *schema.Table {
 		Resolver:            fetchShieldAttacks,
 		PreResourceResolver: getAttack,
 		Transform:           transformers.TransformWithStruct(&types.AttackDetail{}),
-		Multiplex:           client.AccountMultiplex,
+		Multiplex:           client.ServiceAccountRegionMultiplexer("shield"),
 		Columns: []schema.Column{
 			client.DefaultAccountIDColumn(false),
 			{

--- a/plugins/source/aws/resources/services/shield/protection_groups.go
+++ b/plugins/source/aws/resources/services/shield/protection_groups.go
@@ -13,7 +13,7 @@ func ProtectionGroups() *schema.Table {
 		Description: `https://docs.aws.amazon.com/waf/latest/DDOSAPIReference/API_ProtectionGroup.html`,
 		Resolver:    fetchShieldProtectionGroups,
 		Transform:   transformers.TransformWithStruct(&types.ProtectionGroup{}),
-		Multiplex:   client.AccountMultiplex,
+		Multiplex:   client.ServiceAccountRegionMultiplexer("shield"),
 		Columns: []schema.Column{
 			client.DefaultAccountIDColumn(false),
 			{

--- a/plugins/source/aws/resources/services/shield/protections.go
+++ b/plugins/source/aws/resources/services/shield/protections.go
@@ -13,7 +13,7 @@ func Protections() *schema.Table {
 		Description: `https://docs.aws.amazon.com/waf/latest/DDOSAPIReference/API_Protection.html`,
 		Resolver:    fetchShieldProtections,
 		Transform:   transformers.TransformWithStruct(&types.Protection{}),
-		Multiplex:   client.AccountMultiplex,
+		Multiplex:   client.ServiceAccountRegionMultiplexer("shield"),
 		Columns: []schema.Column{
 			client.DefaultAccountIDColumn(false),
 			{

--- a/plugins/source/aws/resources/services/shield/subscriptions.go
+++ b/plugins/source/aws/resources/services/shield/subscriptions.go
@@ -13,7 +13,7 @@ func Subscriptions() *schema.Table {
 		Description: `https://docs.aws.amazon.com/waf/latest/DDOSAPIReference/API_Subscription.html`,
 		Resolver:    fetchShieldSubscriptions,
 		Transform:   transformers.TransformWithStruct(&types.Subscription{}),
-		Multiplex:   client.AccountMultiplex,
+		Multiplex:   client.ServiceAccountRegionMultiplexer("shield"),
 		Columns: []schema.Column{
 			client.DefaultAccountIDColumn(false),
 			{

--- a/plugins/source/aws/resources/services/waf/rule_groups.go
+++ b/plugins/source/aws/resources/services/waf/rule_groups.go
@@ -13,7 +13,7 @@ func RuleGroups() *schema.Table {
 		Description: `https://docs.aws.amazon.com/waf/latest/APIReference/API_waf_RuleGroupSummary.html`,
 		Resolver:    fetchWafRuleGroups,
 		Transform:   transformers.TransformWithStruct(&types.RuleGroup{}),
-		Multiplex:   client.AccountMultiplex,
+		Multiplex:   client.ServiceAccountRegionMultiplexer("waf"),
 		Columns: []schema.Column{
 			client.DefaultAccountIDColumn(false),
 			{

--- a/plugins/source/aws/resources/services/waf/rules.go
+++ b/plugins/source/aws/resources/services/waf/rules.go
@@ -13,7 +13,7 @@ func Rules() *schema.Table {
 		Description: `https://docs.aws.amazon.com/waf/latest/APIReference/API_waf_RuleSummary.html`,
 		Resolver:    fetchWafRules,
 		Transform:   transformers.TransformWithStruct(&types.Rule{}),
-		Multiplex:   client.AccountMultiplex,
+		Multiplex:   client.ServiceAccountRegionMultiplexer("waf"),
 		Columns: []schema.Column{
 			client.DefaultAccountIDColumn(false),
 			{

--- a/plugins/source/aws/resources/services/waf/subscribed_rule_groups.go
+++ b/plugins/source/aws/resources/services/waf/subscribed_rule_groups.go
@@ -13,7 +13,7 @@ func SubscribedRuleGroups() *schema.Table {
 		Description: `https://docs.aws.amazon.com/waf/latest/APIReference/API_waf_SubscribedRuleGroupSummary.html`,
 		Resolver:    fetchWafSubscribedRuleGroups,
 		Transform:   transformers.TransformWithStruct(&types.SubscribedRuleGroupSummary{}),
-		Multiplex:   client.AccountMultiplex,
+		Multiplex:   client.ServiceAccountRegionMultiplexer("waf"),
 		Columns: []schema.Column{
 			{
 				Name:        "account_id",

--- a/plugins/source/aws/resources/services/waf/web_acls.go
+++ b/plugins/source/aws/resources/services/waf/web_acls.go
@@ -12,7 +12,7 @@ func WebAcls() *schema.Table {
 		Description: `https://docs.aws.amazon.com/waf/latest/APIReference/API_waf_WebACLSummary.html`,
 		Resolver:    fetchWafWebAcls,
 		Transform:   transformers.TransformWithStruct(&WebACLWrapper{}, transformers.WithUnwrapStructFields("WebACL")),
-		Multiplex:   client.AccountMultiplex,
+		Multiplex:   client.ServiceAccountRegionMultiplexer("waf"),
 		Columns: []schema.Column{
 			client.DefaultAccountIDColumn(false),
 			{


### PR DESCRIPTION
<!-- 🎉 Thank you for making CloudQuery awesome by submitting a PR 🎉 -->

#### Summary

Now that @erezrokah fixed the fact that the region in the data.json file doesn't have `aws-global` anymore we can now use the same multiplexer for (nearly) all resources
<!--
Use the following steps to ensure your PR is ready to be reviewed

- [ ] Read the [contribution guidelines](../blob/main/CONTRIBUTING.md) 🧑‍🎓
- [ ] Test locally on your own infrastructure
- [ ] Run `go fmt` to format your code 🖊
- [ ] Lint your changes via `golangci-lint run` 🚨 (install golangci-lint [here](https://golangci-lint.run/usage/install/#local-installation))
- [ ] Update or add tests 🧪
- [ ] Ensure the status checks below are successful ✅
--->
