### PR TITLE
fix(website): Add route to plugins _meta.json

### DIFF
--- a/website/pages/_meta.json
+++ b/website/pages/_meta.json
@@ -33,7 +33,8 @@
   },
   "plugins": {
     "title": "Plugins",
-    "href": "/docs/plugins/overview"
+    "href": "/docs/plugins/overview",
+    "route": "/docs/plugins/overview"
   },
   "confirm": {
     "title": "Confirm",


### PR DESCRIPTION
<!-- 🎉 Thank you for making CloudQuery awesome by submitting a PR 🎉 -->

#### Summary

Same as https://github.com/cloudquery/cloudquery/pull/3207, to fix that plugins are always highlighted:
![image](https://user-images.githubusercontent.com/26760571/221926366-88d91f77-771e-40f2-9fd5-78f25e55a4fd.png)


<!--
Use the following steps to ensure your PR is ready to be reviewed

- [ ] Read the [contribution guidelines](../blob/main/CONTRIBUTING.md) 🧑‍🎓
- [ ] Test locally on your own infrastructure
- [ ] Run `go fmt` to format your code 🖊
- [ ] Lint your changes via `golangci-lint run` 🚨 (install golangci-lint [here](https://golangci-lint.run/usage/install/#local-installation))
- [ ] Update or add tests 🧪
- [ ] Ensure the status checks below are successful ✅
--->
