### PR TITLE
fix(azure-resources): Retrieve instance view when sync `azure_compute_virtual_machine_scale_set_vms`

### DIFF
--- a/plugins/source/azure/resources/services/compute/virtual_machine_scale_set_vms.go
+++ b/plugins/source/azure/resources/services/compute/virtual_machine_scale_set_vms.go
@@ -31,7 +31,8 @@ func fetchVirtualMachineScaleSetsVMs(ctx context.Context, meta schema.ClientMeta
 	if err != nil {
 		return err
 	}
-	pager := svc.NewListPager(group, *scaleSet.Name, nil)
+	expand := "instanceView"
+	pager := svc.NewListPager(group, *scaleSet.Name, &armcompute.VirtualMachineScaleSetVMsClientListOptions{Expand: &expand})
 	for pager.More() {
 		p, err := pager.NextPage(ctx)
 		if err != nil {


### PR DESCRIPTION
<!-- 🎉 Thank you for making CloudQuery awesome by submitting a PR 🎉 -->

#### Summary

We need to explicitly set the `expand` option to get the scale set VM instance view

<!--
Use the following steps to ensure your PR is ready to be reviewed

- [ ] Read the [contribution guidelines](../blob/main/CONTRIBUTING.md) 🧑‍🎓
- [ ] Run `make lint` to ensure the proposed changes follow the coding style 🚨 (install golangci-lint [here](https://golangci-lint.run/usage/install/#local-installation))
- [ ] Run `make test` to ensure the proposed changes pass the tests 🧪
- [ ] If changing a source plugin run `make gen` to ensure docs are up to date 📝
- [ ] Ensure the status checks below are successful ✅
--->
