### PR TITLE
feat(deps): Update MongoDB plugin-sdk to v1.38.2

### DIFF
--- a/plugins/destination/mongodb/client/client_test.go
+++ b/plugins/destination/mongodb/client/client_test.go
@@ -5,7 +5,16 @@ import (
 	"testing"
 
 	"github.com/cloudquery/plugin-sdk/plugins/destination"
+	"github.com/cloudquery/plugin-sdk/specs"
 )
+
+var migrateStrategy = destination.MigrateStrategy{
+	AddColumn:           specs.MigrateModeSafe,
+	AddColumnNotNull:    specs.MigrateModeForced,
+	RemoveColumn:        specs.MigrateModeSafe,
+	RemoveColumnNotNull: specs.MigrateModeForced,
+	ChangeColumn:        specs.MigrateModeForced,
+}
 
 func getTestConnection() string {
 	testConn := os.Getenv("CQ_DEST_MONGODB_TEST_CONN")
@@ -24,5 +33,11 @@ func TestPlugin(t *testing.T) {
 			ConnectionString: getTestConnection(),
 			Database:         "destination_mongodb_test",
 		},
-		destination.PluginTestSuiteTests{})
+		destination.PluginTestSuiteTests{
+			SkipMigrateOverwriteForce: true,
+			SkipMigrateAppendForce:    true,
+
+			MigrateStrategyOverwrite: migrateStrategy,
+			MigrateStrategyAppend:    migrateStrategy,
+		})
 }

--- a/plugins/destination/mongodb/client/read.go
+++ b/plugins/destination/mongodb/client/read.go
@@ -44,7 +44,7 @@ func (*Client) createResultsArray(res bson.M, table *schema.Table) []any {
 			}
 			results = append(results, r)
 		case schema.TypeTimestamp:
-			r := (val).(primitive.DateTime).Time()
+			r := (val).(primitive.DateTime).Time().UTC()
 			results = append(results, r)
 		case schema.TypeJSON:
 			r := (val).(primitive.M)

