### PR TITLE
chore(ci): Ignore PR labeler errors

### DIFF
--- a/.github/workflows/pr_labeler.yml
+++ b/.github/workflows/pr_labeler.yml
@@ -12,6 +12,7 @@ jobs:
     permissions:
       contents: read
       pull-requests: write
+    continue-on-error: true
     runs-on: ubuntu-latest
     steps:
       - uses: actions/labeler@v4


### PR DESCRIPTION
<!-- 🎉 Thank you for making CloudQuery awesome by submitting a PR 🎉 -->

#### Summary

GitHub does not support more than 100 labels per PR, so the PR labeler action fails when that happens. There's ongoing work to fix it, see https://github.com/actions/labeler/pull/497, but I think we can ignore the action failures for now.

<!--
Use the following steps to ensure your PR is ready to be reviewed

- [ ] Read the [contribution guidelines](../blob/main/CONTRIBUTING.md) 🧑‍🎓
- [ ] Run `make lint` to ensure the proposed changes follow the coding style 🚨 (install golangci-lint [here](https://golangci-lint.run/usage/install/#local-installation))
- [ ] Run `make test` to ensure the proposed changes pass the tests 🧪
- [ ] If changing a source plugin run `make gen` to ensure docs are up to date 📝
- [ ] Ensure the status checks below are successful ✅
--->
