### PR TITLE
fix(website): Add canonical links

### DIFF
--- a/website/components/_app.tsx
+++ b/website/components/_app.tsx
@@ -1,6 +1,8 @@
 import React from "react";
 import Script from "next/script";
 import { Prism } from "prism-react-renderer";
+import {DefaultSeo} from "next-seo";
+import {useRouter} from "next/router";
 
 (typeof global !== "undefined" ? global : window).Prism = Prism;
 
@@ -24,8 +26,14 @@ declare global {
 }
 
 export default function Nextra({ Component, pageProps }) {
-  return (
+    const router = useRouter();
+    const canonicalUrl = (`https://www.cloudquery.io` + (router.asPath === "/" ? "": router.asPath)).split("?")[0];
+
+    return (
     <React.Fragment>
+      <DefaultSeo
+          canonical={canonicalUrl}
+      />
       <Component {...pageProps} />
       <Script>
         {typeof window !== "undefined" &&

--- a/website/package.json
+++ b/website/package.json
@@ -20,6 +20,7 @@
     "glob": "^9.0.1",
     "gray-matter": "^4.0.3",
     "next": "^13.1.5",
+    "next-seo": "^5.15.0",
     "next-sitemap": "^3.1.47",
     "nextra": "^2.2.16",
     "nextra-theme-docs": "^2.2.16",


### PR DESCRIPTION
I noticed that Google has been indexing some pages under different domains, e.g. `docs.cloudquery.io`, `v1.cloudquery.io` - this adds canonical links to point search engines to the main `www.` version of every page. I made use of the advice on this page https://rishimohan.me/blog/nextjs-canonical-tag to make sure it also works for ISR pages.