### PR TITLE
fix(migration): Don't add trailing comma to create table

### DIFF
--- a/.github/workflows/dest_clickhouse.yml
+++ b/.github/workflows/dest_clickhouse.yml
@@ -26,7 +26,7 @@ jobs:
         working-directory: plugins/destination/clickhouse
     services:
       clickhouse:
-        image:   clickhouse/clickhouse-server:22
+        image:   clickhouse/clickhouse-server:22.1.2
         env:
           CLICKHOUSE_DEFAULT_ACCESS_MANAGEMENT: 1
           CLICKHOUSE_PASSWORD:                  ${{ env.DB_PASSWORD }}

--- a/plugins/destination/clickhouse/queries/tables.go
+++ b/plugins/destination/clickhouse/queries/tables.go
@@ -22,12 +22,15 @@ func CreateTable(table *schema.Table) string {
 	strBuilder.WriteString("CREATE TABLE ")
 	strBuilder.WriteString(sanitizeID(normalized.Name))
 	strBuilder.WriteString(" (\n")
-	for _, col := range normalized.Columns {
+	for i, col := range normalized.Columns {
 		strBuilder.WriteString("  ")
 		strBuilder.WriteString(sanitizeID(col.Name))
 		strBuilder.WriteString(" ")
 		strBuilder.WriteString(chType(&col))
-		strBuilder.WriteString(",\n")
+		if i < len(normalized.Columns)-1 {
+			strBuilder.WriteString(",")
+		}
+		strBuilder.WriteString("\n")
 	}
 	strBuilder.WriteString(") ENGINE = MergeTree ORDER BY (")
 	sortingKeys := sanitized(sortKeys(normalized)...)

--- a/plugins/destination/clickhouse/queries/testdata/create_table.sql
+++ b/plugins/destination/clickhouse/queries/testdata/create_table.sql
@@ -5,5 +5,5 @@ CREATE TABLE `table_name` (
   `_cq_sync_time` Nullable(DateTime64(9)),
   `extra_col` Float64,
   `extra_inet_col` Nullable(String),
-  `extra_inet_arr_col` Array(Nullable(String)),
+  `extra_inet_arr_col` Array(Nullable(String))
 ) ENGINE = MergeTree ORDER BY (`_cq_id`, `extra_col`)

--- a/website/pages/docs/plugins/destinations/clickhouse/overview.mdx
+++ b/website/pages/docs/plugins/destinations/clickhouse/overview.mdx
@@ -11,7 +11,7 @@ import { Callout } from 'nextra-theme-docs'
 
 This destination plugin lets you sync data from a CloudQuery source to [ClickHouse](https://clickhouse.com/) database.
 
-Supported database versions: >= `22`
+Supported database versions: >= `22.1.2`
 
 ## Configuration
 


### PR DESCRIPTION
<!-- 🎉 Thank you for making CloudQuery awesome by submitting a PR 🎉 -->

#### Summary

Fixes https://github.com/cloudquery/cloudquery/issues/8400.

`22.1.2` is the minimal 22 version I could find

<!--
Use the following steps to ensure your PR is ready to be reviewed

- [ ] Read the [contribution guidelines](../blob/main/CONTRIBUTING.md) 🧑‍🎓
- [ ] Test locally on your own infrastructure
- [ ] Run `go fmt` to format your code 🖊
- [ ] Lint your changes via `golangci-lint run` 🚨 (install golangci-lint [here](https://golangci-lint.run/usage/install/#local-installation))
- [ ] Update or add tests 🧪
- [ ] Ensure the status checks below are successful ✅
--->
