### PR TITLE
fix(migrate): Handle timestamps not set by CloudQuery

### DIFF
--- a/plugins/destination/postgresql/client/types.go
+++ b/plugins/destination/postgresql/client/types.go
@@ -1,6 +1,8 @@
 package client
 
 import (
+	"strings"
+
 	"github.com/cloudquery/plugin-sdk/schema"
 )
 
@@ -141,6 +143,9 @@ func (*Client) Pg10ToSchemaType(t string) schema.ValueType {
 	case "bigint[]":
 		return schema.TypeIntArray
 	default:
+		if strings.HasPrefix(t, "timestamp") {
+			return schema.TypeTimestamp
+		}
 		panic("unknown type " + t)
 	}
 }
@@ -161,8 +166,6 @@ func (*Client) CockroachToSchemaType(t string) schema.ValueType {
 		return schema.TypeByteArray
 	case "text[]":
 		return schema.TypeStringArray
-	case "timestamp without time zone":
-		return schema.TypeTimestamp
 	case "jsonb":
 		return schema.TypeJSON
 	case "uuid[]":
@@ -174,6 +177,9 @@ func (*Client) CockroachToSchemaType(t string) schema.ValueType {
 	case "bigint[]":
 		return schema.TypeIntArray
 	default:
+		if strings.HasPrefix(t, "timestamp") {
+			return schema.TypeTimestamp
+		}
 		panic("unknown type " + t)
 	}
 }


### PR DESCRIPTION
<!-- 🎉 Thank you for making CloudQuery awesome by submitting a PR 🎉 -->

#### Summary

Some uses change the column type for `schema.TypeTimestamp` from `timestamp without time zone` to `timestamp(6) without time zone`, so the new migration code fails for them.

Do we want to be more robust here? We can't really account for all use case

<!--
Use the following steps to ensure your PR is ready to be reviewed

- [ ] Read the [contribution guidelines](../blob/main/CONTRIBUTING.md) 🧑‍🎓
- [ ] Test locally on your own infrastructure
- [ ] Run `go fmt` to format your code 🖊
- [ ] Lint your changes via `golangci-lint run` 🚨 (install golangci-lint [here](https://golangci-lint.run/usage/install/#local-installation))
- [ ] Update or add tests 🧪
- [ ] Ensure the status checks below are successful ✅
--->
