### PR TITLE
fix: Revert "fix(website): Add route to plugins _meta.json"

### DIFF
--- a/website/pages/_meta.json
+++ b/website/pages/_meta.json
@@ -33,8 +33,7 @@
   },
   "plugins": {
     "title": "Plugins",
-    "href": "/docs/plugins/overview",
-    "route": "/docs/plugins/overview"
+    "href": "/docs/plugins/overview"
   },
   "confirm": {
     "title": "Confirm",


### PR DESCRIPTION
Reverts cloudquery/cloudquery#8555

Looks like this has an unwanted side effect on not having the sidebar for plugins:
![image](https://user-images.githubusercontent.com/26760571/222172482-b27cf294-ccb7-4fc8-9c8b-384900ce673e.png)
