### PR TITLE
chore(ci-deps): Update Go Releaser version in Docker files

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -3,6 +3,17 @@
     "github>cloudquery/.github//.github/renovate-go-default.json5",
     "github>cloudquery/.github//.github/renovate-node-default.json5",
   ],
+  regexManagers: [
+     {
+      fileMatch: ["Dockerfile$"],
+      matchStrings: [
+        "GORELEASER_VERSION=(?<currentValue>.*)-pro$",
+      ],
+      extractVersionTemplate: "^(?<version>.+)-pro$",
+      depNameTemplate: "goreleaser/goreleaser-pro",
+      datasourceTemplate: "github-releases",
+    },
+  ],
   packageRules: [
     { matchManagers: ["npm"], groupName: "Website" },
     {


### PR DESCRIPTION
<!-- 🎉 Thank you for making CloudQuery awesome by submitting a PR 🎉 -->

#### Summary

We have a few files that reference a specific Go Releaser version. This ensures those get updated.
See https://github.com/cloudquery/cloudquery/pull/8758/files#diff-abcfa13367f012b18849cd3068dab27b53c00480c8bc1dc164ad92d545880452

<!--
Use the following steps to ensure your PR is ready to be reviewed

- [ ] Read the [contribution guidelines](../blob/main/CONTRIBUTING.md) 🧑‍🎓
- [ ] Run `make lint` to ensure the proposed changes follow the coding style 🚨 (install golangci-lint [here](https://golangci-lint.run/usage/install/#local-installation))
- [ ] Run `make test` to ensure the proposed changes pass the tests 🧪
- [ ] If changing a source plugin run `make gen` to ensure docs are up to date 📝
- [ ] Ensure the status checks below are successful ✅
--->
