### PR TITLE
fix(dest-s3)!: Make region required and don't make getbucketlocation

### DIFF
--- a/plugins/destination/s3/client/client.go
+++ b/plugins/destination/s3/client/client.go
@@ -78,15 +78,3 @@ func (*Client) Close(ctx context.Context) error {
 	return nil
 }
 
-func getBucketLocation(ctx context.Context, s3Client *s3.Client, bucket string) (string, error) {
-	output, err := s3Client.GetBucketLocation(ctx, &s3.GetBucketLocationInput{
-		Bucket: aws.String(bucket),
-	})
-	if err != nil {
-		return "", fmt.Errorf("failed to get bucket location: %w", err)
-	}
-	if output.LocationConstraint == "" {
-		return "us-east-1", nil
-	}
-	return string(output.LocationConstraint), nil
-}

--- a/plugins/destination/s3/client/client.go
+++ b/plugins/destination/s3/client/client.go
@@ -57,11 +57,7 @@ func New(ctx context.Context, logger zerolog.Logger, spec specs.Destination) (de
 		return nil, fmt.Errorf("unable to load AWS SDK config: %w", err)
 	}
 
-	location, err := getBucketLocation(ctx, s3.NewFromConfig(cfg), c.pluginSpec.Bucket)
-	if err != nil {
-		return nil, fmt.Errorf("unable to determine region of S3 bucket: %w", err)
-	}
-	cfg.Region = location
+	cfg.Region = c.pluginSpec.Region
 	c.s3Client = s3.NewFromConfig(cfg)
 	c.uploader = manager.NewUploader(c.s3Client)
 	c.downloader = manager.NewDownloader(c.s3Client)

