### PR TITLE
chore: Don't set canonical on non production builds

### DIFF
--- a/website/components/_app.tsx
+++ b/website/components/_app.tsx
@@ -26,7 +26,6 @@ declare global {
 }
 
 const getCanaonicalUrl = (path: string) => {
-  console.log(process.env)
   if (process.env.NEXT_PUBLIC_VERCEL_ENV !== "production") {
     return
   }

--- a/website/components/_app.tsx
+++ b/website/components/_app.tsx
@@ -25,9 +25,18 @@ declare global {
   }
 }
 
+const getCanaonicalUrl = (path: string) => {
+  console.log(process.env)
+  if (process.env.NEXT_PUBLIC_VERCEL_ENV !== "production") {
+    return
+  }
+
+  return (`https://www.cloudquery.io` + (path === "/" ? "": path)).split("?")[0]
+}
+
 export default function Nextra({ Component, pageProps }) {
     const router = useRouter();
-    const canonicalUrl = (`https://www.cloudquery.io` + (router.asPath === "/" ? "": router.asPath)).split("?")[0];
+    const canonicalUrl = getCanaonicalUrl(router.asPath);
 
     return (
     <React.Fragment>

--- a/website/package-lock.json
+++ b/website/package-lock.json
@@ -14,6 +14,7 @@
         "glob": "^9.0.1",
         "gray-matter": "^4.0.3",
         "next": "^13.1.5",
+        "next-seo": "^5.15.0",
         "next-sitemap": "^3.1.47",
         "nextra": "^2.2.16",
         "nextra-theme-docs": "^2.2.16",
@@ -7596,8 +7597,9 @@
       }
     },
     "node_modules/next-seo": {
-      "version": "5.14.1",
-      "license": "MIT",
+      "version": "5.15.0",
+      "resolved": "https://registry.npmjs.org/next-seo/-/next-seo-5.15.0.tgz",
+      "integrity": "sha512-LGbcY91yDKGMb7YI+28n3g+RuChUkt6pXNpa8FkfKkEmNiJkeRDEXTnnjVtwT9FmMhG6NH8qwHTelGrlYm9rgg==",
       "peerDependencies": {
         "next": "^8.1.1-canary.54 || >=9.0.0",
         "react": ">=16.0.0",


### PR DESCRIPTION
<!-- 🎉 Thank you for making CloudQuery awesome by submitting a PR 🎉 -->

#### Summary

~~Still testing this (hence the log message).~~
Deploy previews are not indexed by default, so we don't need the canonical. See https://vercel.com/guides/are-vercel-preview-deployment-indexed-by-search-engines.

If we keep the canonical, every time we add a new page to the Website our broken link check fails on the PR since the link uses the main domain, which doesn't have that page deployed yet

<!--
Use the following steps to ensure your PR is ready to be reviewed

- [ ] Read the [contribution guidelines](../blob/main/CONTRIBUTING.md) 🧑‍🎓
- [ ] Run `make lint` to ensure the proposed changes follow the coding style 🚨 (install golangci-lint [here](https://golangci-lint.run/usage/install/#local-installation))
- [ ] Run `make test` to ensure the proposed changes pass the tests 🧪
- [ ] If changing a source plugin run `make gen` to ensure docs are up to date 📝
- [ ] Ensure the status checks below are successful ✅
--->