--- a/plugins/destination/mongodb/client/write.go
+++ b/plugins/destination/mongodb/client/write.go
@@ -30,7 +30,11 @@ func (c *Client) overwriteTableBatch(ctx context.Context, table *schema.Table, r
 	for i, resource := range resources {
 		operation := mongo.NewUpdateOneModel()
 		operation.SetUpsert(true)
-		filter := make(bson.M, len(table.PrimaryKeys()))
+		if len(pks) == 0 {
+			// If no primary keys are defined, use all columns as a filter
+			pks = table.Columns.Names()
+		}
+		filter := make(bson.M, len(pks))
 		for _, pk := range pks {
 			filter[pk] = resource[table.Columns.Index(pk)]
 		}

--- a/plugins/destination/mongodb/go.mod
+++ b/plugins/destination/mongodb/go.mod
@@ -3,9 +3,16 @@ module github.com/cloudquery/cloudquery/plugins/destination/mongodb
 go 1.19
 
 require (
-	github.com/cloudquery/plugin-sdk v1.37.1
+	github.com/cloudquery/plugin-sdk v1.38.2
 	github.com/rs/zerolog v1.29.0
 	go.mongodb.org/mongo-driver v1.11.1
+)
+
+require (
+	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
+	github.com/stretchr/testify v1.8.1 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
 )
 
 require (

--- a/plugins/destination/mongodb/go.sum
+++ b/plugins/destination/mongodb/go.sum
@@ -40,8 +40,8 @@ github.com/chzyer/logex v1.1.10/go.mod h1:+Ywpsq7O8HXn0nuIou7OrIPyXbp3wmkHB+jjWR
 github.com/chzyer/readline v0.0.0-20180603132655-2972be24d48e/go.mod h1:nSuG5e5PlCu98SY8svDHJxuZscDgtXS6KTTbou5AhLI=
 github.com/chzyer/test v0.0.0-20180213035817-a1ea475d72b1/go.mod h1:Q3SI9o4m/ZMnBNeIyt5eFwwo7qiLfzFZmjNmxjkiQlU=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
-github.com/cloudquery/plugin-sdk v1.37.1 h1:1/9cYMUSqFRkMqq4p+8ZThdPQ+09p+8Nlrt3ii9Fbf8=
-github.com/cloudquery/plugin-sdk v1.37.1/go.mod h1:anjM5gY7qgJDde9CCIlJbeKuFOxM4BBrFeX1jyU1dxo=
+github.com/cloudquery/plugin-sdk v1.38.2 h1:tAWrR+ADCpk+kDydWEC3mP6Doh01jEJjXCrK1hW5j3w=
+github.com/cloudquery/plugin-sdk v1.38.2/go.mod h1:mnz+Lov1Oe99lDhFZEcnIvLoGYRPohjzyW4LNsrn654=
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
 github.com/cncf/udpa/go v0.0.0-20201120205902-5459f2c99403/go.mod h1:WmhPx2Nbnhtbo57+VJT5O0JRkEi1Wbu0z5j0R8u5Hbk=
 github.com/coreos/go-systemd v0.0.0-20190321100706-95778dfbb74e/go.mod h1:F5haX7vjVVG0kc13fIWeqUViNPyEJxv/OmvnBo0Yme4=
@@ -182,11 +182,16 @@ github.com/spf13/cobra v1.6.1/go.mod h1:IOw/AERYS7UzyrGinqmz6HLUo219MORXGxhbaJUq
 github.com/spf13/pflag v1.0.5 h1:iy+VFUOCP1a+8yFto/drg2CJ5u0yRoB7fZw3DKv/JXA=
 github.com/spf13/pflag v1.0.5/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
+github.com/stretchr/objx v0.4.0/go.mod h1:YvHI0jy2hoMjB+UWwv71VJQ9isScKT/TqJzVSSt89Yw=
+github.com/stretchr/objx v0.5.0/go.mod h1:Yh+to48EsGEfYuaHDzXPcE3xhTkx73EhmCGUpEOglKo=
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
 github.com/stretchr/testify v1.5.1/go.mod h1:5W2xD1RspED5o8YsWQXVCued0rvSQ+mT+I5cxcmMvtA=
 github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
+github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
+github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
 github.com/stretchr/testify v1.8.1 h1:w7B6lhMri9wdJUVmEZPGGhZzrYTPvgJArz7wNPgYKsk=
+github.com/stretchr/testify v1.8.1/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
 github.com/thoas/go-funk v0.9.3 h1:7+nAEx3kn5ZJcnDm2Bh23N2yOtweO14bi//dvRtgLpw=
 github.com/thoas/go-funk v0.9.3/go.mod h1:+IWnUfUmFO1+WVYQWQtIJHeRRdaIyyYglZN7xzUPe4Q=
 github.com/tidwall/pretty v1.0.0 h1:HsD+QiTn7sK6flMKIvNmpqz1qrpP3Ps6jOKIKMooyg4=


### PR DESCRIPTION
<!-- 🎉 Thank you for making CloudQuery awesome by submitting a PR 🎉 -->

#### Summary

Updates MongoDB to the new SDK with the following issues discovered in the tests:
- In overwrite mode, for a table with no PKs we used an empty filter always overwriting. The fix is similar to https://github.com/cloudquery/cloudquery/pull/8259 to use all columns as the filter
- When reading timestamp the Go lib uses local timezone. We want to read it as UTC (assuming it's written as UTC).

<!--
Use the following steps to ensure your PR is ready to be reviewed

- [ ] Read the [contribution guidelines](../blob/main/CONTRIBUTING.md) 🧑‍🎓
- [ ] Test locally on your own infrastructure
- [ ] Run `go fmt` to format your code 🖊
- [ ] Lint your changes via `golangci-lint run` 🚨 (install golangci-lint [here](https://golangci-lint.run/usage/install/#local-installation))
- [ ] Update or add tests 🧪
- [ ] Ensure the status checks below are successful ✅
--->
