### PR TITLE
fix(ci): Remove trailing slash from URL on scheduled broken links check

### DIFF
--- a/.github/workflows/broken_links.yml
+++ b/.github/workflows/broken_links.yml
@@ -63,7 +63,7 @@ jobs:
         id: vercel
         run: |
           DEPLOY_URL=${{ steps.preview-deployment.outputs.url }}
-          echo "url=${DEPLOY_URL:-"https://www.cloudquery.io/"}" >> $GITHUB_OUTPUT
+          echo "url=${DEPLOY_URL:-"https://www.cloudquery.io"}" >> $GITHUB_OUTPUT
 
       - name: Check for broken links
         if: steps.broken-links.outputs.check != 'false'


### PR DESCRIPTION
<!-- 🎉 Thank you for making CloudQuery awesome by submitting a PR 🎉 -->

#### Summary

The exclude patterns on our scheduled broken links check don't work since we prefix the URL with `/`, see https://github.com/cloudquery/cloudquery/actions/runs/4343157121/jobs/7584850108#step:7:6

![image](https://user-images.githubusercontent.com/26760571/223114573-863e247f-0b9a-4f60-ae80-4144cdd5b517.png)

This issue does not exist on pull requests, as the Vercel deploy URL does not end with a `/`

> On the scheduled workflow we don't wait for a deployment and check https://www.cloudquery.io

<!--
Use the following steps to ensure your PR is ready to be reviewed

- [ ] Read the [contribution guidelines](../blob/main/CONTRIBUTING.md) 🧑‍🎓
- [ ] Run `make lint` to ensure the proposed changes follow the coding style 🚨 (install golangci-lint [here](https://golangci-lint.run/usage/install/#local-installation))
- [ ] Run `make test` to ensure the proposed changes pass the tests 🧪
- [ ] If changing a source plugin run `make gen` to ensure docs are up to date 📝
- [ ] Ensure the status checks below are successful ✅
--->