--- a/plugins/destination/s3/client/client.go
+++ b/plugins/destination/s3/client/client.go
@@ -77,4 +77,3 @@ func New(ctx context.Context, logger zerolog.Logger, spec specs.Destination) (de
 func (*Client) Close(ctx context.Context) error {
 	return nil
 }
-

--- a/plugins/destination/s3/client/client_test.go
+++ b/plugins/destination/s3/client/client_test.go
@@ -41,6 +41,7 @@ func TestPluginCSV(t *testing.T) {
 func TestPluginJSON(t *testing.T) {
 	spec := Spec{
 		Bucket:   bucket,
+		Region:   region,
 		Path:     t.TempDir()[1:],
 		NoRotate: true,
 		FileSpec: &filetypes.FileSpec{

--- a/plugins/destination/s3/client/client_test.go
+++ b/plugins/destination/s3/client/client_test.go
@@ -8,10 +8,12 @@ import (
 )
 
 const bucket = "cq-playground-test"
+const region = "us-east-1"
 
 func TestPluginCSV(t *testing.T) {
 	spec := Spec{
 		Bucket:   bucket,
+		Region:   region,
 		Path:     t.TempDir()[1:],
 		NoRotate: true,
 		FileSpec: &filetypes.FileSpec{

--- a/plugins/destination/s3/client/spec.go
+++ b/plugins/destination/s3/client/spec.go
@@ -12,6 +12,7 @@ type Spec struct {
 	*filetypes.FileSpec
 	NoRotate bool   `json:"no_rotate,omitempty"`
 	Bucket   string `json:"bucket,omitempty"`
+	Region   string `json:"region,omitempty"`
 	Path     string `json:"path,omitempty"`
 	Athena   bool   `json:"athena,omitempty"`
 }
@@ -33,6 +34,9 @@ func (s *Spec) Validate() error {
 	}
 	if s.Path == "" {
 		return fmt.Errorf("path is required")
+	}
+	if s.Region == "" {
+		return fmt.Errorf("region is required")
 	}
 	if s.NoRotate && strings.Contains(s.Path, PathVarUUID) {
 		return fmt.Errorf("path should not contain %s when no_rotate = true", PathVarUUID)

--- a/plugins/destination/s3/client/spec_test.go
+++ b/plugins/destination/s3/client/spec_test.go
@@ -32,13 +32,13 @@ func TestSpec_Validate(t *testing.T) {
 		Give    Spec
 		WantErr bool
 	}{
-		{Give: Spec{Path: "test/path", FileSpec: &filetypes.FileSpec{Format: "json"}, Bucket: "mybucket"}, WantErr: false},
-		{Give: Spec{Path: "test/path", FileSpec: &filetypes.FileSpec{Format: "json"}}, WantErr: true}, // no bucket
-		{Give: Spec{Path: "test/path/{{TABLE}}.{{UUID}}", FileSpec: &filetypes.FileSpec{Format: "json"}, NoRotate: false, Bucket: "mybucket"}, WantErr: false},
-		{Give: Spec{Path: "test/path/{{TABLE}}.{{UUID}}", FileSpec: &filetypes.FileSpec{Format: "json"}, NoRotate: true, Bucket: "mybucket"}, WantErr: true},   // can't have no_rotate and {{UUID}}
-		{Give: Spec{Path: "/test/path/{{TABLE}}.{{UUID}}", FileSpec: &filetypes.FileSpec{Format: "json"}, NoRotate: true, Bucket: "mybucket"}, WantErr: true},  // begins with a a slash
-		{Give: Spec{Path: "//test/path/{{TABLE}}.{{UUID}}", FileSpec: &filetypes.FileSpec{Format: "json"}, NoRotate: true, Bucket: "mybucket"}, WantErr: true}, // duplicate slashes
-		{Give: Spec{Path: "test//path", FileSpec: &filetypes.FileSpec{Format: "json"}, Bucket: "mybucket"}, WantErr: true},                                     // duplicate slashes
+		{Give: Spec{Path: "test/path", FileSpec: &filetypes.FileSpec{Format: "json"}, Bucket: "mybucket", Region: region}, WantErr: false},
+		{Give: Spec{Path: "test/path", FileSpec: &filetypes.FileSpec{Format: "json"}, Region: "region"}, WantErr: true}, // no bucket
+		{Give: Spec{Path: "test/path/{{TABLE}}.{{UUID}}", FileSpec: &filetypes.FileSpec{Format: "json"}, NoRotate: false, Bucket: "mybucket", Region: region}, WantErr: false},
+		{Give: Spec{Path: "test/path/{{TABLE}}.{{UUID}}", FileSpec: &filetypes.FileSpec{Format: "json"}, NoRotate: true, Bucket: "mybucket", Region: region}, WantErr: true},   // can't have no_rotate and {{UUID}}
+		{Give: Spec{Path: "/test/path/{{TABLE}}.{{UUID}}", FileSpec: &filetypes.FileSpec{Format: "json"}, NoRotate: true, Bucket: "mybucket", Region: region}, WantErr: true},  // begins with a a slash
+		{Give: Spec{Path: "//test/path/{{TABLE}}.{{UUID}}", FileSpec: &filetypes.FileSpec{Format: "json"}, NoRotate: true, Bucket: "mybucket", Region: region}, WantErr: true}, // duplicate slashes
+		{Give: Spec{Path: "test//path", FileSpec: &filetypes.FileSpec{Format: "json"}, Bucket: "mybucket", Region: region}, WantErr: true},                                     // duplicate slashes
 	}
 	for _, tc := range cases {
 		err := tc.Give.Validate()

--- a/website/pages/docs/plugins/destinations/s3/_authentication.mdx
+++ b/website/pages/docs/plugins/destinations/s3/_authentication.mdx
@@ -1,6 +1,6 @@
 The plugin needs to be authenticated with your account(s) in order to sync information from your cloud setup.
 
-The plugin requires only _read_ permissions (we will never make any changes to your cloud setup), so, following the principle of least privilege, it's recommended to grant it read-only permissions.
+The plugin requires only `PutObject` permissions (we will never make any changes to your cloud setup), so, following the principle of least privilege, it's recommended to grant it `PutObject` permissions.
 
 There are multiple ways to authenticate with AWS, and the plugin respects the AWS credential provider chain. This means that CloudQuery will follow the following priorities when attempting to authenticate:
 
@@ -57,13 +57,6 @@ Then, you can either export the `AWS_PROFILE` environment variable (On Linux/Mac
 export AWS_PROFILE=myprofile
 ```
 
-or, configure your desired profile in the `local_profile` field:
-
-```yaml copy filename="aws.yml"
-accounts:
-  id: <account_alias>
-  local_profile: myprofile
-```
 
 ### IAM Roles for AWS Compute Resources
 

--- a/website/pages/docs/plugins/destinations/s3/_configuration.mdx
+++ b/website/pages/docs/plugins/destinations/s3/_configuration.mdx
@@ -13,6 +13,7 @@ spec:
   # batch_size_bytes: 5242880 # optional
   spec:
     bucket: "bucket_name"
+    region: "region-name" # Example: us-east-1
     path: "path/to/files/{{TABLE}}/{{UUID}}.parquet"
     format: "parquet"
     athena: false # <- set this to true for Athena compatibility

--- a/website/pages/docs/plugins/destinations/s3/overview.mdx
+++ b/website/pages/docs/plugins/destinations/s3/overview.mdx
@@ -28,6 +28,10 @@ This is the (nested) spec used by the CSV destination Plugin.
 
   Bucket where to sync the files.
 
+- `region` (string) (required)
+
+  Region where bucket is located.
+
 - `path` (string) (required)
 
   Path to where the files will be uploaded in the above bucket. The path supports the following placeholder variables:


### PR DESCRIPTION
This causes consistent confusion to our users and also don't follow least privilege. This now should require only PutObject. The user anyway always knows where the bucket is located.

https://discord.com/channels/872925471417962546/873606591335759872/1083080462936838245
