### PR TITLE
chore(transformers): Use `client.TransformWithStruct` instead of appending default options

### DIFF
--- a/plugins/source/azuredevops/client/transformers.go
+++ b/plugins/source/azuredevops/client/transformers.go
@@ -25,10 +25,10 @@ func typeTransformer(field reflect.StructField) (schema.ValueType, error) {
 	return schema.TypeInvalid, nil
 }
 
-func Options() []transformers.StructTransformerOption {
-	options := []transformers.StructTransformerOption{
-		transformers.WithTypeTransformer(typeTransformer),
-	}
+var options = []transformers.StructTransformerOption{
+	transformers.WithTypeTransformer(typeTransformer),
+}
 
-	return options
+func TransformWithStruct(t any, opts ...transformers.StructTransformerOption) schema.Transform {
+	return transformers.TransformWithStruct(t, append(options, opts...)...)
 }

--- a/plugins/source/azuredevops/resources/services/core/projects.go
+++ b/plugins/source/azuredevops/resources/services/core/projects.go
@@ -3,7 +3,6 @@ package core
 import (
 	"github.com/cloudquery/cloudquery/plugins/source/azuredevops/client"
 	"github.com/cloudquery/plugin-sdk/schema"
-	"github.com/cloudquery/plugin-sdk/transformers"
 	"github.com/microsoft/azure-devops-go-api/azuredevops/v6/core"
 )
 
@@ -11,6 +10,6 @@ func Projects() *schema.Table {
 	return &schema.Table{
 		Name:      "azuredevops_core_projects",
 		Resolver:  fetchProjects,
-		Transform: transformers.TransformWithStruct(&core.TeamProjectReference{}, client.Options()...),
+		Transform: client.TransformWithStruct(&core.TeamProjectReference{}),
 	}
 }

--- a/plugins/source/facebookmarketing/client/transformers.go
+++ b/plugins/source/facebookmarketing/client/transformers.go
@@ -27,9 +27,11 @@ func ResolverTransformer(field reflect.StructField, path string) schema.ColumnRe
 	return transformers.DefaultResolverTransformer(field, path)
 }
 
-func TransformerOptions() []transformers.StructTransformerOption {
-	return []transformers.StructTransformerOption{
-		transformers.WithTypeTransformer(TypeTransformer),
-		transformers.WithResolverTransformer(ResolverTransformer),
-	}
+var options = []transformers.StructTransformerOption{
+	transformers.WithTypeTransformer(TypeTransformer),
+	transformers.WithResolverTransformer(ResolverTransformer),
+}
+
+func TransformWithStruct(t any, opts ...transformers.StructTransformerOption) schema.Transform {
+	return transformers.TransformWithStruct(t, append(options, opts...)...)
 }

--- a/plugins/source/facebookmarketing/resources/services/ad_place_page_sets.go
+++ b/plugins/source/facebookmarketing/resources/services/ad_place_page_sets.go
@@ -11,7 +11,7 @@ func AdPlacePageSets() *schema.Table {
 	return &schema.Table{
 		Name:        "facebookmarketing_ad_place_page_sets",
 		Resolver:    fetchAdPlacePageSets,
-		Transform:   transformers.TransformWithStruct(&rest.AdPlacePageSet{}, append(client.TransformerOptions(), transformers.WithPrimaryKeys("Id"))...),
+		Transform:   client.TransformWithStruct(&rest.AdPlacePageSet{}, transformers.WithPrimaryKeys("Id")),
 		Description: "https://developers.facebook.com/docs/marketing-api/reference/ad-place-page-set#Reading",
 	}
 }

--- a/plugins/source/facebookmarketing/resources/services/ad_studies.go
+++ b/plugins/source/facebookmarketing/resources/services/ad_studies.go
@@ -11,7 +11,7 @@ func AdStudies() *schema.Table {
 	return &schema.Table{
 		Name:        "facebookmarketing_ad_studies",
 		Resolver:    fetchAdStudies,
-		Transform:   transformers.TransformWithStruct(&rest.AdStudy{}, append(client.TransformerOptions(), transformers.WithPrimaryKeys("Id"))...),
+		Transform:   client.TransformWithStruct(&rest.AdStudy{}, transformers.WithPrimaryKeys("Id")),
 		Description: "https://developers.facebook.com/docs/marketing-api/reference/ad-study/#Reading",
 		Columns: []schema.Column{
 			{

--- a/plugins/source/facebookmarketing/resources/services/adaccounts.go
+++ b/plugins/source/facebookmarketing/resources/services/adaccounts.go
@@ -11,7 +11,7 @@ func Adaccounts() *schema.Table {
 	return &schema.Table{
 		Name:        "facebookmarketing_adaccounts",
 		Resolver:    fetchAdaccounts,
-		Transform:   transformers.TransformWithStruct(&rest.Adaccount{}, append(client.TransformerOptions(), transformers.WithPrimaryKeys("Id"))...),
+		Transform:   client.TransformWithStruct(&rest.Adaccount{}, transformers.WithPrimaryKeys("Id")),
 		Description: "https://developers.facebook.com/docs/marketing-api/reference/ad-account#Reading",
 	}
 }

--- a/plugins/source/facebookmarketing/resources/services/adcloudplayables.go
+++ b/plugins/source/facebookmarketing/resources/services/adcloudplayables.go
@@ -11,7 +11,7 @@ func Adcloudplayables() *schema.Table {
 	return &schema.Table{
 		Name:      "facebookmarketing_adcloudplayables",
 		Resolver:  fetchAdcloudplayables,
-		Transform: transformers.TransformWithStruct(&rest.Adcloudplayable{}, append(client.TransformerOptions(), transformers.WithPrimaryKeys("Id"))...),
+		Transform: client.TransformWithStruct(&rest.Adcloudplayable{}, transformers.WithPrimaryKeys("Id")),
 		Columns: []schema.Column{
 			{
 				Name:     "account_id",

--- a/plugins/source/facebookmarketing/resources/services/adcreatives.go
+++ b/plugins/source/facebookmarketing/resources/services/adcreatives.go
@@ -11,7 +11,7 @@ func Adcreatives() *schema.Table {
 	return &schema.Table{
 		Name:        "facebookmarketing_adcreatives",
 		Resolver:    fetchAdcreatives,
-		Transform:   transformers.TransformWithStruct(&rest.Adcreative{}, append(client.TransformerOptions(), transformers.WithPrimaryKeys("Id"))...),
+		Transform:   client.TransformWithStruct(&rest.Adcreative{}, transformers.WithPrimaryKeys("Id")),
 		Description: "https://developers.facebook.com/docs/marketing-api/reference/ad-creative#Reading",
 	}
 }

--- a/plugins/source/facebookmarketing/resources/services/adimages.go
+++ b/plugins/source/facebookmarketing/resources/services/adimages.go
@@ -11,7 +11,7 @@ func Adimages() *schema.Table {
 	return &schema.Table{
 		Name:        "facebookmarketing_adimages",
 		Resolver:    fetchAdimages,
-		Transform:   transformers.TransformWithStruct(&rest.Adimage{}, append(client.TransformerOptions(), transformers.WithPrimaryKeys("Id"))...),
+		Transform:   client.TransformWithStruct(&rest.Adimage{}, transformers.WithPrimaryKeys("Id")),
 		Description: "https://developers.facebook.com/docs/marketing-api/reference/ad-image#Reading",
 	}
 }

--- a/plugins/source/facebookmarketing/resources/services/adlabels.go
+++ b/plugins/source/facebookmarketing/resources/services/adlabels.go
@@ -11,7 +11,7 @@ func Adlabels() *schema.Table {
 	return &schema.Table{
 		Name:        "facebookmarketing_adlabels",
 		Resolver:    fetchAdlabels,
-		Transform:   transformers.TransformWithStruct(&rest.Adlabel{}, append(client.TransformerOptions(), transformers.WithPrimaryKeys("Id"))...),
+		Transform:   client.TransformWithStruct(&rest.Adlabel{}, transformers.WithPrimaryKeys("Id")),
 		Description: "https://developers.facebook.com/docs/marketing-api/reference/ad-label#Reading",
 		Columns: []schema.Column{
 			{

--- a/plugins/source/facebookmarketing/resources/services/adplayables.go
+++ b/plugins/source/facebookmarketing/resources/services/adplayables.go
@@ -11,7 +11,7 @@ func Adplayables() *schema.Table {
 	return &schema.Table{
 		Name:      "facebookmarketing_adplayables",
 		Resolver:  fetchAdplayables,
-		Transform: transformers.TransformWithStruct(&rest.Adplayable{}, append(client.TransformerOptions(), transformers.WithPrimaryKeys("Id"))...),
+		Transform: client.TransformWithStruct(&rest.Adplayable{}, transformers.WithPrimaryKeys("Id")),
 		Columns: []schema.Column{
 			{
 				Name:     "account_id",

--- a/plugins/source/facebookmarketing/resources/services/adrules.go
+++ b/plugins/source/facebookmarketing/resources/services/adrules.go
@@ -11,7 +11,7 @@ func Adrules() *schema.Table {
 	return &schema.Table{
 		Name:        "facebookmarketing_adrules",
 		Resolver:    fetchAdrules,
-		Transform:   transformers.TransformWithStruct(&rest.Adrule{}, append(client.TransformerOptions(), transformers.WithPrimaryKeys("Id"))...),
+		Transform:   client.TransformWithStruct(&rest.Adrule{}, transformers.WithPrimaryKeys("Id")),
 		Description: "https://developers.facebook.com/docs/marketing-api/reference/ad-rule#Reading",
 	}
 }

--- a/plugins/source/facebookmarketing/resources/services/ads.go
+++ b/plugins/source/facebookmarketing/resources/services/ads.go
@@ -11,7 +11,7 @@ func Ads() *schema.Table {
 	return &schema.Table{
 		Name:        "facebookmarketing_ads",
 		Resolver:    fetchAds,
-		Transform:   transformers.TransformWithStruct(&rest.Ad{}, append(client.TransformerOptions(), transformers.WithPrimaryKeys("Id"))...),
+		Transform:   client.TransformWithStruct(&rest.Ad{}, transformers.WithPrimaryKeys("Id")),
 		Description: "https://developers.facebook.com/docs/marketing-api/reference/adgroup",
 	}
 }

--- a/plugins/source/facebookmarketing/resources/services/adsets.go
+++ b/plugins/source/facebookmarketing/resources/services/adsets.go
@@ -11,7 +11,7 @@ func Adsets() *schema.Table {
 	return &schema.Table{
 		Name:        "facebookmarketing_adsets",
 		Resolver:    fetchAdsets,
-		Transform:   transformers.TransformWithStruct(&rest.Adset{}, append(client.TransformerOptions(), transformers.WithPrimaryKeys("Id"))...),
+		Transform:   client.TransformWithStruct(&rest.Adset{}, transformers.WithPrimaryKeys("Id")),
 		Description: "https://developers.facebook.com/docs/marketing-api/reference/ad-campaign#Reading",
 	}
 }

--- a/plugins/source/facebookmarketing/resources/services/adspixelss.go
+++ b/plugins/source/facebookmarketing/resources/services/adspixelss.go
@@ -11,7 +11,7 @@ func Adspixels() *schema.Table {
 	return &schema.Table{
 		Name:      "facebookmarketing_adspixels",
 		Resolver:  fetchAdspixels,
-		Transform: transformers.TransformWithStruct(&rest.Adspixel{}, append(client.TransformerOptions(), transformers.WithPrimaryKeys("Id"))...),
+		Transform: client.TransformWithStruct(&rest.Adspixel{}, transformers.WithPrimaryKeys("Id")),
 		Columns: []schema.Column{
 			{
 				Name:     "account_id",

--- a/plugins/source/facebookmarketing/resources/services/advertisable_applications.go
+++ b/plugins/source/facebookmarketing/resources/services/advertisable_applications.go
@@ -11,7 +11,7 @@ func AdvertisableApplications() *schema.Table {
 	return &schema.Table{
 		Name:      "facebookmarketing_applications",
 		Resolver:  fetchAdvertisableApplications,
-		Transform: transformers.TransformWithStruct(&rest.Application{}, append(client.TransformerOptions(), transformers.WithPrimaryKeys("Id"))...),
+		Transform: client.TransformWithStruct(&rest.Application{}, transformers.WithPrimaryKeys("Id")),
 		Columns: []schema.Column{
 			{
 				Name:     "account_id",

--- a/plugins/source/facebookmarketing/resources/services/advideos.go
+++ b/plugins/source/facebookmarketing/resources/services/advideos.go
@@ -11,7 +11,7 @@ func Advideos() *schema.Table {
 	return &schema.Table{
 		Name:      "facebookmarketing_advideos",
 		Resolver:  fetchAdvideos,
-		Transform: transformers.TransformWithStruct(&rest.Advideo{}, append(client.TransformerOptions(), transformers.WithPrimaryKeys("Id"))...),
+		Transform: client.TransformWithStruct(&rest.Advideo{}, transformers.WithPrimaryKeys("Id")),
 		Columns: []schema.Column{
 			{
 				Name:     "account_id",

--- a/plugins/source/facebookmarketing/resources/services/broad_targeting_categories.go
+++ b/plugins/source/facebookmarketing/resources/services/broad_targeting_categories.go
@@ -11,7 +11,7 @@ func BroadTargetingCategoriess() *schema.Table {
 	return &schema.Table{
 		Name:      "facebookmarketing_broad_targeting_categories",
 		Resolver:  fetchBroadTargetingCategories,
-		Transform: transformers.TransformWithStruct(&rest.BroadTargetingCategories{}, append(client.TransformerOptions(), transformers.WithPrimaryKeys("Id"))...),
+		Transform: client.TransformWithStruct(&rest.BroadTargetingCategories{}, transformers.WithPrimaryKeys("Id")),
 		Columns: []schema.Column{
 			{
 				Name:     "account_id",

--- a/plugins/source/facebookmarketing/resources/services/businesss.go
+++ b/plugins/source/facebookmarketing/resources/services/businesss.go
@@ -11,7 +11,7 @@ func Businesses() *schema.Table {
 	return &schema.Table{
 		Name:        "facebookmarketing_businesses",
 		Resolver:    fetchBusinesss,
-		Transform:   transformers.TransformWithStruct(&rest.Business{}, append(client.TransformerOptions(), transformers.WithPrimaryKeys("Id"))...),
+		Transform:   client.TransformWithStruct(&rest.Business{}, transformers.WithPrimaryKeys("Id")),
 		Description: "https://developers.facebook.com/docs/marketing-api/reference/business/#Reading",
 	}
 }

--- a/plugins/source/facebookmarketing/resources/services/campaigns.go
+++ b/plugins/source/facebookmarketing/resources/services/campaigns.go
@@ -11,7 +11,7 @@ func Campaigns() *schema.Table {
 	return &schema.Table{
 		Name:        "facebookmarketing_campaigns",
 		Resolver:    fetchCampaigns,
-		Transform:   transformers.TransformWithStruct(&rest.Campaign{}, append(client.TransformerOptions(), transformers.WithPrimaryKeys("Id"))...),
+		Transform:   client.TransformWithStruct(&rest.Campaign{}, transformers.WithPrimaryKeys("Id")),
 		Description: "https://developers.facebook.com/docs/marketing-api/reference/ad-campaign-group/",
 	}
 }

--- a/plugins/source/facebookmarketing/resources/services/connected_instagram_accounts.go
+++ b/plugins/source/facebookmarketing/resources/services/connected_instagram_accounts.go
@@ -11,7 +11,7 @@ func ConnectedInstagramAccounts() *schema.Table {
 	return &schema.Table{
 		Name:      "facebookmarketing_connected_instagram_accounts",
 		Resolver:  fetchConnectedInstagramAccounts,
-		Transform: transformers.TransformWithStruct(&rest.ConnnectedInstagramAccount{}, append(client.TransformerOptions(), transformers.WithPrimaryKeys("Id"))...),
+		Transform: client.TransformWithStruct(&rest.ConnnectedInstagramAccount{}, transformers.WithPrimaryKeys("Id")),
 		Columns: []schema.Column{
 			{
 				Name:     "account_id",

--- a/plugins/source/facebookmarketing/resources/services/customaudiences.go
+++ b/plugins/source/facebookmarketing/resources/services/customaudiences.go
@@ -11,7 +11,7 @@ func Customaudiences() *schema.Table {
 	return &schema.Table{
 		Name:        "facebookmarketing_customaudiences",
 		Resolver:    fetchCustomaudiences,
-		Transform:   transformers.TransformWithStruct(&rest.Customaudience{}, append(client.TransformerOptions(), transformers.WithPrimaryKeys("Id"))...),
+		Transform:   client.TransformWithStruct(&rest.Customaudience{}, transformers.WithPrimaryKeys("Id")),
 		Description: "https://developers.facebook.com/docs/marketing-api/reference/custom-audience#Reading",
 	}
 }

--- a/plugins/source/facebookmarketing/resources/services/customconversions.go
+++ b/plugins/source/facebookmarketing/resources/services/customconversions.go
@@ -11,6 +11,6 @@ func Customconversions() *schema.Table {
 	return &schema.Table{
 		Name:      "facebookmarketing_customconversions",
 		Resolver:  fetchCustomconversions,
-		Transform: transformers.TransformWithStruct(&rest.Customconversion{}, append(client.TransformerOptions(), transformers.WithPrimaryKeys("Id"))...),
+		Transform: client.TransformWithStruct(&rest.Customconversion{}, transformers.WithPrimaryKeys("Id")),
 	}
 }

--- a/plugins/source/facebookmarketing/resources/services/max_bids.go
+++ b/plugins/source/facebookmarketing/resources/services/max_bids.go
@@ -4,14 +4,13 @@ import (
 	"github.com/cloudquery/cloudquery/plugins/source/facebookmarketing/client"
 	"github.com/cloudquery/cloudquery/plugins/source/facebookmarketing/rest"
 	"github.com/cloudquery/plugin-sdk/schema"
-	"github.com/cloudquery/plugin-sdk/transformers"
 )
 
 func MaxBids() *schema.Table {
 	return &schema.Table{
 		Name:      "facebookmarketing_max_bids",
 		Resolver:  fetchMaxBids,
-		Transform: transformers.TransformWithStruct(&rest.MaxBid{}, client.TransformerOptions()...),
+		Transform: client.TransformWithStruct(&rest.MaxBid{}),
 		Columns: []schema.Column{
 			{
 				Name:     "account_id",

--- a/plugins/source/facebookmarketing/resources/services/offline_conversion_data_sets.go
+++ b/plugins/source/facebookmarketing/resources/services/offline_conversion_data_sets.go
@@ -11,7 +11,7 @@ func OfflineConversionDataSets() *schema.Table {
 	return &schema.Table{
 		Name:      "facebookmarketing_offline_conversion_data_sets",
 		Resolver:  fetchOfflineConversionDataSets,
-		Transform: transformers.TransformWithStruct(&rest.OfflineConversionDataSet{}, append(client.TransformerOptions(), transformers.WithPrimaryKeys("Id"))...),
+		Transform: client.TransformWithStruct(&rest.OfflineConversionDataSet{}, transformers.WithPrimaryKeys("Id")),
 		Columns: []schema.Column{
 			{
 				Name:     "account_id",

--- a/plugins/source/facebookmarketing/resources/services/promote_pages.go
+++ b/plugins/source/facebookmarketing/resources/services/promote_pages.go
@@ -11,7 +11,7 @@ func PromotePages() *schema.Table {
 	return &schema.Table{
 		Name:      "facebookmarketing_promote_pages",
 		Resolver:  fetchPromotePages,
-		Transform: transformers.TransformWithStruct(&rest.PromotePage{}, append(client.TransformerOptions(), transformers.WithPrimaryKeys("Id"))...),
+		Transform: client.TransformWithStruct(&rest.PromotePage{}, transformers.WithPrimaryKeys("Id")),
 		Columns: []schema.Column{
 			{
 				Name:     "account_id",

--- a/plugins/source/facebookmarketing/resources/services/publisher_block_lists.go
+++ b/plugins/source/facebookmarketing/resources/services/publisher_block_lists.go
@@ -11,7 +11,7 @@ func PublisherBlockLists() *schema.Table {
 	return &schema.Table{
 		Name:      "facebookmarketing_publisher_block_lists",
 		Resolver:  fetchPublisherBlockLists,
-		Transform: transformers.TransformWithStruct(&rest.PublisherBlockList{}, append(client.TransformerOptions(), transformers.WithPrimaryKeys("Id"))...),
+		Transform: client.TransformWithStruct(&rest.PublisherBlockList{}, transformers.WithPrimaryKeys("Id")),
 		Columns: []schema.Column{
 			{
 				Name:     "account_id",

--- a/plugins/source/facebookmarketing/resources/services/reach_frequency_predictions.go
+++ b/plugins/source/facebookmarketing/resources/services/reach_frequency_predictions.go
@@ -11,7 +11,7 @@ func ReachFrequencyPredictions() *schema.Table {
 	return &schema.Table{
 		Name:        "facebookmarketing_reach_frequency_predictions",
 		Resolver:    fetchReachFrequencyPredictions,
-		Transform:   transformers.TransformWithStruct(&rest.ReachFrequencyPrediction{}, append(client.TransformerOptions(), transformers.WithPrimaryKeys("Id"))...),
+		Transform:   client.TransformWithStruct(&rest.ReachFrequencyPrediction{}, transformers.WithPrimaryKeys("Id")),
 		Description: "https://developers.facebook.com/docs/marketing-api/reference/reach-frequency-prediction/#Reading",
 	}
 }

--- a/plugins/source/facebookmarketing/resources/services/saved_audiences.go
+++ b/plugins/source/facebookmarketing/resources/services/saved_audiences.go
@@ -11,7 +11,7 @@ func SavedAudiences() *schema.Table {
 	return &schema.Table{
 		Name:        "facebookmarketing_saved_audiences",
 		Resolver:    fetchSavedAudiences,
-		Transform:   transformers.TransformWithStruct(&rest.SavedAudience{}, append(client.TransformerOptions(), transformers.WithPrimaryKeys("Id"))...),
+		Transform:   client.TransformWithStruct(&rest.SavedAudience{}, transformers.WithPrimaryKeys("Id")),
 		Description: "https://developers.facebook.com/docs/marketing-api/reference/saved-audience/#Reading",
 	}
 }

--- a/plugins/source/facebookmarketing/resources/services/users.go
+++ b/plugins/source/facebookmarketing/resources/services/users.go
@@ -11,7 +11,7 @@ func Users() *schema.Table {
 	return &schema.Table{
 		Name:      "facebookmarketing_adaccount_users",
 		Resolver:  fetchUsers,
-		Transform: transformers.TransformWithStruct(&rest.Adaccountuser{}, append(client.TransformerOptions(), transformers.WithPrimaryKeys("Id"))...),
+		Transform: client.TransformWithStruct(&rest.Adaccountuser{}, transformers.WithPrimaryKeys("Id")),
 		Columns: []schema.Column{
 			{
 				Name:     "account_id",

--- a/plugins/source/gcp/client/transformers.go
+++ b/plugins/source/gcp/client/transformers.go
@@ -77,13 +77,13 @@ func ignoreInTestsTransformer(field reflect.StructField) bool {
 	return false
 }
 
-func Options() []transformers.StructTransformerOption {
-	options := []transformers.StructTransformerOption{
-		transformers.WithNameTransformer(replaceTransformer),
-		transformers.WithTypeTransformer(typeTransformer),
-		transformers.WithResolverTransformer(resolverTransformer),
-		transformers.WithIgnoreInTestsTransformer(ignoreInTestsTransformer),
-	}
+var options = []transformers.StructTransformerOption{
+	transformers.WithNameTransformer(replaceTransformer),
+	transformers.WithTypeTransformer(typeTransformer),
+	transformers.WithResolverTransformer(resolverTransformer),
+	transformers.WithIgnoreInTestsTransformer(ignoreInTestsTransformer),
+}
 
-	return options
+func TransformWithStruct(t any, opts ...transformers.StructTransformerOption) schema.Transform {
+	return transformers.TransformWithStruct(t, append(options, opts...)...)
 }

--- a/plugins/source/gcp/resources/services/aiplatform/batch_prediction_jobs.go
+++ b/plugins/source/gcp/resources/services/aiplatform/batch_prediction_jobs.go
@@ -23,7 +23,7 @@ func BatchPredictionJobs() *schema.Table {
 		Description: `https://cloud.google.com/vertex-ai/docs/reference/rest/v1/projects.locations.batchPredictionJobs#BatchPredictionJob`,
 		Resolver:    fetchBatchPredictionJobs,
 		Multiplex:   client.ProjectMultiplexEnabledServices("aiplatform.googleapis.com"),
-		Transform:   transformers.TransformWithStruct(&pb.BatchPredictionJob{}, append(client.Options(), transformers.WithPrimaryKeys("Name"))...),
+		Transform:   client.TransformWithStruct(&pb.BatchPredictionJob{}, transformers.WithPrimaryKeys("Name")),
 		Columns: []schema.Column{
 			{
 				Name:     "project_id",

--- a/plugins/source/gcp/resources/services/aiplatform/custom_jobs.go
+++ b/plugins/source/gcp/resources/services/aiplatform/custom_jobs.go
@@ -23,7 +23,7 @@ func CustomJobs() *schema.Table {
 		Description: `https://cloud.google.com/vertex-ai/docs/reference/rest/v1/projects.locations.customJobs#CustomJob`,
 		Resolver:    fetchCustomJobs,
 		Multiplex:   client.ProjectMultiplexEnabledServices("aiplatform.googleapis.com"),
-		Transform:   transformers.TransformWithStruct(&pb.CustomJob{}, append(client.Options(), transformers.WithPrimaryKeys("Name"))...),
+		Transform:   client.TransformWithStruct(&pb.CustomJob{}, transformers.WithPrimaryKeys("Name")),
 		Columns: []schema.Column{
 			{
 				Name:     "project_id",

--- a/plugins/source/gcp/resources/services/aiplatform/data_labeling_jobs.go
+++ b/plugins/source/gcp/resources/services/aiplatform/data_labeling_jobs.go
@@ -23,7 +23,7 @@ func DataLabelingJobs() *schema.Table {
 		Description: `https://cloud.google.com/vertex-ai/docs/reference/rest/v1/projects.locations.dataLabelingJobs#DataLabelingJob`,
 		Resolver:    fetchDataLabelingJobs,
 		Multiplex:   client.ProjectMultiplexEnabledServices("aiplatform.googleapis.com"),
-		Transform:   transformers.TransformWithStruct(&pb.DataLabelingJob{}, append(client.Options(), transformers.WithPrimaryKeys("Name"))...),
+		Transform:   client.TransformWithStruct(&pb.DataLabelingJob{}, transformers.WithPrimaryKeys("Name")),
 		Columns: []schema.Column{
 			{
 				Name:     "project_id",

--- a/plugins/source/gcp/resources/services/aiplatform/dataset_locations.go
+++ b/plugins/source/gcp/resources/services/aiplatform/dataset_locations.go
@@ -21,7 +21,7 @@ func DatasetLocations() *schema.Table {
 		Description: `https://cloud.google.com/api-gateway/docs/reference/rest/v1/projects.locations#Location`,
 		Resolver:    fetchDatasetLocations,
 		Multiplex:   client.ProjectMultiplexEnabledServices("aiplatform.googleapis.com"),
-		Transform:   transformers.TransformWithStruct(&pb.Location{}, append(client.Options(), transformers.WithPrimaryKeys("Name"))...),
+		Transform:   client.TransformWithStruct(&pb.Location{}, transformers.WithPrimaryKeys("Name")),
 		Columns: []schema.Column{
 			{
 				Name:     "project_id",

--- a/plugins/source/gcp/resources/services/aiplatform/datasets.go
+++ b/plugins/source/gcp/resources/services/aiplatform/datasets.go
@@ -23,7 +23,7 @@ func Datasets() *schema.Table {
 		Description: `https://cloud.google.com/vertex-ai/docs/reference/rest/v1/projects.locations.datasets#Dataset`,
 		Resolver:    fetchDatasets,
 		Multiplex:   client.ProjectMultiplexEnabledServices("aiplatform.googleapis.com"),
-		Transform:   transformers.TransformWithStruct(&pb.Dataset{}, append(client.Options(), transformers.WithPrimaryKeys("Name"))...),
+		Transform:   client.TransformWithStruct(&pb.Dataset{}, transformers.WithPrimaryKeys("Name")),
 		Columns: []schema.Column{
 			{
 				Name:     "project_id",

--- a/plugins/source/gcp/resources/services/aiplatform/endpoint_locations.go
+++ b/plugins/source/gcp/resources/services/aiplatform/endpoint_locations.go
@@ -21,7 +21,7 @@ func EndpointLocations() *schema.Table {
 		Description: `https://cloud.google.com/api-gateway/docs/reference/rest/v1/projects.locations#Location`,
 		Resolver:    fetchEndpointLocations,
 		Multiplex:   client.ProjectMultiplexEnabledServices("aiplatform.googleapis.com"),
-		Transform:   transformers.TransformWithStruct(&pb.Location{}, append(client.Options(), transformers.WithPrimaryKeys("Name"))...),
+		Transform:   client.TransformWithStruct(&pb.Location{}, transformers.WithPrimaryKeys("Name")),
 		Columns: []schema.Column{
 			{
 				Name:     "project_id",

--- a/plugins/source/gcp/resources/services/aiplatform/endpoints.go
+++ b/plugins/source/gcp/resources/services/aiplatform/endpoints.go
@@ -23,7 +23,7 @@ func Endpoints() *schema.Table {
 		Description: `https://cloud.google.com/vertex-ai/docs/reference/rest/v1/projects.locations.endpoints#Endpoint`,
 		Resolver:    fetchEndpoints,
 		Multiplex:   client.ProjectMultiplexEnabledServices("aiplatform.googleapis.com"),
-		Transform:   transformers.TransformWithStruct(&pb.Endpoint{}, append(client.Options(), transformers.WithPrimaryKeys("Name"))...),
+		Transform:   client.TransformWithStruct(&pb.Endpoint{}, transformers.WithPrimaryKeys("Name")),
 		Columns: []schema.Column{
 			{
 				Name:     "project_id",

--- a/plugins/source/gcp/resources/services/aiplatform/featurestore_locations.go
+++ b/plugins/source/gcp/resources/services/aiplatform/featurestore_locations.go
@@ -21,7 +21,7 @@ func FeaturestoreLocations() *schema.Table {
 		Description: `https://cloud.google.com/api-gateway/docs/reference/rest/v1/projects.locations#Location`,
 		Resolver:    fetchFeaturestoreLocations,
 		Multiplex:   client.ProjectMultiplexEnabledServices("aiplatform.googleapis.com"),
-		Transform:   transformers.TransformWithStruct(&pb.Location{}, append(client.Options(), transformers.WithPrimaryKeys("Name"))...),
+		Transform:   client.TransformWithStruct(&pb.Location{}, transformers.WithPrimaryKeys("Name")),
 		Columns: []schema.Column{
 			{
 				Name:     "project_id",

--- a/plugins/source/gcp/resources/services/aiplatform/featurestores.go
+++ b/plugins/source/gcp/resources/services/aiplatform/featurestores.go
@@ -23,7 +23,7 @@ func Featurestores() *schema.Table {
 		Description: `https://cloud.google.com/vertex-ai/docs/reference/rest/v1/projects.locations.featurestores#Featurestore`,
 		Resolver:    fetchFeaturestores,
 		Multiplex:   client.ProjectMultiplexEnabledServices("aiplatform.googleapis.com"),
-		Transform:   transformers.TransformWithStruct(&pb.Featurestore{}, append(client.Options(), transformers.WithPrimaryKeys("Name"))...),
+		Transform:   client.TransformWithStruct(&pb.Featurestore{}, transformers.WithPrimaryKeys("Name")),
 		Columns: []schema.Column{
 			{
 				Name:     "project_id",

--- a/plugins/source/gcp/resources/services/aiplatform/hyperparameter_tuning_jobs.go
+++ b/plugins/source/gcp/resources/services/aiplatform/hyperparameter_tuning_jobs.go
@@ -23,7 +23,7 @@ func HyperparameterTuningJobs() *schema.Table {
 		Description: `https://cloud.google.com/vertex-ai/docs/reference/rest/v1/projects.locations.hyperparameterTuningJobs#HyperparameterTuningJob`,
 		Resolver:    fetchHyperparameterTuningJobs,
 		Multiplex:   client.ProjectMultiplexEnabledServices("aiplatform.googleapis.com"),
-		Transform:   transformers.TransformWithStruct(&pb.HyperparameterTuningJob{}, append(client.Options(), transformers.WithPrimaryKeys("Name"))...),
+		Transform:   client.TransformWithStruct(&pb.HyperparameterTuningJob{}, transformers.WithPrimaryKeys("Name")),
 		Columns: []schema.Column{
 			{
 				Name:     "project_id",

--- a/plugins/source/gcp/resources/services/aiplatform/index_endpoints.go
+++ b/plugins/source/gcp/resources/services/aiplatform/index_endpoints.go
@@ -23,7 +23,7 @@ func IndexEndpoints() *schema.Table {
 		Description: `https://cloud.google.com/vertex-ai/docs/reference/rest/v1/projects.locations.indexEndpoints#IndexEndpoint`,
 		Resolver:    fetchIndexEndpoints,
 		Multiplex:   client.ProjectMultiplexEnabledServices("aiplatform.googleapis.com"),
-		Transform:   transformers.TransformWithStruct(&pb.IndexEndpoint{}, append(client.Options(), transformers.WithPrimaryKeys("Name"))...),
+		Transform:   client.TransformWithStruct(&pb.IndexEndpoint{}, transformers.WithPrimaryKeys("Name")),
 		Columns: []schema.Column{
 			{
 				Name:     "project_id",

--- a/plugins/source/gcp/resources/services/aiplatform/index_locations.go
+++ b/plugins/source/gcp/resources/services/aiplatform/index_locations.go
@@ -21,7 +21,7 @@ func IndexLocations() *schema.Table {
 		Description: `https://cloud.google.com/api-gateway/docs/reference/rest/v1/projects.locations#Location`,
 		Resolver:    fetchIndexLocations,
 		Multiplex:   client.ProjectMultiplexEnabledServices("aiplatform.googleapis.com"),
-		Transform:   transformers.TransformWithStruct(&pb.Location{}, append(client.Options(), transformers.WithPrimaryKeys("Name"))...),
+		Transform:   client.TransformWithStruct(&pb.Location{}, transformers.WithPrimaryKeys("Name")),
 		Columns: []schema.Column{
 			{
 				Name:     "project_id",

--- a/plugins/source/gcp/resources/services/aiplatform/indexendpoint_locations.go
+++ b/plugins/source/gcp/resources/services/aiplatform/indexendpoint_locations.go
@@ -21,7 +21,7 @@ func IndexendpointLocations() *schema.Table {
 		Description: `https://cloud.google.com/api-gateway/docs/reference/rest/v1/projects.locations#Location`,
 		Resolver:    fetchIndexendpointLocations,
 		Multiplex:   client.ProjectMultiplexEnabledServices("aiplatform.googleapis.com"),
-		Transform:   transformers.TransformWithStruct(&pb.Location{}, append(client.Options(), transformers.WithPrimaryKeys("Name"))...),
+		Transform:   client.TransformWithStruct(&pb.Location{}, transformers.WithPrimaryKeys("Name")),
 		Columns: []schema.Column{
 			{
 				Name:     "project_id",

--- a/plugins/source/gcp/resources/services/aiplatform/indexes.go
+++ b/plugins/source/gcp/resources/services/aiplatform/indexes.go
@@ -23,7 +23,7 @@ func Indexes() *schema.Table {
 		Description: `https://cloud.google.com/vertex-ai/docs/reference/rest/v1/projects.locations.indexes#Index`,
 		Resolver:    fetchIndexes,
 		Multiplex:   client.ProjectMultiplexEnabledServices("aiplatform.googleapis.com"),
-		Transform:   transformers.TransformWithStruct(&pb.Index{}, append(client.Options(), transformers.WithPrimaryKeys("Name"))...),
+		Transform:   client.TransformWithStruct(&pb.Index{}, transformers.WithPrimaryKeys("Name")),
 		Columns: []schema.Column{
 			{
 				Name:     "project_id",

--- a/plugins/source/gcp/resources/services/aiplatform/job_locations.go
+++ b/plugins/source/gcp/resources/services/aiplatform/job_locations.go
@@ -21,7 +21,7 @@ func JobLocations() *schema.Table {
 		Description: `https://cloud.google.com/api-gateway/docs/reference/rest/v1/projects.locations#Location`,
 		Resolver:    fetchJobLocations,
 		Multiplex:   client.ProjectMultiplexEnabledServices("aiplatform.googleapis.com"),
-		Transform:   transformers.TransformWithStruct(&pb.Location{}, append(client.Options(), transformers.WithPrimaryKeys("Name"))...),
+		Transform:   client.TransformWithStruct(&pb.Location{}, transformers.WithPrimaryKeys("Name")),
 		Columns: []schema.Column{
 			{
 				Name:     "project_id",

--- a/plugins/source/gcp/resources/services/aiplatform/metadata_locations.go
+++ b/plugins/source/gcp/resources/services/aiplatform/metadata_locations.go
@@ -21,7 +21,7 @@ func MetadataLocations() *schema.Table {
 		Description: `https://cloud.google.com/api-gateway/docs/reference/rest/v1/projects.locations#Location`,
 		Resolver:    fetchMetadataLocations,
 		Multiplex:   client.ProjectMultiplexEnabledServices("aiplatform.googleapis.com"),
-		Transform:   transformers.TransformWithStruct(&pb.Location{}, append(client.Options(), transformers.WithPrimaryKeys("Name"))...),
+		Transform:   client.TransformWithStruct(&pb.Location{}, transformers.WithPrimaryKeys("Name")),
 		Columns: []schema.Column{
 			{
 				Name:     "project_id",

--- a/plugins/source/gcp/resources/services/aiplatform/metadata_stores.go
+++ b/plugins/source/gcp/resources/services/aiplatform/metadata_stores.go
@@ -23,7 +23,7 @@ func MetadataStores() *schema.Table {
 		Description: `https://cloud.google.com/vertex-ai/docs/reference/rest/v1/projects.locations.metadataStores#MetadataStore`,
 		Resolver:    fetchMetadataStores,
 		Multiplex:   client.ProjectMultiplexEnabledServices("aiplatform.googleapis.com"),
-		Transform:   transformers.TransformWithStruct(&pb.MetadataStore{}, append(client.Options(), transformers.WithPrimaryKeys("Name"))...),
+		Transform:   client.TransformWithStruct(&pb.MetadataStore{}, transformers.WithPrimaryKeys("Name")),
 		Columns: []schema.Column{
 			{
 				Name:     "project_id",

--- a/plugins/source/gcp/resources/services/aiplatform/model_deployment_monitoring_jobs.go
+++ b/plugins/source/gcp/resources/services/aiplatform/model_deployment_monitoring_jobs.go
@@ -23,7 +23,7 @@ func ModelDeploymentMonitoringJobs() *schema.Table {
 		Description: `https://cloud.google.com/vertex-ai/docs/reference/rest/v1/projects.locations.modelDeploymentMonitoringJobs#ModelDeploymentMonitoringJob`,
 		Resolver:    fetchModelDeploymentMonitoringJobs,
 		Multiplex:   client.ProjectMultiplexEnabledServices("aiplatform.googleapis.com"),
-		Transform:   transformers.TransformWithStruct(&pb.ModelDeploymentMonitoringJob{}, append(client.Options(), transformers.WithPrimaryKeys("Name"))...),
+		Transform:   client.TransformWithStruct(&pb.ModelDeploymentMonitoringJob{}, transformers.WithPrimaryKeys("Name")),
 		Columns: []schema.Column{
 			{
 				Name:     "project_id",

--- a/plugins/source/gcp/resources/services/aiplatform/model_locations.go
+++ b/plugins/source/gcp/resources/services/aiplatform/model_locations.go
@@ -21,7 +21,7 @@ func ModelLocations() *schema.Table {
 		Description: `https://cloud.google.com/api-gateway/docs/reference/rest/v1/projects.locations#Location`,
 		Resolver:    fetchModelLocations,
 		Multiplex:   client.ProjectMultiplexEnabledServices("aiplatform.googleapis.com"),
-		Transform:   transformers.TransformWithStruct(&pb.Location{}, append(client.Options(), transformers.WithPrimaryKeys("Name"))...),
+		Transform:   client.TransformWithStruct(&pb.Location{}, transformers.WithPrimaryKeys("Name")),
 		Columns: []schema.Column{
 			{
 				Name:     "project_id",

--- a/plugins/source/gcp/resources/services/aiplatform/models.go
+++ b/plugins/source/gcp/resources/services/aiplatform/models.go
@@ -23,7 +23,7 @@ func Models() *schema.Table {
 		Description: `https://cloud.google.com/vertex-ai/docs/reference/rest/v1/projects.locations.models#Model`,
 		Resolver:    fetchModels,
 		Multiplex:   client.ProjectMultiplexEnabledServices("aiplatform.googleapis.com"),
-		Transform:   transformers.TransformWithStruct(&pb.Model{}, append(client.Options(), transformers.WithSkipFields("Metadata"), transformers.WithPrimaryKeys("Name"))...),
+		Transform:   client.TransformWithStruct(&pb.Model{}, transformers.WithSkipFields("Metadata"), transformers.WithPrimaryKeys("Name")),
 		Columns: []schema.Column{
 			{
 				Name:     "project_id",

--- a/plugins/source/gcp/resources/services/aiplatform/operations.go
+++ b/plugins/source/gcp/resources/services/aiplatform/operations.go
@@ -21,7 +21,7 @@ func Operations() *schema.Table {
 		Description: `https://cloud.google.com/vertex-ai/docs/reference/rest/v1/projects.locations.operations#Operation`,
 		Resolver:    fetchOperations,
 		Multiplex:   client.ProjectMultiplexEnabledServices("aiplatform.googleapis.com"),
-		Transform:   transformers.TransformWithStruct(&pb.Operation{}, append(client.Options(), transformers.WithPrimaryKeys("Name"))...),
+		Transform:   client.TransformWithStruct(&pb.Operation{}, transformers.WithPrimaryKeys("Name")),
 		Columns: []schema.Column{
 			{
 				Name:     "project_id",

--- a/plugins/source/gcp/resources/services/aiplatform/pipeline_jobs.go
+++ b/plugins/source/gcp/resources/services/aiplatform/pipeline_jobs.go
@@ -23,7 +23,7 @@ func PipelineJobs() *schema.Table {
 		Description: `https://cloud.google.com/vertex-ai/docs/reference/rest/v1/projects.locations.pipelineJobs#PipelineJob`,
 		Resolver:    fetchPipelineJobs,
 		Multiplex:   client.ProjectMultiplexEnabledServices("aiplatform.googleapis.com"),
-		Transform:   transformers.TransformWithStruct(&pb.PipelineJob{}, append(client.Options(), transformers.WithPrimaryKeys("Name"))...),
+		Transform:   client.TransformWithStruct(&pb.PipelineJob{}, transformers.WithPrimaryKeys("Name")),
 		Columns: []schema.Column{
 			{
 				Name:     "project_id",

--- a/plugins/source/gcp/resources/services/aiplatform/pipeline_locations.go
+++ b/plugins/source/gcp/resources/services/aiplatform/pipeline_locations.go
@@ -21,7 +21,7 @@ func PipelineLocations() *schema.Table {
 		Description: `https://cloud.google.com/api-gateway/docs/reference/rest/v1/projects.locations#Location`,
 		Resolver:    fetchPipelineLocations,
 		Multiplex:   client.ProjectMultiplexEnabledServices("aiplatform.googleapis.com"),
-		Transform:   transformers.TransformWithStruct(&pb.Location{}, append(client.Options(), transformers.WithPrimaryKeys("Name"))...),
+		Transform:   client.TransformWithStruct(&pb.Location{}, transformers.WithPrimaryKeys("Name")),
 		Columns: []schema.Column{
 			{
 				Name:     "project_id",

--- a/plugins/source/gcp/resources/services/aiplatform/specialist_pools.go
+++ b/plugins/source/gcp/resources/services/aiplatform/specialist_pools.go
@@ -23,7 +23,7 @@ func SpecialistPools() *schema.Table {
 		Description: `https://cloud.google.com/vertex-ai/docs/reference/rest/v1/projects.locations.specialistPools#SpecialistPool`,
 		Resolver:    fetchSpecialistPools,
 		Multiplex:   client.ProjectMultiplexEnabledServices("aiplatform.googleapis.com"),
-		Transform:   transformers.TransformWithStruct(&pb.SpecialistPool{}, append(client.Options(), transformers.WithPrimaryKeys("Name"))...),
+		Transform:   client.TransformWithStruct(&pb.SpecialistPool{}, transformers.WithPrimaryKeys("Name")),
 		Columns: []schema.Column{
 			{
 				Name:     "project_id",

--- a/plugins/source/gcp/resources/services/aiplatform/specialistpool_locations.go
+++ b/plugins/source/gcp/resources/services/aiplatform/specialistpool_locations.go
@@ -21,7 +21,7 @@ func SpecialistpoolLocations() *schema.Table {
 		Description: `https://cloud.google.com/api-gateway/docs/reference/rest/v1/projects.locations#Location`,
 		Resolver:    fetchSpecialistpoolLocations,
 		Multiplex:   client.ProjectMultiplexEnabledServices("aiplatform.googleapis.com"),
-		Transform:   transformers.TransformWithStruct(&pb.Location{}, append(client.Options(), transformers.WithPrimaryKeys("Name"))...),
+		Transform:   client.TransformWithStruct(&pb.Location{}, transformers.WithPrimaryKeys("Name")),
 		Columns: []schema.Column{
 			{
 				Name:     "project_id",

--- a/plugins/source/gcp/resources/services/aiplatform/studies.go
+++ b/plugins/source/gcp/resources/services/aiplatform/studies.go
@@ -23,7 +23,7 @@ func Studies() *schema.Table {
 		Description: `https://cloud.google.com/vertex-ai/docs/reference/rest/v1/projects.locations.studies#Study`,
 		Resolver:    fetchStudies,
 		Multiplex:   client.ProjectMultiplexEnabledServices("aiplatform.googleapis.com"),
-		Transform:   transformers.TransformWithStruct(&pb.Study{}, append(client.Options(), transformers.WithPrimaryKeys("Name"))...),
+		Transform:   client.TransformWithStruct(&pb.Study{}, transformers.WithPrimaryKeys("Name")),
 		Columns: []schema.Column{
 			{
 				Name:     "project_id",

--- a/plugins/source/gcp/resources/services/aiplatform/tensorboard_locations.go
+++ b/plugins/source/gcp/resources/services/aiplatform/tensorboard_locations.go
@@ -21,7 +21,7 @@ func TensorboardLocations() *schema.Table {
 		Description: `https://cloud.google.com/api-gateway/docs/reference/rest/v1/projects.locations#Location`,
 		Resolver:    fetchTensorboardLocations,
 		Multiplex:   client.ProjectMultiplexEnabledServices("aiplatform.googleapis.com"),
-		Transform:   transformers.TransformWithStruct(&pb.Location{}, append(client.Options(), transformers.WithPrimaryKeys("Name"))...),
+		Transform:   client.TransformWithStruct(&pb.Location{}, transformers.WithPrimaryKeys("Name")),
 		Columns: []schema.Column{
 			{
 				Name:     "project_id",

--- a/plugins/source/gcp/resources/services/aiplatform/tensorboards.go
+++ b/plugins/source/gcp/resources/services/aiplatform/tensorboards.go
@@ -23,7 +23,7 @@ func Tensorboards() *schema.Table {
 		Description: `https://cloud.google.com/vertex-ai/docs/reference/rest/v1/projects.locations.tensorboards#Tensorboard`,
 		Resolver:    fetchTensorboards,
 		Multiplex:   client.ProjectMultiplexEnabledServices("aiplatform.googleapis.com"),
-		Transform:   transformers.TransformWithStruct(&pb.Tensorboard{}, append(client.Options(), transformers.WithPrimaryKeys("Name"))...),
+		Transform:   client.TransformWithStruct(&pb.Tensorboard{}, transformers.WithPrimaryKeys("Name")),
 		Columns: []schema.Column{
 			{
 				Name:     "project_id",

--- a/plugins/source/gcp/resources/services/aiplatform/training_pipelines.go
+++ b/plugins/source/gcp/resources/services/aiplatform/training_pipelines.go
@@ -23,7 +23,7 @@ func TrainingPipelines() *schema.Table {
 		Description: `https://cloud.google.com/vertex-ai/docs/reference/rest/v1/projects.locations.trainingPipelines#TrainingPipeline`,
 		Resolver:    fetchTrainingPipelines,
 		Multiplex:   client.ProjectMultiplexEnabledServices("aiplatform.googleapis.com"),
-		Transform:   transformers.TransformWithStruct(&pb.TrainingPipeline{}, append(client.Options(), transformers.WithPrimaryKeys("Name"))...),
+		Transform:   client.TransformWithStruct(&pb.TrainingPipeline{}, transformers.WithPrimaryKeys("Name")),
 		Columns: []schema.Column{
 			{
 				Name:     "project_id",

--- a/plugins/source/gcp/resources/services/aiplatform/vizier_locations.go
+++ b/plugins/source/gcp/resources/services/aiplatform/vizier_locations.go
@@ -21,7 +21,7 @@ func VizierLocations() *schema.Table {
 		Description: `https://cloud.google.com/api-gateway/docs/reference/rest/v1/projects.locations#Location`,
 		Resolver:    fetchVizierLocations,
 		Multiplex:   client.ProjectMultiplexEnabledServices("aiplatform.googleapis.com"),
-		Transform:   transformers.TransformWithStruct(&pb.Location{}, append(client.Options(), transformers.WithPrimaryKeys("Name"))...),
+		Transform:   client.TransformWithStruct(&pb.Location{}, transformers.WithPrimaryKeys("Name")),
 		Columns: []schema.Column{
 			{
 				Name:     "project_id",

--- a/plugins/source/gcp/resources/services/apigateway/apis.go
+++ b/plugins/source/gcp/resources/services/apigateway/apis.go
@@ -19,7 +19,7 @@ func Apis() *schema.Table {
 		Description: `https://cloud.google.com/api-gateway/docs/reference/rest/v1/projects.locations.apis#Api`,
 		Resolver:    fetchApis,
 		Multiplex:   client.ProjectMultiplexEnabledServices("apigateway.googleapis.com"),
-		Transform:   transformers.TransformWithStruct(&pb.Api{}, append(client.Options(), transformers.WithPrimaryKeys("Name"))...),
+		Transform:   client.TransformWithStruct(&pb.Api{}, transformers.WithPrimaryKeys("Name")),
 		Columns: []schema.Column{
 			{
 				Name:     "project_id",

--- a/plugins/source/gcp/resources/services/apigateway/gateways.go
+++ b/plugins/source/gcp/resources/services/apigateway/gateways.go
@@ -19,7 +19,7 @@ func Gateways() *schema.Table {
 		Description: `https://cloud.google.com/api-gateway/docs/reference/rest/v1/projects.locations.gateways#Gateway`,
 		Resolver:    fetchGateways,
 		Multiplex:   client.ProjectMultiplexEnabledServices("apigateway.googleapis.com"),
-		Transform:   transformers.TransformWithStruct(&pb.Gateway{}, append(client.Options(), transformers.WithPrimaryKeys("Name"))...),
+		Transform:   client.TransformWithStruct(&pb.Gateway{}, transformers.WithPrimaryKeys("Name")),
 		Columns: []schema.Column{
 			{
 				Name:     "project_id",

--- a/plugins/source/gcp/resources/services/apikeys/keys.go
+++ b/plugins/source/gcp/resources/services/apikeys/keys.go
@@ -19,7 +19,7 @@ func Keys() *schema.Table {
 		Description: `https://cloud.google.com/api-keys/docs/reference/rest/v2/projects.locations.keys#Key`,
 		Resolver:    fetchKeys,
 		Multiplex:   client.ProjectMultiplexEnabledServices("apikeys.googleapis.com"),
-		Transform:   transformers.TransformWithStruct(&pb.Key{}, append(client.Options(), transformers.WithPrimaryKeys("Uid"))...),
+		Transform:   client.TransformWithStruct(&pb.Key{}, transformers.WithPrimaryKeys("Uid")),
 		Columns: []schema.Column{
 			{
 				Name:     "project_id",

--- a/plugins/source/gcp/resources/services/appengine/apps.go
+++ b/plugins/source/gcp/resources/services/appengine/apps.go
@@ -13,7 +13,7 @@ func Apps() *schema.Table {
 		Description: `https://cloud.google.com/appengine/docs/admin-api/reference/rest/v1/apps#Application`,
 		Resolver:    fetchApps,
 		Multiplex:   client.ProjectMultiplexEnabledServices("appengine.googleapis.com"),
-		Transform:   transformers.TransformWithStruct(&pb.Application{}, append(client.Options(), transformers.WithPrimaryKeys("Name"))...),
+		Transform:   client.TransformWithStruct(&pb.Application{}, transformers.WithPrimaryKeys("Name")),
 		Columns: []schema.Column{
 			{
 				Name:     "project_id",

--- a/plugins/source/gcp/resources/services/appengine/authorized_certificates.go
+++ b/plugins/source/gcp/resources/services/appengine/authorized_certificates.go
@@ -19,7 +19,7 @@ func AuthorizedCertificates() *schema.Table {
 		Description: `https://cloud.google.com/appengine/docs/admin-api/reference/rest/v1/apps.authorizedCertificates#AuthorizedCertificate`,
 		Resolver:    fetchAuthorizedCertificates,
 		Multiplex:   client.ProjectMultiplexEnabledServices("appengine.googleapis.com"),
-		Transform:   transformers.TransformWithStruct(&pb.AuthorizedCertificate{}, append(client.Options(), transformers.WithPrimaryKeys("Name"))...),
+		Transform:   client.TransformWithStruct(&pb.AuthorizedCertificate{}, transformers.WithPrimaryKeys("Name")),
 		Columns: []schema.Column{
 			{
 				Name:     "project_id",

--- a/plugins/source/gcp/resources/services/appengine/authorized_domains.go
+++ b/plugins/source/gcp/resources/services/appengine/authorized_domains.go
@@ -19,7 +19,7 @@ func AuthorizedDomains() *schema.Table {
 		Description: `https://cloud.google.com/appengine/docs/admin-api/reference/rest/v1/apps.authorizedDomains#AuthorizedDomain`,
 		Resolver:    fetchAuthorizedDomains,
 		Multiplex:   client.ProjectMultiplexEnabledServices("appengine.googleapis.com"),
-		Transform:   transformers.TransformWithStruct(&pb.AuthorizedDomain{}, append(client.Options(), transformers.WithPrimaryKeys("Name"))...),
+		Transform:   client.TransformWithStruct(&pb.AuthorizedDomain{}, transformers.WithPrimaryKeys("Name")),
 		Columns: []schema.Column{
 			{
 				Name:     "project_id",

--- a/plugins/source/gcp/resources/services/appengine/domain_mappings.go
+++ b/plugins/source/gcp/resources/services/appengine/domain_mappings.go
@@ -19,7 +19,7 @@ func DomainMappings() *schema.Table {
 		Description: `https://cloud.google.com/appengine/docs/admin-api/reference/rest/v1/apps.domainMappings#DomainMapping`,
 		Resolver:    fetchDomainMappings,
 		Multiplex:   client.ProjectMultiplexEnabledServices("appengine.googleapis.com"),
-		Transform:   transformers.TransformWithStruct(&pb.DomainMapping{}, append(client.Options(), transformers.WithPrimaryKeys("Name"))...),
+		Transform:   client.TransformWithStruct(&pb.DomainMapping{}, transformers.WithPrimaryKeys("Name")),
 		Columns: []schema.Column{
 			{
 				Name:     "project_id",

--- a/plugins/source/gcp/resources/services/appengine/firewall_ingress_rules.go
+++ b/plugins/source/gcp/resources/services/appengine/firewall_ingress_rules.go
@@ -7,7 +7,6 @@ import (
 
 	pb "cloud.google.com/go/appengine/apiv1/appenginepb"
 	"github.com/cloudquery/plugin-sdk/schema"
-	"github.com/cloudquery/plugin-sdk/transformers"
 	"github.com/cloudquery/plugins/source/gcp/client"
 
 	appengine "cloud.google.com/go/appengine/apiv1"
@@ -19,7 +18,7 @@ func FirewallIngressRules() *schema.Table {
 		Description: `https://cloud.google.com/appengine/docs/admin-api/reference/rest/v1/apps.firewall.ingressRules#FirewallRule`,
 		Resolver:    fetchFirewallIngressRules,
 		Multiplex:   client.ProjectMultiplexEnabledServices("appengine.googleapis.com"),
-		Transform:   transformers.TransformWithStruct(&pb.FirewallRule{}, client.Options()...),
+		Transform:   client.TransformWithStruct(&pb.FirewallRule{}),
 		Columns: []schema.Column{
 			{
 				Name:     "project_id",

--- a/plugins/source/gcp/resources/services/appengine/instances.go
+++ b/plugins/source/gcp/resources/services/appengine/instances.go
@@ -19,7 +19,7 @@ func Instances() *schema.Table {
 		Description: `https://cloud.google.com/appengine/docs/admin-api/reference/rest/v1/apps.services.versions.instances#Instance`,
 		Resolver:    fetchInstances,
 		Multiplex:   client.ProjectMultiplexEnabledServices("appengine.googleapis.com"),
-		Transform:   transformers.TransformWithStruct(&pb.Instance{}, append(client.Options(), transformers.WithPrimaryKeys("Name"))...),
+		Transform:   client.TransformWithStruct(&pb.Instance{}, transformers.WithPrimaryKeys("Name")),
 		Columns: []schema.Column{
 			{
 				Name:     "project_id",

--- a/plugins/source/gcp/resources/services/appengine/services.go
+++ b/plugins/source/gcp/resources/services/appengine/services.go
@@ -19,7 +19,7 @@ func Services() *schema.Table {
 		Description: `https://cloud.google.com/appengine/docs/admin-api/reference/rest/v1/apps.services#Service`,
 		Resolver:    fetchServices,
 		Multiplex:   client.ProjectMultiplexEnabledServices("appengine.googleapis.com"),
-		Transform:   transformers.TransformWithStruct(&pb.Service{}, append(client.Options(), transformers.WithPrimaryKeys("Name"))...),
+		Transform:   client.TransformWithStruct(&pb.Service{}, transformers.WithPrimaryKeys("Name")),
 		Columns: []schema.Column{
 			{
 				Name:     "project_id",

--- a/plugins/source/gcp/resources/services/appengine/versions.go
+++ b/plugins/source/gcp/resources/services/appengine/versions.go
@@ -19,7 +19,7 @@ func Versions() *schema.Table {
 		Description: `https://cloud.google.com/appengine/docs/admin-api/reference/rest/v1/apps.services.versions#Version`,
 		Resolver:    fetchVersions,
 		Multiplex:   client.ProjectMultiplexEnabledServices("appengine.googleapis.com"),
-		Transform:   transformers.TransformWithStruct(&pb.Version{}, append(client.Options(), transformers.WithPrimaryKeys("Name"))...),
+		Transform:   client.TransformWithStruct(&pb.Version{}, transformers.WithPrimaryKeys("Name")),
 		Columns: []schema.Column{
 			{
 				Name:     "project_id",

--- a/plugins/source/gcp/resources/services/artifactregistry/docker_images.go
+++ b/plugins/source/gcp/resources/services/artifactregistry/docker_images.go
@@ -19,7 +19,7 @@ func DockerImages() *schema.Table {
 		Description: `https://cloud.google.com/artifact-registry/docs/reference/rest/v1/projects.locations.repositories.dockerImages#DockerImage`,
 		Resolver:    fetchDockerImages,
 		Multiplex:   client.ProjectMultiplexEnabledServices("artifactregistry.googleapis.com"),
-		Transform:   transformers.TransformWithStruct(&pb.DockerImage{}, append(client.Options(), transformers.WithPrimaryKeys("Name"))...),
+		Transform:   client.TransformWithStruct(&pb.DockerImage{}, transformers.WithPrimaryKeys("Name")),
 		Columns: []schema.Column{
 			{
 				Name:     "project_id",

--- a/plugins/source/gcp/resources/services/artifactregistry/files.go
+++ b/plugins/source/gcp/resources/services/artifactregistry/files.go
@@ -19,7 +19,7 @@ func Files() *schema.Table {
 		Description: `https://cloud.google.com/artifact-registry/docs/reference/rest/v1/projects.locations.repositories.files#File`,
 		Resolver:    fetchFiles,
 		Multiplex:   client.ProjectMultiplexEnabledServices("artifactregistry.googleapis.com"),
-		Transform:   transformers.TransformWithStruct(&pb.File{}, append(client.Options(), transformers.WithPrimaryKeys("Name"))...),
+		Transform:   client.TransformWithStruct(&pb.File{}, transformers.WithPrimaryKeys("Name")),
 		Columns: []schema.Column{
 			{
 				Name:     "project_id",

--- a/plugins/source/gcp/resources/services/artifactregistry/locations.go
+++ b/plugins/source/gcp/resources/services/artifactregistry/locations.go
@@ -13,7 +13,7 @@ func Locations() *schema.Table {
 		Description: `https://cloud.google.com/artifact-registry/docs/reference/rest/Shared.Types/ListLocationsResponse#Location`,
 		Resolver:    fetchLocations,
 		Multiplex:   client.ProjectMultiplexEnabledServices("artifactregistry.googleapis.com"),
-		Transform:   transformers.TransformWithStruct(&pb.Location{}, append(client.Options(), transformers.WithPrimaryKeys("Name"))...),
+		Transform:   client.TransformWithStruct(&pb.Location{}, transformers.WithPrimaryKeys("Name")),
 		Columns: []schema.Column{
 			{
 				Name:     "project_id",

--- a/plugins/source/gcp/resources/services/artifactregistry/packages.go
+++ b/plugins/source/gcp/resources/services/artifactregistry/packages.go
@@ -19,7 +19,7 @@ func Packages() *schema.Table {
 		Description: `https://cloud.google.com/artifact-registry/docs/reference/rest/v1/projects.locations.repositories.packages#Package`,
 		Resolver:    fetchPackages,
 		Multiplex:   client.ProjectMultiplexEnabledServices("artifactregistry.googleapis.com"),
-		Transform:   transformers.TransformWithStruct(&pb.Package{}, append(client.Options(), transformers.WithPrimaryKeys("Name"))...),
+		Transform:   client.TransformWithStruct(&pb.Package{}, transformers.WithPrimaryKeys("Name")),
 		Columns: []schema.Column{
 			{
 				Name:     "project_id",

--- a/plugins/source/gcp/resources/services/artifactregistry/repositories.go
+++ b/plugins/source/gcp/resources/services/artifactregistry/repositories.go
@@ -13,7 +13,7 @@ func Repositories() *schema.Table {
 		Description: `https://cloud.google.com/artifact-registry/docs/reference/rest/v1/projects.locations.repositories#Repository`,
 		Resolver:    fetchRepositories,
 		Multiplex:   client.ProjectMultiplexEnabledServices("artifactregistry.googleapis.com"),
-		Transform:   transformers.TransformWithStruct(&pb.Repository{}, append(client.Options(), transformers.WithPrimaryKeys("Name"))...),
+		Transform:   client.TransformWithStruct(&pb.Repository{}, transformers.WithPrimaryKeys("Name")),
 		Columns: []schema.Column{
 			{
 				Name:     "project_id",

--- a/plugins/source/gcp/resources/services/artifactregistry/tags.go
+++ b/plugins/source/gcp/resources/services/artifactregistry/tags.go
@@ -19,7 +19,7 @@ func Tags() *schema.Table {
 		Description: `https://cloud.google.com/artifact-registry/docs/reference/rest/v1/projects.locations.repositories.packages.tags#Tag`,
 		Resolver:    fetchTags,
 		Multiplex:   client.ProjectMultiplexEnabledServices("artifactregistry.googleapis.com"),
-		Transform:   transformers.TransformWithStruct(&pb.Tag{}, append(client.Options(), transformers.WithPrimaryKeys("Name"))...),
+		Transform:   client.TransformWithStruct(&pb.Tag{}, transformers.WithPrimaryKeys("Name")),
 		Columns: []schema.Column{
 			{
 				Name:     "project_id",

--- a/plugins/source/gcp/resources/services/artifactregistry/versions.go
+++ b/plugins/source/gcp/resources/services/artifactregistry/versions.go
@@ -19,7 +19,7 @@ func Versions() *schema.Table {
 		Description: `https://cloud.google.com/artifact-registry/docs/reference/rest/v1/projects.locations.repositories.packages.versions#Version`,
 		Resolver:    fetchVersions,
 		Multiplex:   client.ProjectMultiplexEnabledServices("artifactregistry.googleapis.com"),
-		Transform:   transformers.TransformWithStruct(&pb.Version{}, append(client.Options(), transformers.WithPrimaryKeys("Name"))...),
+		Transform:   client.TransformWithStruct(&pb.Version{}, transformers.WithPrimaryKeys("Name")),
 		Columns: []schema.Column{
 			{
 				Name:     "project_id",

--- a/plugins/source/gcp/resources/services/baremetalsolution/instances.go
+++ b/plugins/source/gcp/resources/services/baremetalsolution/instances.go
@@ -19,7 +19,7 @@ func Instances() *schema.Table {
 		Description: `https://cloud.google.com/bare-metal/docs/reference/rest/v2/projects.locations.instances#Instance`,
 		Resolver:    fetchInstances,
 		Multiplex:   client.ProjectMultiplexEnabledServices("baremetalsolution.googleapis.com"),
-		Transform:   transformers.TransformWithStruct(&pb.Instance{}, append(client.Options(), transformers.WithPrimaryKeys("Name"))...),
+		Transform:   client.TransformWithStruct(&pb.Instance{}, transformers.WithPrimaryKeys("Name")),
 		Columns: []schema.Column{
 			{
 				Name:     "project_id",

--- a/plugins/source/gcp/resources/services/baremetalsolution/networks.go
+++ b/plugins/source/gcp/resources/services/baremetalsolution/networks.go
@@ -19,7 +19,7 @@ func Networks() *schema.Table {
 		Description: `https://cloud.google.com/bare-metal/docs/reference/rest/v2/projects.locations.networks#Network`,
 		Resolver:    fetchNetworks,
 		Multiplex:   client.ProjectMultiplexEnabledServices("baremetalsolution.googleapis.com"),
-		Transform:   transformers.TransformWithStruct(&pb.Network{}, append(client.Options(), transformers.WithPrimaryKeys("Name"))...),
+		Transform:   client.TransformWithStruct(&pb.Network{}, transformers.WithPrimaryKeys("Name")),
 		Columns: []schema.Column{
 			{
 				Name:     "project_id",

--- a/plugins/source/gcp/resources/services/baremetalsolution/nfs_shares.go
+++ b/plugins/source/gcp/resources/services/baremetalsolution/nfs_shares.go
@@ -19,7 +19,7 @@ func NfsShares() *schema.Table {
 		Description: `https://cloud.google.com/bare-metal/docs/reference/rest/v2/projects.locations.nfsShares#NfsShare`,
 		Resolver:    fetchNfsShares,
 		Multiplex:   client.ProjectMultiplexEnabledServices("baremetalsolution.googleapis.com"),
-		Transform:   transformers.TransformWithStruct(&pb.NfsShare{}, append(client.Options(), transformers.WithPrimaryKeys("Name"))...),
+		Transform:   client.TransformWithStruct(&pb.NfsShare{}, transformers.WithPrimaryKeys("Name")),
 		Columns: []schema.Column{
 			{
 				Name:     "project_id",

--- a/plugins/source/gcp/resources/services/baremetalsolution/volume_luns.go
+++ b/plugins/source/gcp/resources/services/baremetalsolution/volume_luns.go
@@ -19,7 +19,7 @@ func VolumeLuns() *schema.Table {
 		Description: `https://cloud.google.com/bare-metal/docs/reference/rest/v2/projects.locations.volumes.luns#Lun`,
 		Resolver:    fetchVolumeLuns,
 		Multiplex:   client.ProjectMultiplexEnabledServices("baremetalsolution.googleapis.com"),
-		Transform:   transformers.TransformWithStruct(&pb.Lun{}, append(client.Options(), transformers.WithPrimaryKeys("Name"))...),
+		Transform:   client.TransformWithStruct(&pb.Lun{}, transformers.WithPrimaryKeys("Name")),
 		Columns: []schema.Column{
 			{
 				Name:     "project_id",

--- a/plugins/source/gcp/resources/services/baremetalsolution/volumes.go
+++ b/plugins/source/gcp/resources/services/baremetalsolution/volumes.go
@@ -19,7 +19,7 @@ func Volumes() *schema.Table {
 		Description: `https://cloud.google.com/bare-metal/docs/reference/rest/v2/projects.locations.volumes#Volume`,
 		Resolver:    fetchVolumes,
 		Multiplex:   client.ProjectMultiplexEnabledServices("baremetalsolution.googleapis.com"),
-		Transform:   transformers.TransformWithStruct(&pb.Volume{}, append(client.Options(), transformers.WithPrimaryKeys("Name"))...),
+		Transform:   client.TransformWithStruct(&pb.Volume{}, transformers.WithPrimaryKeys("Name")),
 		Columns: []schema.Column{
 			{
 				Name:     "project_id",

--- a/plugins/source/gcp/resources/services/batch/jobs.go
+++ b/plugins/source/gcp/resources/services/batch/jobs.go
@@ -19,7 +19,7 @@ func Jobs() *schema.Table {
 		Description: `https://cloud.google.com/batch/docs/reference/rest/v1/projects.locations.jobs#Job`,
 		Resolver:    fetchJobs,
 		Multiplex:   client.ProjectMultiplexEnabledServices("batch.googleapis.com"),
-		Transform:   transformers.TransformWithStruct(&pb.Job{}, append(client.Options(), transformers.WithPrimaryKeys("Name"))...),
+		Transform:   client.TransformWithStruct(&pb.Job{}, transformers.WithPrimaryKeys("Name")),
 		Columns: []schema.Column{
 			{
 				Name:     "project_id",

--- a/plugins/source/gcp/resources/services/batch/task_groups.go
+++ b/plugins/source/gcp/resources/services/batch/task_groups.go
@@ -19,7 +19,7 @@ func TaskGroups() *schema.Table {
 		Description: `https://cloud.google.com/batch/docs/reference/rest/v1/projects.locations.jobs#TaskGroup`,
 		Resolver:    fetchTaskGroups,
 		Multiplex:   client.ProjectMultiplexEnabledServices("batch.googleapis.com"),
-		Transform:   transformers.TransformWithStruct(&pb.TaskGroup{}, append(client.Options(), transformers.WithPrimaryKeys("Name"))...),
+		Transform:   client.TransformWithStruct(&pb.TaskGroup{}, transformers.WithPrimaryKeys("Name")),
 		Columns: []schema.Column{
 			{
 				Name:     "project_id",

--- a/plugins/source/gcp/resources/services/batch/tasks.go
+++ b/plugins/source/gcp/resources/services/batch/tasks.go
@@ -19,7 +19,7 @@ func Tasks() *schema.Table {
 		Description: `https://cloud.google.com/batch/docs/reference/rest/v1/projects.locations.jobs.taskGroups.tasks/list`,
 		Resolver:    fetchTasks,
 		Multiplex:   client.ProjectMultiplexEnabledServices("batch.googleapis.com"),
-		Transform:   transformers.TransformWithStruct(&pb.Task{}, append(client.Options(), transformers.WithPrimaryKeys("Name"))...),
+		Transform:   client.TransformWithStruct(&pb.Task{}, transformers.WithPrimaryKeys("Name")),
 		Columns: []schema.Column{
 			{
 				Name:     "project_id",

--- a/plugins/source/gcp/resources/services/beyondcorp/app_connections.go
+++ b/plugins/source/gcp/resources/services/beyondcorp/app_connections.go
@@ -19,7 +19,7 @@ func AppConnections() *schema.Table {
 		Description: `https://cloud.google.com/beyondcorp/docs/reference/rest/v1/projects.locations.appConnections#AppConnection`,
 		Resolver:    fetchAppConnections,
 		Multiplex:   client.ProjectMultiplexEnabledServices("beyondcorp.googleapis.com"),
-		Transform:   transformers.TransformWithStruct(&pb.AppConnection{}, append(client.Options(), transformers.WithPrimaryKeys("Name"))...),
+		Transform:   client.TransformWithStruct(&pb.AppConnection{}, transformers.WithPrimaryKeys("Name")),
 		Columns: []schema.Column{
 			{
 				Name:     "project_id",

--- a/plugins/source/gcp/resources/services/beyondcorp/app_connectors.go
+++ b/plugins/source/gcp/resources/services/beyondcorp/app_connectors.go
@@ -19,7 +19,7 @@ func AppConnectors() *schema.Table {
 		Description: `https://cloud.google.com/beyondcorp/docs/reference/rest/v1/projects.locations.appConnectors#AppConnector`,
 		Resolver:    fetchAppConnectors,
 		Multiplex:   client.ProjectMultiplexEnabledServices("beyondcorp.googleapis.com"),
-		Transform:   transformers.TransformWithStruct(&pb.AppConnector{}, append(client.Options(), transformers.WithPrimaryKeys("Name"))...),
+		Transform:   client.TransformWithStruct(&pb.AppConnector{}, transformers.WithPrimaryKeys("Name")),
 		Columns: []schema.Column{
 			{
 				Name:     "project_id",

--- a/plugins/source/gcp/resources/services/beyondcorp/app_gateways.go
+++ b/plugins/source/gcp/resources/services/beyondcorp/app_gateways.go
@@ -19,7 +19,7 @@ func AppGateways() *schema.Table {
 		Description: `https://cloud.google.com/beyondcorp/docs/reference/rest/v1/projects.locations.appGateways#AppGateway`,
 		Resolver:    fetchAppGateways,
 		Multiplex:   client.ProjectMultiplexEnabledServices("beyondcorp.googleapis.com"),
-		Transform:   transformers.TransformWithStruct(&pb.AppGateway{}, append(client.Options(), transformers.WithPrimaryKeys("Name"))...),
+		Transform:   client.TransformWithStruct(&pb.AppGateway{}, transformers.WithPrimaryKeys("Name")),
 		Columns: []schema.Column{
 			{
 				Name:     "project_id",

--- a/plugins/source/gcp/resources/services/beyondcorp/client_connector_services.go
+++ b/plugins/source/gcp/resources/services/beyondcorp/client_connector_services.go
@@ -19,7 +19,7 @@ func ClientConnectorServices() *schema.Table {
 		Description: `https://cloud.google.com/beyondcorp/docs/reference/rest/v1/projects.locations.clientConnectorServices#ClientConnectorService`,
 		Resolver:    fetchClientConnectorServices,
 		Multiplex:   client.ProjectMultiplexEnabledServices("beyondcorp.googleapis.com"),
-		Transform:   transformers.TransformWithStruct(&pb.ClientConnectorService{}, append(client.Options(), transformers.WithPrimaryKeys("Name"))...),
+		Transform:   client.TransformWithStruct(&pb.ClientConnectorService{}, transformers.WithPrimaryKeys("Name")),
 		Columns: []schema.Column{
 			{
 				Name:     "project_id",

--- a/plugins/source/gcp/resources/services/beyondcorp/client_gateways.go
+++ b/plugins/source/gcp/resources/services/beyondcorp/client_gateways.go
@@ -19,7 +19,7 @@ func ClientGateways() *schema.Table {
 		Description: `https://cloud.google.com/beyondcorp/docs/reference/rest/v1/projects.locations.clientGateways#ClientGateway`,
 		Resolver:    fetchClientGateways,
 		Multiplex:   client.ProjectMultiplexEnabledServices("beyondcorp.googleapis.com"),
-		Transform:   transformers.TransformWithStruct(&pb.ClientGateway{}, append(client.Options(), transformers.WithPrimaryKeys("Name"))...),
+		Transform:   client.TransformWithStruct(&pb.ClientGateway{}, transformers.WithPrimaryKeys("Name")),
 		Columns: []schema.Column{
 			{
 				Name:     "project_id",

--- a/plugins/source/gcp/resources/services/bigquery/datasets.go
+++ b/plugins/source/gcp/resources/services/bigquery/datasets.go
@@ -14,7 +14,7 @@ func Datasets() *schema.Table {
 		PreResourceResolver: datasetGet,
 		Resolver:            fetchDatasets,
 		Multiplex:           client.ProjectMultiplexEnabledServices("bigquery.googleapis.com"),
-		Transform:           transformers.TransformWithStruct(&pb.Dataset{}, append(client.Options(), transformers.WithPrimaryKeys("Id"))...),
+		Transform:           client.TransformWithStruct(&pb.Dataset{}, transformers.WithPrimaryKeys("Id")),
 		Columns: []schema.Column{
 			{
 				Name:     "project_id",

--- a/plugins/source/gcp/resources/services/bigquery/tables.go
+++ b/plugins/source/gcp/resources/services/bigquery/tables.go
@@ -14,7 +14,7 @@ func Tables() *schema.Table {
 		PreResourceResolver: tableGet,
 		Resolver:            fetchTables,
 		Multiplex:           client.ProjectMultiplexEnabledServices("bigquery.googleapis.com"),
-		Transform:           transformers.TransformWithStruct(&pb.Table{}, append(client.Options(), transformers.WithPrimaryKeys("Id"))...),
+		Transform:           client.TransformWithStruct(&pb.Table{}, transformers.WithPrimaryKeys("Id")),
 		Columns: []schema.Column{
 			{
 				Name:     "project_id",

--- a/plugins/source/gcp/resources/services/bigtableadmin/app_profiles.go
+++ b/plugins/source/gcp/resources/services/bigtableadmin/app_profiles.go
@@ -13,7 +13,7 @@ func AppProfiles() *schema.Table {
 		Description: `https://cloud.google.com/bigtable/docs/reference/admin/rest/v2/projects.instances.appProfiles#AppProfile`,
 		Resolver:    fetchAppProfiles,
 		Multiplex:   client.ProjectMultiplexEnabledServices("bigtableadmin.googleapis.com"),
-		Transform:   transformers.TransformWithStruct(&pb.AppProfile{}, append(client.Options(), transformers.WithPrimaryKeys("Name"))...),
+		Transform:   client.TransformWithStruct(&pb.AppProfile{}, transformers.WithPrimaryKeys("Name")),
 		Columns: []schema.Column{
 			{
 				Name:     "project_id",

--- a/plugins/source/gcp/resources/services/bigtableadmin/backups.go
+++ b/plugins/source/gcp/resources/services/bigtableadmin/backups.go
@@ -13,7 +13,7 @@ func Backups() *schema.Table {
 		Description: `https://cloud.google.com/bigtable/docs/reference/admin/rest/v2/projects.instances.clusters.backups#Backup`,
 		Resolver:    fetchBackups,
 		Multiplex:   client.ProjectMultiplexEnabledServices("bigtableadmin.googleapis.com"),
-		Transform:   transformers.TransformWithStruct(&pb.BackupInfo{}, append(client.Options(), transformers.WithPrimaryKeys("Name"))...),
+		Transform:   client.TransformWithStruct(&pb.BackupInfo{}, transformers.WithPrimaryKeys("Name")),
 		Columns: []schema.Column{
 			{
 				Name:     "project_id",

--- a/plugins/source/gcp/resources/services/bigtableadmin/clusters.go
+++ b/plugins/source/gcp/resources/services/bigtableadmin/clusters.go
@@ -13,7 +13,7 @@ func Clusters() *schema.Table {
 		Description: `https://cloud.google.com/bigtable/docs/reference/admin/rest/v2/projects.instances.clusters#Cluster`,
 		Resolver:    fetchClusters,
 		Multiplex:   client.ProjectMultiplexEnabledServices("bigtableadmin.googleapis.com"),
-		Transform:   transformers.TransformWithStruct(&pb.ClusterInfo{}, append(client.Options(), transformers.WithPrimaryKeys("Name"))...),
+		Transform:   client.TransformWithStruct(&pb.ClusterInfo{}, transformers.WithPrimaryKeys("Name")),
 		Columns: []schema.Column{
 			{
 				Name:     "project_id",

--- a/plugins/source/gcp/resources/services/bigtableadmin/instances.go
+++ b/plugins/source/gcp/resources/services/bigtableadmin/instances.go
@@ -13,7 +13,7 @@ func Instances() *schema.Table {
 		Description: `https://cloud.google.com/bigtable/docs/reference/admin/rest/v2/projects.instances#Instance`,
 		Resolver:    fetchInstances,
 		Multiplex:   client.ProjectMultiplexEnabledServices("bigtableadmin.googleapis.com"),
-		Transform:   transformers.TransformWithStruct(&pb.InstanceInfo{}, append(client.Options(), transformers.WithPrimaryKeys("Name"))...),
+		Transform:   client.TransformWithStruct(&pb.InstanceInfo{}, transformers.WithPrimaryKeys("Name")),
 		Columns: []schema.Column{
 			{
 				Name:     "project_id",

--- a/plugins/source/gcp/resources/services/bigtableadmin/tables.go
+++ b/plugins/source/gcp/resources/services/bigtableadmin/tables.go
@@ -13,7 +13,7 @@ func Tables() *schema.Table {
 		PreResourceResolver: getTableInfo,
 		Resolver:            fetchTables,
 		Multiplex:           client.ProjectMultiplexEnabledServices("bigtableadmin.googleapis.com"),
-		Transform:           transformers.TransformWithStruct(&tableInfoWithName{}, append(client.Options(), transformers.WithUnwrapStructFields("TableInfo"), transformers.WithPrimaryKeys("Name"))...),
+		Transform:           client.TransformWithStruct(&tableInfoWithName{}, transformers.WithUnwrapStructFields("TableInfo"), transformers.WithPrimaryKeys("Name")),
 		Columns: []schema.Column{
 			{
 				Name:     "project_id",

--- a/plugins/source/gcp/resources/services/billing/billing_accounts.go
+++ b/plugins/source/gcp/resources/services/billing/billing_accounts.go
@@ -19,7 +19,7 @@ func BillingAccounts() *schema.Table {
 		Description: `https://cloud.google.com/billing/docs/reference/rest/v1/billingAccounts#BillingAccount`,
 		Resolver:    fetchBillingAccounts,
 		Multiplex:   client.ProjectMultiplexEnabledServices("cloudbilling.googleapis.com"),
-		Transform:   transformers.TransformWithStruct(&pb.BillingAccount{}, append(client.Options(), transformers.WithPrimaryKeys("Name"))...),
+		Transform:   client.TransformWithStruct(&pb.BillingAccount{}, transformers.WithPrimaryKeys("Name")),
 		Columns: []schema.Column{
 			{
 				Name:     "project_id",

--- a/plugins/source/gcp/resources/services/billing/budgets.go
+++ b/plugins/source/gcp/resources/services/billing/budgets.go
@@ -13,7 +13,7 @@ func Budgets() *schema.Table {
 		Description: `https://cloud.google.com/billing/docs/reference/budget/rest/v1/billingAccounts.budgets#Budget`,
 		Resolver:    fetchBudgets,
 		Multiplex:   client.ProjectMultiplex,
-		Transform:   transformers.TransformWithStruct(&pb.Budget{}, append(client.Options(), transformers.WithPrimaryKeys("Name"))...),
+		Transform:   client.TransformWithStruct(&pb.Budget{}, transformers.WithPrimaryKeys("Name")),
 		Columns: []schema.Column{
 			{
 				Name:     "project_id",

--- a/plugins/source/gcp/resources/services/billing/services.go
+++ b/plugins/source/gcp/resources/services/billing/services.go
@@ -19,7 +19,7 @@ func Services() *schema.Table {
 		Description: `https://cloud.google.com/billing/docs/reference/rest/v1/services/list#Service`,
 		Resolver:    fetchServices,
 		Multiplex:   client.ProjectMultiplex,
-		Transform:   transformers.TransformWithStruct(&pb.Service{}, append(client.Options(), transformers.WithPrimaryKeys("Name"))...),
+		Transform:   client.TransformWithStruct(&pb.Service{}, transformers.WithPrimaryKeys("Name")),
 		Columns: []schema.Column{
 			{
 				Name:     "project_id",

--- a/plugins/source/gcp/resources/services/binaryauthorization/assertors.go
+++ b/plugins/source/gcp/resources/services/binaryauthorization/assertors.go
@@ -19,7 +19,7 @@ func Assertors() *schema.Table {
 		Description: `https://cloud.google.com/binary-authorization/docs/reference/rest/v1/projects.attestors#Attestor`,
 		Resolver:    fetchAssertors,
 		Multiplex:   client.ProjectMultiplexEnabledServices("binaryauthorization.googleapis.com"),
-		Transform:   transformers.TransformWithStruct(&pb.Attestor{}, append(client.Options(), transformers.WithPrimaryKeys("Name"))...),
+		Transform:   client.TransformWithStruct(&pb.Attestor{}, transformers.WithPrimaryKeys("Name")),
 		Columns: []schema.Column{
 			{
 				Name:     "project_id",

--- a/plugins/source/gcp/resources/services/certificatemanager/certificate_issuance_configs.go
+++ b/plugins/source/gcp/resources/services/certificatemanager/certificate_issuance_configs.go
@@ -19,7 +19,7 @@ func CertificateIssuanceConfigs() *schema.Table {
 		Description: `https://cloud.google.com/certificate-manager/docs/reference/rest/v1/projects.locations.certificateIssuanceConfigs#CertificateIssuanceConfig`,
 		Resolver:    fetchCertificateIssuanceConfigs,
 		Multiplex:   client.ProjectMultiplexEnabledServices("certificatemanager.googleapis.com"),
-		Transform:   transformers.TransformWithStruct(&pb.CertificateIssuanceConfig{}, append(client.Options(), transformers.WithPrimaryKeys("Name"))...),
+		Transform:   client.TransformWithStruct(&pb.CertificateIssuanceConfig{}, transformers.WithPrimaryKeys("Name")),
 		Columns: []schema.Column{
 			{
 				Name:     "project_id",

--- a/plugins/source/gcp/resources/services/certificatemanager/certificate_map_entries.go
+++ b/plugins/source/gcp/resources/services/certificatemanager/certificate_map_entries.go
@@ -19,7 +19,7 @@ func CertificateMapEntries() *schema.Table {
 		Description: `https://cloud.google.com/certificate-manager/docs/reference/rest/v1/projects.locations.certificateMaps.certificateMapEntries#CertificateMapEntry`,
 		Resolver:    fetchCertificateMapEntries,
 		Multiplex:   client.ProjectMultiplexEnabledServices("certificatemanager.googleapis.com"),
-		Transform:   transformers.TransformWithStruct(&pb.CertificateMapEntry{}, append(client.Options(), transformers.WithPrimaryKeys("Name"))...),
+		Transform:   client.TransformWithStruct(&pb.CertificateMapEntry{}, transformers.WithPrimaryKeys("Name")),
 		Columns: []schema.Column{
 			{
 				Name:     "project_id",

--- a/plugins/source/gcp/resources/services/certificatemanager/certificate_maps.go
+++ b/plugins/source/gcp/resources/services/certificatemanager/certificate_maps.go
@@ -19,7 +19,7 @@ func CertificateMaps() *schema.Table {
 		Description: `https://cloud.google.com/certificate-manager/docs/reference/rest/v1/projects.locations.certificateMaps#CertificateMap`,
 		Resolver:    fetchCertificateMaps,
 		Multiplex:   client.ProjectMultiplexEnabledServices("certificatemanager.googleapis.com"),
-		Transform:   transformers.TransformWithStruct(&pb.CertificateMap{}, append(client.Options(), transformers.WithPrimaryKeys("Name"))...),
+		Transform:   client.TransformWithStruct(&pb.CertificateMap{}, transformers.WithPrimaryKeys("Name")),
 		Columns: []schema.Column{
 			{
 				Name:     "project_id",

--- a/plugins/source/gcp/resources/services/certificatemanager/certificates.go
+++ b/plugins/source/gcp/resources/services/certificatemanager/certificates.go
@@ -19,7 +19,7 @@ func Certificates() *schema.Table {
 		Description: `https://cloud.google.com/certificate-manager/docs/reference/rest/v1/projects.locations.certificates#Certificate`,
 		Resolver:    fetchCertificates,
 		Multiplex:   client.ProjectMultiplexEnabledServices("certificatemanager.googleapis.com"),
-		Transform:   transformers.TransformWithStruct(&pb.Certificate{}, append(client.Options(), transformers.WithPrimaryKeys("Name"))...),
+		Transform:   client.TransformWithStruct(&pb.Certificate{}, transformers.WithPrimaryKeys("Name")),
 		Columns: []schema.Column{
 			{
 				Name:     "project_id",

--- a/plugins/source/gcp/resources/services/certificatemanager/dns_authorizations.go
+++ b/plugins/source/gcp/resources/services/certificatemanager/dns_authorizations.go
@@ -19,7 +19,7 @@ func DnsAuthorizations() *schema.Table {
 		Description: `https://cloud.google.com/certificate-manager/docs/reference/rest/v1/projects.locations.dnsAuthorizations#DnsAuthorization`,
 		Resolver:    fetchDnsAuthorizations,
 		Multiplex:   client.ProjectMultiplexEnabledServices("certificatemanager.googleapis.com"),
-		Transform:   transformers.TransformWithStruct(&pb.DnsAuthorization{}, append(client.Options(), transformers.WithPrimaryKeys("Name"))...),
+		Transform:   client.TransformWithStruct(&pb.DnsAuthorization{}, transformers.WithPrimaryKeys("Name")),
 		Columns: []schema.Column{
 			{
 				Name:     "project_id",

--- a/plugins/source/gcp/resources/services/clouddeploy/delivery_pipelines.go
+++ b/plugins/source/gcp/resources/services/clouddeploy/delivery_pipelines.go
@@ -19,7 +19,7 @@ func DeliveryPipelines() *schema.Table {
 		Description: `https://cloud.google.com/deploy/docs/api/reference/rest/v1/projects.locations.deliveryPipelines#DeliveryPipeline`,
 		Resolver:    fetchDeliveryPipelines,
 		Multiplex:   client.ProjectMultiplexEnabledServices("clouddeploy.googleapis.com"),
-		Transform:   transformers.TransformWithStruct(&pb.DeliveryPipeline{}, append(client.Options(), transformers.WithPrimaryKeys("Name"))...),
+		Transform:   client.TransformWithStruct(&pb.DeliveryPipeline{}, transformers.WithPrimaryKeys("Name")),
 		Columns: []schema.Column{
 			{
 				Name:     "project_id",

--- a/plugins/source/gcp/resources/services/clouddeploy/job_runs.go
+++ b/plugins/source/gcp/resources/services/clouddeploy/job_runs.go
@@ -19,7 +19,7 @@ func JobRuns() *schema.Table {
 		Description: `https://cloud.google.com/deploy/docs/api/reference/rest/v1/projects.locations.deliveryPipelines.releases.rollouts.jobRuns#JobRun`,
 		Resolver:    fetchJobRuns,
 		Multiplex:   client.ProjectMultiplexEnabledServices("clouddeploy.googleapis.com"),
-		Transform:   transformers.TransformWithStruct(&pb.JobRun{}, append(client.Options(), transformers.WithPrimaryKeys("Name"))...),
+		Transform:   client.TransformWithStruct(&pb.JobRun{}, transformers.WithPrimaryKeys("Name")),
 		Columns: []schema.Column{
 			{
 				Name:     "project_id",

--- a/plugins/source/gcp/resources/services/clouddeploy/releases.go
+++ b/plugins/source/gcp/resources/services/clouddeploy/releases.go
@@ -19,7 +19,7 @@ func Releases() *schema.Table {
 		Description: `https://cloud.google.com/deploy/docs/api/reference/rest/v1/projects.locations.deliveryPipelines.releases#Release`,
 		Resolver:    fetchReleases,
 		Multiplex:   client.ProjectMultiplexEnabledServices("clouddeploy.googleapis.com"),
-		Transform:   transformers.TransformWithStruct(&pb.Release{}, append(client.Options(), transformers.WithPrimaryKeys("Name"))...),
+		Transform:   client.TransformWithStruct(&pb.Release{}, transformers.WithPrimaryKeys("Name")),
 		Columns: []schema.Column{
 			{
 				Name:     "project_id",

--- a/plugins/source/gcp/resources/services/clouddeploy/rollouts.go
+++ b/plugins/source/gcp/resources/services/clouddeploy/rollouts.go
@@ -19,7 +19,7 @@ func Rollouts() *schema.Table {
 		Description: `https://cloud.google.com/deploy/docs/api/reference/rest/v1/projects.locations.deliveryPipelines.releases.rollouts#Rollout`,
 		Resolver:    fetchRollouts,
 		Multiplex:   client.ProjectMultiplexEnabledServices("clouddeploy.googleapis.com"),
-		Transform:   transformers.TransformWithStruct(&pb.Rollout{}, append(client.Options(), transformers.WithPrimaryKeys("Name"))...),
+		Transform:   client.TransformWithStruct(&pb.Rollout{}, transformers.WithPrimaryKeys("Name")),
 		Columns: []schema.Column{
 			{
 				Name:     "project_id",

--- a/plugins/source/gcp/resources/services/clouddeploy/targets.go
+++ b/plugins/source/gcp/resources/services/clouddeploy/targets.go
@@ -19,7 +19,7 @@ func Targets() *schema.Table {
 		Description: `https://cloud.google.com/deploy/docs/api/reference/rest/v1/projects.locations.targets#Target`,
 		Resolver:    fetchTargets,
 		Multiplex:   client.ProjectMultiplexEnabledServices("clouddeploy.googleapis.com"),
-		Transform:   transformers.TransformWithStruct(&pb.Target{}, append(client.Options(), transformers.WithPrimaryKeys("Name"))...),
+		Transform:   client.TransformWithStruct(&pb.Target{}, transformers.WithPrimaryKeys("Name")),
 		Columns: []schema.Column{
 			{
 				Name:     "project_id",

--- a/plugins/source/gcp/resources/services/clouderrorreporting/error_events.go
+++ b/plugins/source/gcp/resources/services/clouderrorreporting/error_events.go
@@ -7,7 +7,6 @@ import (
 
 	pb "cloud.google.com/go/errorreporting/apiv1beta1/errorreportingpb"
 	"github.com/cloudquery/plugin-sdk/schema"
-	"github.com/cloudquery/plugin-sdk/transformers"
 	"github.com/cloudquery/plugins/source/gcp/client"
 
 	errorreporting "cloud.google.com/go/errorreporting/apiv1beta1"
@@ -19,7 +18,7 @@ func ErrorEvents() *schema.Table {
 		Description: `https://cloud.google.com/error-reporting/reference/rest/v1beta1/ErrorEvent`,
 		Resolver:    fetchErrorEvents,
 		Multiplex:   client.ProjectMultiplexEnabledServices("clouderrorreporting.googleapis.com"),
-		Transform:   transformers.TransformWithStruct(&pb.ErrorEvent{}, client.Options()...),
+		Transform:   client.TransformWithStruct(&pb.ErrorEvent{}),
 		Columns: []schema.Column{
 			{
 				Name:     "project_id",

--- a/plugins/source/gcp/resources/services/clouderrorreporting/error_group_stats.go
+++ b/plugins/source/gcp/resources/services/clouderrorreporting/error_group_stats.go
@@ -7,7 +7,6 @@ import (
 
 	pb "cloud.google.com/go/errorreporting/apiv1beta1/errorreportingpb"
 	"github.com/cloudquery/plugin-sdk/schema"
-	"github.com/cloudquery/plugin-sdk/transformers"
 	"github.com/cloudquery/plugins/source/gcp/client"
 
 	errorreporting "cloud.google.com/go/errorreporting/apiv1beta1"
@@ -19,7 +18,7 @@ func ErrorGroupStats() *schema.Table {
 		Description: `https://cloud.google.com/error-reporting/reference/rest/v1beta1/projects.groupStats/list#ErrorGroupStats`,
 		Resolver:    fetchErrorGroupStats,
 		Multiplex:   client.ProjectMultiplexEnabledServices("clouderrorreporting.googleapis.com"),
-		Transform:   transformers.TransformWithStruct(&pb.ErrorGroupStats{}, client.Options()...),
+		Transform:   client.TransformWithStruct(&pb.ErrorGroupStats{}),
 		Columns: []schema.Column{
 			{
 				Name:     "project_id",

--- a/plugins/source/gcp/resources/services/cloudiot/device_configs.go
+++ b/plugins/source/gcp/resources/services/cloudiot/device_configs.go
@@ -13,7 +13,7 @@ func DeviceConfigs() *schema.Table {
 		Description: `https://cloud.google.com/iot/docs/reference/cloudiot/rest/v1/projects.locations.registries.devices.configVersions#DeviceConfig`,
 		Resolver:    fetchDeviceConfigs,
 		Multiplex:   client.ProjectMultiplexEnabledServices("cloudiot.googleapis.com"),
-		Transform:   transformers.TransformWithStruct(&pb.DeviceConfig{}, append(client.Options(), transformers.WithPrimaryKeys("Version"))...),
+		Transform:   client.TransformWithStruct(&pb.DeviceConfig{}, transformers.WithPrimaryKeys("Version")),
 		Columns: []schema.Column{
 			{
 				Name:     "project_id",

--- a/plugins/source/gcp/resources/services/cloudiot/device_registries.go
+++ b/plugins/source/gcp/resources/services/cloudiot/device_registries.go
@@ -13,7 +13,7 @@ func DeviceRegistries() *schema.Table {
 		Description: `https://cloud.google.com/iot/docs/reference/cloudiot/rest/v1/projects.locations.registries#DeviceRegistry`,
 		Resolver:    fetchDeviceRegistries,
 		Multiplex:   client.ProjectMultiplexEnabledServices("cloudiot.googleapis.com"),
-		Transform:   transformers.TransformWithStruct(&pb.DeviceRegistry{}, append(client.Options(), transformers.WithPrimaryKeys("Name"))...),
+		Transform:   client.TransformWithStruct(&pb.DeviceRegistry{}, transformers.WithPrimaryKeys("Name")),
 		Columns: []schema.Column{
 			{
 				Name:     "project_id",

--- a/plugins/source/gcp/resources/services/cloudiot/device_states.go
+++ b/plugins/source/gcp/resources/services/cloudiot/device_states.go
@@ -13,7 +13,7 @@ func DeviceStates() *schema.Table {
 		Description: `https://cloud.google.com/iot/docs/reference/cloudiot/rest/v1/projects.locations.registries.devices.states#DeviceState`,
 		Resolver:    fetchDeviceStates,
 		Multiplex:   client.ProjectMultiplexEnabledServices("cloudiot.googleapis.com"),
-		Transform:   transformers.TransformWithStruct(&pb.DeviceState{}, append(client.Options(), transformers.WithPrimaryKeys("UpdateTime"))...),
+		Transform:   client.TransformWithStruct(&pb.DeviceState{}, transformers.WithPrimaryKeys("UpdateTime")),
 		Columns: []schema.Column{
 			{
 				Name:     "project_id",

--- a/plugins/source/gcp/resources/services/cloudiot/devices.go
+++ b/plugins/source/gcp/resources/services/cloudiot/devices.go
@@ -13,7 +13,7 @@ func Devices() *schema.Table {
 		Description: `https://cloud.google.com/iot/docs/reference/cloudiot/rest/v1/projects.locations.registries.devices#Device`,
 		Resolver:    fetchDevices,
 		Multiplex:   client.ProjectMultiplexEnabledServices("cloudiot.googleapis.com"),
-		Transform:   transformers.TransformWithStruct(&pb.Device{}, append(client.Options(), transformers.WithPrimaryKeys("Name"))...),
+		Transform:   client.TransformWithStruct(&pb.Device{}, transformers.WithPrimaryKeys("Name")),
 		Columns: []schema.Column{
 			{
 				Name:     "project_id",

--- a/plugins/source/gcp/resources/services/cloudresourcemanager/organizations.go
+++ b/plugins/source/gcp/resources/services/cloudresourcemanager/organizations.go
@@ -15,7 +15,7 @@ func Organizations() *schema.Table {
 		Description: `https://cloud.google.com/resource-manager/reference/rest/v1/organizations#Organization`,
 		Resolver:    fetchOrganizations,
 		Multiplex:   client.OrgMultiplex,
-		Transform:   transformers.TransformWithStruct(&crmv1.Organization{}, append(client.Options(), transformers.WithPrimaryKeys("Name"))...),
+		Transform:   client.TransformWithStruct(&crmv1.Organization{}, transformers.WithPrimaryKeys("Name")),
 	}
 }
 

--- a/plugins/source/gcp/resources/services/cloudscheduler/jobs.go
+++ b/plugins/source/gcp/resources/services/cloudscheduler/jobs.go
@@ -13,7 +13,7 @@ func Jobs() *schema.Table {
 		Description: `https://cloud.google.com/scheduler/docs/reference/rest/v1/projects.locations.jobs#Job`,
 		Resolver:    fetchJobs,
 		Multiplex:   client.ProjectMultiplexEnabledServices("cloudscheduler.googleapis.com"),
-		Transform:   transformers.TransformWithStruct(&pb.Job{}, append(client.Options(), transformers.WithPrimaryKeys("Name"))...),
+		Transform:   client.TransformWithStruct(&pb.Job{}, transformers.WithPrimaryKeys("Name")),
 		Columns: []schema.Column{
 			{
 				Name:     "project_id",

--- a/plugins/source/gcp/resources/services/cloudscheduler/locations.go
+++ b/plugins/source/gcp/resources/services/cloudscheduler/locations.go
@@ -13,7 +13,7 @@ func Locations() *schema.Table {
 		Description: `https://cloud.google.com/scheduler/docs/reference/rest/v1/projects.locations#Location`,
 		Resolver:    fetchLocations,
 		Multiplex:   client.ProjectMultiplexEnabledServices("cloudscheduler.googleapis.com"),
-		Transform:   transformers.TransformWithStruct(&pb.Location{}, append(client.Options(), transformers.WithPrimaryKeys("Name"))...),
+		Transform:   client.TransformWithStruct(&pb.Location{}, transformers.WithPrimaryKeys("Name")),
 		Columns: []schema.Column{
 			{
 				Name:     "project_id",

--- a/plugins/source/gcp/resources/services/cloudsupport/cases.go
+++ b/plugins/source/gcp/resources/services/cloudsupport/cases.go
@@ -13,7 +13,7 @@ func Cases() *schema.Table {
 		Description: `https://cloud.google.com/support/docs/reference/rest/v2beta/cases#Case`,
 		Resolver:    fetchCases,
 		Multiplex:   client.ProjectMultiplexEnabledServices("cloudsupport.googleapis.com"),
-		Transform:   transformers.TransformWithStruct(&pb.Case{}, append(client.Options(), transformers.WithPrimaryKeys("Name"))...),
+		Transform:   client.TransformWithStruct(&pb.Case{}, transformers.WithPrimaryKeys("Name")),
 		Columns: []schema.Column{
 			{
 				Name:     "project_id",

--- a/plugins/source/gcp/resources/services/compute/addresses.go
+++ b/plugins/source/gcp/resources/services/compute/addresses.go
@@ -19,7 +19,7 @@ func Addresses() *schema.Table {
 		Description: `https://cloud.google.com/compute/docs/reference/rest/v1/addresses#Address`,
 		Resolver:    fetchAddresses,
 		Multiplex:   client.ProjectMultiplexEnabledServices("compute.googleapis.com"),
-		Transform:   transformers.TransformWithStruct(&pb.Address{}, append(client.Options(), transformers.WithPrimaryKeys("SelfLink"))...),
+		Transform:   client.TransformWithStruct(&pb.Address{}, transformers.WithPrimaryKeys("SelfLink")),
 		Columns: []schema.Column{
 			{
 				Name:     "project_id",

--- a/plugins/source/gcp/resources/services/compute/autoscalers.go
+++ b/plugins/source/gcp/resources/services/compute/autoscalers.go
@@ -19,7 +19,7 @@ func Autoscalers() *schema.Table {
 		Description: `https://cloud.google.com/compute/docs/reference/rest/v1/autoscalers#Autoscaler`,
 		Resolver:    fetchAutoscalers,
 		Multiplex:   client.ProjectMultiplexEnabledServices("compute.googleapis.com"),
-		Transform:   transformers.TransformWithStruct(&pb.Autoscaler{}, append(client.Options(), transformers.WithPrimaryKeys("SelfLink"))...),
+		Transform:   client.TransformWithStruct(&pb.Autoscaler{}, transformers.WithPrimaryKeys("SelfLink")),
 		Columns: []schema.Column{
 			{
 				Name:     "project_id",

--- a/plugins/source/gcp/resources/services/compute/backend_services.go
+++ b/plugins/source/gcp/resources/services/compute/backend_services.go
@@ -19,7 +19,7 @@ func BackendServices() *schema.Table {
 		Description: `https://cloud.google.com/compute/docs/reference/rest/v1/backendServices#BackendService`,
 		Resolver:    fetchBackendServices,
 		Multiplex:   client.ProjectMultiplexEnabledServices("compute.googleapis.com"),
-		Transform:   transformers.TransformWithStruct(&pb.BackendService{}, append(client.Options(), transformers.WithPrimaryKeys("SelfLink"))...),
+		Transform:   client.TransformWithStruct(&pb.BackendService{}, transformers.WithPrimaryKeys("SelfLink")),
 		Columns: []schema.Column{
 			{
 				Name:     "project_id",

--- a/plugins/source/gcp/resources/services/compute/disk_types.go
+++ b/plugins/source/gcp/resources/services/compute/disk_types.go
@@ -19,7 +19,7 @@ func DiskTypes() *schema.Table {
 		Description: `https://cloud.google.com/compute/docs/reference/rest/v1/diskTypes#DiskType`,
 		Resolver:    fetchDiskTypes,
 		Multiplex:   client.ProjectMultiplexEnabledServices("compute.googleapis.com"),
-		Transform:   transformers.TransformWithStruct(&pb.DiskType{}, append(client.Options(), transformers.WithPrimaryKeys("SelfLink"))...),
+		Transform:   client.TransformWithStruct(&pb.DiskType{}, transformers.WithPrimaryKeys("SelfLink")),
 		Columns: []schema.Column{
 			{
 				Name:     "project_id",

--- a/plugins/source/gcp/resources/services/compute/disks.go
+++ b/plugins/source/gcp/resources/services/compute/disks.go
@@ -19,7 +19,7 @@ func Disks() *schema.Table {
 		Description: `https://cloud.google.com/compute/docs/reference/rest/v1/disks#Disk`,
 		Resolver:    fetchDisks,
 		Multiplex:   client.ProjectMultiplexEnabledServices("compute.googleapis.com"),
-		Transform:   transformers.TransformWithStruct(&pb.Disk{}, append(client.Options(), transformers.WithPrimaryKeys("SelfLink"))...),
+		Transform:   client.TransformWithStruct(&pb.Disk{}, transformers.WithPrimaryKeys("SelfLink")),
 		Columns: []schema.Column{
 			{
 				Name:     "project_id",

--- a/plugins/source/gcp/resources/services/compute/firewalls.go
+++ b/plugins/source/gcp/resources/services/compute/firewalls.go
@@ -19,7 +19,7 @@ func Firewalls() *schema.Table {
 		Description: ``,
 		Resolver:    fetchFirewalls,
 		Multiplex:   client.ProjectMultiplexEnabledServices("compute.googleapis.com"),
-		Transform:   transformers.TransformWithStruct(&pb.Firewall{}, append(client.Options(), transformers.WithPrimaryKeys("SelfLink"))...),
+		Transform:   client.TransformWithStruct(&pb.Firewall{}, transformers.WithPrimaryKeys("SelfLink")),
 		Columns: []schema.Column{
 			{
 				Name:     "project_id",

--- a/plugins/source/gcp/resources/services/compute/forwarding_rules.go
+++ b/plugins/source/gcp/resources/services/compute/forwarding_rules.go
@@ -19,7 +19,7 @@ func ForwardingRules() *schema.Table {
 		Description: `https://cloud.google.com/compute/docs/reference/rest/v1/forwardingRules#ForwardingRule`,
 		Resolver:    fetchForwardingRules,
 		Multiplex:   client.ProjectMultiplexEnabledServices("compute.googleapis.com"),
-		Transform:   transformers.TransformWithStruct(&pb.ForwardingRule{}, append(client.Options(), transformers.WithPrimaryKeys("SelfLink"))...),
+		Transform:   client.TransformWithStruct(&pb.ForwardingRule{}, transformers.WithPrimaryKeys("SelfLink")),
 		Columns: []schema.Column{
 			{
 				Name:     "project_id",

--- a/plugins/source/gcp/resources/services/compute/images.go
+++ b/plugins/source/gcp/resources/services/compute/images.go
@@ -19,7 +19,7 @@ func Images() *schema.Table {
 		Description: ``,
 		Resolver:    fetchImages,
 		Multiplex:   client.ProjectMultiplexEnabledServices("compute.googleapis.com"),
-		Transform:   transformers.TransformWithStruct(&pb.Image{}, append(client.Options(), transformers.WithPrimaryKeys("SelfLink"))...),
+		Transform:   client.TransformWithStruct(&pb.Image{}, transformers.WithPrimaryKeys("SelfLink")),
 		Columns: []schema.Column{
 			{
 				Name:     "project_id",

--- a/plugins/source/gcp/resources/services/compute/instance_groups.go
+++ b/plugins/source/gcp/resources/services/compute/instance_groups.go
@@ -19,7 +19,7 @@ func InstanceGroups() *schema.Table {
 		Description: `https://cloud.google.com/compute/docs/reference/rest/v1/instanceGroups#InstanceGroup`,
 		Resolver:    fetchInstanceGroups,
 		Multiplex:   client.ProjectMultiplexEnabledServices("compute.googleapis.com"),
-		Transform:   transformers.TransformWithStruct(&pb.InstanceGroup{}, append(client.Options(), transformers.WithPrimaryKeys("SelfLink"))...),
+		Transform:   client.TransformWithStruct(&pb.InstanceGroup{}, transformers.WithPrimaryKeys("SelfLink")),
 		Columns: []schema.Column{
 			{
 				Name:     "project_id",

--- a/plugins/source/gcp/resources/services/compute/instances.go
+++ b/plugins/source/gcp/resources/services/compute/instances.go
@@ -19,7 +19,7 @@ func Instances() *schema.Table {
 		Description: `https://cloud.google.com/compute/docs/reference/rest/v1/instances#Instance`,
 		Resolver:    fetchInstances,
 		Multiplex:   client.ProjectMultiplexEnabledServices("compute.googleapis.com"),
-		Transform:   transformers.TransformWithStruct(&pb.Instance{}, append(client.Options(), transformers.WithPrimaryKeys("SelfLink"))...),
+		Transform:   client.TransformWithStruct(&pb.Instance{}, transformers.WithPrimaryKeys("SelfLink")),
 		Columns: []schema.Column{
 			{
 				Name:     "project_id",

--- a/plugins/source/gcp/resources/services/compute/interconnects.go
+++ b/plugins/source/gcp/resources/services/compute/interconnects.go
@@ -19,7 +19,7 @@ func Interconnects() *schema.Table {
 		Description: ``,
 		Resolver:    fetchInterconnects,
 		Multiplex:   client.ProjectMultiplexEnabledServices("compute.googleapis.com"),
-		Transform:   transformers.TransformWithStruct(&pb.Interconnect{}, append(client.Options(), transformers.WithPrimaryKeys("SelfLink"))...),
+		Transform:   client.TransformWithStruct(&pb.Interconnect{}, transformers.WithPrimaryKeys("SelfLink")),
 		Columns: []schema.Column{
 			{
 				Name:     "project_id",

--- a/plugins/source/gcp/resources/services/compute/machine_types.go
+++ b/plugins/source/gcp/resources/services/compute/machine_types.go
@@ -23,7 +23,7 @@ func machineTypes() *schema.Table {
 		Description: `https://cloud.google.com/compute/docs/reference/rest/v1/machineTypes/list#response-body`,
 		Resolver:    fetchMachineTypes,
 		Multiplex:   client.ProjectMultiplexEnabledServices("compute.googleapis.com"),
-		Transform:   transformers.TransformWithStruct(&pb.MachineType{}, append(client.Options(), transformers.WithPrimaryKeys("SelfLink"))...),
+		Transform:   client.TransformWithStruct(&pb.MachineType{}, transformers.WithPrimaryKeys("SelfLink")),
 		Columns: []schema.Column{
 			{
 				Name:     "project_id",

--- a/plugins/source/gcp/resources/services/compute/networks.go
+++ b/plugins/source/gcp/resources/services/compute/networks.go
@@ -19,7 +19,7 @@ func Networks() *schema.Table {
 		Description: ``,
 		Resolver:    fetchNetworks,
 		Multiplex:   client.ProjectMultiplexEnabledServices("compute.googleapis.com"),
-		Transform:   transformers.TransformWithStruct(&pb.Network{}, append(client.Options(), transformers.WithPrimaryKeys("SelfLink"))...),
+		Transform:   client.TransformWithStruct(&pb.Network{}, transformers.WithPrimaryKeys("SelfLink")),
 		Columns: []schema.Column{
 			{
 				Name:     "project_id",

--- a/plugins/source/gcp/resources/services/compute/projects.go
+++ b/plugins/source/gcp/resources/services/compute/projects.go
@@ -13,7 +13,7 @@ func Projects() *schema.Table {
 		Description: ``,
 		Resolver:    fetchProjects,
 		Multiplex:   client.ProjectMultiplexEnabledServices("compute.googleapis.com"),
-		Transform:   transformers.TransformWithStruct(&pb.Project{}, append(client.Options(), transformers.WithPrimaryKeys("SelfLink"))...),
+		Transform:   client.TransformWithStruct(&pb.Project{}, transformers.WithPrimaryKeys("SelfLink")),
 		Columns: []schema.Column{
 			{
 				Name:     "project_id",

--- a/plugins/source/gcp/resources/services/compute/router_nat_mapping_infos.go
+++ b/plugins/source/gcp/resources/services/compute/router_nat_mapping_infos.go
@@ -7,7 +7,6 @@ import (
 	compute "cloud.google.com/go/compute/apiv1"
 	pb "cloud.google.com/go/compute/apiv1/computepb"
 	"github.com/cloudquery/plugin-sdk/schema"
-	"github.com/cloudquery/plugin-sdk/transformers"
 	"github.com/cloudquery/plugins/source/gcp/client"
 	"google.golang.org/api/iterator"
 )
@@ -18,7 +17,7 @@ func routerNatMappingInfos() *schema.Table {
 		Description: `https://cloud.google.com/compute/docs/reference/rest/v1/routers/getNatMappingInfo#response-body`,
 		Resolver:    fetchRouterNatMappingInfo,
 		Multiplex:   client.ProjectMultiplexEnabledServices("compute.googleapis.com"),
-		Transform:   transformers.TransformWithStruct(&pb.VmEndpointNatMappings{}, client.Options()...),
+		Transform:   client.TransformWithStruct(&pb.VmEndpointNatMappings{}),
 		Columns: []schema.Column{
 			{
 				Name:     "project_id",

--- a/plugins/source/gcp/resources/services/compute/routers.go
+++ b/plugins/source/gcp/resources/services/compute/routers.go
@@ -17,7 +17,7 @@ func Routers() *schema.Table {
 		Description: `https://cloud.google.com/compute/docs/reference/rest/v1/routers/list#response-body`,
 		Resolver:    fetchRouters,
 		Multiplex:   client.ProjectMultiplexEnabledServices("compute.googleapis.com"),
-		Transform:   transformers.TransformWithStruct(&pb.Router{}, append(client.Options(), transformers.WithPrimaryKeys("Id"))...),
+		Transform:   client.TransformWithStruct(&pb.Router{}, transformers.WithPrimaryKeys("Id")),
 		Columns: []schema.Column{
 			{
 				Name:     "project_id",

--- a/plugins/source/gcp/resources/services/compute/ssl_certificates.go
+++ b/plugins/source/gcp/resources/services/compute/ssl_certificates.go
@@ -19,7 +19,7 @@ func SslCertificates() *schema.Table {
 		Description: `https://cloud.google.com/compute/docs/reference/rest/v1/sslCertificates#SslCertificate`,
 		Resolver:    fetchSslCertificates,
 		Multiplex:   client.ProjectMultiplexEnabledServices("compute.googleapis.com"),
-		Transform:   transformers.TransformWithStruct(&pb.SslCertificate{}, append(client.Options(), transformers.WithPrimaryKeys("SelfLink"))...),
+		Transform:   client.TransformWithStruct(&pb.SslCertificate{}, transformers.WithPrimaryKeys("SelfLink")),
 		Columns: []schema.Column{
 			{
 				Name:     "project_id",

--- a/plugins/source/gcp/resources/services/compute/ssl_policies.go
+++ b/plugins/source/gcp/resources/services/compute/ssl_policies.go
@@ -19,7 +19,7 @@ func SslPolicies() *schema.Table {
 		Description: ``,
 		Resolver:    fetchSslPolicies,
 		Multiplex:   client.ProjectMultiplexEnabledServices("compute.googleapis.com"),
-		Transform:   transformers.TransformWithStruct(&pb.SslPolicy{}, append(client.Options(), transformers.WithPrimaryKeys("SelfLink"))...),
+		Transform:   client.TransformWithStruct(&pb.SslPolicy{}, transformers.WithPrimaryKeys("SelfLink")),
 		Columns: []schema.Column{
 			{
 				Name:     "project_id",

--- a/plugins/source/gcp/resources/services/compute/subnetworks.go
+++ b/plugins/source/gcp/resources/services/compute/subnetworks.go
@@ -19,7 +19,7 @@ func Subnetworks() *schema.Table {
 		Description: `https://cloud.google.com/compute/docs/reference/rest/v1/subnetworks#Subnetwork`,
 		Resolver:    fetchSubnetworks,
 		Multiplex:   client.ProjectMultiplexEnabledServices("compute.googleapis.com"),
-		Transform:   transformers.TransformWithStruct(&pb.Subnetwork{}, append(client.Options(), transformers.WithPrimaryKeys("SelfLink"))...),
+		Transform:   client.TransformWithStruct(&pb.Subnetwork{}, transformers.WithPrimaryKeys("SelfLink")),
 		Columns: []schema.Column{
 			{
 				Name:     "project_id",

--- a/plugins/source/gcp/resources/services/compute/target_http_proxies.go
+++ b/plugins/source/gcp/resources/services/compute/target_http_proxies.go
@@ -19,7 +19,7 @@ func TargetHttpProxies() *schema.Table {
 		Description: `https://cloud.google.com/compute/docs/reference/rest/v1/targetHttpProxies#TargetHttpProxy`,
 		Resolver:    fetchTargetHttpProxies,
 		Multiplex:   client.ProjectMultiplexEnabledServices("compute.googleapis.com"),
-		Transform:   transformers.TransformWithStruct(&pb.TargetHttpProxy{}, append(client.Options(), transformers.WithPrimaryKeys("SelfLink"))...),
+		Transform:   client.TransformWithStruct(&pb.TargetHttpProxy{}, transformers.WithPrimaryKeys("SelfLink")),
 		Columns: []schema.Column{
 			{
 				Name:     "project_id",

--- a/plugins/source/gcp/resources/services/compute/target_ssl_proxies.go
+++ b/plugins/source/gcp/resources/services/compute/target_ssl_proxies.go
@@ -19,7 +19,7 @@ func TargetSslProxies() *schema.Table {
 		Description: ``,
 		Resolver:    fetchTargetSslProxies,
 		Multiplex:   client.ProjectMultiplexEnabledServices("compute.googleapis.com"),
-		Transform:   transformers.TransformWithStruct(&pb.TargetSslProxy{}, append(client.Options(), transformers.WithPrimaryKeys("SelfLink"))...),
+		Transform:   client.TransformWithStruct(&pb.TargetSslProxy{}, transformers.WithPrimaryKeys("SelfLink")),
 		Columns: []schema.Column{
 			{
 				Name:     "project_id",

--- a/plugins/source/gcp/resources/services/compute/url_maps.go
+++ b/plugins/source/gcp/resources/services/compute/url_maps.go
@@ -19,7 +19,7 @@ func UrlMaps() *schema.Table {
 		Description: `https://cloud.google.com/compute/docs/reference/rest/v1/urlMaps#UrlMap`,
 		Resolver:    fetchUrlMaps,
 		Multiplex:   client.ProjectMultiplexEnabledServices("compute.googleapis.com"),
-		Transform:   transformers.TransformWithStruct(&pb.UrlMap{}, append(client.Options(), transformers.WithPrimaryKeys("SelfLink"))...),
+		Transform:   client.TransformWithStruct(&pb.UrlMap{}, transformers.WithPrimaryKeys("SelfLink")),
 		Columns: []schema.Column{
 			{
 				Name:     "project_id",

--- a/plugins/source/gcp/resources/services/compute/vpn_gateways.go
+++ b/plugins/source/gcp/resources/services/compute/vpn_gateways.go
@@ -19,7 +19,7 @@ func VpnGateways() *schema.Table {
 		Description: `https://cloud.google.com/compute/docs/reference/rest/v1/vpnGateways#VpnGateway`,
 		Resolver:    fetchVpnGateways,
 		Multiplex:   client.ProjectMultiplexEnabledServices("compute.googleapis.com"),
-		Transform:   transformers.TransformWithStruct(&pb.VpnGateway{}, append(client.Options(), transformers.WithPrimaryKeys("SelfLink"))...),
+		Transform:   client.TransformWithStruct(&pb.VpnGateway{}, transformers.WithPrimaryKeys("SelfLink")),
 		Columns: []schema.Column{
 			{
 				Name:     "project_id",

--- a/plugins/source/gcp/resources/services/compute/zones.go
+++ b/plugins/source/gcp/resources/services/compute/zones.go
@@ -19,7 +19,7 @@ func Zones() *schema.Table {
 		Description: `https://cloud.google.com/compute/docs/reference/rest/v1/zones/list#response-body`,
 		Resolver:    fetchZones,
 		Multiplex:   client.ProjectMultiplexEnabledServices("compute.googleapis.com"),
-		Transform:   transformers.TransformWithStruct(&pb.Zone{}, append(client.Options(), transformers.WithPrimaryKeys("SelfLink"))...),
+		Transform:   client.TransformWithStruct(&pb.Zone{}, transformers.WithPrimaryKeys("SelfLink")),
 		Columns: []schema.Column{
 			{
 				Name:     "project_id",

--- a/plugins/source/gcp/resources/services/container/clusters.go
+++ b/plugins/source/gcp/resources/services/container/clusters.go
@@ -13,7 +13,7 @@ func Clusters() *schema.Table {
 		Description: `https://cloud.google.com/kubernetes-engine/docs/reference/rest/v1/projects.locations.clusters#Cluster`,
 		Resolver:    fetchClusters,
 		Multiplex:   client.ProjectMultiplexEnabledServices("container.googleapis.com"),
-		Transform:   transformers.TransformWithStruct(&pb.Cluster{}, append(client.Options(), transformers.WithPrimaryKeys("SelfLink"))...),
+		Transform:   client.TransformWithStruct(&pb.Cluster{}, transformers.WithPrimaryKeys("SelfLink")),
 		Columns: []schema.Column{
 			{
 				Name:     "project_id",

--- a/plugins/source/gcp/resources/services/containeranalysis/occurrences.go
+++ b/plugins/source/gcp/resources/services/containeranalysis/occurrences.go
@@ -19,7 +19,7 @@ func Occurrences() *schema.Table {
 		Description: `https://cloud.google.com/container-analysis/docs/reference/rest/v1beta1/projects.occurrences#Occurrence`,
 		Resolver:    fetchOccurrences,
 		Multiplex:   client.ProjectMultiplexEnabledServices("containeranalysis.googleapis.com"),
-		Transform:   transformers.TransformWithStruct(&pb.Occurrence{}, append(client.Options(), transformers.WithPrimaryKeys("Name"))...),
+		Transform:   client.TransformWithStruct(&pb.Occurrence{}, transformers.WithPrimaryKeys("Name")),
 		Columns: []schema.Column{
 			{
 				Name:     "project_id",

--- a/plugins/source/gcp/resources/services/dns/managed_zones.go
+++ b/plugins/source/gcp/resources/services/dns/managed_zones.go
@@ -13,7 +13,7 @@ func ManagedZones() *schema.Table {
 		Description: `https://cloud.google.com/dns/docs/reference/v1/managedZones#resource`,
 		Resolver:    fetchManagedZones,
 		Multiplex:   client.ProjectMultiplexEnabledServices("dns.googleapis.com"),
-		Transform:   transformers.TransformWithStruct(&pb.ManagedZone{}, append(client.Options(), transformers.WithPrimaryKeys("Id"))...),
+		Transform:   client.TransformWithStruct(&pb.ManagedZone{}, transformers.WithPrimaryKeys("Id")),
 		Columns: []schema.Column{
 			{
 				Name:     "project_id",

--- a/plugins/source/gcp/resources/services/dns/policies.go
+++ b/plugins/source/gcp/resources/services/dns/policies.go
@@ -13,7 +13,7 @@ func Policies() *schema.Table {
 		Description: `https://cloud.google.com/dns/docs/reference/v1/policies#resource`,
 		Resolver:    fetchPolicies,
 		Multiplex:   client.ProjectMultiplexEnabledServices("dns.googleapis.com"),
-		Transform:   transformers.TransformWithStruct(&pb.Policy{}, append(client.Options(), transformers.WithPrimaryKeys("Id"))...),
+		Transform:   client.TransformWithStruct(&pb.Policy{}, transformers.WithPrimaryKeys("Id")),
 		Columns: []schema.Column{
 			{
 				Name:     "project_id",

--- a/plugins/source/gcp/resources/services/domains/registrations.go
+++ b/plugins/source/gcp/resources/services/domains/registrations.go
@@ -2,6 +2,7 @@ package domains
 
 import (
 	"context"
+	"fmt"
 
 	"google.golang.org/api/iterator"
 
@@ -11,8 +12,6 @@ import (
 	"github.com/cloudquery/plugins/source/gcp/client"
 
 	domains "cloud.google.com/go/domains/apiv1beta1"
-
-	"fmt"
 )
 
 func Registrations() *schema.Table {
@@ -21,7 +20,7 @@ func Registrations() *schema.Table {
 		Description: `https://cloud.google.com/domains/docs/reference/rest/v1beta1/projects.locations.registrations#Registration`,
 		Resolver:    fetchRegistrations,
 		Multiplex:   client.ProjectMultiplexEnabledServices("domains.googleapis.com"),
-		Transform:   transformers.TransformWithStruct(&pb.Registration{}, append(client.Options(), transformers.WithPrimaryKeys("Name"))...),
+		Transform:   client.TransformWithStruct(&pb.Registration{}, transformers.WithPrimaryKeys("Name")),
 		Columns: []schema.Column{
 			{
 				Name:     "project_id",

--- a/plugins/source/gcp/resources/services/functions/functions.go
+++ b/plugins/source/gcp/resources/services/functions/functions.go
@@ -19,7 +19,7 @@ func Functions() *schema.Table {
 		Description: `https://cloud.google.com/functions/docs/reference/rest/v1/projects.locations.functions#CloudFunction`,
 		Resolver:    fetchFunctions,
 		Multiplex:   client.ProjectMultiplexEnabledServices("cloudfunctions.googleapis.com"),
-		Transform:   transformers.TransformWithStruct(&pb.CloudFunction{}, append(client.Options(), transformers.WithPrimaryKeys("Name"))...),
+		Transform:   client.TransformWithStruct(&pb.CloudFunction{}, transformers.WithPrimaryKeys("Name")),
 		Columns: []schema.Column{
 			{
 				Name:     "project_id",

--- a/plugins/source/gcp/resources/services/iam/deny_policies.go
+++ b/plugins/source/gcp/resources/services/iam/deny_policies.go
@@ -13,7 +13,7 @@ func DenyPolicies() *schema.Table {
 		Description: `https://cloud.google.com/iam/docs/reference/rest/v2beta/policies#Policy`,
 		Resolver:    fetchDenyPolicies,
 		Multiplex:   client.ProjectMultiplexEnabledServices("iam.googleapis.com"),
-		Transform:   transformers.TransformWithStruct(&pb.Policy{}, append(client.Options(), transformers.WithPrimaryKeys("Name"))...),
+		Transform:   client.TransformWithStruct(&pb.Policy{}, transformers.WithPrimaryKeys("Name")),
 		Columns: []schema.Column{
 			{
 				Name:     "project_id",

--- a/plugins/source/gcp/resources/services/iam/roles.go
+++ b/plugins/source/gcp/resources/services/iam/roles.go
@@ -13,7 +13,7 @@ func Roles() *schema.Table {
 		Description: `https://cloud.google.com/iam/docs/reference/rest/v1/roles#Role`,
 		Resolver:    fetchRoles,
 		Multiplex:   client.ProjectMultiplexEnabledServices("iam.googleapis.com"),
-		Transform:   transformers.TransformWithStruct(&pb.Role{}, append(client.Options(), transformers.WithPrimaryKeys("Name"))...),
+		Transform:   client.TransformWithStruct(&pb.Role{}, transformers.WithPrimaryKeys("Name")),
 		Columns: []schema.Column{
 			{
 				Name:     "project_id",

--- a/plugins/source/gcp/resources/services/iam/service_account_keys.go
+++ b/plugins/source/gcp/resources/services/iam/service_account_keys.go
@@ -13,7 +13,7 @@ func ServiceAccountKeys() *schema.Table {
 		Description: `https://cloud.google.com/iam/docs/reference/rest/v1/projects.serviceAccounts.keys#ServiceAccountKey`,
 		Resolver:    fetchServiceAccountKeys,
 		Multiplex:   client.ProjectMultiplexEnabledServices("iam.googleapis.com"),
-		Transform:   transformers.TransformWithStruct(&pb.ServiceAccountKey{}, append(client.Options(), transformers.WithSkipFields("PrivateKeyData", "PrivateKeyType"), transformers.WithPrimaryKeys("Name"))...),
+		Transform:   client.TransformWithStruct(&pb.ServiceAccountKey{}, transformers.WithSkipFields("PrivateKeyData", "PrivateKeyType"), transformers.WithPrimaryKeys("Name")),
 		Columns: []schema.Column{
 			{
 				Name:     "project_id",

--- a/plugins/source/gcp/resources/services/iam/service_accounts.go
+++ b/plugins/source/gcp/resources/services/iam/service_accounts.go
@@ -20,7 +20,7 @@ func ServiceAccounts() *schema.Table {
 		Description: `https://cloud.google.com/iam/docs/reference/rest/v1/projects.serviceAccounts#ServiceAccount`,
 		Resolver:    fetchServiceAccounts,
 		Multiplex:   client.ProjectMultiplexEnabledServices("iam.googleapis.com"),
-		Transform:   transformers.TransformWithStruct(&pb.ServiceAccount{}, append(client.Options(), transformers.WithPrimaryKeys("Name"))...),
+		Transform:   client.TransformWithStruct(&pb.ServiceAccount{}, transformers.WithPrimaryKeys("Name")),
 		Columns: []schema.Column{
 			{
 				Name:     "project_id",

--- a/plugins/source/gcp/resources/services/kms/crypto_key_versions.go
+++ b/plugins/source/gcp/resources/services/kms/crypto_key_versions.go
@@ -13,7 +13,7 @@ func CryptoKeyVersions() *schema.Table {
 		Description: `https://cloud.google.com/kms/docs/reference/rest/v1/projects.locations.keyRings.cryptoKeys.cryptoKeyVersions#CryptoKeyVersion`,
 		Resolver:    fetchCryptoKeyVersions,
 		Multiplex:   client.ProjectMultiplexEnabledServices("cloudkms.googleapis.com"),
-		Transform:   transformers.TransformWithStruct(&pb.CryptoKeyVersion{}, append(client.Options(), transformers.WithPrimaryKeys("Name"))...),
+		Transform:   client.TransformWithStruct(&pb.CryptoKeyVersion{}, transformers.WithPrimaryKeys("Name")),
 		Columns: []schema.Column{
 			{
 				Name:     "project_id",

--- a/plugins/source/gcp/resources/services/kms/crypto_keys.go
+++ b/plugins/source/gcp/resources/services/kms/crypto_keys.go
@@ -13,7 +13,7 @@ func CryptoKeys() *schema.Table {
 		Description: `https://cloud.google.com/kms/docs/reference/rest/v1/projects.locations.keyRings.cryptoKeys#CryptoKey`,
 		Resolver:    fetchCryptoKeys,
 		Multiplex:   client.ProjectMultiplexEnabledServices("cloudkms.googleapis.com"),
-		Transform:   transformers.TransformWithStruct(&pb.CryptoKey{}, append(client.Options(), transformers.WithPrimaryKeys("Name"))...),
+		Transform:   client.TransformWithStruct(&pb.CryptoKey{}, transformers.WithPrimaryKeys("Name")),
 		Columns: []schema.Column{
 			{
 				Name:     "project_id",

--- a/plugins/source/gcp/resources/services/kms/ekm_connections.go
+++ b/plugins/source/gcp/resources/services/kms/ekm_connections.go
@@ -13,7 +13,7 @@ func EkmConnections() *schema.Table {
 		Description: `https://cloud.google.com/kms/docs/reference/rest/v1/projects.locations.ekmConnections#EkmConnection`,
 		Resolver:    fetchEkmConnections,
 		Multiplex:   client.ProjectMultiplexEnabledServices("cloudkms.googleapis.com"),
-		Transform:   transformers.TransformWithStruct(&pb.EkmConnection{}, append(client.Options(), transformers.WithPrimaryKeys("Name"))...),
+		Transform:   client.TransformWithStruct(&pb.EkmConnection{}, transformers.WithPrimaryKeys("Name")),
 		Columns: []schema.Column{
 			{
 				Name:     "project_id",

--- a/plugins/source/gcp/resources/services/kms/import_jobs.go
+++ b/plugins/source/gcp/resources/services/kms/import_jobs.go
@@ -13,7 +13,7 @@ func ImportJobs() *schema.Table {
 		Description: `https://cloud.google.com/kms/docs/reference/rest/v1/projects.locations.keyRings.importJobs#ImportJob`,
 		Resolver:    fetchImportJobs,
 		Multiplex:   client.ProjectMultiplexEnabledServices("cloudkms.googleapis.com"),
-		Transform:   transformers.TransformWithStruct(&pb.ImportJob{}, append(client.Options(), transformers.WithPrimaryKeys("Name"))...),
+		Transform:   client.TransformWithStruct(&pb.ImportJob{}, transformers.WithPrimaryKeys("Name")),
 		Columns: []schema.Column{
 			{
 				Name:     "project_id",

--- a/plugins/source/gcp/resources/services/kms/keyrings.go
+++ b/plugins/source/gcp/resources/services/kms/keyrings.go
@@ -13,7 +13,7 @@ func KeyRings() *schema.Table {
 		Description: `https://cloud.google.com/kms/docs/reference/rest/v1/projects.locations.keyRings#KeyRing`,
 		Resolver:    fetchKeyrings,
 		Multiplex:   client.ProjectMultiplexEnabledServices("cloudkms.googleapis.com"),
-		Transform:   transformers.TransformWithStruct(&pb.KeyRing{}, append(client.Options(), transformers.WithPrimaryKeys("Name"))...),
+		Transform:   client.TransformWithStruct(&pb.KeyRing{}, transformers.WithPrimaryKeys("Name")),
 		Columns: []schema.Column{
 			{
 				Name:     "project_id",

--- a/plugins/source/gcp/resources/services/kms/locations.go
+++ b/plugins/source/gcp/resources/services/kms/locations.go
@@ -13,7 +13,7 @@ func Locations() *schema.Table {
 		Description: `https://cloud.google.com/kms/docs/reference/rest/v1/projects.locations.keyRings#KeyRing`,
 		Resolver:    fetchLocations,
 		Multiplex:   client.ProjectMultiplexEnabledServices("cloudkms.googleapis.com"),
-		Transform:   transformers.TransformWithStruct(&locationpb.Location{}, append(client.Options(), transformers.WithPrimaryKeys("Name"))...),
+		Transform:   client.TransformWithStruct(&locationpb.Location{}, transformers.WithPrimaryKeys("Name")),
 		Columns: []schema.Column{
 			{
 				Name:     "project_id",

--- a/plugins/source/gcp/resources/services/livestream/channels.go
+++ b/plugins/source/gcp/resources/services/livestream/channels.go
@@ -13,7 +13,7 @@ func Channels() *schema.Table {
 		Description: `https://cloud.google.com/livestream/docs/reference/rest/v1/projects.locations.channels`,
 		Resolver:    fetchChannels,
 		Multiplex:   client.ProjectMultiplexEnabledServices("livestream.googleapis.com"),
-		Transform:   transformers.TransformWithStruct(&pb.Channel{}, append(client.Options(), transformers.WithPrimaryKeys("Name"))...),
+		Transform:   client.TransformWithStruct(&pb.Channel{}, transformers.WithPrimaryKeys("Name")),
 		Columns: []schema.Column{
 			{
 				Name:     "project_id",

--- a/plugins/source/gcp/resources/services/livestream/inputs.go
+++ b/plugins/source/gcp/resources/services/livestream/inputs.go
@@ -13,7 +13,7 @@ func Inputs() *schema.Table {
 		Description: `https://cloud.google.com/livestream/docs/reference/rest/v1/projects.locations.inputs`,
 		Resolver:    fetchInputs,
 		Multiplex:   client.ProjectMultiplexEnabledServices("livestream.googleapis.com"),
-		Transform:   transformers.TransformWithStruct(&pb.Input{}, append(client.Options(), transformers.WithPrimaryKeys("Name"))...),
+		Transform:   client.TransformWithStruct(&pb.Input{}, transformers.WithPrimaryKeys("Name")),
 		Columns: []schema.Column{
 			{
 				Name:     "project_id",

--- a/plugins/source/gcp/resources/services/logging/metrics.go
+++ b/plugins/source/gcp/resources/services/logging/metrics.go
@@ -19,7 +19,7 @@ func Metrics() *schema.Table {
 		Description: `https://cloud.google.com/logging/docs/reference/v2/rest/v2/projects.metrics#LogMetric`,
 		Resolver:    fetchMetrics,
 		Multiplex:   client.ProjectMultiplexEnabledServices("logging.googleapis.com"),
-		Transform:   transformers.TransformWithStruct(&pb.LogMetric{}, append(client.Options(), transformers.WithPrimaryKeys("Name"))...),
+		Transform:   client.TransformWithStruct(&pb.LogMetric{}, transformers.WithPrimaryKeys("Name")),
 		Columns: []schema.Column{
 			{
 				Name:     "project_id",

--- a/plugins/source/gcp/resources/services/logging/sinks.go
+++ b/plugins/source/gcp/resources/services/logging/sinks.go
@@ -19,7 +19,7 @@ func Sinks() *schema.Table {
 		Description: `https://cloud.google.com/logging/docs/reference/v2/rest/v2/projects.sinks#LogSink`,
 		Resolver:    fetchSinks,
 		Multiplex:   client.ProjectMultiplexEnabledServices("logging.googleapis.com"),
-		Transform:   transformers.TransformWithStruct(&pb.LogSink{}, append(client.Options(), transformers.WithPrimaryKeys("Name"))...),
+		Transform:   client.TransformWithStruct(&pb.LogSink{}, transformers.WithPrimaryKeys("Name")),
 		Columns: []schema.Column{
 			{
 				Name:     "project_id",

--- a/plugins/source/gcp/resources/services/monitoring/alert_policies.go
+++ b/plugins/source/gcp/resources/services/monitoring/alert_policies.go
@@ -19,7 +19,7 @@ func AlertPolicies() *schema.Table {
 		Description: `https://cloud.google.com/monitoring/api/ref_v3/rest/v3/projects.alertPolicies#AlertPolicy`,
 		Resolver:    fetchAlertPolicies,
 		Multiplex:   client.ProjectMultiplexEnabledServices("monitoring.googleapis.com"),
-		Transform:   transformers.TransformWithStruct(&pb.AlertPolicy{}, append(client.Options(), transformers.WithPrimaryKeys("Name"))...),
+		Transform:   client.TransformWithStruct(&pb.AlertPolicy{}, transformers.WithPrimaryKeys("Name")),
 		Columns: []schema.Column{
 			{
 				Name:     "project_id",

--- a/plugins/source/gcp/resources/services/redis/instances.go
+++ b/plugins/source/gcp/resources/services/redis/instances.go
@@ -19,7 +19,7 @@ func Instances() *schema.Table {
 		Description: `https://cloud.google.com/memorystore/docs/redis/reference/rest/v1/projects.locations.instances#Instance`,
 		Resolver:    fetchInstances,
 		Multiplex:   client.ProjectMultiplexEnabledServices("redis.googleapis.com"),
-		Transform:   transformers.TransformWithStruct(&pb.Instance{}, append(client.Options(), transformers.WithPrimaryKeys("Name"))...),
+		Transform:   client.TransformWithStruct(&pb.Instance{}, transformers.WithPrimaryKeys("Name")),
 		Columns: []schema.Column{
 			{
 				Name:     "project_id",

--- a/plugins/source/gcp/resources/services/resourcemanager/folders.go
+++ b/plugins/source/gcp/resources/services/resourcemanager/folders.go
@@ -13,7 +13,7 @@ func Folders() *schema.Table {
 		Description: `https://cloud.google.com/resource-manager/reference/rest/v3/folders#Folder`,
 		Resolver:    fetchFolders,
 		Multiplex:   client.OrgMultiplex,
-		Transform:   transformers.TransformWithStruct(&pb.Folder{}, append(client.Options(), transformers.WithPrimaryKeys("Name"))...),
+		Transform:   client.TransformWithStruct(&pb.Folder{}, transformers.WithPrimaryKeys("Name")),
 		Columns: []schema.Column{
 			{
 				Name:     "organization_id",

--- a/plugins/source/gcp/resources/services/resourcemanager/project_policies.go
+++ b/plugins/source/gcp/resources/services/resourcemanager/project_policies.go
@@ -2,7 +2,6 @@ package resourcemanager
 
 import (
 	"github.com/cloudquery/plugin-sdk/schema"
-	"github.com/cloudquery/plugin-sdk/transformers"
 	"github.com/cloudquery/plugins/source/gcp/client"
 	pb "google.golang.org/api/cloudresourcemanager/v3"
 )
@@ -13,7 +12,7 @@ func ProjectPolicies() *schema.Table {
 		Description: `https://cloud.google.com/resource-manager/reference/rest/Shared.Types/Policy`,
 		Resolver:    fetchProjectPolicies,
 		Multiplex:   client.ProjectMultiplexEnabledServices("cloudresourcemanager.googleapis.com"),
-		Transform:   transformers.TransformWithStruct(&pb.Policy{}, client.Options()...),
+		Transform:   client.TransformWithStruct(&pb.Policy{}),
 		Columns: []schema.Column{
 			{
 				Name:     "project_id",

--- a/plugins/source/gcp/resources/services/resourcemanager/projects.go
+++ b/plugins/source/gcp/resources/services/resourcemanager/projects.go
@@ -13,7 +13,7 @@ func Projects() *schema.Table {
 		Description: `https://cloud.google.com/resource-manager/reference/rest/v3/projects#Project`,
 		Resolver:    fetchProjects,
 		Multiplex:   client.ProjectMultiplexEnabledServices("cloudresourcemanager.googleapis.com"),
-		Transform:   transformers.TransformWithStruct(&pb.Project{}, append(client.Options(), transformers.WithPrimaryKeys("Name"))...),
+		Transform:   client.TransformWithStruct(&pb.Project{}, transformers.WithPrimaryKeys("Name")),
 		Columns: []schema.Column{
 			{
 				Name:     "project_id",

--- a/plugins/source/gcp/resources/services/run/locations.go
+++ b/plugins/source/gcp/resources/services/run/locations.go
@@ -13,7 +13,7 @@ func Locations() *schema.Table {
 		Description: `https://cloud.google.com/run/docs/reference/rest/v1/projects.locations#Location`,
 		Resolver:    fetchLocations,
 		Multiplex:   client.ProjectMultiplexEnabledServices("run.googleapis.com"),
-		Transform:   transformers.TransformWithStruct(&pb.Location{}, append(client.Options(), transformers.WithPrimaryKeys("Name"))...),
+		Transform:   client.TransformWithStruct(&pb.Location{}, transformers.WithPrimaryKeys("Name")),
 		Columns: []schema.Column{
 			{
 				Name:     "project_id",

--- a/plugins/source/gcp/resources/services/run/services.go
+++ b/plugins/source/gcp/resources/services/run/services.go
@@ -13,7 +13,7 @@ func Services() *schema.Table {
 		Description: `https://cloud.google.com/run/docs/reference/rest/v2/projects.locations.services#Service`,
 		Resolver:    fetchServices,
 		Multiplex:   client.ProjectMultiplexEnabledServices("run.googleapis.com"),
-		Transform:   transformers.TransformWithStruct(&pb.Service{}, append(client.Options(), transformers.WithPrimaryKeys("Name"))...),
+		Transform:   client.TransformWithStruct(&pb.Service{}, transformers.WithPrimaryKeys("Name")),
 		Columns: []schema.Column{
 			{
 				Name:     "project_id",

--- a/plugins/source/gcp/resources/services/secretmanager/secrets.go
+++ b/plugins/source/gcp/resources/services/secretmanager/secrets.go
@@ -19,7 +19,7 @@ func Secrets() *schema.Table {
 		Description: `https://cloud.google.com/secret-manager/docs/reference/rest/v1/projects.secrets#Secret`,
 		Resolver:    fetchSecrets,
 		Multiplex:   client.ProjectMultiplexEnabledServices("secretmanager.googleapis.com"),
-		Transform:   transformers.TransformWithStruct(&pb.Secret{}, append(client.Options(), transformers.WithPrimaryKeys("Name"))...),
+		Transform:   client.TransformWithStruct(&pb.Secret{}, transformers.WithPrimaryKeys("Name")),
 		Columns: []schema.Column{
 			{
 				Name:     "project_id",

--- a/plugins/source/gcp/resources/services/securitycenter/folder_findings.go
+++ b/plugins/source/gcp/resources/services/securitycenter/folder_findings.go
@@ -5,7 +5,6 @@ import (
 
 	pb "cloud.google.com/go/securitycenter/apiv1/securitycenterpb"
 	"github.com/cloudquery/plugin-sdk/schema"
-	"github.com/cloudquery/plugin-sdk/transformers"
 	"github.com/cloudquery/plugins/source/gcp/client"
 )
 
@@ -16,7 +15,7 @@ func FolderFindings() *schema.Table {
 		Resolver:      fetchFolderFindings,
 		Multiplex:     client.FolderMultiplex,
 		IsIncremental: true,
-		Transform:     transformers.TransformWithStruct(&pb.ListFindingsResponse_ListFindingsResult{}, client.Options()...),
+		Transform:     client.TransformWithStruct(&pb.ListFindingsResponse_ListFindingsResult{}),
 		Columns: []schema.Column{
 			{
 				Name:     "folder_id",

--- a/plugins/source/gcp/resources/services/securitycenter/organization_findings.go
+++ b/plugins/source/gcp/resources/services/securitycenter/organization_findings.go
@@ -5,7 +5,6 @@ import (
 
 	pb "cloud.google.com/go/securitycenter/apiv1/securitycenterpb"
 	"github.com/cloudquery/plugin-sdk/schema"
-	"github.com/cloudquery/plugin-sdk/transformers"
 	"github.com/cloudquery/plugins/source/gcp/client"
 )
 
@@ -16,7 +15,7 @@ func OrganizationFindings() *schema.Table {
 		Resolver:      fetchOrganizationFindings,
 		Multiplex:     client.OrgMultiplex,
 		IsIncremental: true,
-		Transform:     transformers.TransformWithStruct(&pb.ListFindingsResponse_ListFindingsResult{}, client.Options()...),
+		Transform:     client.TransformWithStruct(&pb.ListFindingsResponse_ListFindingsResult{}),
 		Columns: []schema.Column{
 			{
 				Name:     "organization_id",

--- a/plugins/source/gcp/resources/services/securitycenter/project_findings.go
+++ b/plugins/source/gcp/resources/services/securitycenter/project_findings.go
@@ -5,7 +5,6 @@ import (
 
 	pb "cloud.google.com/go/securitycenter/apiv1/securitycenterpb"
 	"github.com/cloudquery/plugin-sdk/schema"
-	"github.com/cloudquery/plugin-sdk/transformers"
 	"github.com/cloudquery/plugins/source/gcp/client"
 )
 
@@ -16,7 +15,7 @@ func ProjectFindings() *schema.Table {
 		Resolver:      fetchProjectFindings,
 		IsIncremental: true,
 		Multiplex:     client.ProjectMultiplexEnabledServices("securitycenter.googleapis.com"),
-		Transform:     transformers.TransformWithStruct(&pb.ListFindingsResponse_ListFindingsResult{}, client.Options()...),
+		Transform:     client.TransformWithStruct(&pb.ListFindingsResponse_ListFindingsResult{}),
 		Columns: []schema.Column{
 			{
 				Name:     "project_id",

--- a/plugins/source/gcp/resources/services/serviceusage/services.go
+++ b/plugins/source/gcp/resources/services/serviceusage/services.go
@@ -13,7 +13,7 @@ func Services() *schema.Table {
 		Description: `https://cloud.google.com/service-usage/docs/reference/rest/v1/services#Service`,
 		Resolver:    fetchServices,
 		Multiplex:   client.ProjectMultiplexEnabledServices("serviceusage.googleapis.com"),
-		Transform:   transformers.TransformWithStruct(&pb.Service{}, append(client.Options(), transformers.WithPrimaryKeys("Name"))...),
+		Transform:   client.TransformWithStruct(&pb.Service{}, transformers.WithPrimaryKeys("Name")),
 		Columns: []schema.Column{
 			{
 				Name:     "project_id",

--- a/plugins/source/gcp/resources/services/sql/instances.go
+++ b/plugins/source/gcp/resources/services/sql/instances.go
@@ -13,7 +13,7 @@ func Instances() *schema.Table {
 		Description: `https://cloud.google.com/sql/docs/mysql/admin-api/rest/v1beta4/instances#DatabaseInstance`,
 		Resolver:    fetchInstances,
 		Multiplex:   client.ProjectMultiplexEnabledServices("sqladmin.googleapis.com"),
-		Transform:   transformers.TransformWithStruct(&pb.DatabaseInstance{}, append(client.Options(), transformers.WithPrimaryKeys("SelfLink"))...),
+		Transform:   client.TransformWithStruct(&pb.DatabaseInstance{}, transformers.WithPrimaryKeys("SelfLink")),
 		Columns: []schema.Column{
 			{
 				Name:     "project_id",

--- a/plugins/source/gcp/resources/services/sql/users.go
+++ b/plugins/source/gcp/resources/services/sql/users.go
@@ -13,7 +13,7 @@ func Users() *schema.Table {
 		Description: `https://cloud.google.com/sql/docs/mysql/admin-api/rest/v1beta4/users#User`,
 		Resolver:    fetchUsers,
 		Multiplex:   client.ProjectMultiplexEnabledServices("sqladmin.googleapis.com"),
-		Transform:   transformers.TransformWithStruct(&pb.User{}, append(client.Options(), transformers.WithPrimaryKeys("Instance", "Name"))...),
+		Transform:   client.TransformWithStruct(&pb.User{}, transformers.WithPrimaryKeys("Instance", "Name")),
 		Columns: []schema.Column{
 			{
 				Name:     "project_id",

--- a/plugins/source/gcp/resources/services/storage/bucket_policies.go
+++ b/plugins/source/gcp/resources/services/storage/bucket_policies.go
@@ -3,7 +3,6 @@ package storage
 import (
 	pb "cloud.google.com/go/iam"
 	"github.com/cloudquery/plugin-sdk/schema"
-	"github.com/cloudquery/plugin-sdk/transformers"
 	"github.com/cloudquery/plugins/source/gcp/client"
 )
 
@@ -13,7 +12,7 @@ func BucketPolicies() *schema.Table {
 		Description: `https://cloud.google.com/iam/docs/reference/rest/v1/Policy`,
 		Resolver:    fetchBucketPolicies,
 		Multiplex:   client.ProjectMultiplexEnabledServices("storage.googleapis.com"),
-		Transform:   transformers.TransformWithStruct(&pb.Policy3{}, client.Options()...),
+		Transform:   client.TransformWithStruct(&pb.Policy3{}),
 		Columns: []schema.Column{
 			{
 				Name:     "project_id",

--- a/plugins/source/gcp/resources/services/storage/buckets.go
+++ b/plugins/source/gcp/resources/services/storage/buckets.go
@@ -13,7 +13,7 @@ func Buckets() *schema.Table {
 		Description: `https://cloud.google.com/storage/docs/json_api/v1/buckets#resource`,
 		Resolver:    fetchBuckets,
 		Multiplex:   client.ProjectMultiplexEnabledServices("storage.googleapis.com"),
-		Transform:   transformers.TransformWithStruct(&pb.BucketAttrs{}, append(client.Options(), transformers.WithPrimaryKeys("Name"))...),
+		Transform:   client.TransformWithStruct(&pb.BucketAttrs{}, transformers.WithPrimaryKeys("Name")),
 		Columns: []schema.Column{
 			{
 				Name:     "project_id",

--- a/plugins/source/gcp/resources/services/translate/glossaries.go
+++ b/plugins/source/gcp/resources/services/translate/glossaries.go
@@ -13,7 +13,7 @@ func Glossaries() *schema.Table {
 		Description: `https://cloud.google.com/translate/docs/reference/rest/v3/projects.locations.glossaries#resource:-glossary`,
 		Resolver:    fetchGlossaries,
 		Multiplex:   client.ProjectMultiplexEnabledServices("translate.googleapis.com"),
-		Transform:   transformers.TransformWithStruct(&pb.Glossary{}, append(client.Options(), transformers.WithPrimaryKeys("Name"))...),
+		Transform:   client.TransformWithStruct(&pb.Glossary{}, transformers.WithPrimaryKeys("Name")),
 		Columns: []schema.Column{
 			{
 				Name:     "project_id",

--- a/plugins/source/gcp/resources/services/videotranscoder/job_templates.go
+++ b/plugins/source/gcp/resources/services/videotranscoder/job_templates.go
@@ -13,7 +13,7 @@ func JobTemplates() *schema.Table {
 		Description: `https://cloud.google.com/transcoder/docs/reference/rest/v1/projects.locations.jobTemplates`,
 		Resolver:    fetchJobTemplates,
 		Multiplex:   client.ProjectMultiplexEnabledServices("transcoder.googleapis.com"),
-		Transform:   transformers.TransformWithStruct(&pb.JobTemplate{}, append(client.Options(), transformers.WithPrimaryKeys("Name"))...),
+		Transform:   client.TransformWithStruct(&pb.JobTemplate{}, transformers.WithPrimaryKeys("Name")),
 		Columns: []schema.Column{
 			{
 				Name:     "project_id",

--- a/plugins/source/gcp/resources/services/videotranscoder/jobs.go
+++ b/plugins/source/gcp/resources/services/videotranscoder/jobs.go
@@ -13,7 +13,7 @@ func Jobs() *schema.Table {
 		Description: `https://cloud.google.com/transcoder/docs/reference/rest/v1/projects.locations.jobs`,
 		Resolver:    fetchJobs,
 		Multiplex:   client.ProjectMultiplexEnabledServices("transcoder.googleapis.com"),
-		Transform:   transformers.TransformWithStruct(&pb.Job{}, append(client.Options(), transformers.WithPrimaryKeys("Name"))...),
+		Transform:   client.TransformWithStruct(&pb.Job{}, transformers.WithPrimaryKeys("Name")),
 		Columns: []schema.Column{
 			{
 				Name:     "project_id",

--- a/plugins/source/gcp/resources/services/vision/products.go
+++ b/plugins/source/gcp/resources/services/vision/products.go
@@ -17,7 +17,7 @@ func Products() *schema.Table {
 			[]string{
 				"us-west1", "us-east1", "asia-east1", "europe-west1",
 			}),
-		Transform: transformers.TransformWithStruct(&pb.Product{}, append(client.Options(), transformers.WithPrimaryKeys("Name"))...),
+		Transform: client.TransformWithStruct(&pb.Product{}, transformers.WithPrimaryKeys("Name")),
 		Columns: []schema.Column{
 			{
 				Name:     "project_id",

--- a/plugins/source/gcp/resources/services/vision/reference_image.go
+++ b/plugins/source/gcp/resources/services/vision/reference_image.go
@@ -12,7 +12,7 @@ func ReferenceImages() *schema.Table {
 		Name:        "gcp_vision_product_reference_images",
 		Description: `https://cloud.google.com/vision/docs/reference/rest/v1/projects.locations.products.referenceImages`,
 		Resolver:    fetchReferenceImages,
-		Transform:   transformers.TransformWithStruct(&pb.ReferenceImage{}, append(client.Options(), transformers.WithPrimaryKeys("Name"))...),
+		Transform:   client.TransformWithStruct(&pb.ReferenceImage{}, transformers.WithPrimaryKeys("Name")),
 		Columns: []schema.Column{
 			{
 				Name:     "project_id",

--- a/plugins/source/gcp/resources/services/vmmigration/groups.go
+++ b/plugins/source/gcp/resources/services/vmmigration/groups.go
@@ -13,7 +13,7 @@ func Groups() *schema.Table {
 		Description: `https://cloud.google.com/migrate/virtual-machines/docs/5.0/reference/rest/v1/projects.locations.groups`,
 		Resolver:    fetchGroups,
 		Multiplex:   client.ProjectMultiplexEnabledServices("vmmigration.googleapis.com"),
-		Transform:   transformers.TransformWithStruct(&pb.Group{}, append(client.Options(), transformers.WithPrimaryKeys("Name"))...),
+		Transform:   client.TransformWithStruct(&pb.Group{}, transformers.WithPrimaryKeys("Name")),
 		Columns: []schema.Column{
 			{
 				Name:     "project_id",

--- a/plugins/source/gcp/resources/services/vmmigration/source_migrating_vm_clone_jobs.go
+++ b/plugins/source/gcp/resources/services/vmmigration/source_migrating_vm_clone_jobs.go
@@ -13,7 +13,7 @@ func CloneJobs() *schema.Table {
 		Description: `https://cloud.google.com/migrate/virtual-machines/docs/5.0/reference/rest/v1/projects.locations.sources.migratingVms.cloneJobs`,
 		Resolver:    fetchCloneJobs,
 		Multiplex:   client.ProjectMultiplexEnabledServices("vmmigration.googleapis.com"),
-		Transform:   transformers.TransformWithStruct(&pb.CloneJob{}, append(client.Options(), transformers.WithPrimaryKeys("Name"))...),
+		Transform:   client.TransformWithStruct(&pb.CloneJob{}, transformers.WithPrimaryKeys("Name")),
 		Columns: []schema.Column{
 			{
 				Name:     "project_id",

--- a/plugins/source/gcp/resources/services/vmmigration/source_migrating_vm_cutover_jobs.go
+++ b/plugins/source/gcp/resources/services/vmmigration/source_migrating_vm_cutover_jobs.go
@@ -13,7 +13,7 @@ func CutoverJobs() *schema.Table {
 		Description: `https://cloud.google.com/migrate/virtual-machines/docs/5.0/reference/rest/v1/projects.locations.sources.migratingVms.cutoverJobs`,
 		Resolver:    fetchCutoverJobs,
 		Multiplex:   client.ProjectMultiplexEnabledServices("vmmigration.googleapis.com"),
-		Transform:   transformers.TransformWithStruct(&pb.CutoverJob{}, append(client.Options(), transformers.WithPrimaryKeys("Name"))...),
+		Transform:   client.TransformWithStruct(&pb.CutoverJob{}, transformers.WithPrimaryKeys("Name")),
 		Columns: []schema.Column{
 			{
 				Name:     "project_id",

--- a/plugins/source/gcp/resources/services/vmmigration/sources.go
+++ b/plugins/source/gcp/resources/services/vmmigration/sources.go
@@ -13,7 +13,7 @@ func Sources() *schema.Table {
 		Description: `https://cloud.google.com/migrate/virtual-machines/docs/5.0/reference/rest/v1/projects.locations.sources`,
 		Resolver:    fetchSources,
 		Multiplex:   client.ProjectMultiplexEnabledServices("vmmigration.googleapis.com"),
-		Transform:   transformers.TransformWithStruct(&pb.Source{}, append(client.Options(), transformers.WithPrimaryKeys("Name"))...),
+		Transform:   client.TransformWithStruct(&pb.Source{}, transformers.WithPrimaryKeys("Name")),
 		Columns: []schema.Column{
 			{
 				Name:     "project_id",

--- a/plugins/source/gcp/resources/services/vmmigration/sources_datacenter_connectors.go
+++ b/plugins/source/gcp/resources/services/vmmigration/sources_datacenter_connectors.go
@@ -13,7 +13,7 @@ func DatacenterConnectors() *schema.Table {
 		Description: `https://cloud.google.com/migrate/virtual-machines/docs/5.0/reference/rest/v1/projects.locations.sources.datacenterConnectors`,
 		Resolver:    fetchDatacenterConnectors,
 		Multiplex:   client.ProjectMultiplexEnabledServices("vmmigration.googleapis.com"),
-		Transform:   transformers.TransformWithStruct(&pb.DatacenterConnector{}, append(client.Options(), transformers.WithPrimaryKeys("Name"))...),
+		Transform:   client.TransformWithStruct(&pb.DatacenterConnector{}, transformers.WithPrimaryKeys("Name")),
 		Columns: []schema.Column{
 			{
 				Name:     "project_id",

--- a/plugins/source/gcp/resources/services/vmmigration/sources_migrating_vms.go
+++ b/plugins/source/gcp/resources/services/vmmigration/sources_migrating_vms.go
@@ -13,7 +13,7 @@ func MigratingVms() *schema.Table {
 		Description: `https://cloud.google.com/migrate/virtual-machines/docs/5.0/reference/rest/v1/projects.locations.sources.migratingVms`,
 		Resolver:    fetchMigratingVms,
 		Multiplex:   client.ProjectMultiplexEnabledServices("vmmigration.googleapis.com"),
-		Transform:   transformers.TransformWithStruct(&pb.MigratingVm{}, append(client.Options(), transformers.WithPrimaryKeys("Name"))...),
+		Transform:   client.TransformWithStruct(&pb.MigratingVm{}, transformers.WithPrimaryKeys("Name")),
 		Columns: []schema.Column{
 			{
 				Name:     "project_id",

--- a/plugins/source/gcp/resources/services/vmmigration/target_projects.go
+++ b/plugins/source/gcp/resources/services/vmmigration/target_projects.go
@@ -13,7 +13,7 @@ func TargetProjects() *schema.Table {
 		Description: `https://cloud.google.com/migrate/virtual-machines/docs/5.0/reference/rest/v1/projects.locations.targetProjects`,
 		Resolver:    fetchTargetProjects,
 		Multiplex:   client.ProjectMultiplexEnabledServices("vmmigration.googleapis.com"),
-		Transform:   transformers.TransformWithStruct(&pb.TargetProject{}, append(client.Options(), transformers.WithPrimaryKeys("Name"))...),
+		Transform:   client.TransformWithStruct(&pb.TargetProject{}, transformers.WithPrimaryKeys("Name")),
 		Columns: []schema.Column{
 			{
 				Name:     "project_id",

--- a/plugins/source/gcp/resources/services/vmmigration/utilization_reports.go
+++ b/plugins/source/gcp/resources/services/vmmigration/utilization_reports.go
@@ -13,7 +13,7 @@ func UtilizationReports() *schema.Table {
 		Description: `https://cloud.google.com/migrate/virtual-machines/docs/5.0/reference/rest/v1/projects.locations.sources.utilizationReports`,
 		Resolver:    fetchUtilizationReports,
 		Multiplex:   client.ProjectMultiplexEnabledServices("vmmigration.googleapis.com"),
-		Transform:   transformers.TransformWithStruct(&pb.UtilizationReport{}, append(client.Options(), transformers.WithPrimaryKeys("Name"))...),
+		Transform:   client.TransformWithStruct(&pb.UtilizationReport{}, transformers.WithPrimaryKeys("Name")),
 		Columns: []schema.Column{
 			{
 				Name:     "project_id",

--- a/plugins/source/gcp/resources/services/vpcaccess/connectors.go
+++ b/plugins/source/gcp/resources/services/vpcaccess/connectors.go
@@ -14,7 +14,7 @@ func Connectors() *schema.Table {
 		Description: `https://cloud.google.com/vpc/docs/reference/vpcaccess/rest/v1/projects.locations.connectors`,
 		Resolver:    fetchConnectors,
 		Multiplex:   client.ProjectMultiplexEnabledServices("vpcaccess.googleapis.com"),
-		Transform:   transformers.TransformWithStruct(&pb.Connector{}, append(client.Options(), transformers.WithPrimaryKeys("Name"))...),
+		Transform:   client.TransformWithStruct(&pb.Connector{}, transformers.WithPrimaryKeys("Name")),
 		Columns: []schema.Column{
 			{
 				Name:     "project_id",

--- a/plugins/source/gcp/resources/services/vpcaccess/locations.go
+++ b/plugins/source/gcp/resources/services/vpcaccess/locations.go
@@ -13,7 +13,7 @@ func Locations() *schema.Table {
 		Description: `https://cloud.google.com/vpc/docs/reference/vpcaccess/rest/Shared.Types/ListLocationsResponse#Location`,
 		Resolver:    fetchLocations,
 		Multiplex:   client.ProjectMultiplexEnabledServices("vpcaccess.googleapis.com"),
-		Transform:   transformers.TransformWithStruct(&locationpb.Location{}, append(client.Options(), transformers.WithPrimaryKeys("Name"))...),
+		Transform:   client.TransformWithStruct(&locationpb.Location{}, transformers.WithPrimaryKeys("Name")),
 		Columns: []schema.Column{
 			{
 				Name:     "project_id",

--- a/plugins/source/gcp/resources/services/websecurityscanner/crawled_urls.go
+++ b/plugins/source/gcp/resources/services/websecurityscanner/crawled_urls.go
@@ -3,7 +3,6 @@ package websecurityscanner
 import (
 	pb "cloud.google.com/go/websecurityscanner/apiv1/websecurityscannerpb"
 	"github.com/cloudquery/plugin-sdk/schema"
-	"github.com/cloudquery/plugin-sdk/transformers"
 	"github.com/cloudquery/plugins/source/gcp/client"
 )
 
@@ -13,7 +12,7 @@ func CrawledUrls() *schema.Table {
 		Description: `https://cloud.google.com/security-command-center/docs/reference/web-security-scanner/rest/v1/projects.scanConfigs.scanRuns.crawledUrls/list#CrawledUrl`,
 		Resolver:    fetchCrawledUrls,
 		Multiplex:   client.ProjectMultiplexEnabledServices("websecurityscanner.googleapis.com"),
-		Transform:   transformers.TransformWithStruct(&pb.CrawledUrl{}, client.Options()...),
+		Transform:   client.TransformWithStruct(&pb.CrawledUrl{}),
 		Columns: []schema.Column{
 			{
 				Name:     "project_id",

--- a/plugins/source/gcp/resources/services/websecurityscanner/findings.go
+++ b/plugins/source/gcp/resources/services/websecurityscanner/findings.go
@@ -13,7 +13,7 @@ func Findings() *schema.Table {
 		Description: `https://cloud.google.com/security-command-center/docs/reference/web-security-scanner/rest/v1/projects.scanConfigs.scanRuns.findings`,
 		Resolver:    fetchFindings,
 		Multiplex:   client.ProjectMultiplexEnabledServices("websecurityscanner.googleapis.com"),
-		Transform:   transformers.TransformWithStruct(&pb.Finding{}, append(client.Options(), transformers.WithPrimaryKeys("Name"))...),
+		Transform:   client.TransformWithStruct(&pb.Finding{}, transformers.WithPrimaryKeys("Name")),
 		Columns: []schema.Column{
 			{
 				Name:     "project_id",

--- a/plugins/source/gcp/resources/services/websecurityscanner/scan_configs.go
+++ b/plugins/source/gcp/resources/services/websecurityscanner/scan_configs.go
@@ -13,7 +13,7 @@ func ScanConfigs() *schema.Table {
 		Description: `https://cloud.google.com/security-command-center/docs/reference/web-security-scanner/rest/v1/projects.scanConfigs#resource:-scanconfig`,
 		Resolver:    fetchScanConfigs,
 		Multiplex:   client.ProjectMultiplexEnabledServices("websecurityscanner.googleapis.com"),
-		Transform:   transformers.TransformWithStruct(&pb.ScanConfig{}, append(client.Options(), transformers.WithPrimaryKeys("Name"))...),
+		Transform:   client.TransformWithStruct(&pb.ScanConfig{}, transformers.WithPrimaryKeys("Name")),
 		Columns: []schema.Column{
 			{
 				Name:     "project_id",

--- a/plugins/source/gcp/resources/services/websecurityscanner/scan_runs.go
+++ b/plugins/source/gcp/resources/services/websecurityscanner/scan_runs.go
@@ -13,7 +13,7 @@ func ScanRuns() *schema.Table {
 		Description: `https://cloud.google.com/security-command-center/docs/reference/web-security-scanner/rest/v1/projects.scanConfigs.scanRuns`,
 		Resolver:    fetchScanRuns,
 		Multiplex:   client.ProjectMultiplexEnabledServices("websecurityscanner.googleapis.com"),
-		Transform:   transformers.TransformWithStruct(&pb.ScanRun{}, append(client.Options(), transformers.WithPrimaryKeys("Name"))...),
+		Transform:   client.TransformWithStruct(&pb.ScanRun{}, transformers.WithPrimaryKeys("Name")),
 		Columns: []schema.Column{
 			{
 				Name:     "project_id",

--- a/plugins/source/gcp/resources/services/workflows/workflows.go
+++ b/plugins/source/gcp/resources/services/workflows/workflows.go
@@ -13,7 +13,7 @@ func Workflows() *schema.Table {
 		Description: `https://cloud.google.com/workflows/docs/reference/rest/v1/projects.locations.workflows#resource:-workflow`,
 		Resolver:    fetchWorkflows,
 		Multiplex:   client.ProjectMultiplexEnabledServices("workflows.googleapis.com"),
-		Transform:   transformers.TransformWithStruct(&pb.Workflow{}, append(client.Options(), transformers.WithPrimaryKeys("Name"))...),
+		Transform:   client.TransformWithStruct(&pb.Workflow{}, transformers.WithPrimaryKeys("Name")),
 		Columns: []schema.Column{
 			{
 				Name:     "project_id",

--- a/plugins/source/github/client/transformers.go
+++ b/plugins/source/github/client/transformers.go
@@ -8,12 +8,14 @@ import (
 	"github.com/google/go-github/v48/github"
 )
 
-func SharedTransformers() []transformers.StructTransformerOption {
-	return []transformers.StructTransformerOption{
-		transformers.WithUnwrapAllEmbeddedStructs(),
-		transformers.WithUnwrapStructFields("Spec", "Status"),
-		transformers.WithTypeTransformer(typeTransformer),
-	}
+var options = []transformers.StructTransformerOption{
+	transformers.WithUnwrapAllEmbeddedStructs(),
+	transformers.WithUnwrapStructFields("Spec", "Status"),
+	transformers.WithTypeTransformer(typeTransformer),
+}
+
+func TransformWithStruct(t any, opts ...transformers.StructTransformerOption) schema.Transform {
+	return transformers.TransformWithStruct(t, append(options, opts...)...)
 }
 
 func typeTransformer(field reflect.StructField) (schema.ValueType, error) {

--- a/plugins/source/github/resources/services/actions/workflows.go
+++ b/plugins/source/github/resources/services/actions/workflows.go
@@ -16,8 +16,7 @@ func Workflows() *schema.Table {
 		Name:      "github_workflows",
 		Resolver:  fetchWorkflows,
 		Multiplex: client.OrgRepositoryMultiplex,
-		Transform: transformers.TransformWithStruct(&github.Workflow{},
-			append(client.SharedTransformers(), transformers.WithPrimaryKeys("ID"))...),
+		Transform: client.TransformWithStruct(&github.Workflow{}, transformers.WithPrimaryKeys("ID")),
 		Columns: []schema.Column{
 			client.OrgColumn,
 			client.RepositoryIDColumn,

--- a/plugins/source/github/resources/services/billing/action.go
+++ b/plugins/source/github/resources/services/billing/action.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/cloudquery/cloudquery/plugins/source/github/client"
 	"github.com/cloudquery/plugin-sdk/schema"
-	"github.com/cloudquery/plugin-sdk/transformers"
 	"github.com/google/go-github/v48/github"
 )
 
@@ -14,7 +13,7 @@ func Action() *schema.Table {
 		Name:      "github_billing_action",
 		Resolver:  fetchAction,
 		Multiplex: client.OrgMultiplex,
-		Transform: transformers.TransformWithStruct(&github.ActionBilling{}, client.SharedTransformers()...),
+		Transform: client.TransformWithStruct(&github.ActionBilling{}),
 		Columns:   []schema.Column{client.OrgColumn},
 	}
 }

--- a/plugins/source/github/resources/services/billing/package.go
+++ b/plugins/source/github/resources/services/billing/package.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/cloudquery/cloudquery/plugins/source/github/client"
 	"github.com/cloudquery/plugin-sdk/schema"
-	"github.com/cloudquery/plugin-sdk/transformers"
 	"github.com/google/go-github/v48/github"
 )
 
@@ -14,7 +13,7 @@ func Package() *schema.Table {
 		Name:      "github_billing_package",
 		Resolver:  fetchPackage,
 		Multiplex: client.OrgMultiplex,
-		Transform: transformers.TransformWithStruct(&github.PackageBilling{}, client.SharedTransformers()...),
+		Transform: client.TransformWithStruct(&github.PackageBilling{}),
 		Columns:   []schema.Column{client.OrgColumn},
 	}
 }

--- a/plugins/source/github/resources/services/billing/storage.go
+++ b/plugins/source/github/resources/services/billing/storage.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/cloudquery/cloudquery/plugins/source/github/client"
 	"github.com/cloudquery/plugin-sdk/schema"
-	"github.com/cloudquery/plugin-sdk/transformers"
 	"github.com/google/go-github/v48/github"
 )
 
@@ -14,7 +13,7 @@ func Storage() *schema.Table {
 		Name:      "github_billing_storage",
 		Resolver:  fetchStorage,
 		Multiplex: client.OrgMultiplex,
-		Transform: transformers.TransformWithStruct(&github.StorageBilling{}, client.SharedTransformers()...),
+		Transform: client.TransformWithStruct(&github.StorageBilling{}),
 		Columns:   []schema.Column{client.OrgColumn},
 	}
 }

--- a/plugins/source/github/resources/services/external/groups.go
+++ b/plugins/source/github/resources/services/external/groups.go
@@ -14,9 +14,8 @@ func Groups() *schema.Table {
 		Name:      "github_external_groups",
 		Resolver:  fetchGroups,
 		Multiplex: client.OrgMultiplex,
-		Transform: transformers.TransformWithStruct(&github.ExternalGroup{},
-			append(client.SharedTransformers(), transformers.WithPrimaryKeys("GroupID"))...),
-		Columns: []schema.Column{client.OrgColumn},
+		Transform: client.TransformWithStruct(&github.ExternalGroup{}, transformers.WithPrimaryKeys("GroupID")),
+		Columns:   []schema.Column{client.OrgColumn},
 	}
 }
 

--- a/plugins/source/github/resources/services/hooks/deliveries.go
+++ b/plugins/source/github/resources/services/hooks/deliveries.go
@@ -14,8 +14,7 @@ func deliveries() *schema.Table {
 		Name:                "github_hook_deliveries",
 		Resolver:            fetchDeliveries,
 		PreResourceResolver: hooksGet,
-		Transform: transformers.TransformWithStruct(&github.HookDelivery{},
-			append(client.SharedTransformers(), transformers.WithPrimaryKeys("ID"))...),
+		Transform:           client.TransformWithStruct(&github.HookDelivery{}, transformers.WithPrimaryKeys("ID")),
 		Columns: []schema.Column{
 			client.OrgColumn,
 			{

--- a/plugins/source/github/resources/services/hooks/hooks.go
+++ b/plugins/source/github/resources/services/hooks/hooks.go
@@ -14,8 +14,7 @@ func Hooks() *schema.Table {
 		Name:      "github_hooks",
 		Resolver:  fetchHooks,
 		Multiplex: client.OrgMultiplex,
-		Transform: transformers.TransformWithStruct(&github.Hook{},
-			append(client.SharedTransformers(), transformers.WithPrimaryKeys("ID"))...),
+		Transform: client.TransformWithStruct(&github.Hook{}, transformers.WithPrimaryKeys("ID")),
 		Columns:   []schema.Column{client.OrgColumn},
 		Relations: []*schema.Table{deliveries()},
 	}

--- a/plugins/source/github/resources/services/installations/installations.go
+++ b/plugins/source/github/resources/services/installations/installations.go
@@ -14,9 +14,8 @@ func Installations() *schema.Table {
 		Name:      "github_installations",
 		Resolver:  fetchInstallations,
 		Multiplex: client.OrgMultiplex,
-		Transform: transformers.TransformWithStruct(&github.Installation{},
-			append(client.SharedTransformers(), transformers.WithPrimaryKeys("ID"))...),
-		Columns: []schema.Column{client.OrgColumn},
+		Transform: client.TransformWithStruct(&github.Installation{}, transformers.WithPrimaryKeys("ID")),
+		Columns:   []schema.Column{client.OrgColumn},
 	}
 }
 

--- a/plugins/source/github/resources/services/issues/issues.go
+++ b/plugins/source/github/resources/services/issues/issues.go
@@ -14,9 +14,8 @@ func Issues() *schema.Table {
 		Name:      "github_issues",
 		Resolver:  fetchIssues,
 		Multiplex: client.OrgMultiplex,
-		Transform: transformers.TransformWithStruct(&github.Issue{},
-			append(client.SharedTransformers(), transformers.WithPrimaryKeys("ID"))...),
-		Columns: []schema.Column{client.OrgColumn},
+		Transform: client.TransformWithStruct(&github.Issue{}, transformers.WithPrimaryKeys("ID")),
+		Columns:   []schema.Column{client.OrgColumn},
 	}
 }
 

--- a/plugins/source/github/resources/services/organizations/alerts.go
+++ b/plugins/source/github/resources/services/organizations/alerts.go
@@ -11,11 +11,10 @@ import (
 
 func alerts() *schema.Table {
 	return &schema.Table{
-		Name:     "github_organization_dependabot_alerts",
-		Resolver: fetchAlerts,
-		Transform: transformers.TransformWithStruct(&github.DependabotAlert{},
-			append(client.SharedTransformers(), transformers.WithPrimaryKeys("HTMLURL"))...),
-		Columns: []schema.Column{client.OrgColumn},
+		Name:      "github_organization_dependabot_alerts",
+		Resolver:  fetchAlerts,
+		Transform: client.TransformWithStruct(&github.DependabotAlert{}, transformers.WithPrimaryKeys("HTMLURL")),
+		Columns:   []schema.Column{client.OrgColumn},
 	}
 }
 

--- a/plugins/source/github/resources/services/organizations/members.go
+++ b/plugins/source/github/resources/services/organizations/members.go
@@ -11,10 +11,9 @@ import (
 
 func members() *schema.Table {
 	return &schema.Table{
-		Name:     "github_organization_members",
-		Resolver: fetchMembers,
-		Transform: transformers.TransformWithStruct(&github.User{},
-			append(client.SharedTransformers(), transformers.WithPrimaryKeys("ID"))...),
+		Name:      "github_organization_members",
+		Resolver:  fetchMembers,
+		Transform: client.TransformWithStruct(&github.User{}, transformers.WithPrimaryKeys("ID")),
 		Columns: []schema.Column{
 			client.OrgColumn,
 			{

--- a/plugins/source/github/resources/services/organizations/organizations.go
+++ b/plugins/source/github/resources/services/organizations/organizations.go
@@ -14,8 +14,7 @@ func Organizations() *schema.Table {
 		Name:      "github_organizations",
 		Resolver:  fetchOrganizations,
 		Multiplex: client.OrgMultiplex,
-		Transform: transformers.TransformWithStruct(&github.Organization{},
-			append(client.SharedTransformers(), transformers.WithPrimaryKeys("ID"))...),
+		Transform: client.TransformWithStruct(&github.Organization{}, transformers.WithPrimaryKeys("ID")),
 		Columns:   []schema.Column{client.OrgColumn},
 		Relations: []*schema.Table{alerts(), members(), secrets()},
 	}

--- a/plugins/source/github/resources/services/organizations/secrets.go
+++ b/plugins/source/github/resources/services/organizations/secrets.go
@@ -11,11 +11,10 @@ import (
 
 func secrets() *schema.Table {
 	return &schema.Table{
-		Name:     "github_organization_dependabot_secrets",
-		Resolver: fetchSecrets,
-		Transform: transformers.TransformWithStruct(&github.Secret{},
-			append(client.SharedTransformers(), transformers.WithPrimaryKeys("Name"))...),
-		Columns: []schema.Column{client.OrgColumn},
+		Name:      "github_organization_dependabot_secrets",
+		Resolver:  fetchSecrets,
+		Transform: client.TransformWithStruct(&github.Secret{}, transformers.WithPrimaryKeys("Name")),
+		Columns:   []schema.Column{client.OrgColumn},
 	}
 }
 

--- a/plugins/source/github/resources/services/repositories/alerts.go
+++ b/plugins/source/github/resources/services/repositories/alerts.go
@@ -11,11 +11,10 @@ import (
 
 func alerts() *schema.Table {
 	return &schema.Table{
-		Name:     "github_repository_dependabot_alerts",
-		Resolver: fetchAlerts,
-		Transform: transformers.TransformWithStruct(&github.DependabotAlert{},
-			append(client.SharedTransformers(), transformers.WithPrimaryKeys("Number"))...),
-		Columns: []schema.Column{client.OrgColumn, client.RepositoryIDColumn},
+		Name:      "github_repository_dependabot_alerts",
+		Resolver:  fetchAlerts,
+		Transform: client.TransformWithStruct(&github.DependabotAlert{}, transformers.WithPrimaryKeys("Number")),
+		Columns:   []schema.Column{client.OrgColumn, client.RepositoryIDColumn},
 	}
 }
 

--- a/plugins/source/github/resources/services/repositories/assets.go
+++ b/plugins/source/github/resources/services/repositories/assets.go
@@ -11,11 +11,10 @@ import (
 
 func assets() *schema.Table {
 	return &schema.Table{
-		Name:     "github_release_assets",
-		Resolver: fetchAssets,
-		Transform: transformers.TransformWithStruct(&github.ReleaseAsset{},
-			append(client.SharedTransformers(), transformers.WithPrimaryKeys("ID"))...),
-		Columns: []schema.Column{client.OrgColumn, client.RepositoryIDColumn},
+		Name:      "github_release_assets",
+		Resolver:  fetchAssets,
+		Transform: client.TransformWithStruct(&github.ReleaseAsset{}, transformers.WithPrimaryKeys("ID")),
+		Columns:   []schema.Column{client.OrgColumn, client.RepositoryIDColumn},
 	}
 }
 

--- a/plugins/source/github/resources/services/repositories/releases.go
+++ b/plugins/source/github/resources/services/repositories/releases.go
@@ -11,10 +11,9 @@ import (
 
 func releases() *schema.Table {
 	return &schema.Table{
-		Name:     "github_releases",
-		Resolver: fetchReleases,
-		Transform: transformers.TransformWithStruct(&github.RepositoryRelease{},
-			append(client.SharedTransformers(), transformers.WithPrimaryKeys("ID"))...),
+		Name:      "github_releases",
+		Resolver:  fetchReleases,
+		Transform: client.TransformWithStruct(&github.RepositoryRelease{}, transformers.WithPrimaryKeys("ID")),
 		Columns:   []schema.Column{client.OrgColumn, client.RepositoryIDColumn},
 		Relations: []*schema.Table{assets()},
 	}

--- a/plugins/source/github/resources/services/repositories/repositories.go
+++ b/plugins/source/github/resources/services/repositories/repositories.go
@@ -14,8 +14,7 @@ func Repositories() *schema.Table {
 		Name:      "github_repositories",
 		Resolver:  fetchRepositories,
 		Multiplex: client.OrgRepositoryMultiplex,
-		Transform: transformers.TransformWithStruct(&github.Repository{},
-			append(client.SharedTransformers(), transformers.WithPrimaryKeys("ID"))...),
+		Transform: client.TransformWithStruct(&github.Repository{}, transformers.WithPrimaryKeys("ID")),
 		Columns:   []schema.Column{client.OrgColumn},
 		Relations: []*schema.Table{alerts(), releases(), secrets()},
 	}

--- a/plugins/source/github/resources/services/repositories/secrets.go
+++ b/plugins/source/github/resources/services/repositories/secrets.go
@@ -11,11 +11,10 @@ import (
 
 func secrets() *schema.Table {
 	return &schema.Table{
-		Name:     "github_repository_dependabot_secrets",
-		Resolver: fetchSecrets,
-		Transform: transformers.TransformWithStruct(&github.Secret{},
-			append(client.SharedTransformers(), transformers.WithPrimaryKeys("Name"))...),
-		Columns: []schema.Column{client.OrgColumn, client.RepositoryIDColumn},
+		Name:      "github_repository_dependabot_secrets",
+		Resolver:  fetchSecrets,
+		Transform: client.TransformWithStruct(&github.Secret{}, transformers.WithPrimaryKeys("Name")),
+		Columns:   []schema.Column{client.OrgColumn, client.RepositoryIDColumn},
 	}
 }
 

--- a/plugins/source/github/resources/services/teams/members.go
+++ b/plugins/source/github/resources/services/teams/members.go
@@ -13,10 +13,9 @@ import (
 
 func members() *schema.Table {
 	return &schema.Table{
-		Name:     "github_team_members",
-		Resolver: fetchMembers,
-		Transform: transformers.TransformWithStruct(&github.User{},
-			append(client.SharedTransformers(), transformers.WithPrimaryKeys("ID"))...),
+		Name:      "github_team_members",
+		Resolver:  fetchMembers,
+		Transform: client.TransformWithStruct(&github.User{}, transformers.WithPrimaryKeys("ID")),
 		Columns: []schema.Column{
 			client.OrgColumn,
 			teamIDColumn,

--- a/plugins/source/github/resources/services/teams/repositories.go
+++ b/plugins/source/github/resources/services/teams/repositories.go
@@ -13,11 +13,10 @@ import (
 
 func repositories() *schema.Table {
 	return &schema.Table{
-		Name:     "github_team_repositories",
-		Resolver: fetchRepositories,
-		Transform: transformers.TransformWithStruct(&github.Repository{},
-			append(client.SharedTransformers(), transformers.WithPrimaryKeys("ID"))...),
-		Columns: []schema.Column{client.OrgColumn, teamIDColumn},
+		Name:      "github_team_repositories",
+		Resolver:  fetchRepositories,
+		Transform: client.TransformWithStruct(&github.Repository{}, transformers.WithPrimaryKeys("ID")),
+		Columns:   []schema.Column{client.OrgColumn, teamIDColumn},
 	}
 }
 

--- a/plugins/source/github/resources/services/teams/teams.go
+++ b/plugins/source/github/resources/services/teams/teams.go
@@ -14,8 +14,7 @@ func Teams() *schema.Table {
 		Name:      "github_teams",
 		Resolver:  fetchTeams,
 		Multiplex: client.OrgMultiplex,
-		Transform: transformers.TransformWithStruct(&github.Team{},
-			append(client.SharedTransformers(), transformers.WithPrimaryKeys("ID"))...),
+		Transform: client.TransformWithStruct(&github.Team{}, transformers.WithPrimaryKeys("ID")),
 		Columns:   []schema.Column{client.OrgColumn},
 		Relations: []*schema.Table{members(), repositories()},
 	}

--- a/plugins/source/github/resources/services/traffic/clones.go
+++ b/plugins/source/github/resources/services/traffic/clones.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/cloudquery/cloudquery/plugins/source/github/client"
 	"github.com/cloudquery/plugin-sdk/schema"
-	"github.com/cloudquery/plugin-sdk/transformers"
 	"github.com/google/go-github/v48/github"
 )
 
@@ -15,7 +14,7 @@ func Clones() *schema.Table {
 		Description: "https://docs.github.com/en/rest/metrics/traffic?apiVersion=2022-11-28#get-repository-clones",
 		Resolver:    fetchClones,
 		Multiplex:   client.OrgRepositoryMultiplex,
-		Transform:   transformers.TransformWithStruct(&github.TrafficClones{}, client.SharedTransformers()...),
+		Transform:   client.TransformWithStruct(&github.TrafficClones{}),
 		Columns:     []schema.Column{client.OrgColumn, client.RepositoryIDColumn},
 	}
 }

--- a/plugins/source/github/resources/services/traffic/paths.go
+++ b/plugins/source/github/resources/services/traffic/paths.go
@@ -15,7 +15,7 @@ func Paths() *schema.Table {
 		Description: "https://docs.github.com/en/rest/metrics/traffic?apiVersion=2022-11-28#get-top-referral-paths",
 		Resolver:    fetchPaths,
 		Multiplex:   client.OrgRepositoryMultiplex,
-		Transform:   transformers.TransformWithStruct(&github.TrafficPath{}, append(client.SharedTransformers(), transformers.WithPrimaryKeys("Path"))...),
+		Transform:   client.TransformWithStruct(&github.TrafficPath{}, transformers.WithPrimaryKeys("Path")),
 		Columns:     []schema.Column{client.OrgColumn, client.RepositoryIDColumn},
 	}
 }

--- a/plugins/source/github/resources/services/traffic/referrers.go
+++ b/plugins/source/github/resources/services/traffic/referrers.go
@@ -15,9 +15,8 @@ func Referrers() *schema.Table {
 		Description: "https://docs.github.com/en/rest/metrics/traffic?apiVersion=2022-11-28#get-top-referral-sources",
 		Resolver:    fetchReferrers,
 		Multiplex:   client.OrgRepositoryMultiplex,
-		Transform: transformers.TransformWithStruct(&github.TrafficReferrer{},
-			append(client.SharedTransformers(), transformers.WithPrimaryKeys("Referrer"))...),
-		Columns: []schema.Column{client.OrgColumn, client.RepositoryIDColumn},
+		Transform:   client.TransformWithStruct(&github.TrafficReferrer{}, transformers.WithPrimaryKeys("Referrer")),
+		Columns:     []schema.Column{client.OrgColumn, client.RepositoryIDColumn},
 	}
 }
 

--- a/plugins/source/github/resources/services/traffic/views.go
+++ b/plugins/source/github/resources/services/traffic/views.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/cloudquery/cloudquery/plugins/source/github/client"
 	"github.com/cloudquery/plugin-sdk/schema"
-	"github.com/cloudquery/plugin-sdk/transformers"
 	"github.com/google/go-github/v48/github"
 )
 
@@ -15,7 +14,7 @@ func Views() *schema.Table {
 		Description: "https://docs.github.com/en/rest/metrics/traffic?apiVersion=2022-11-28#get-page-views",
 		Resolver:    fetchViews,
 		Multiplex:   client.OrgRepositoryMultiplex,
-		Transform:   transformers.TransformWithStruct(&github.TrafficViews{}, client.SharedTransformers()...),
+		Transform:   client.TransformWithStruct(&github.TrafficViews{}),
 		Columns:     []schema.Column{client.OrgColumn, client.RepositoryIDColumn},
 	}
 }

--- a/plugins/source/gitlab/client/transformers.go
+++ b/plugins/source/gitlab/client/transformers.go
@@ -9,12 +9,14 @@ import (
 	"github.com/xanzy/go-gitlab"
 )
 
-func SharedTransformers() []transformers.StructTransformerOption {
-	return []transformers.StructTransformerOption{
-		transformers.WithUnwrapAllEmbeddedStructs(),
-		transformers.WithUnwrapStructFields("Spec", "Status"),
-		transformers.WithTypeTransformer(typeTransformer),
-	}
+var options = []transformers.StructTransformerOption{
+	transformers.WithUnwrapAllEmbeddedStructs(),
+	transformers.WithUnwrapStructFields("Spec", "Status"),
+	transformers.WithTypeTransformer(typeTransformer),
+}
+
+func TransformWithStruct(t any, opts ...transformers.StructTransformerOption) schema.Transform {
+	return transformers.TransformWithStruct(t, append(options, opts...)...)
 }
 
 func typeTransformer(field reflect.StructField) (schema.ValueType, error) {

--- a/plugins/source/gitlab/resources/services/groups/group_members.go
+++ b/plugins/source/gitlab/resources/services/groups/group_members.go
@@ -3,7 +3,6 @@ package groups
 import (
 	"github.com/cloudquery/cloudquery/plugins/source/gitlab/client"
 	"github.com/cloudquery/plugin-sdk/schema"
-	"github.com/cloudquery/plugin-sdk/transformers"
 	"github.com/xanzy/go-gitlab"
 )
 
@@ -11,7 +10,7 @@ func GroupMembers() *schema.Table {
 	return &schema.Table{
 		Name:      "gitlab_group_members",
 		Resolver:  fetchGroupMembers,
-		Transform: transformers.TransformWithStruct(&gitlab.GroupMember{}, client.SharedTransformers()...),
+		Transform: client.TransformWithStruct(&gitlab.GroupMember{}),
 		Columns: []schema.Column{
 			{
 				Name:     "base_url",

--- a/plugins/source/gitlab/resources/services/groups/groups.go
+++ b/plugins/source/gitlab/resources/services/groups/groups.go
@@ -3,7 +3,6 @@ package groups
 import (
 	"github.com/cloudquery/cloudquery/plugins/source/gitlab/client"
 	"github.com/cloudquery/plugin-sdk/schema"
-	"github.com/cloudquery/plugin-sdk/transformers"
 	"github.com/xanzy/go-gitlab"
 )
 
@@ -11,7 +10,7 @@ func Groups() *schema.Table {
 	return &schema.Table{
 		Name:      "gitlab_groups",
 		Resolver:  fetchGroups,
-		Transform: transformers.TransformWithStruct(&gitlab.Group{}, client.SharedTransformers()...),
+		Transform: client.TransformWithStruct(&gitlab.Group{}),
 		Columns: []schema.Column{
 			{
 				Name:     "base_url",

--- a/plugins/source/gitlab/resources/services/projects/project_branches.go
+++ b/plugins/source/gitlab/resources/services/projects/project_branches.go
@@ -3,7 +3,6 @@ package projects
 import (
 	"github.com/cloudquery/cloudquery/plugins/source/gitlab/client"
 	"github.com/cloudquery/plugin-sdk/schema"
-	"github.com/cloudquery/plugin-sdk/transformers"
 	"github.com/xanzy/go-gitlab"
 )
 
@@ -11,7 +10,7 @@ func ProjectBranches() *schema.Table {
 	return &schema.Table{
 		Name:      "gitlab_project_branches",
 		Resolver:  fetchProjectBranches,
-		Transform: transformers.TransformWithStruct(&gitlab.Branch{}, client.SharedTransformers()...),
+		Transform: client.TransformWithStruct(&gitlab.Branch{}),
 		Columns: []schema.Column{
 			{
 				Name:     "base_url",

--- a/plugins/source/gitlab/resources/services/projects/projects.go
+++ b/plugins/source/gitlab/resources/services/projects/projects.go
@@ -3,7 +3,6 @@ package projects
 import (
 	"github.com/cloudquery/cloudquery/plugins/source/gitlab/client"
 	"github.com/cloudquery/plugin-sdk/schema"
-	"github.com/cloudquery/plugin-sdk/transformers"
 	"github.com/xanzy/go-gitlab"
 )
 
@@ -11,7 +10,7 @@ func Projects() *schema.Table {
 	return &schema.Table{
 		Name:      "gitlab_projects",
 		Resolver:  fetchProjects,
-		Transform: transformers.TransformWithStruct(&gitlab.Project{}, client.SharedTransformers()...),
+		Transform: client.TransformWithStruct(&gitlab.Project{}),
 		Columns: []schema.Column{
 			{
 				Name:     "base_url",

--- a/plugins/source/gitlab/resources/services/projects/projects_releases.go
+++ b/plugins/source/gitlab/resources/services/projects/projects_releases.go
@@ -3,7 +3,6 @@ package projects
 import (
 	"github.com/cloudquery/cloudquery/plugins/source/gitlab/client"
 	"github.com/cloudquery/plugin-sdk/schema"
-	"github.com/cloudquery/plugin-sdk/transformers"
 	"github.com/xanzy/go-gitlab"
 )
 
@@ -11,7 +10,7 @@ func ProjectsReleases() *schema.Table {
 	return &schema.Table{
 		Name:      "gitlab_projects_releases",
 		Resolver:  fetchProjectsReleases,
-		Transform: transformers.TransformWithStruct(&gitlab.Release{}, client.SharedTransformers()...),
+		Transform: client.TransformWithStruct(&gitlab.Release{}),
 		Columns: []schema.Column{
 			{
 				Name:     "base_url",

--- a/plugins/source/gitlab/resources/services/settings/settings.go
+++ b/plugins/source/gitlab/resources/services/settings/settings.go
@@ -3,7 +3,6 @@ package settings
 import (
 	"github.com/cloudquery/cloudquery/plugins/source/gitlab/client"
 	"github.com/cloudquery/plugin-sdk/schema"
-	"github.com/cloudquery/plugin-sdk/transformers"
 	"github.com/xanzy/go-gitlab"
 )
 
@@ -11,7 +10,7 @@ func Settings() *schema.Table {
 	return &schema.Table{
 		Name:      "gitlab_settings",
 		Resolver:  fetchSettings,
-		Transform: transformers.TransformWithStruct(&gitlab.Settings{}, client.SharedTransformers()...),
+		Transform: client.TransformWithStruct(&gitlab.Settings{}),
 		Columns: []schema.Column{
 			{
 				Name:     "base_url",

--- a/plugins/source/gitlab/resources/services/users/users.go
+++ b/plugins/source/gitlab/resources/services/users/users.go
@@ -3,7 +3,6 @@ package users
 import (
 	"github.com/cloudquery/cloudquery/plugins/source/gitlab/client"
 	"github.com/cloudquery/plugin-sdk/schema"
-	"github.com/cloudquery/plugin-sdk/transformers"
 	"github.com/xanzy/go-gitlab"
 )
 
@@ -11,7 +10,7 @@ func Users() *schema.Table {
 	return &schema.Table{
 		Name:      "gitlab_users",
 		Resolver:  fetchUsers,
-		Transform: transformers.TransformWithStruct(&gitlab.User{}, client.SharedTransformers()...),
+		Transform: client.TransformWithStruct(&gitlab.User{}),
 		Columns: []schema.Column{
 			{
 				Name:     "base_url",

--- a/plugins/source/k8s/client/transformers.go
+++ b/plugins/source/k8s/client/transformers.go
@@ -7,26 +7,29 @@ import (
 	"github.com/cloudquery/plugin-sdk/transformers"
 )
 
-func SharedTransformersWithMoreSkipFields(skips []string) []transformers.StructTransformerOption {
-	return []transformers.StructTransformerOption{
+var (
+	options = []transformers.StructTransformerOption{
 		transformers.WithUnwrapAllEmbeddedStructs(),
-		transformers.WithSkipFields(
-			append([]string{
-				"GenerateName",
-				"SelfLink",
-				"CreationTimestamp",
-				"DeletionTimestamp",
-				"ZZZ_DeprecatedClusterName",
-				"ManagedFields",
-			}, skips...)...,
-		),
+		transformers.WithSkipFields(skipFields...),
 		transformers.WithUnwrapStructFields("Spec", "Status"),
 		transformers.WithTypeTransformer(typeTransformer),
 	}
+	skipFields = []string{
+		"GenerateName",
+		"SelfLink",
+		"CreationTimestamp",
+		"DeletionTimestamp",
+		"ZZZ_DeprecatedClusterName",
+		"ManagedFields",
+	}
+)
+
+func TransformWithStruct(t any, opts ...transformers.StructTransformerOption) schema.Transform {
+	return transformers.TransformWithStruct(t, append(options, opts...)...)
 }
 
-func SharedTransformers() []transformers.StructTransformerOption {
-	return SharedTransformersWithMoreSkipFields(nil)
+func WithMoreSkipFields(extra ...string) transformers.StructTransformerOption {
+	return transformers.WithSkipFields(append(skipFields, extra...)...)
 }
 
 func typeTransformer(field reflect.StructField) (schema.ValueType, error) {

--- a/plugins/source/k8s/resources/services/admissionregistration/mutating_webhook_configurations.go
+++ b/plugins/source/k8s/resources/services/admissionregistration/mutating_webhook_configurations.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/cloudquery/cloudquery/plugins/source/k8s/client"
 	"github.com/cloudquery/plugin-sdk/schema"
-	"github.com/cloudquery/plugin-sdk/transformers"
 	v1 "k8s.io/api/admissionregistration/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -15,7 +14,7 @@ func MutatingWebhookConfigurations() *schema.Table {
 		Name:      "k8s_admissionregistration_mutating_webhook_configurations",
 		Resolver:  fetchMutatingWebhookConfigurations,
 		Multiplex: client.ContextMultiplex,
-		Transform: transformers.TransformWithStruct(&v1.MutatingWebhookConfiguration{}, client.SharedTransformers()...),
+		Transform: client.TransformWithStruct(&v1.MutatingWebhookConfiguration{}),
 		Columns: []schema.Column{
 			{
 				Name:     "context",

--- a/plugins/source/k8s/resources/services/admissionregistration/validating_webhook_configurations.go
+++ b/plugins/source/k8s/resources/services/admissionregistration/validating_webhook_configurations.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/cloudquery/cloudquery/plugins/source/k8s/client"
 	"github.com/cloudquery/plugin-sdk/schema"
-	"github.com/cloudquery/plugin-sdk/transformers"
 	v1 "k8s.io/api/admissionregistration/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -15,7 +14,7 @@ func ValidatingWebhookConfigurations() *schema.Table {
 		Name:      "k8s_admissionregistration_validating_webhook_configurations",
 		Resolver:  fetchValidatingWebhookConfigurations,
 		Multiplex: client.ContextMultiplex,
-		Transform: transformers.TransformWithStruct(&v1.ValidatingWebhookConfiguration{}, client.SharedTransformers()...),
+		Transform: client.TransformWithStruct(&v1.ValidatingWebhookConfiguration{}),
 		Columns: []schema.Column{
 			{
 				Name:     "context",

--- a/plugins/source/k8s/resources/services/apps/daemon_sets.go
+++ b/plugins/source/k8s/resources/services/apps/daemon_sets.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/cloudquery/cloudquery/plugins/source/k8s/client"
 	"github.com/cloudquery/plugin-sdk/schema"
-	"github.com/cloudquery/plugin-sdk/transformers"
 	v1 "k8s.io/api/apps/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -15,7 +14,7 @@ func DaemonSets() *schema.Table {
 		Name:      "k8s_apps_daemon_sets",
 		Resolver:  fetchDaemonSets,
 		Multiplex: client.ContextMultiplex,
-		Transform: transformers.TransformWithStruct(&v1.DaemonSet{}, client.SharedTransformers()...),
+		Transform: client.TransformWithStruct(&v1.DaemonSet{}),
 		Columns: []schema.Column{
 			{
 				Name:     "context",

--- a/plugins/source/k8s/resources/services/apps/deployments.go
+++ b/plugins/source/k8s/resources/services/apps/deployments.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/cloudquery/cloudquery/plugins/source/k8s/client"
 	"github.com/cloudquery/plugin-sdk/schema"
-	"github.com/cloudquery/plugin-sdk/transformers"
 	v1 "k8s.io/api/apps/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -15,7 +14,7 @@ func Deployments() *schema.Table {
 		Name:      "k8s_apps_deployments",
 		Resolver:  fetchDeployments,
 		Multiplex: client.ContextMultiplex,
-		Transform: transformers.TransformWithStruct(&v1.Deployment{}, client.SharedTransformers()...),
+		Transform: client.TransformWithStruct(&v1.Deployment{}),
 		Columns: []schema.Column{
 			{
 				Name:     "context",

--- a/plugins/source/k8s/resources/services/apps/replica_sets.go
+++ b/plugins/source/k8s/resources/services/apps/replica_sets.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/cloudquery/cloudquery/plugins/source/k8s/client"
 	"github.com/cloudquery/plugin-sdk/schema"
-	"github.com/cloudquery/plugin-sdk/transformers"
 	v1 "k8s.io/api/apps/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -15,7 +14,7 @@ func ReplicaSets() *schema.Table {
 		Name:      "k8s_apps_replica_sets",
 		Resolver:  fetchReplicaSets,
 		Multiplex: client.ContextMultiplex,
-		Transform: transformers.TransformWithStruct(&v1.ReplicaSet{}, client.SharedTransformers()...),
+		Transform: client.TransformWithStruct(&v1.ReplicaSet{}),
 		Columns: []schema.Column{
 			{
 				Name:     "context",

--- a/plugins/source/k8s/resources/services/apps/stateful_sets.go
+++ b/plugins/source/k8s/resources/services/apps/stateful_sets.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/cloudquery/cloudquery/plugins/source/k8s/client"
 	"github.com/cloudquery/plugin-sdk/schema"
-	"github.com/cloudquery/plugin-sdk/transformers"
 	v1 "k8s.io/api/apps/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -15,7 +14,7 @@ func StatefulSets() *schema.Table {
 		Name:      "k8s_apps_stateful_sets",
 		Resolver:  fetchStatefulSets,
 		Multiplex: client.ContextMultiplex,
-		Transform: transformers.TransformWithStruct(&v1.StatefulSet{}, client.SharedTransformers()...),
+		Transform: client.TransformWithStruct(&v1.StatefulSet{}),
 		Columns: []schema.Column{
 			{
 				Name:     "context",

--- a/plugins/source/k8s/resources/services/autoscaling/hpas.go
+++ b/plugins/source/k8s/resources/services/autoscaling/hpas.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/cloudquery/cloudquery/plugins/source/k8s/client"
 	"github.com/cloudquery/plugin-sdk/schema"
-	"github.com/cloudquery/plugin-sdk/transformers"
 	v1 "k8s.io/api/autoscaling/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -15,7 +14,7 @@ func Hpas() *schema.Table {
 		Name:      "k8s_autoscaling_hpas",
 		Resolver:  fetchHpas,
 		Multiplex: client.ContextMultiplex,
-		Transform: transformers.TransformWithStruct(&v1.HorizontalPodAutoscaler{}, client.SharedTransformers()...),
+		Transform: client.TransformWithStruct(&v1.HorizontalPodAutoscaler{}),
 		Columns: []schema.Column{
 			{
 				Name:     "context",

--- a/plugins/source/k8s/resources/services/batch/cron_jobs.go
+++ b/plugins/source/k8s/resources/services/batch/cron_jobs.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/cloudquery/cloudquery/plugins/source/k8s/client"
 	"github.com/cloudquery/plugin-sdk/schema"
-	"github.com/cloudquery/plugin-sdk/transformers"
 	v1 "k8s.io/api/batch/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -15,7 +14,7 @@ func CronJobs() *schema.Table {
 		Name:      "k8s_batch_cron_jobs",
 		Resolver:  fetchCronJobs,
 		Multiplex: client.APIFilterContextMultiplex("/apis/batch/v1/cronjobs"),
-		Transform: transformers.TransformWithStruct(&v1.CronJob{}, client.SharedTransformers()...),
+		Transform: client.TransformWithStruct(&v1.CronJob{}),
 		Columns: []schema.Column{
 			{
 				Name:     "context",

--- a/plugins/source/k8s/resources/services/batch/jobs.go
+++ b/plugins/source/k8s/resources/services/batch/jobs.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/cloudquery/cloudquery/plugins/source/k8s/client"
 	"github.com/cloudquery/plugin-sdk/schema"
-	"github.com/cloudquery/plugin-sdk/transformers"
 	v1 "k8s.io/api/batch/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -15,7 +14,7 @@ func Jobs() *schema.Table {
 		Name:      "k8s_batch_jobs",
 		Resolver:  fetchJobs,
 		Multiplex: client.ContextMultiplex,
-		Transform: transformers.TransformWithStruct(&v1.Job{}, client.SharedTransformers()...),
+		Transform: client.TransformWithStruct(&v1.Job{}),
 		Columns: []schema.Column{
 			{
 				Name:     "context",

--- a/plugins/source/k8s/resources/services/certificates/signing_requests.go
+++ b/plugins/source/k8s/resources/services/certificates/signing_requests.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/cloudquery/cloudquery/plugins/source/k8s/client"
 	"github.com/cloudquery/plugin-sdk/schema"
-	"github.com/cloudquery/plugin-sdk/transformers"
 	v1 "k8s.io/api/certificates/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -15,7 +14,7 @@ func SigningRequests() *schema.Table {
 		Name:      "k8s_certificates_signing_requests",
 		Resolver:  fetchSigningRequests,
 		Multiplex: client.ContextMultiplex,
-		Transform: transformers.TransformWithStruct(&v1.CertificateSigningRequest{}, client.SharedTransformers()...),
+		Transform: client.TransformWithStruct(&v1.CertificateSigningRequest{}),
 		Columns: []schema.Column{
 			{
 				Name:     "context",

--- a/plugins/source/k8s/resources/services/coordination/leases.go
+++ b/plugins/source/k8s/resources/services/coordination/leases.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/cloudquery/cloudquery/plugins/source/k8s/client"
 	"github.com/cloudquery/plugin-sdk/schema"
-	"github.com/cloudquery/plugin-sdk/transformers"
 	v1 "k8s.io/api/coordination/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -15,7 +14,7 @@ func Leases() *schema.Table {
 		Name:      "k8s_coordination_leases",
 		Resolver:  fetchLeases,
 		Multiplex: client.ContextMultiplex,
-		Transform: transformers.TransformWithStruct(&v1.Lease{}, client.SharedTransformers()...),
+		Transform: client.TransformWithStruct(&v1.Lease{}),
 		Columns: []schema.Column{
 			{
 				Name:     "context",

--- a/plugins/source/k8s/resources/services/core/component_statuses.go
+++ b/plugins/source/k8s/resources/services/core/component_statuses.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/cloudquery/cloudquery/plugins/source/k8s/client"
 	"github.com/cloudquery/plugin-sdk/schema"
-	"github.com/cloudquery/plugin-sdk/transformers"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -15,7 +14,7 @@ func ComponentStatuses() *schema.Table {
 		Name:      "k8s_core_component_statuses",
 		Resolver:  fetchComponentStatuses,
 		Multiplex: client.ContextMultiplex,
-		Transform: transformers.TransformWithStruct(&v1.ComponentStatus{}, client.SharedTransformers()...),
+		Transform: client.TransformWithStruct(&v1.ComponentStatus{}),
 		Columns: []schema.Column{
 			{
 				Name:     "context",

--- a/plugins/source/k8s/resources/services/core/config_maps.go
+++ b/plugins/source/k8s/resources/services/core/config_maps.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/cloudquery/cloudquery/plugins/source/k8s/client"
 	"github.com/cloudquery/plugin-sdk/schema"
-	"github.com/cloudquery/plugin-sdk/transformers"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -15,7 +14,7 @@ func ConfigMaps() *schema.Table {
 		Name:      "k8s_core_config_maps",
 		Resolver:  fetchConfigMaps,
 		Multiplex: client.ContextMultiplex,
-		Transform: transformers.TransformWithStruct(&v1.ConfigMap{}, client.SharedTransformers()...),
+		Transform: client.TransformWithStruct(&v1.ConfigMap{}),
 		Columns: []schema.Column{
 			{
 				Name:     "context",

--- a/plugins/source/k8s/resources/services/core/endpoints.go
+++ b/plugins/source/k8s/resources/services/core/endpoints.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/cloudquery/cloudquery/plugins/source/k8s/client"
 	"github.com/cloudquery/plugin-sdk/schema"
-	"github.com/cloudquery/plugin-sdk/transformers"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -15,7 +14,7 @@ func Endpoints() *schema.Table {
 		Name:      "k8s_core_endpoints",
 		Resolver:  fetchEndpoints,
 		Multiplex: client.ContextMultiplex,
-		Transform: transformers.TransformWithStruct(&v1.Endpoints{}, client.SharedTransformers()...),
+		Transform: client.TransformWithStruct(&v1.Endpoints{}),
 		Columns: []schema.Column{
 			{
 				Name:     "context",

--- a/plugins/source/k8s/resources/services/core/events.go
+++ b/plugins/source/k8s/resources/services/core/events.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/cloudquery/cloudquery/plugins/source/k8s/client"
 	"github.com/cloudquery/plugin-sdk/schema"
-	"github.com/cloudquery/plugin-sdk/transformers"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -15,7 +14,7 @@ func Events() *schema.Table {
 		Name:      "k8s_core_events",
 		Resolver:  fetchEvents,
 		Multiplex: client.ContextMultiplex,
-		Transform: transformers.TransformWithStruct(&v1.Event{}, client.SharedTransformers()...),
+		Transform: client.TransformWithStruct(&v1.Event{}),
 		Columns: []schema.Column{
 			{
 				Name:     "context",

--- a/plugins/source/k8s/resources/services/core/limit_ranges.go
+++ b/plugins/source/k8s/resources/services/core/limit_ranges.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/cloudquery/cloudquery/plugins/source/k8s/client"
 	"github.com/cloudquery/plugin-sdk/schema"
-	"github.com/cloudquery/plugin-sdk/transformers"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -15,7 +14,7 @@ func LimitRanges() *schema.Table {
 		Name:      "k8s_core_limit_ranges",
 		Resolver:  fetchLimitRanges,
 		Multiplex: client.ContextMultiplex,
-		Transform: transformers.TransformWithStruct(&v1.LimitRange{}, client.SharedTransformers()...),
+		Transform: client.TransformWithStruct(&v1.LimitRange{}),
 		Columns: []schema.Column{
 			{
 				Name:     "context",

--- a/plugins/source/k8s/resources/services/core/namespaces.go
+++ b/plugins/source/k8s/resources/services/core/namespaces.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/cloudquery/cloudquery/plugins/source/k8s/client"
 	"github.com/cloudquery/plugin-sdk/schema"
-	"github.com/cloudquery/plugin-sdk/transformers"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -15,7 +14,7 @@ func Namespaces() *schema.Table {
 		Name:      "k8s_core_namespaces",
 		Resolver:  fetchNamespaces,
 		Multiplex: client.ContextMultiplex,
-		Transform: transformers.TransformWithStruct(&v1.Namespace{}, client.SharedTransformers()...),
+		Transform: client.TransformWithStruct(&v1.Namespace{}),
 		Columns: []schema.Column{
 			{
 				Name:     "context",

--- a/plugins/source/k8s/resources/services/core/nodes.go
+++ b/plugins/source/k8s/resources/services/core/nodes.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/cloudquery/cloudquery/plugins/source/k8s/client"
 	"github.com/cloudquery/plugin-sdk/schema"
-	"github.com/cloudquery/plugin-sdk/transformers"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -15,10 +14,7 @@ func Nodes() *schema.Table {
 		Name:      "k8s_core_nodes",
 		Resolver:  fetchNodes,
 		Multiplex: client.ContextMultiplex,
-		Transform: transformers.TransformWithStruct(&v1.Node{},
-			client.SharedTransformersWithMoreSkipFields([]string{
-				"DoNotUseExternalID", // Deprecated
-			})...),
+		Transform: client.TransformWithStruct(&v1.Node{}, client.WithMoreSkipFields("DoNotUseExternalID")),
 		Columns: []schema.Column{
 			{
 				Name:     "context",

--- a/plugins/source/k8s/resources/services/core/pods.go
+++ b/plugins/source/k8s/resources/services/core/pods.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/cloudquery/cloudquery/plugins/source/k8s/client"
 	"github.com/cloudquery/plugin-sdk/schema"
-	"github.com/cloudquery/plugin-sdk/transformers"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -15,10 +14,7 @@ func Pods() *schema.Table {
 		Name:      "k8s_core_pods",
 		Resolver:  fetchPods,
 		Multiplex: client.ContextMultiplex,
-		Transform: transformers.TransformWithStruct(&v1.Pod{},
-			client.SharedTransformersWithMoreSkipFields([]string{
-				"DeprecatedServiceAccount", // Deprecated
-			})...),
+		Transform: client.TransformWithStruct(&v1.Pod{}, client.WithMoreSkipFields("DeprecatedServiceAccount")),
 		Columns: []schema.Column{
 			{
 				Name:     "context",

--- a/plugins/source/k8s/resources/services/core/pvcs.go
+++ b/plugins/source/k8s/resources/services/core/pvcs.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/cloudquery/cloudquery/plugins/source/k8s/client"
 	"github.com/cloudquery/plugin-sdk/schema"
-	"github.com/cloudquery/plugin-sdk/transformers"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -15,7 +14,7 @@ func Pvcs() *schema.Table {
 		Name:      "k8s_core_pvcs",
 		Resolver:  fetchPvcs,
 		Multiplex: client.ContextMultiplex,
-		Transform: transformers.TransformWithStruct(&v1.PersistentVolumeClaim{}, client.SharedTransformers()...),
+		Transform: client.TransformWithStruct(&v1.PersistentVolumeClaim{}),
 		Columns: []schema.Column{
 			{
 				Name:     "context",

--- a/plugins/source/k8s/resources/services/core/pvs.go
+++ b/plugins/source/k8s/resources/services/core/pvs.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/cloudquery/cloudquery/plugins/source/k8s/client"
 	"github.com/cloudquery/plugin-sdk/schema"
-	"github.com/cloudquery/plugin-sdk/transformers"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -15,7 +14,7 @@ func Pvs() *schema.Table {
 		Name:      "k8s_core_pvs",
 		Resolver:  fetchPvs,
 		Multiplex: client.ContextMultiplex,
-		Transform: transformers.TransformWithStruct(&v1.PersistentVolume{}, client.SharedTransformers()...),
+		Transform: client.TransformWithStruct(&v1.PersistentVolume{}),
 		Columns: []schema.Column{
 			{
 				Name:     "context",

--- a/plugins/source/k8s/resources/services/core/replication_controllers.go
+++ b/plugins/source/k8s/resources/services/core/replication_controllers.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/cloudquery/cloudquery/plugins/source/k8s/client"
 	"github.com/cloudquery/plugin-sdk/schema"
-	"github.com/cloudquery/plugin-sdk/transformers"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -15,7 +14,7 @@ func ReplicationControllers() *schema.Table {
 		Name:      "k8s_core_replication_controllers",
 		Resolver:  fetchReplicationControllers,
 		Multiplex: client.ContextMultiplex,
-		Transform: transformers.TransformWithStruct(&v1.ReplicationController{}, client.SharedTransformers()...),
+		Transform: client.TransformWithStruct(&v1.ReplicationController{}),
 		Columns: []schema.Column{
 			{
 				Name:     "context",

--- a/plugins/source/k8s/resources/services/core/resource_quotas.go
+++ b/plugins/source/k8s/resources/services/core/resource_quotas.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/cloudquery/cloudquery/plugins/source/k8s/client"
 	"github.com/cloudquery/plugin-sdk/schema"
-	"github.com/cloudquery/plugin-sdk/transformers"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -15,7 +14,7 @@ func ResourceQuotas() *schema.Table {
 		Name:      "k8s_core_resource_quotas",
 		Resolver:  fetchResourceQuotas,
 		Multiplex: client.ContextMultiplex,
-		Transform: transformers.TransformWithStruct(&v1.ResourceQuota{}, client.SharedTransformers()...),
+		Transform: client.TransformWithStruct(&v1.ResourceQuota{}),
 		Columns: []schema.Column{
 			{
 				Name:     "context",

--- a/plugins/source/k8s/resources/services/core/secrets.go
+++ b/plugins/source/k8s/resources/services/core/secrets.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/cloudquery/cloudquery/plugins/source/k8s/client"
 	"github.com/cloudquery/plugin-sdk/schema"
-	"github.com/cloudquery/plugin-sdk/transformers"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -15,11 +14,7 @@ func Secrets() *schema.Table {
 		Name:      "k8s_core_secrets",
 		Resolver:  fetchSecrets,
 		Multiplex: client.ContextMultiplex,
-		Transform: transformers.TransformWithStruct(&v1.Secret{},
-			client.SharedTransformersWithMoreSkipFields([]string{
-				"Data",
-				"StringData",
-			})...),
+		Transform: client.TransformWithStruct(&v1.Secret{}, client.WithMoreSkipFields("Data", "StringData")),
 		Columns: []schema.Column{
 			{
 				Name:     "context",

--- a/plugins/source/k8s/resources/services/core/service_accounts.go
+++ b/plugins/source/k8s/resources/services/core/service_accounts.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/cloudquery/cloudquery/plugins/source/k8s/client"
 	"github.com/cloudquery/plugin-sdk/schema"
-	"github.com/cloudquery/plugin-sdk/transformers"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -15,7 +14,7 @@ func ServiceAccounts() *schema.Table {
 		Name:      "k8s_core_service_accounts",
 		Resolver:  fetchServiceAccounts,
 		Multiplex: client.ContextMultiplex,
-		Transform: transformers.TransformWithStruct(&v1.ServiceAccount{}, client.SharedTransformers()...),
+		Transform: client.TransformWithStruct(&v1.ServiceAccount{}),
 		Columns: []schema.Column{
 			{
 				Name:     "context",

--- a/plugins/source/k8s/resources/services/core/services.go
+++ b/plugins/source/k8s/resources/services/core/services.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/cloudquery/cloudquery/plugins/source/k8s/client"
 	"github.com/cloudquery/plugin-sdk/schema"
-	"github.com/cloudquery/plugin-sdk/transformers"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -15,7 +14,7 @@ func Services() *schema.Table {
 		Name:      "k8s_core_services",
 		Resolver:  fetchServices,
 		Multiplex: client.ContextMultiplex,
-		Transform: transformers.TransformWithStruct(&v1.Service{}, client.SharedTransformers()...),
+		Transform: client.TransformWithStruct(&v1.Service{}),
 		Columns: []schema.Column{
 			{
 				Name:     "context",

--- a/plugins/source/k8s/resources/services/discovery/endpoint_slices.go
+++ b/plugins/source/k8s/resources/services/discovery/endpoint_slices.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/cloudquery/cloudquery/plugins/source/k8s/client"
 	"github.com/cloudquery/plugin-sdk/schema"
-	"github.com/cloudquery/plugin-sdk/transformers"
 	v1 "k8s.io/api/discovery/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -15,7 +14,7 @@ func EndpointSlices() *schema.Table {
 		Name:      "k8s_discovery_endpoint_slices",
 		Resolver:  fetchEndpointSlices,
 		Multiplex: client.ContextMultiplex,
-		Transform: transformers.TransformWithStruct(&v1.EndpointSlice{}, client.SharedTransformers()...),
+		Transform: client.TransformWithStruct(&v1.EndpointSlice{}),
 		Columns: []schema.Column{
 			{
 				Name:     "context",

--- a/plugins/source/k8s/resources/services/networking/ingress_classes.go
+++ b/plugins/source/k8s/resources/services/networking/ingress_classes.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/cloudquery/cloudquery/plugins/source/k8s/client"
 	"github.com/cloudquery/plugin-sdk/schema"
-	"github.com/cloudquery/plugin-sdk/transformers"
 	v1 "k8s.io/api/networking/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -15,7 +14,7 @@ func IngressClasses() *schema.Table {
 		Name:      "k8s_networking_ingress_classes",
 		Resolver:  fetchIngressClasses,
 		Multiplex: client.ContextMultiplex,
-		Transform: transformers.TransformWithStruct(&v1.IngressClass{}, client.SharedTransformers()...),
+		Transform: client.TransformWithStruct(&v1.IngressClass{}),
 		Columns: []schema.Column{
 			{
 				Name:     "context",

--- a/plugins/source/k8s/resources/services/networking/ingresses.go
+++ b/plugins/source/k8s/resources/services/networking/ingresses.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/cloudquery/cloudquery/plugins/source/k8s/client"
 	"github.com/cloudquery/plugin-sdk/schema"
-	"github.com/cloudquery/plugin-sdk/transformers"
 	v1 "k8s.io/api/networking/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -15,7 +14,7 @@ func Ingresses() *schema.Table {
 		Name:      "k8s_networking_ingresses",
 		Resolver:  fetchIngresses,
 		Multiplex: client.ContextMultiplex,
-		Transform: transformers.TransformWithStruct(&v1.Ingress{}, client.SharedTransformers()...),
+		Transform: client.TransformWithStruct(&v1.Ingress{}),
 		Columns: []schema.Column{
 			{
 				Name:     "context",

--- a/plugins/source/k8s/resources/services/networking/network_policies.go
+++ b/plugins/source/k8s/resources/services/networking/network_policies.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/cloudquery/cloudquery/plugins/source/k8s/client"
 	"github.com/cloudquery/plugin-sdk/schema"
-	"github.com/cloudquery/plugin-sdk/transformers"
 	v1 "k8s.io/api/networking/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -15,7 +14,7 @@ func NetworkPolicies() *schema.Table {
 		Name:      "k8s_networking_network_policies",
 		Resolver:  fetchNetworkPolicies,
 		Multiplex: client.ContextMultiplex,
-		Transform: transformers.TransformWithStruct(&v1.NetworkPolicy{}, client.SharedTransformers()...),
+		Transform: client.TransformWithStruct(&v1.NetworkPolicy{}),
 		Columns: []schema.Column{
 			{
 				Name:     "context",

--- a/plugins/source/k8s/resources/services/nodes/runtime_classes.go
+++ b/plugins/source/k8s/resources/services/nodes/runtime_classes.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/cloudquery/cloudquery/plugins/source/k8s/client"
 	"github.com/cloudquery/plugin-sdk/schema"
-	"github.com/cloudquery/plugin-sdk/transformers"
 	v1 "k8s.io/api/node/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -15,7 +14,7 @@ func RuntimeClasses() *schema.Table {
 		Name:      "k8s_nodes_runtime_classes",
 		Resolver:  fetchRuntimeClasses,
 		Multiplex: client.ContextMultiplex,
-		Transform: transformers.TransformWithStruct(&v1.RuntimeClass{}, client.SharedTransformers()...),
+		Transform: client.TransformWithStruct(&v1.RuntimeClass{}),
 		Columns: []schema.Column{
 			{
 				Name:     "context",

--- a/plugins/source/k8s/resources/services/policy/pod_disruption_budgets.go
+++ b/plugins/source/k8s/resources/services/policy/pod_disruption_budgets.go
@@ -15,7 +15,7 @@ func PodDisruptionBudgets() *schema.Table {
 		Name:      "k8s_policy_pod_disruption_budgets",
 		Resolver:  fetchPodDisruptionBudgets,
 		Multiplex: client.ContextNamespaceMultiplex,
-		Transform: transformers.TransformWithStruct(&policy.PodDisruptionBudget{}, append(client.SharedTransformers(), transformers.WithPrimaryKeys("UID"))...),
+		Transform: client.TransformWithStruct(&policy.PodDisruptionBudget{}, transformers.WithPrimaryKeys("UID")),
 		Columns: []schema.Column{
 			{
 				Name:     "context",

--- a/plugins/source/k8s/resources/services/rbac/cluster_role_bindings.go
+++ b/plugins/source/k8s/resources/services/rbac/cluster_role_bindings.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/cloudquery/cloudquery/plugins/source/k8s/client"
 	"github.com/cloudquery/plugin-sdk/schema"
-	"github.com/cloudquery/plugin-sdk/transformers"
 	v1 "k8s.io/api/rbac/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -15,7 +14,7 @@ func ClusterRoleBindings() *schema.Table {
 		Name:      "k8s_rbac_cluster_role_bindings",
 		Resolver:  fetchClusterRoleBindings,
 		Multiplex: client.ContextMultiplex,
-		Transform: transformers.TransformWithStruct(&v1.ClusterRoleBinding{}, client.SharedTransformers()...),
+		Transform: client.TransformWithStruct(&v1.ClusterRoleBinding{}),
 		Columns: []schema.Column{
 			{
 				Name:     "context",

--- a/plugins/source/k8s/resources/services/rbac/cluster_roles.go
+++ b/plugins/source/k8s/resources/services/rbac/cluster_roles.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/cloudquery/cloudquery/plugins/source/k8s/client"
 	"github.com/cloudquery/plugin-sdk/schema"
-	"github.com/cloudquery/plugin-sdk/transformers"
 	v1 "k8s.io/api/rbac/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -15,7 +14,7 @@ func ClusterRoles() *schema.Table {
 		Name:      "k8s_rbac_cluster_roles",
 		Resolver:  fetchClusterRoles,
 		Multiplex: client.ContextMultiplex,
-		Transform: transformers.TransformWithStruct(&v1.ClusterRole{}, client.SharedTransformers()...),
+		Transform: client.TransformWithStruct(&v1.ClusterRole{}),
 		Columns: []schema.Column{
 			{
 				Name:     "context",

--- a/plugins/source/k8s/resources/services/rbac/role_bindings.go
+++ b/plugins/source/k8s/resources/services/rbac/role_bindings.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/cloudquery/cloudquery/plugins/source/k8s/client"
 	"github.com/cloudquery/plugin-sdk/schema"
-	"github.com/cloudquery/plugin-sdk/transformers"
 	v1 "k8s.io/api/rbac/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -15,7 +14,7 @@ func RoleBindings() *schema.Table {
 		Name:      "k8s_rbac_role_bindings",
 		Resolver:  fetchRoleBindings,
 		Multiplex: client.ContextMultiplex,
-		Transform: transformers.TransformWithStruct(&v1.RoleBinding{}, client.SharedTransformers()...),
+		Transform: client.TransformWithStruct(&v1.RoleBinding{}),
 		Columns: []schema.Column{
 			{
 				Name:     "context",

--- a/plugins/source/k8s/resources/services/rbac/roles.go
+++ b/plugins/source/k8s/resources/services/rbac/roles.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/cloudquery/cloudquery/plugins/source/k8s/client"
 	"github.com/cloudquery/plugin-sdk/schema"
-	"github.com/cloudquery/plugin-sdk/transformers"
 	v1 "k8s.io/api/rbac/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -15,7 +14,7 @@ func Roles() *schema.Table {
 		Name:      "k8s_rbac_roles",
 		Resolver:  fetchRoles,
 		Multiplex: client.ContextMultiplex,
-		Transform: transformers.TransformWithStruct(&v1.Role{}, client.SharedTransformers()...),
+		Transform: client.TransformWithStruct(&v1.Role{}),
 		Columns: []schema.Column{
 			{
 				Name:     "context",

--- a/plugins/source/k8s/resources/services/storage/csi_drivers.go
+++ b/plugins/source/k8s/resources/services/storage/csi_drivers.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/cloudquery/cloudquery/plugins/source/k8s/client"
 	"github.com/cloudquery/plugin-sdk/schema"
-	"github.com/cloudquery/plugin-sdk/transformers"
 	v1 "k8s.io/api/storage/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -15,7 +14,7 @@ func CsiDrivers() *schema.Table {
 		Name:      "k8s_storage_csi_drivers",
 		Resolver:  fetchCsiDrivers,
 		Multiplex: client.ContextMultiplex,
-		Transform: transformers.TransformWithStruct(&v1.CSIDriver{}, client.SharedTransformers()...),
+		Transform: client.TransformWithStruct(&v1.CSIDriver{}),
 		Columns: []schema.Column{
 			{
 				Name:     "context",

--- a/plugins/source/k8s/resources/services/storage/csi_nodes.go
+++ b/plugins/source/k8s/resources/services/storage/csi_nodes.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/cloudquery/cloudquery/plugins/source/k8s/client"
 	"github.com/cloudquery/plugin-sdk/schema"
-	"github.com/cloudquery/plugin-sdk/transformers"
 	v1 "k8s.io/api/storage/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -15,7 +14,7 @@ func CsiNodes() *schema.Table {
 		Name:      "k8s_storage_csi_nodes",
 		Resolver:  fetchCsiNodes,
 		Multiplex: client.ContextMultiplex,
-		Transform: transformers.TransformWithStruct(&v1.CSINode{}, client.SharedTransformers()...),
+		Transform: client.TransformWithStruct(&v1.CSINode{}),
 		Columns: []schema.Column{
 			{
 				Name:     "context",

--- a/plugins/source/k8s/resources/services/storage/csi_storage_capacities.go
+++ b/plugins/source/k8s/resources/services/storage/csi_storage_capacities.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/cloudquery/cloudquery/plugins/source/k8s/client"
 	"github.com/cloudquery/plugin-sdk/schema"
-	"github.com/cloudquery/plugin-sdk/transformers"
 	v1 "k8s.io/api/storage/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -15,7 +14,7 @@ func CsiStorageCapacities() *schema.Table {
 		Name:      "k8s_storage_csi_storage_capacities",
 		Resolver:  fetchCsiStorageCapacities,
 		Multiplex: client.ContextMultiplex,
-		Transform: transformers.TransformWithStruct(&v1.CSIStorageCapacity{}, client.SharedTransformers()...),
+		Transform: client.TransformWithStruct(&v1.CSIStorageCapacity{}),
 		Columns: []schema.Column{
 			{
 				Name:     "context",

--- a/plugins/source/k8s/resources/services/storage/storage_classes.go
+++ b/plugins/source/k8s/resources/services/storage/storage_classes.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/cloudquery/cloudquery/plugins/source/k8s/client"
 	"github.com/cloudquery/plugin-sdk/schema"
-	"github.com/cloudquery/plugin-sdk/transformers"
 	v1 "k8s.io/api/storage/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -15,7 +14,7 @@ func StorageClasses() *schema.Table {
 		Name:      "k8s_storage_storage_classes",
 		Resolver:  fetchStorageClasses,
 		Multiplex: client.ContextMultiplex,
-		Transform: transformers.TransformWithStruct(&v1.StorageClass{}, client.SharedTransformers()...),
+		Transform: client.TransformWithStruct(&v1.StorageClass{}),
 		Columns: []schema.Column{
 			{
 				Name:     "context",

--- a/plugins/source/k8s/resources/services/storage/volume_attachments.go
+++ b/plugins/source/k8s/resources/services/storage/volume_attachments.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/cloudquery/cloudquery/plugins/source/k8s/client"
 	"github.com/cloudquery/plugin-sdk/schema"
-	"github.com/cloudquery/plugin-sdk/transformers"
 	v1 "k8s.io/api/storage/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -15,7 +14,7 @@ func VolumeAttachments() *schema.Table {
 		Name:      "k8s_storage_volume_attachments",
 		Resolver:  fetchVolumeAttachments,
 		Multiplex: client.ContextMultiplex,
-		Transform: transformers.TransformWithStruct(&v1.VolumeAttachment{}, client.SharedTransformers()...),
+		Transform: client.TransformWithStruct(&v1.VolumeAttachment{}),
 		Columns: []schema.Column{
 			{
 				Name:     "context",

--- a/plugins/source/launchdarkly/client/transformers.go
+++ b/plugins/source/launchdarkly/client/transformers.go
@@ -4,13 +4,16 @@ import (
 	"reflect"
 	"strings"
 
+	"github.com/cloudquery/plugin-sdk/schema"
 	"github.com/cloudquery/plugin-sdk/transformers"
 )
 
-func SharedTransformers(others ...transformers.StructTransformerOption) []transformers.StructTransformerOption {
-	return append([]transformers.StructTransformerOption{
-		transformers.WithNameTransformer(nameTransformer),
-	}, others...)
+var options = []transformers.StructTransformerOption{
+	transformers.WithNameTransformer(nameTransformer),
+}
+
+func TransformWithStruct(t any, opts ...transformers.StructTransformerOption) schema.Transform {
+	return transformers.TransformWithStruct(t, append(options, opts...)...)
 }
 
 func nameTransformer(f reflect.StructField) (string, error) {

--- a/plugins/source/launchdarkly/resources/services/auditlog/auditlog_entries.go
+++ b/plugins/source/launchdarkly/resources/services/auditlog/auditlog_entries.go
@@ -16,7 +16,7 @@ func AuditLogEntries() *schema.Table {
 		Name:        "launchdarkly_auditlog_entries",
 		Description: `https://apidocs.launchdarkly.com/tag/Audit-log#operation/getAuditLogEntries`,
 		Resolver:    fetchAuditLogEntries,
-		Transform:   transformers.TransformWithStruct(&ldapi.AuditLogEntryListingRep{}, client.SharedTransformers(transformers.WithPrimaryKeys("Id"), transformers.WithSkipFields("Date", "Links"))...),
+		Transform:   client.TransformWithStruct(&ldapi.AuditLogEntryListingRep{}, transformers.WithPrimaryKeys("Id"), transformers.WithSkipFields("Date", "Links")),
 		Columns: schema.ColumnList{
 			{
 				Name:     "date",

--- a/plugins/source/launchdarkly/resources/services/projects/project_environments.go
+++ b/plugins/source/launchdarkly/resources/services/projects/project_environments.go
@@ -14,7 +14,7 @@ func ProjectEnvironments() *schema.Table {
 		Name:        "launchdarkly_project_environments",
 		Description: `https://apidocs.launchdarkly.com/tag/Environments#operation/getEnvironment`,
 		Resolver:    fetchProjectEnvironments,
-		Transform:   transformers.TransformWithStruct(&ldapi.Environment{}, client.SharedTransformers(transformers.WithPrimaryKeys("Id"), transformers.WithSkipFields("Links"))...),
+		Transform:   client.TransformWithStruct(&ldapi.Environment{}, transformers.WithPrimaryKeys("Id"), transformers.WithSkipFields("Links")),
 		Columns: schema.ColumnList{
 			{
 				Name:     "project_id",

--- a/plugins/source/launchdarkly/resources/services/projects/project_flag_defaults.go
+++ b/plugins/source/launchdarkly/resources/services/projects/project_flag_defaults.go
@@ -14,7 +14,7 @@ func ProjectFlagDefaults() *schema.Table {
 		Name:        "launchdarkly_project_flag_defaults",
 		Description: `https://apidocs.launchdarkly.com/tag/Projects#operation/getFlagDefaultsByProject`,
 		Resolver:    fetchProjectFlagDefaults,
-		Transform:   transformers.TransformWithStruct(&ldapi.FlagDefaultsRep{}, client.SharedTransformers(transformers.WithSkipFields("Links"))...),
+		Transform:   client.TransformWithStruct(&ldapi.FlagDefaultsRep{}, transformers.WithSkipFields("Links")),
 		Columns: schema.ColumnList{
 			{
 				Name:     "project_id",

--- a/plugins/source/launchdarkly/resources/services/projects/project_flags.go
+++ b/plugins/source/launchdarkly/resources/services/projects/project_flags.go
@@ -14,7 +14,7 @@ func ProjectFlags() *schema.Table {
 		Name:        "launchdarkly_project_flags",
 		Description: `https://apidocs.launchdarkly.com/tag/Feature-flags#operation/getFeatureFlags`,
 		Resolver:    fetchProjectFlags,
-		Transform:   transformers.TransformWithStruct(&ldapi.FeatureFlag{}, client.SharedTransformers(transformers.WithPrimaryKeys("Key"), transformers.WithSkipFields("Links"))...),
+		Transform:   client.TransformWithStruct(&ldapi.FeatureFlag{}, transformers.WithPrimaryKeys("Key"), transformers.WithSkipFields("Links")),
 		Columns: schema.ColumnList{
 			{
 				Name:     "project_id",

--- a/plugins/source/launchdarkly/resources/services/projects/project_metrics.go
+++ b/plugins/source/launchdarkly/resources/services/projects/project_metrics.go
@@ -14,7 +14,7 @@ func ProjectMetrics() *schema.Table {
 		Name:        "launchdarkly_project_metrics",
 		Description: `https://apidocs.launchdarkly.com/tag/Metrics#operation/getMetrics`,
 		Resolver:    fetchProjectMetrics,
-		Transform:   transformers.TransformWithStruct(&ldapi.MetricListingRep{}, client.SharedTransformers(transformers.WithPrimaryKeys("Id"), transformers.WithSkipFields("Links", "Site"))...),
+		Transform:   client.TransformWithStruct(&ldapi.MetricListingRep{}, transformers.WithPrimaryKeys("Id"), transformers.WithSkipFields("Links", "Site")),
 		Columns: schema.ColumnList{
 			{
 				Name:     "project_id",

--- a/plugins/source/launchdarkly/resources/services/projects/projects.go
+++ b/plugins/source/launchdarkly/resources/services/projects/projects.go
@@ -14,7 +14,7 @@ func Projects() *schema.Table {
 		Name:        "launchdarkly_projects",
 		Description: `https://apidocs.launchdarkly.com/tag/Projects#operation/getProjects`,
 		Resolver:    fetchProjects,
-		Transform:   transformers.TransformWithStruct(&ldapi.Project{}, client.SharedTransformers(transformers.WithPrimaryKeys("Id"), transformers.WithSkipFields("Environments", "Links"))...),
+		Transform:   client.TransformWithStruct(&ldapi.Project{}, transformers.WithPrimaryKeys("Id"), transformers.WithSkipFields("Environments", "Links")),
 		Relations: []*schema.Table{
 			ProjectEnvironments(),
 			ProjectFlagDefaults(),

--- a/plugins/source/mixpanel/client/transformers.go
+++ b/plugins/source/mixpanel/client/transformers.go
@@ -8,10 +8,12 @@ import (
 	"github.com/cloudquery/plugin-sdk/transformers"
 )
 
-func SharedTransformers(others ...transformers.StructTransformerOption) []transformers.StructTransformerOption {
-	return append([]transformers.StructTransformerOption{
-		transformers.WithTypeTransformer(typeTransformer),
-	}, others...)
+var options = []transformers.StructTransformerOption{
+	transformers.WithTypeTransformer(typeTransformer),
+}
+
+func TransformWithStruct(t any, opts ...transformers.StructTransformerOption) schema.Transform {
+	return transformers.TransformWithStruct(t, append(options, opts...)...)
 }
 
 func typeTransformer(field reflect.StructField) (schema.ValueType, error) {

--- a/plugins/source/mixpanel/resources/services/annotations/annotations.go
+++ b/plugins/source/mixpanel/resources/services/annotations/annotations.go
@@ -15,7 +15,7 @@ func Annotations() *schema.Table {
 		Name:        "mixpanel_annotations",
 		Description: `https://developer.mixpanel.com/reference/list-all-annotations-for-project`,
 		Resolver:    fetchAnnotations,
-		Transform:   transformers.TransformWithStruct(&mixpanel.Annotation{}, client.SharedTransformers(transformers.WithPrimaryKeys("ID"))...),
+		Transform:   client.TransformWithStruct(&mixpanel.Annotation{}, transformers.WithPrimaryKeys("ID")),
 		Columns: []schema.Column{
 			{
 				Name:     "project_id",

--- a/plugins/source/mixpanel/resources/services/cohorts/cohort_members.go
+++ b/plugins/source/mixpanel/resources/services/cohorts/cohort_members.go
@@ -16,7 +16,7 @@ func CohortMembers() *schema.Table {
 		Name:        "mixpanel_cohort_members",
 		Description: `https://developer.mixpanel.com/reference/engage-query`,
 		Resolver:    fetchCohortMembers,
-		Transform:   transformers.TransformWithStruct(&mixpanel.EngageProfile{}, client.SharedTransformers(transformers.WithPrimaryKeys("DistinctID"))...),
+		Transform:   client.TransformWithStruct(&mixpanel.EngageProfile{}, transformers.WithPrimaryKeys("DistinctID")),
 		Columns: []schema.Column{
 			{
 				Name:     "project_id",

--- a/plugins/source/mixpanel/resources/services/cohorts/cohorts.go
+++ b/plugins/source/mixpanel/resources/services/cohorts/cohorts.go
@@ -14,7 +14,7 @@ func Cohorts() *schema.Table {
 		Name:        "mixpanel_cohorts",
 		Description: `https://developer.mixpanel.com/reference/cohorts-list`,
 		Resolver:    fetchCohorts,
-		Transform:   transformers.TransformWithStruct(&mixpanel.Cohort{}, client.SharedTransformers(transformers.WithPrimaryKeys("ID"))...),
+		Transform:   client.TransformWithStruct(&mixpanel.Cohort{}, transformers.WithPrimaryKeys("ID")),
 		Relations: []*schema.Table{
 			CohortMembers(),
 		},

--- a/plugins/source/mixpanel/resources/services/engage/revenues.go
+++ b/plugins/source/mixpanel/resources/services/engage/revenues.go
@@ -13,7 +13,7 @@ func EngageRevenues() *schema.Table {
 	return &schema.Table{
 		Name:      "mixpanel_engage_revenues",
 		Resolver:  fetchEngageRevenues,
-		Transform: transformers.TransformWithStruct(&mixpanel.EngageRevenue{}, client.SharedTransformers(transformers.WithPrimaryKeys("Date"))...),
+		Transform: client.TransformWithStruct(&mixpanel.EngageRevenue{}, transformers.WithPrimaryKeys("Date")),
 		Columns: schema.ColumnList{
 			{
 				Name:     "project_id",

--- a/plugins/source/mixpanel/resources/services/export/export_events.go
+++ b/plugins/source/mixpanel/resources/services/export/export_events.go
@@ -21,7 +21,7 @@ func ExportEvents() *schema.Table {
 		Description:          `https://developer.mixpanel.com/reference/raw-event-export`,
 		Resolver:             fetchExportEvents,
 		PostResourceResolver: postExportEvents,
-		Transform:            transformers.TransformWithStruct(&mixpanel.ExportEvent{}, client.SharedTransformers(transformers.WithPrimaryKeys("Event"))...),
+		Transform:            client.TransformWithStruct(&mixpanel.ExportEvent{}, transformers.WithPrimaryKeys("Event")),
 		IsIncremental:        true,
 		Columns: []schema.Column{
 			{

--- a/plugins/source/mixpanel/resources/services/funnels/funnel_reports.go
+++ b/plugins/source/mixpanel/resources/services/funnels/funnel_reports.go
@@ -14,7 +14,7 @@ func FunnelReports() *schema.Table {
 		Name:        "mixpanel_funnel_reports",
 		Description: `https://developer.mixpanel.com/reference/funnels-query`,
 		Resolver:    fetchFunnelReports,
-		Transform:   transformers.TransformWithStruct(&mixpanel.FunnelData{}, client.SharedTransformers(transformers.WithPrimaryKeys("Date"))...),
+		Transform:   client.TransformWithStruct(&mixpanel.FunnelData{}, transformers.WithPrimaryKeys("Date")),
 		Columns: []schema.Column{
 			{
 				Name:     "project_id",

--- a/plugins/source/mixpanel/resources/services/funnels/funnels.go
+++ b/plugins/source/mixpanel/resources/services/funnels/funnels.go
@@ -14,7 +14,7 @@ func Funnels() *schema.Table {
 		Name:        "mixpanel_funnels",
 		Description: `https://developer.mixpanel.com/reference/funnels-list-saved`,
 		Resolver:    fetchFunnels,
-		Transform:   transformers.TransformWithStruct(&mixpanel.Funnel{}, client.SharedTransformers(transformers.WithPrimaryKeys("FunnelID"))...),
+		Transform:   client.TransformWithStruct(&mixpanel.Funnel{}, transformers.WithPrimaryKeys("FunnelID")),
 		Columns: []schema.Column{
 			{
 				Name:     "project_id",

--- a/plugins/source/okta/client/transformers.go
+++ b/plugins/source/okta/client/transformers.go
@@ -8,11 +8,13 @@ import (
 	"github.com/okta/okta-sdk-golang/v3/okta"
 )
 
-func SharedTransformers() []transformers.StructTransformerOption {
-	return []transformers.StructTransformerOption{
-		transformers.WithTypeTransformer(typeTransformer),
-		transformers.WithResolverTransformer(resolverTransformer),
-	}
+var options = []transformers.StructTransformerOption{
+	transformers.WithTypeTransformer(typeTransformer),
+	transformers.WithResolverTransformer(resolverTransformer),
+}
+
+func TransformWithStruct(t any, opts ...transformers.StructTransformerOption) schema.Transform {
+	return transformers.TransformWithStruct(t, append(options, opts...)...)
 }
 
 func typeTransformer(field reflect.StructField) (schema.ValueType, error) {

--- a/plugins/source/okta/resources/services/applications/application_group_assignments.go
+++ b/plugins/source/okta/resources/services/applications/application_group_assignments.go
@@ -3,7 +3,6 @@ package applications
 import (
 	"github.com/cloudquery/cloudquery/plugins/source/okta/client"
 	"github.com/cloudquery/plugin-sdk/schema"
-	"github.com/cloudquery/plugin-sdk/transformers"
 	"github.com/okta/okta-sdk-golang/v3/okta"
 )
 
@@ -11,7 +10,7 @@ func ApplicationGroupAssignments() *schema.Table {
 	return &schema.Table{
 		Name:      "okta_application_group_assignments",
 		Resolver:  fetchApplicationGroupAssignments,
-		Transform: transformers.TransformWithStruct(&okta.ApplicationGroupAssignment{}, client.SharedTransformers()...),
+		Transform: client.TransformWithStruct(&okta.ApplicationGroupAssignment{}),
 		Columns: []schema.Column{
 			{
 				Name:     "app_id",

--- a/plugins/source/okta/resources/services/applications/application_users.go
+++ b/plugins/source/okta/resources/services/applications/application_users.go
@@ -3,7 +3,6 @@ package applications
 import (
 	"github.com/cloudquery/cloudquery/plugins/source/okta/client"
 	"github.com/cloudquery/plugin-sdk/schema"
-	"github.com/cloudquery/plugin-sdk/transformers"
 	"github.com/okta/okta-sdk-golang/v3/okta"
 )
 
@@ -11,7 +10,7 @@ func ApplicationUsers() *schema.Table {
 	return &schema.Table{
 		Name:      "okta_application_users",
 		Resolver:  fetchApplicationUsers,
-		Transform: transformers.TransformWithStruct(&okta.AppUser{}, client.SharedTransformers()...),
+		Transform: client.TransformWithStruct(&okta.AppUser{}),
 		Columns: []schema.Column{
 			{
 				Name:     "app_id",

--- a/plugins/source/okta/resources/services/applications/applications.go
+++ b/plugins/source/okta/resources/services/applications/applications.go
@@ -3,7 +3,6 @@ package applications
 import (
 	"github.com/cloudquery/cloudquery/plugins/source/okta/client"
 	"github.com/cloudquery/plugin-sdk/schema"
-	"github.com/cloudquery/plugin-sdk/transformers"
 	"github.com/okta/okta-sdk-golang/v3/okta"
 )
 
@@ -11,7 +10,7 @@ func Applications() *schema.Table {
 	return &schema.Table{
 		Name:      "okta_applications",
 		Resolver:  fetchApplications,
-		Transform: transformers.TransformWithStruct(&okta.Application{}, client.SharedTransformers()...),
+		Transform: client.TransformWithStruct(&okta.Application{}),
 		Columns: []schema.Column{
 			{
 				Name:     "id",

--- a/plugins/source/okta/resources/services/groups/group_users.go
+++ b/plugins/source/okta/resources/services/groups/group_users.go
@@ -4,14 +4,13 @@ import (
 	"github.com/cloudquery/cloudquery/plugins/source/okta/client"
 	"github.com/cloudquery/cloudquery/plugins/source/okta/resources/services/groups/models"
 	"github.com/cloudquery/plugin-sdk/schema"
-	"github.com/cloudquery/plugin-sdk/transformers"
 )
 
 func GroupUsers() *schema.Table {
 	return &schema.Table{
 		Name:      "okta_group_users",
 		Resolver:  fetchGroupUsers,
-		Transform: transformers.TransformWithStruct(&models.GroupUser{}, client.SharedTransformers()...),
+		Transform: client.TransformWithStruct(&models.GroupUser{}),
 		Columns: []schema.Column{
 			{
 				Name:     "group_id",

--- a/plugins/source/okta/resources/services/groups/groups.go
+++ b/plugins/source/okta/resources/services/groups/groups.go
@@ -3,7 +3,6 @@ package groups
 import (
 	"github.com/cloudquery/cloudquery/plugins/source/okta/client"
 	"github.com/cloudquery/plugin-sdk/schema"
-	"github.com/cloudquery/plugin-sdk/transformers"
 	"github.com/okta/okta-sdk-golang/v3/okta"
 )
 
@@ -11,7 +10,7 @@ func Groups() *schema.Table {
 	return &schema.Table{
 		Name:      "okta_groups",
 		Resolver:  fetchGroups,
-		Transform: transformers.TransformWithStruct(&okta.Group{}, client.SharedTransformers()...),
+		Transform: client.TransformWithStruct(&okta.Group{}),
 		Columns: []schema.Column{
 			{
 				Name:     "id",

--- a/plugins/source/okta/resources/services/users/users.go
+++ b/plugins/source/okta/resources/services/users/users.go
@@ -3,7 +3,6 @@ package users
 import (
 	"github.com/cloudquery/cloudquery/plugins/source/okta/client"
 	"github.com/cloudquery/plugin-sdk/schema"
-	"github.com/cloudquery/plugin-sdk/transformers"
 	"github.com/okta/okta-sdk-golang/v3/okta"
 )
 
@@ -11,7 +10,7 @@ func Users() *schema.Table {
 	return &schema.Table{
 		Name:      "okta_users",
 		Resolver:  fetchUsers,
-		Transform: transformers.TransformWithStruct(&okta.User{}, client.SharedTransformers()...),
+		Transform: client.TransformWithStruct(&okta.User{}),
 		Columns: []schema.Column{
 			{
 				Name:     "id",

--- a/plugins/source/stripe/client/transformers.go
+++ b/plugins/source/stripe/client/transformers.go
@@ -7,12 +7,13 @@ import (
 	"github.com/cloudquery/plugin-sdk/transformers"
 )
 
-func SharedTransformers(others ...transformers.StructTransformerOption) []transformers.StructTransformerOption {
-	return append([]transformers.StructTransformerOption{
-		transformers.WithTypeTransformer(typeTransformer),
-	}, others...)
+var options = []transformers.StructTransformerOption{
+	transformers.WithTypeTransformer(typeTransformer),
 }
 
+func TransformWithStruct(t any, opts ...transformers.StructTransformerOption) schema.Transform {
+	return transformers.TransformWithStruct(t, append(options, opts...)...)
+}
 func typeTransformer(field reflect.StructField) (schema.ValueType, error) {
 	if field.Name == "Created" && field.Type == reflect.TypeOf(int64(0)) {
 		return schema.TypeTimestamp, nil

--- a/plugins/source/stripe/codegen/templates/get.go.tpl
+++ b/plugins/source/stripe/codegen/templates/get.go.tpl
@@ -15,10 +15,10 @@ func {{.TableName | ToPascal}}() *schema.Table {
 		{{- if .Description}}
       Description: `{{.Description}}`,
     {{- end}}
-      Transform:   transformers.TransformWithStruct(&stripe.{{.StructName}}{}, client.SharedTransformers(
+      Transform:   client.TransformWithStruct(&stripe.{{.StructName}}{},
 {{- if .SkipFields}}transformers.WithSkipFields({{.SkipFields | QuoteJoin}}),{{end -}}
 {{- if .IgnoreInTests}}transformers.WithIgnoreInTestsTransformer(client.CreateIgnoreInTestsTransformer({{.IgnoreInTests | QuoteJoin}})),{{end -}}
-				)...),
+				),
       Resolver:    fetch{{.TableName | ToPascal}},
 {{if .HasIDPK}}
 		  Columns: []schema.Column{

--- a/plugins/source/stripe/codegen/templates/list.go.tpl
+++ b/plugins/source/stripe/codegen/templates/list.go.tpl
@@ -19,10 +19,10 @@ func {{.TableName | ToPascal}}() *schema.Table {
 		{{- if .Description}}
       Description: `{{.Description}}`,
     {{- end}}
-      Transform:   transformers.TransformWithStruct(&stripe.{{.StructName}}{}, client.SharedTransformers(
+      Transform:   client.TransformWithStruct(&stripe.{{.StructName}}{},
 {{- if .SkipFields}}transformers.WithSkipFields({{.SkipFields | QuoteJoin}}),{{end -}}
 {{- if .IgnoreInTests}}transformers.WithIgnoreInTestsTransformer(client.CreateIgnoreInTestsTransformer({{.IgnoreInTests | QuoteJoin}})),{{end -}}
-				)...),
+				),
       Resolver:    fetch{{.TableName | ToPascal}},
 {{if .HasIDPK}}
 		  Columns: []schema.Column{

--- a/plugins/source/stripe/resources/services/accounts/accounts.go
+++ b/plugins/source/stripe/resources/services/accounts/accounts.go
@@ -2,7 +2,6 @@ package accounts
 
 import (
 	"context"
-
 	"fmt"
 	"strconv"
 
@@ -16,7 +15,7 @@ func Accounts() *schema.Table {
 	return &schema.Table{
 		Name:        "stripe_accounts",
 		Description: `https://stripe.com/docs/api/accounts`,
-		Transform:   transformers.TransformWithStruct(&stripe.Account{}, client.SharedTransformers(transformers.WithSkipFields("APIResource", "ID"))...),
+		Transform:   client.TransformWithStruct(&stripe.Account{}, transformers.WithSkipFields("APIResource", "ID")),
 		Resolver:    fetchAccounts,
 
 		Columns: []schema.Column{

--- a/plugins/source/stripe/resources/services/accounts/capabilities.go
+++ b/plugins/source/stripe/resources/services/accounts/capabilities.go
@@ -13,7 +13,7 @@ func Capabilities() *schema.Table {
 	return &schema.Table{
 		Name:        "stripe_capabilities",
 		Description: `https://stripe.com/docs/api/capabilities`,
-		Transform:   transformers.TransformWithStruct(&stripe.Capability{}, client.SharedTransformers(transformers.WithSkipFields("APIResource", "ID"))...),
+		Transform:   client.TransformWithStruct(&stripe.Capability{}, transformers.WithSkipFields("APIResource", "ID")),
 		Resolver:    fetchCapabilities,
 
 		Columns: []schema.Column{

--- a/plugins/source/stripe/resources/services/apple_pay_domains/apple_pay_domains.go
+++ b/plugins/source/stripe/resources/services/apple_pay_domains/apple_pay_domains.go
@@ -13,7 +13,7 @@ func ApplePayDomains() *schema.Table {
 	return &schema.Table{
 		Name:        "stripe_apple_pay_domains",
 		Description: `https://stripe.com/docs/api/apple_pay_domains`,
-		Transform:   transformers.TransformWithStruct(&stripe.ApplePayDomain{}, client.SharedTransformers(transformers.WithSkipFields("APIResource", "ID"))...),
+		Transform:   client.TransformWithStruct(&stripe.ApplePayDomain{}, transformers.WithSkipFields("APIResource", "ID")),
 		Resolver:    fetchApplePayDomains,
 
 		Columns: []schema.Column{

--- a/plugins/source/stripe/resources/services/application_fees/application_fees.go
+++ b/plugins/source/stripe/resources/services/application_fees/application_fees.go
@@ -2,7 +2,6 @@ package application_fees
 
 import (
 	"context"
-
 	"fmt"
 	"strconv"
 
@@ -16,7 +15,7 @@ func ApplicationFees() *schema.Table {
 	return &schema.Table{
 		Name:        "stripe_application_fees",
 		Description: `https://stripe.com/docs/api/application_fees`,
-		Transform:   transformers.TransformWithStruct(&stripe.ApplicationFee{}, client.SharedTransformers(transformers.WithSkipFields("APIResource", "ID"))...),
+		Transform:   client.TransformWithStruct(&stripe.ApplicationFee{}, transformers.WithSkipFields("APIResource", "ID")),
 		Resolver:    fetchApplicationFees,
 
 		Columns: []schema.Column{

--- a/plugins/source/stripe/resources/services/application_fees/fee_refunds.go
+++ b/plugins/source/stripe/resources/services/application_fees/fee_refunds.go
@@ -13,7 +13,7 @@ func FeeRefunds() *schema.Table {
 	return &schema.Table{
 		Name:        "stripe_fee_refunds",
 		Description: `https://stripe.com/docs/api/fee_refunds`,
-		Transform:   transformers.TransformWithStruct(&stripe.FeeRefund{}, client.SharedTransformers(transformers.WithSkipFields("APIResource", "ID"))...),
+		Transform:   client.TransformWithStruct(&stripe.FeeRefund{}, transformers.WithSkipFields("APIResource", "ID")),
 		Resolver:    fetchFeeRefunds,
 
 		Columns: []schema.Column{

--- a/plugins/source/stripe/resources/services/balance/balance.go
+++ b/plugins/source/stripe/resources/services/balance/balance.go
@@ -13,7 +13,7 @@ func Balance() *schema.Table {
 	return &schema.Table{
 		Name:        "stripe_balance",
 		Description: `https://stripe.com/docs/api/balance`,
-		Transform:   transformers.TransformWithStruct(&stripe.Balance{}, client.SharedTransformers(transformers.WithSkipFields("APIResource"))...),
+		Transform:   client.TransformWithStruct(&stripe.Balance{}, transformers.WithSkipFields("APIResource")),
 		Resolver:    fetchBalance,
 	}
 }

--- a/plugins/source/stripe/resources/services/balance/balance_transactions.go
+++ b/plugins/source/stripe/resources/services/balance/balance_transactions.go
@@ -2,7 +2,6 @@ package balance
 
 import (
 	"context"
-
 	"fmt"
 	"strconv"
 
@@ -16,7 +15,7 @@ func BalanceTransactions() *schema.Table {
 	return &schema.Table{
 		Name:        "stripe_balance_transactions",
 		Description: `https://stripe.com/docs/api/balance_transactions`,
-		Transform:   transformers.TransformWithStruct(&stripe.BalanceTransaction{}, client.SharedTransformers(transformers.WithSkipFields("APIResource", "ID"))...),
+		Transform:   client.TransformWithStruct(&stripe.BalanceTransaction{}, transformers.WithSkipFields("APIResource", "ID")),
 		Resolver:    fetchBalanceTransactions,
 
 		Columns: []schema.Column{

--- a/plugins/source/stripe/resources/services/billing_portal/billing_portal_configurations.go
+++ b/plugins/source/stripe/resources/services/billing_portal/billing_portal_configurations.go
@@ -13,7 +13,7 @@ func BillingPortalConfigurations() *schema.Table {
 	return &schema.Table{
 		Name:        "stripe_billing_portal_configurations",
 		Description: `https://stripe.com/docs/api/billing_portal_configurations`,
-		Transform:   transformers.TransformWithStruct(&stripe.BillingPortalConfiguration{}, client.SharedTransformers(transformers.WithSkipFields("APIResource", "ID"))...),
+		Transform:   client.TransformWithStruct(&stripe.BillingPortalConfiguration{}, transformers.WithSkipFields("APIResource", "ID")),
 		Resolver:    fetchBillingPortalConfigurations,
 
 		Columns: []schema.Column{

--- a/plugins/source/stripe/resources/services/charges/charges.go
+++ b/plugins/source/stripe/resources/services/charges/charges.go
@@ -2,7 +2,6 @@ package charges
 
 import (
 	"context"
-
 	"fmt"
 	"strconv"
 
@@ -16,7 +15,7 @@ func Charges() *schema.Table {
 	return &schema.Table{
 		Name:        "stripe_charges",
 		Description: `https://stripe.com/docs/api/charges`,
-		Transform:   transformers.TransformWithStruct(&stripe.Charge{}, client.SharedTransformers(transformers.WithSkipFields("APIResource", "ID"), transformers.WithIgnoreInTestsTransformer(client.CreateIgnoreInTestsTransformer("Destination", "Dispute", "Level3", "Source")))...),
+		Transform:   client.TransformWithStruct(&stripe.Charge{}, transformers.WithSkipFields("APIResource", "ID"), transformers.WithIgnoreInTestsTransformer(client.CreateIgnoreInTestsTransformer("Destination", "Dispute", "Level3", "Source"))),
 		Resolver:    fetchCharges,
 
 		Columns: []schema.Column{

--- a/plugins/source/stripe/resources/services/checkout/checkout_sessions.go
+++ b/plugins/source/stripe/resources/services/checkout/checkout_sessions.go
@@ -13,7 +13,7 @@ func CheckoutSessions() *schema.Table {
 	return &schema.Table{
 		Name:        "stripe_checkout_sessions",
 		Description: `https://stripe.com/docs/api/checkout_sessions`,
-		Transform:   transformers.TransformWithStruct(&stripe.CheckoutSession{}, client.SharedTransformers(transformers.WithSkipFields("APIResource", "ID"))...),
+		Transform:   client.TransformWithStruct(&stripe.CheckoutSession{}, transformers.WithSkipFields("APIResource", "ID")),
 		Resolver:    fetchCheckoutSessions,
 
 		Columns: []schema.Column{

--- a/plugins/source/stripe/resources/services/country_specs/country_specs.go
+++ b/plugins/source/stripe/resources/services/country_specs/country_specs.go
@@ -13,7 +13,7 @@ func CountrySpecs() *schema.Table {
 	return &schema.Table{
 		Name:        "stripe_country_specs",
 		Description: `https://stripe.com/docs/api/country_specs`,
-		Transform:   transformers.TransformWithStruct(&stripe.CountrySpec{}, client.SharedTransformers(transformers.WithSkipFields("APIResource", "ID"))...),
+		Transform:   client.TransformWithStruct(&stripe.CountrySpec{}, transformers.WithSkipFields("APIResource", "ID")),
 		Resolver:    fetchCountrySpecs,
 
 		Columns: []schema.Column{

--- a/plugins/source/stripe/resources/services/coupons/coupons.go
+++ b/plugins/source/stripe/resources/services/coupons/coupons.go
@@ -2,7 +2,6 @@ package coupons
 
 import (
 	"context"
-
 	"fmt"
 	"strconv"
 
@@ -16,7 +15,7 @@ func Coupons() *schema.Table {
 	return &schema.Table{
 		Name:        "stripe_coupons",
 		Description: `https://stripe.com/docs/api/coupons`,
-		Transform:   transformers.TransformWithStruct(&stripe.Coupon{}, client.SharedTransformers(transformers.WithSkipFields("APIResource", "ID"))...),
+		Transform:   client.TransformWithStruct(&stripe.Coupon{}, transformers.WithSkipFields("APIResource", "ID")),
 		Resolver:    fetchCoupons,
 
 		Columns: []schema.Column{

--- a/plugins/source/stripe/resources/services/credit_notes/credit_notes.go
+++ b/plugins/source/stripe/resources/services/credit_notes/credit_notes.go
@@ -13,7 +13,7 @@ func CreditNotes() *schema.Table {
 	return &schema.Table{
 		Name:        "stripe_credit_notes",
 		Description: `https://stripe.com/docs/api/credit_notes`,
-		Transform:   transformers.TransformWithStruct(&stripe.CreditNote{}, client.SharedTransformers(transformers.WithSkipFields("APIResource", "ID"))...),
+		Transform:   client.TransformWithStruct(&stripe.CreditNote{}, transformers.WithSkipFields("APIResource", "ID")),
 		Resolver:    fetchCreditNotes,
 
 		Columns: []schema.Column{

--- a/plugins/source/stripe/resources/services/customers/customers.go
+++ b/plugins/source/stripe/resources/services/customers/customers.go
@@ -2,7 +2,6 @@ package customers
 
 import (
 	"context"
-
 	"fmt"
 	"strconv"
 
@@ -16,7 +15,7 @@ func Customers() *schema.Table {
 	return &schema.Table{
 		Name:        "stripe_customers",
 		Description: `https://stripe.com/docs/api/customers`,
-		Transform:   transformers.TransformWithStruct(&stripe.Customer{}, client.SharedTransformers(transformers.WithSkipFields("APIResource", "ID"), transformers.WithIgnoreInTestsTransformer(client.CreateIgnoreInTestsTransformer("DefaultSource")))...),
+		Transform:   client.TransformWithStruct(&stripe.Customer{}, transformers.WithSkipFields("APIResource", "ID"), transformers.WithIgnoreInTestsTransformer(client.CreateIgnoreInTestsTransformer("DefaultSource"))),
 		Resolver:    fetchCustomers,
 
 		Columns: []schema.Column{

--- a/plugins/source/stripe/resources/services/disputes/disputes.go
+++ b/plugins/source/stripe/resources/services/disputes/disputes.go
@@ -2,7 +2,6 @@ package disputes
 
 import (
 	"context"
-
 	"fmt"
 	"strconv"
 
@@ -16,7 +15,7 @@ func Disputes() *schema.Table {
 	return &schema.Table{
 		Name:        "stripe_disputes",
 		Description: `https://stripe.com/docs/api/disputes`,
-		Transform:   transformers.TransformWithStruct(&stripe.Dispute{}, client.SharedTransformers(transformers.WithSkipFields("APIResource", "ID"))...),
+		Transform:   client.TransformWithStruct(&stripe.Dispute{}, transformers.WithSkipFields("APIResource", "ID")),
 		Resolver:    fetchDisputes,
 
 		Columns: []schema.Column{

--- a/plugins/source/stripe/resources/services/events/events.go
+++ b/plugins/source/stripe/resources/services/events/events.go
@@ -2,7 +2,6 @@ package events
 
 import (
 	"context"
-
 	"fmt"
 	"strconv"
 
@@ -16,7 +15,7 @@ func Events() *schema.Table {
 	return &schema.Table{
 		Name:        "stripe_events",
 		Description: `https://stripe.com/docs/api/events`,
-		Transform:   transformers.TransformWithStruct(&stripe.Event{}, client.SharedTransformers(transformers.WithSkipFields("APIResource", "ID"))...),
+		Transform:   client.TransformWithStruct(&stripe.Event{}, transformers.WithSkipFields("APIResource", "ID")),
 		Resolver:    fetchEvents,
 
 		Columns: []schema.Column{

--- a/plugins/source/stripe/resources/services/file_links/file_links.go
+++ b/plugins/source/stripe/resources/services/file_links/file_links.go
@@ -2,7 +2,6 @@ package file_links
 
 import (
 	"context"
-
 	"fmt"
 	"strconv"
 
@@ -16,7 +15,7 @@ func FileLinks() *schema.Table {
 	return &schema.Table{
 		Name:        "stripe_file_links",
 		Description: `https://stripe.com/docs/api/file_links`,
-		Transform:   transformers.TransformWithStruct(&stripe.FileLink{}, client.SharedTransformers(transformers.WithSkipFields("APIResource", "ID"))...),
+		Transform:   client.TransformWithStruct(&stripe.FileLink{}, transformers.WithSkipFields("APIResource", "ID")),
 		Resolver:    fetchFileLinks,
 
 		Columns: []schema.Column{

--- a/plugins/source/stripe/resources/services/files/files.go
+++ b/plugins/source/stripe/resources/services/files/files.go
@@ -2,7 +2,6 @@ package files
 
 import (
 	"context"
-
 	"fmt"
 	"strconv"
 
@@ -16,7 +15,7 @@ func Files() *schema.Table {
 	return &schema.Table{
 		Name:        "stripe_files",
 		Description: `https://stripe.com/docs/api/files`,
-		Transform:   transformers.TransformWithStruct(&stripe.File{}, client.SharedTransformers(transformers.WithSkipFields("APIResource", "ID"))...),
+		Transform:   client.TransformWithStruct(&stripe.File{}, transformers.WithSkipFields("APIResource", "ID")),
 		Resolver:    fetchFiles,
 
 		Columns: []schema.Column{

--- a/plugins/source/stripe/resources/services/identity/identity_verification_reports.go
+++ b/plugins/source/stripe/resources/services/identity/identity_verification_reports.go
@@ -2,7 +2,6 @@ package identity
 
 import (
 	"context"
-
 	"fmt"
 	"strconv"
 
@@ -16,7 +15,7 @@ func IdentityVerificationReports() *schema.Table {
 	return &schema.Table{
 		Name:        "stripe_identity_verification_reports",
 		Description: `https://stripe.com/docs/api/identity_verification_reports`,
-		Transform:   transformers.TransformWithStruct(&stripe.IdentityVerificationReport{}, client.SharedTransformers(transformers.WithSkipFields("APIResource", "ID"))...),
+		Transform:   client.TransformWithStruct(&stripe.IdentityVerificationReport{}, transformers.WithSkipFields("APIResource", "ID")),
 		Resolver:    fetchIdentityVerificationReports,
 
 		Columns: []schema.Column{

--- a/plugins/source/stripe/resources/services/invoices/invoice_items.go
+++ b/plugins/source/stripe/resources/services/invoices/invoice_items.go
@@ -13,7 +13,7 @@ func InvoiceItems() *schema.Table {
 	return &schema.Table{
 		Name:        "stripe_invoice_items",
 		Description: `https://stripe.com/docs/api/invoiceitems`,
-		Transform:   transformers.TransformWithStruct(&stripe.InvoiceItem{}, client.SharedTransformers(transformers.WithSkipFields("APIResource", "ID"), transformers.WithIgnoreInTestsTransformer(client.CreateIgnoreInTestsTransformer("Plan")))...),
+		Transform:   client.TransformWithStruct(&stripe.InvoiceItem{}, transformers.WithSkipFields("APIResource", "ID"), transformers.WithIgnoreInTestsTransformer(client.CreateIgnoreInTestsTransformer("Plan"))),
 		Resolver:    fetchInvoiceItems,
 
 		Columns: []schema.Column{

--- a/plugins/source/stripe/resources/services/invoices/invoices.go
+++ b/plugins/source/stripe/resources/services/invoices/invoices.go
@@ -2,7 +2,6 @@ package invoices
 
 import (
 	"context"
-
 	"fmt"
 	"strconv"
 
@@ -16,7 +15,7 @@ func Invoices() *schema.Table {
 	return &schema.Table{
 		Name:        "stripe_invoices",
 		Description: `https://stripe.com/docs/api/invoices`,
-		Transform:   transformers.TransformWithStruct(&stripe.Invoice{}, client.SharedTransformers(transformers.WithSkipFields("APIResource", "ID"), transformers.WithIgnoreInTestsTransformer(client.CreateIgnoreInTestsTransformer("DefaultSource")))...),
+		Transform:   client.TransformWithStruct(&stripe.Invoice{}, transformers.WithSkipFields("APIResource", "ID"), transformers.WithIgnoreInTestsTransformer(client.CreateIgnoreInTestsTransformer("DefaultSource"))),
 		Resolver:    fetchInvoices,
 
 		Columns: []schema.Column{

--- a/plugins/source/stripe/resources/services/issuing/issuing_authorizations.go
+++ b/plugins/source/stripe/resources/services/issuing/issuing_authorizations.go
@@ -2,7 +2,6 @@ package issuing
 
 import (
 	"context"
-
 	"fmt"
 	"strconv"
 
@@ -16,7 +15,7 @@ func IssuingAuthorizations() *schema.Table {
 	return &schema.Table{
 		Name:        "stripe_issuing_authorizations",
 		Description: `https://stripe.com/docs/api/issuing_authorizations`,
-		Transform:   transformers.TransformWithStruct(&stripe.IssuingAuthorization{}, client.SharedTransformers(transformers.WithSkipFields("APIResource", "ID"))...),
+		Transform:   client.TransformWithStruct(&stripe.IssuingAuthorization{}, transformers.WithSkipFields("APIResource", "ID")),
 		Resolver:    fetchIssuingAuthorizations,
 
 		Columns: []schema.Column{

--- a/plugins/source/stripe/resources/services/issuing/issuing_cardholders.go
+++ b/plugins/source/stripe/resources/services/issuing/issuing_cardholders.go
@@ -2,7 +2,6 @@ package issuing
 
 import (
 	"context"
-
 	"fmt"
 	"strconv"
 
@@ -16,7 +15,7 @@ func IssuingCardholders() *schema.Table {
 	return &schema.Table{
 		Name:        "stripe_issuing_cardholders",
 		Description: `https://stripe.com/docs/api/issuing_cardholders`,
-		Transform:   transformers.TransformWithStruct(&stripe.IssuingCardholder{}, client.SharedTransformers(transformers.WithSkipFields("APIResource", "ID"))...),
+		Transform:   client.TransformWithStruct(&stripe.IssuingCardholder{}, transformers.WithSkipFields("APIResource", "ID")),
 		Resolver:    fetchIssuingCardholders,
 
 		Columns: []schema.Column{

--- a/plugins/source/stripe/resources/services/issuing/issuing_cards.go
+++ b/plugins/source/stripe/resources/services/issuing/issuing_cards.go
@@ -2,7 +2,6 @@ package issuing
 
 import (
 	"context"
-
 	"fmt"
 	"strconv"
 
@@ -16,7 +15,7 @@ func IssuingCards() *schema.Table {
 	return &schema.Table{
 		Name:        "stripe_issuing_cards",
 		Description: `https://stripe.com/docs/api/issuing_cards`,
-		Transform:   transformers.TransformWithStruct(&stripe.IssuingCard{}, client.SharedTransformers(transformers.WithSkipFields("APIResource", "ID"))...),
+		Transform:   client.TransformWithStruct(&stripe.IssuingCard{}, transformers.WithSkipFields("APIResource", "ID")),
 		Resolver:    fetchIssuingCards,
 
 		Columns: []schema.Column{

--- a/plugins/source/stripe/resources/services/issuing/issuing_disputes.go
+++ b/plugins/source/stripe/resources/services/issuing/issuing_disputes.go
@@ -2,7 +2,6 @@ package issuing
 
 import (
 	"context"
-
 	"fmt"
 	"strconv"
 
@@ -16,7 +15,7 @@ func IssuingDisputes() *schema.Table {
 	return &schema.Table{
 		Name:        "stripe_issuing_disputes",
 		Description: `https://stripe.com/docs/api/issuing_disputes`,
-		Transform:   transformers.TransformWithStruct(&stripe.IssuingDispute{}, client.SharedTransformers(transformers.WithSkipFields("APIResource", "ID"))...),
+		Transform:   client.TransformWithStruct(&stripe.IssuingDispute{}, transformers.WithSkipFields("APIResource", "ID")),
 		Resolver:    fetchIssuingDisputes,
 
 		Columns: []schema.Column{

--- a/plugins/source/stripe/resources/services/issuing/issuing_transactions.go
+++ b/plugins/source/stripe/resources/services/issuing/issuing_transactions.go
@@ -2,7 +2,6 @@ package issuing
 
 import (
 	"context"
-
 	"fmt"
 	"strconv"
 
@@ -16,7 +15,7 @@ func IssuingTransactions() *schema.Table {
 	return &schema.Table{
 		Name:        "stripe_issuing_transactions",
 		Description: `https://stripe.com/docs/api/issuing_transactions`,
-		Transform:   transformers.TransformWithStruct(&stripe.IssuingTransaction{}, client.SharedTransformers(transformers.WithSkipFields("APIResource", "ID"))...),
+		Transform:   client.TransformWithStruct(&stripe.IssuingTransaction{}, transformers.WithSkipFields("APIResource", "ID")),
 		Resolver:    fetchIssuingTransactions,
 
 		Columns: []schema.Column{

--- a/plugins/source/stripe/resources/services/payment/payment_intents.go
+++ b/plugins/source/stripe/resources/services/payment/payment_intents.go
@@ -2,7 +2,6 @@ package payment
 
 import (
 	"context"
-
 	"fmt"
 	"strconv"
 
@@ -16,7 +15,7 @@ func PaymentIntents() *schema.Table {
 	return &schema.Table{
 		Name:        "stripe_payment_intents",
 		Description: `https://stripe.com/docs/api/payment_intents`,
-		Transform:   transformers.TransformWithStruct(&stripe.PaymentIntent{}, client.SharedTransformers(transformers.WithSkipFields("APIResource", "ID"), transformers.WithIgnoreInTestsTransformer(client.CreateIgnoreInTestsTransformer("Source")))...),
+		Transform:   client.TransformWithStruct(&stripe.PaymentIntent{}, transformers.WithSkipFields("APIResource", "ID"), transformers.WithIgnoreInTestsTransformer(client.CreateIgnoreInTestsTransformer("Source"))),
 		Resolver:    fetchPaymentIntents,
 
 		Columns: []schema.Column{

--- a/plugins/source/stripe/resources/services/payment/payment_links.go
+++ b/plugins/source/stripe/resources/services/payment/payment_links.go
@@ -13,7 +13,7 @@ func PaymentLinks() *schema.Table {
 	return &schema.Table{
 		Name:        "stripe_payment_links",
 		Description: `https://stripe.com/docs/api/payment_links`,
-		Transform:   transformers.TransformWithStruct(&stripe.PaymentLink{}, client.SharedTransformers(transformers.WithSkipFields("APIResource", "ID"))...),
+		Transform:   client.TransformWithStruct(&stripe.PaymentLink{}, transformers.WithSkipFields("APIResource", "ID")),
 		Resolver:    fetchPaymentLinks,
 
 		Columns: []schema.Column{

--- a/plugins/source/stripe/resources/services/payment/payment_methods.go
+++ b/plugins/source/stripe/resources/services/payment/payment_methods.go
@@ -13,7 +13,7 @@ func PaymentMethods() *schema.Table {
 	return &schema.Table{
 		Name:        "stripe_payment_methods",
 		Description: `https://stripe.com/docs/api/payment_methods`,
-		Transform:   transformers.TransformWithStruct(&stripe.PaymentMethod{}, client.SharedTransformers(transformers.WithSkipFields("APIResource", "ID"))...),
+		Transform:   client.TransformWithStruct(&stripe.PaymentMethod{}, transformers.WithSkipFields("APIResource", "ID")),
 		Resolver:    fetchPaymentMethods,
 
 		Columns: []schema.Column{

--- a/plugins/source/stripe/resources/services/payouts/payouts.go
+++ b/plugins/source/stripe/resources/services/payouts/payouts.go
@@ -2,7 +2,6 @@ package payouts
 
 import (
 	"context"
-
 	"fmt"
 	"strconv"
 
@@ -16,7 +15,7 @@ func Payouts() *schema.Table {
 	return &schema.Table{
 		Name:        "stripe_payouts",
 		Description: `https://stripe.com/docs/api/payouts`,
-		Transform:   transformers.TransformWithStruct(&stripe.Payout{}, client.SharedTransformers(transformers.WithSkipFields("APIResource", "ID"))...),
+		Transform:   client.TransformWithStruct(&stripe.Payout{}, transformers.WithSkipFields("APIResource", "ID")),
 		Resolver:    fetchPayouts,
 
 		Columns: []schema.Column{

--- a/plugins/source/stripe/resources/services/plans/plans.go
+++ b/plugins/source/stripe/resources/services/plans/plans.go
@@ -2,7 +2,6 @@ package plans
 
 import (
 	"context"
-
 	"fmt"
 	"strconv"
 
@@ -16,7 +15,7 @@ func Plans() *schema.Table {
 	return &schema.Table{
 		Name:        "stripe_plans",
 		Description: `https://stripe.com/docs/api/plans`,
-		Transform:   transformers.TransformWithStruct(&stripe.Plan{}, client.SharedTransformers(transformers.WithSkipFields("APIResource", "ID"))...),
+		Transform:   client.TransformWithStruct(&stripe.Plan{}, transformers.WithSkipFields("APIResource", "ID")),
 		Resolver:    fetchPlans,
 
 		Columns: []schema.Column{

--- a/plugins/source/stripe/resources/services/prices/prices.go
+++ b/plugins/source/stripe/resources/services/prices/prices.go
@@ -2,7 +2,6 @@ package prices
 
 import (
 	"context"
-
 	"fmt"
 	"strconv"
 
@@ -16,7 +15,7 @@ func Prices() *schema.Table {
 	return &schema.Table{
 		Name:        "stripe_prices",
 		Description: `https://stripe.com/docs/api/prices`,
-		Transform:   transformers.TransformWithStruct(&stripe.Price{}, client.SharedTransformers(transformers.WithSkipFields("APIResource", "ID"))...),
+		Transform:   client.TransformWithStruct(&stripe.Price{}, transformers.WithSkipFields("APIResource", "ID")),
 		Resolver:    fetchPrices,
 
 		Columns: []schema.Column{

--- a/plugins/source/stripe/resources/services/products/products.go
+++ b/plugins/source/stripe/resources/services/products/products.go
@@ -2,7 +2,6 @@ package products
 
 import (
 	"context"
-
 	"fmt"
 	"strconv"
 
@@ -16,7 +15,7 @@ func Products() *schema.Table {
 	return &schema.Table{
 		Name:        "stripe_products",
 		Description: `https://stripe.com/docs/api/products`,
-		Transform:   transformers.TransformWithStruct(&stripe.Product{}, client.SharedTransformers(transformers.WithSkipFields("APIResource", "ID"), transformers.WithIgnoreInTestsTransformer(client.CreateIgnoreInTestsTransformer("Attributes", "DeactivateOn")))...),
+		Transform:   client.TransformWithStruct(&stripe.Product{}, transformers.WithSkipFields("APIResource", "ID"), transformers.WithIgnoreInTestsTransformer(client.CreateIgnoreInTestsTransformer("Attributes", "DeactivateOn"))),
 		Resolver:    fetchProducts,
 
 		Columns: []schema.Column{

--- a/plugins/source/stripe/resources/services/promotion_codes/promotion_codes.go
+++ b/plugins/source/stripe/resources/services/promotion_codes/promotion_codes.go
@@ -2,7 +2,6 @@ package promotion_codes
 
 import (
 	"context"
-
 	"fmt"
 	"strconv"
 
@@ -16,7 +15,7 @@ func PromotionCodes() *schema.Table {
 	return &schema.Table{
 		Name:        "stripe_promotion_codes",
 		Description: `https://stripe.com/docs/api/promotion_codes`,
-		Transform:   transformers.TransformWithStruct(&stripe.PromotionCode{}, client.SharedTransformers(transformers.WithSkipFields("APIResource", "ID"))...),
+		Transform:   client.TransformWithStruct(&stripe.PromotionCode{}, transformers.WithSkipFields("APIResource", "ID")),
 		Resolver:    fetchPromotionCodes,
 
 		Columns: []schema.Column{

--- a/plugins/source/stripe/resources/services/quotes/quotes.go
+++ b/plugins/source/stripe/resources/services/quotes/quotes.go
@@ -13,7 +13,7 @@ func Quotes() *schema.Table {
 	return &schema.Table{
 		Name:        "stripe_quotes",
 		Description: `https://stripe.com/docs/api/quotes`,
-		Transform:   transformers.TransformWithStruct(&stripe.Quote{}, client.SharedTransformers(transformers.WithSkipFields("APIResource", "ID"))...),
+		Transform:   client.TransformWithStruct(&stripe.Quote{}, transformers.WithSkipFields("APIResource", "ID")),
 		Resolver:    fetchQuotes,
 
 		Columns: []schema.Column{

--- a/plugins/source/stripe/resources/services/radar/radar_early_fraud_warnings.go
+++ b/plugins/source/stripe/resources/services/radar/radar_early_fraud_warnings.go
@@ -13,7 +13,7 @@ func RadarEarlyFraudWarnings() *schema.Table {
 	return &schema.Table{
 		Name:        "stripe_radar_early_fraud_warnings",
 		Description: `https://stripe.com/docs/api/radar_early_fraud_warnings`,
-		Transform:   transformers.TransformWithStruct(&stripe.RadarEarlyFraudWarning{}, client.SharedTransformers(transformers.WithSkipFields("APIResource", "ID"))...),
+		Transform:   client.TransformWithStruct(&stripe.RadarEarlyFraudWarning{}, transformers.WithSkipFields("APIResource", "ID")),
 		Resolver:    fetchRadarEarlyFraudWarnings,
 
 		Columns: []schema.Column{

--- a/plugins/source/stripe/resources/services/refunds/refunds.go
+++ b/plugins/source/stripe/resources/services/refunds/refunds.go
@@ -2,7 +2,6 @@ package refunds
 
 import (
 	"context"
-
 	"fmt"
 	"strconv"
 
@@ -16,7 +15,7 @@ func Refunds() *schema.Table {
 	return &schema.Table{
 		Name:        "stripe_refunds",
 		Description: `https://stripe.com/docs/api/refunds`,
-		Transform:   transformers.TransformWithStruct(&stripe.Refund{}, client.SharedTransformers(transformers.WithSkipFields("APIResource", "ID"))...),
+		Transform:   client.TransformWithStruct(&stripe.Refund{}, transformers.WithSkipFields("APIResource", "ID")),
 		Resolver:    fetchRefunds,
 
 		Columns: []schema.Column{

--- a/plugins/source/stripe/resources/services/reporting/reporting_report_runs.go
+++ b/plugins/source/stripe/resources/services/reporting/reporting_report_runs.go
@@ -2,7 +2,6 @@ package reporting
 
 import (
 	"context"
-
 	"fmt"
 	"strconv"
 
@@ -16,7 +15,7 @@ func ReportingReportRuns() *schema.Table {
 	return &schema.Table{
 		Name:        "stripe_reporting_report_runs",
 		Description: `https://stripe.com/docs/api/reporting_report_runs`,
-		Transform:   transformers.TransformWithStruct(&stripe.ReportingReportRun{}, client.SharedTransformers(transformers.WithSkipFields("APIResource", "ID"))...),
+		Transform:   client.TransformWithStruct(&stripe.ReportingReportRun{}, transformers.WithSkipFields("APIResource", "ID")),
 		Resolver:    fetchReportingReportRuns,
 
 		Columns: []schema.Column{

--- a/plugins/source/stripe/resources/services/reporting/reporting_report_types.go
+++ b/plugins/source/stripe/resources/services/reporting/reporting_report_types.go
@@ -13,7 +13,7 @@ func ReportingReportTypes() *schema.Table {
 	return &schema.Table{
 		Name:        "stripe_reporting_report_types",
 		Description: `https://stripe.com/docs/api/reporting_report_types`,
-		Transform:   transformers.TransformWithStruct(&stripe.ReportingReportType{}, client.SharedTransformers(transformers.WithSkipFields("APIResource", "ID"))...),
+		Transform:   client.TransformWithStruct(&stripe.ReportingReportType{}, transformers.WithSkipFields("APIResource", "ID")),
 		Resolver:    fetchReportingReportTypes,
 
 		Columns: []schema.Column{

--- a/plugins/source/stripe/resources/services/reviews/reviews.go
+++ b/plugins/source/stripe/resources/services/reviews/reviews.go
@@ -2,7 +2,6 @@ package reviews
 
 import (
 	"context"
-
 	"fmt"
 	"strconv"
 
@@ -16,7 +15,7 @@ func Reviews() *schema.Table {
 	return &schema.Table{
 		Name:        "stripe_reviews",
 		Description: `https://stripe.com/docs/api/reviews`,
-		Transform:   transformers.TransformWithStruct(&stripe.Review{}, client.SharedTransformers(transformers.WithSkipFields("APIResource", "ID"))...),
+		Transform:   client.TransformWithStruct(&stripe.Review{}, transformers.WithSkipFields("APIResource", "ID")),
 		Resolver:    fetchReviews,
 
 		Columns: []schema.Column{

--- a/plugins/source/stripe/resources/services/shipping_rates/shipping_rates.go
+++ b/plugins/source/stripe/resources/services/shipping_rates/shipping_rates.go
@@ -2,7 +2,6 @@ package shipping_rates
 
 import (
 	"context"
-
 	"fmt"
 	"strconv"
 
@@ -16,7 +15,7 @@ func ShippingRates() *schema.Table {
 	return &schema.Table{
 		Name:        "stripe_shipping_rates",
 		Description: `https://stripe.com/docs/api/shipping_rates`,
-		Transform:   transformers.TransformWithStruct(&stripe.ShippingRate{}, client.SharedTransformers(transformers.WithSkipFields("APIResource", "ID"))...),
+		Transform:   client.TransformWithStruct(&stripe.ShippingRate{}, transformers.WithSkipFields("APIResource", "ID")),
 		Resolver:    fetchShippingRates,
 
 		Columns: []schema.Column{

--- a/plugins/source/stripe/resources/services/sigma/sigma_scheduled_query_runs.go
+++ b/plugins/source/stripe/resources/services/sigma/sigma_scheduled_query_runs.go
@@ -13,7 +13,7 @@ func SigmaScheduledQueryRuns() *schema.Table {
 	return &schema.Table{
 		Name:        "stripe_sigma_scheduled_query_runs",
 		Description: `https://stripe.com/docs/api/sigma_scheduled_query_runs`,
-		Transform:   transformers.TransformWithStruct(&stripe.SigmaScheduledQueryRun{}, client.SharedTransformers(transformers.WithSkipFields("APIResource", "ID"))...),
+		Transform:   client.TransformWithStruct(&stripe.SigmaScheduledQueryRun{}, transformers.WithSkipFields("APIResource", "ID")),
 		Resolver:    fetchSigmaScheduledQueryRuns,
 
 		Columns: []schema.Column{

--- a/plugins/source/stripe/resources/services/subscription/subscription_schedules.go
+++ b/plugins/source/stripe/resources/services/subscription/subscription_schedules.go
@@ -2,7 +2,6 @@ package subscription
 
 import (
 	"context"
-
 	"fmt"
 	"strconv"
 
@@ -16,7 +15,7 @@ func SubscriptionSchedules() *schema.Table {
 	return &schema.Table{
 		Name:        "stripe_subscription_schedules",
 		Description: `https://stripe.com/docs/api/subscription_schedules`,
-		Transform:   transformers.TransformWithStruct(&stripe.SubscriptionSchedule{}, client.SharedTransformers(transformers.WithSkipFields("APIResource", "ID"))...),
+		Transform:   client.TransformWithStruct(&stripe.SubscriptionSchedule{}, transformers.WithSkipFields("APIResource", "ID")),
 		Resolver:    fetchSubscriptionSchedules,
 
 		Columns: []schema.Column{

--- a/plugins/source/stripe/resources/services/subscription/subscriptions.go
+++ b/plugins/source/stripe/resources/services/subscription/subscriptions.go
@@ -2,7 +2,6 @@ package subscription
 
 import (
 	"context"
-
 	"fmt"
 	"strconv"
 
@@ -16,7 +15,7 @@ func Subscriptions() *schema.Table {
 	return &schema.Table{
 		Name:        "stripe_subscriptions",
 		Description: `https://stripe.com/docs/api/subscriptions`,
-		Transform:   transformers.TransformWithStruct(&stripe.Subscription{}, client.SharedTransformers(transformers.WithSkipFields("APIResource", "ID"), transformers.WithIgnoreInTestsTransformer(client.CreateIgnoreInTestsTransformer("DefaultSource")))...),
+		Transform:   client.TransformWithStruct(&stripe.Subscription{}, transformers.WithSkipFields("APIResource", "ID"), transformers.WithIgnoreInTestsTransformer(client.CreateIgnoreInTestsTransformer("DefaultSource"))),
 		Resolver:    fetchSubscriptions,
 
 		Columns: []schema.Column{

--- a/plugins/source/stripe/resources/services/tax/tax_codes.go
+++ b/plugins/source/stripe/resources/services/tax/tax_codes.go
@@ -13,7 +13,7 @@ func TaxCodes() *schema.Table {
 	return &schema.Table{
 		Name:        "stripe_tax_codes",
 		Description: `https://stripe.com/docs/api/tax_codes`,
-		Transform:   transformers.TransformWithStruct(&stripe.TaxCode{}, client.SharedTransformers(transformers.WithSkipFields("APIResource", "ID"))...),
+		Transform:   client.TransformWithStruct(&stripe.TaxCode{}, transformers.WithSkipFields("APIResource", "ID")),
 		Resolver:    fetchTaxCodes,
 
 		Columns: []schema.Column{

--- a/plugins/source/stripe/resources/services/tax/tax_rates.go
+++ b/plugins/source/stripe/resources/services/tax/tax_rates.go
@@ -2,7 +2,6 @@ package tax
 
 import (
 	"context"
-
 	"fmt"
 	"strconv"
 
@@ -16,7 +15,7 @@ func TaxRates() *schema.Table {
 	return &schema.Table{
 		Name:        "stripe_tax_rates",
 		Description: `https://stripe.com/docs/api/tax_rates`,
-		Transform:   transformers.TransformWithStruct(&stripe.TaxRate{}, client.SharedTransformers(transformers.WithSkipFields("APIResource", "ID"))...),
+		Transform:   client.TransformWithStruct(&stripe.TaxRate{}, transformers.WithSkipFields("APIResource", "ID")),
 		Resolver:    fetchTaxRates,
 
 		Columns: []schema.Column{

--- a/plugins/source/stripe/resources/services/terminal/terminal_configurations.go
+++ b/plugins/source/stripe/resources/services/terminal/terminal_configurations.go
@@ -13,7 +13,7 @@ func TerminalConfigurations() *schema.Table {
 	return &schema.Table{
 		Name:        "stripe_terminal_configurations",
 		Description: `https://stripe.com/docs/api/terminal_configurations`,
-		Transform:   transformers.TransformWithStruct(&stripe.TerminalConfiguration{}, client.SharedTransformers(transformers.WithSkipFields("APIResource", "ID"))...),
+		Transform:   client.TransformWithStruct(&stripe.TerminalConfiguration{}, transformers.WithSkipFields("APIResource", "ID")),
 		Resolver:    fetchTerminalConfigurations,
 
 		Columns: []schema.Column{

--- a/plugins/source/stripe/resources/services/terminal/terminal_locations.go
+++ b/plugins/source/stripe/resources/services/terminal/terminal_locations.go
@@ -13,7 +13,7 @@ func TerminalLocations() *schema.Table {
 	return &schema.Table{
 		Name:        "stripe_terminal_locations",
 		Description: `https://stripe.com/docs/api/terminal_locations`,
-		Transform:   transformers.TransformWithStruct(&stripe.TerminalLocation{}, client.SharedTransformers(transformers.WithSkipFields("APIResource", "ID"))...),
+		Transform:   client.TransformWithStruct(&stripe.TerminalLocation{}, transformers.WithSkipFields("APIResource", "ID")),
 		Resolver:    fetchTerminalLocations,
 
 		Columns: []schema.Column{

--- a/plugins/source/stripe/resources/services/terminal/terminal_readers.go
+++ b/plugins/source/stripe/resources/services/terminal/terminal_readers.go
@@ -13,7 +13,7 @@ func TerminalReaders() *schema.Table {
 	return &schema.Table{
 		Name:        "stripe_terminal_readers",
 		Description: `https://stripe.com/docs/api/terminal_readers`,
-		Transform:   transformers.TransformWithStruct(&stripe.TerminalReader{}, client.SharedTransformers(transformers.WithSkipFields("APIResource", "ID"))...),
+		Transform:   client.TransformWithStruct(&stripe.TerminalReader{}, transformers.WithSkipFields("APIResource", "ID")),
 		Resolver:    fetchTerminalReaders,
 
 		Columns: []schema.Column{

--- a/plugins/source/stripe/resources/services/topups/topups.go
+++ b/plugins/source/stripe/resources/services/topups/topups.go
@@ -2,7 +2,6 @@ package topups
 
 import (
 	"context"
-
 	"fmt"
 	"strconv"
 
@@ -16,7 +15,7 @@ func Topups() *schema.Table {
 	return &schema.Table{
 		Name:        "stripe_topups",
 		Description: `https://stripe.com/docs/api/topups`,
-		Transform:   transformers.TransformWithStruct(&stripe.Topup{}, client.SharedTransformers(transformers.WithSkipFields("APIResource", "ID"), transformers.WithIgnoreInTestsTransformer(client.CreateIgnoreInTestsTransformer("Source")))...),
+		Transform:   client.TransformWithStruct(&stripe.Topup{}, transformers.WithSkipFields("APIResource", "ID"), transformers.WithIgnoreInTestsTransformer(client.CreateIgnoreInTestsTransformer("Source"))),
 		Resolver:    fetchTopups,
 
 		Columns: []schema.Column{

--- a/plugins/source/stripe/resources/services/transfers/transfers.go
+++ b/plugins/source/stripe/resources/services/transfers/transfers.go
@@ -2,7 +2,6 @@ package transfers
 
 import (
 	"context"
-
 	"fmt"
 	"strconv"
 
@@ -16,7 +15,7 @@ func Transfers() *schema.Table {
 	return &schema.Table{
 		Name:        "stripe_transfers",
 		Description: `https://stripe.com/docs/api/transfers`,
-		Transform:   transformers.TransformWithStruct(&stripe.Transfer{}, client.SharedTransformers(transformers.WithSkipFields("APIResource", "ID"))...),
+		Transform:   client.TransformWithStruct(&stripe.Transfer{}, transformers.WithSkipFields("APIResource", "ID")),
 		Resolver:    fetchTransfers,
 
 		Columns: []schema.Column{

--- a/plugins/source/stripe/resources/services/treasury/treasury_credit_reversals.go
+++ b/plugins/source/stripe/resources/services/treasury/treasury_credit_reversals.go
@@ -13,7 +13,7 @@ func TreasuryCreditReversals() *schema.Table {
 	return &schema.Table{
 		Name:        "stripe_treasury_credit_reversals",
 		Description: `https://stripe.com/docs/api/treasury_credit_reversals`,
-		Transform:   transformers.TransformWithStruct(&stripe.TreasuryCreditReversal{}, client.SharedTransformers(transformers.WithSkipFields("APIResource", "ID"))...),
+		Transform:   client.TransformWithStruct(&stripe.TreasuryCreditReversal{}, transformers.WithSkipFields("APIResource", "ID")),
 		Resolver:    fetchTreasuryCreditReversals,
 
 		Columns: []schema.Column{

--- a/plugins/source/stripe/resources/services/treasury/treasury_debit_reversals.go
+++ b/plugins/source/stripe/resources/services/treasury/treasury_debit_reversals.go
@@ -13,7 +13,7 @@ func TreasuryDebitReversals() *schema.Table {
 	return &schema.Table{
 		Name:        "stripe_treasury_debit_reversals",
 		Description: `https://stripe.com/docs/api/treasury_debit_reversals`,
-		Transform:   transformers.TransformWithStruct(&stripe.TreasuryDebitReversal{}, client.SharedTransformers(transformers.WithSkipFields("APIResource", "ID"))...),
+		Transform:   client.TransformWithStruct(&stripe.TreasuryDebitReversal{}, transformers.WithSkipFields("APIResource", "ID")),
 		Resolver:    fetchTreasuryDebitReversals,
 
 		Columns: []schema.Column{

--- a/plugins/source/stripe/resources/services/treasury/treasury_financial_accounts.go
+++ b/plugins/source/stripe/resources/services/treasury/treasury_financial_accounts.go
@@ -2,7 +2,6 @@ package treasury
 
 import (
 	"context"
-
 	"fmt"
 	"strconv"
 
@@ -16,7 +15,7 @@ func TreasuryFinancialAccounts() *schema.Table {
 	return &schema.Table{
 		Name:        "stripe_treasury_financial_accounts",
 		Description: `https://stripe.com/docs/api/treasury_financial_accounts`,
-		Transform:   transformers.TransformWithStruct(&stripe.TreasuryFinancialAccount{}, client.SharedTransformers(transformers.WithSkipFields("APIResource", "ID"))...),
+		Transform:   client.TransformWithStruct(&stripe.TreasuryFinancialAccount{}, transformers.WithSkipFields("APIResource", "ID")),
 		Resolver:    fetchTreasuryFinancialAccounts,
 
 		Columns: []schema.Column{

--- a/plugins/source/stripe/resources/services/treasury/treasury_inbound_transfers.go
+++ b/plugins/source/stripe/resources/services/treasury/treasury_inbound_transfers.go
@@ -13,7 +13,7 @@ func TreasuryInboundTransfers() *schema.Table {
 	return &schema.Table{
 		Name:        "stripe_treasury_inbound_transfers",
 		Description: `https://stripe.com/docs/api/treasury_inbound_transfers`,
-		Transform:   transformers.TransformWithStruct(&stripe.TreasuryInboundTransfer{}, client.SharedTransformers(transformers.WithSkipFields("APIResource", "ID"))...),
+		Transform:   client.TransformWithStruct(&stripe.TreasuryInboundTransfer{}, transformers.WithSkipFields("APIResource", "ID")),
 		Resolver:    fetchTreasuryInboundTransfers,
 
 		Columns: []schema.Column{

--- a/plugins/source/stripe/resources/services/treasury/treasury_outbound_payments.go
+++ b/plugins/source/stripe/resources/services/treasury/treasury_outbound_payments.go
@@ -13,7 +13,7 @@ func TreasuryOutboundPayments() *schema.Table {
 	return &schema.Table{
 		Name:        "stripe_treasury_outbound_payments",
 		Description: `https://stripe.com/docs/api/treasury_outbound_payments`,
-		Transform:   transformers.TransformWithStruct(&stripe.TreasuryOutboundPayment{}, client.SharedTransformers(transformers.WithSkipFields("APIResource", "ID"))...),
+		Transform:   client.TransformWithStruct(&stripe.TreasuryOutboundPayment{}, transformers.WithSkipFields("APIResource", "ID")),
 		Resolver:    fetchTreasuryOutboundPayments,
 
 		Columns: []schema.Column{

--- a/plugins/source/stripe/resources/services/treasury/treasury_outbound_transfers.go
+++ b/plugins/source/stripe/resources/services/treasury/treasury_outbound_transfers.go
@@ -13,7 +13,7 @@ func TreasuryOutboundTransfers() *schema.Table {
 	return &schema.Table{
 		Name:        "stripe_treasury_outbound_transfers",
 		Description: `https://stripe.com/docs/api/treasury_outbound_transfers`,
-		Transform:   transformers.TransformWithStruct(&stripe.TreasuryOutboundTransfer{}, client.SharedTransformers(transformers.WithSkipFields("APIResource", "ID"))...),
+		Transform:   client.TransformWithStruct(&stripe.TreasuryOutboundTransfer{}, transformers.WithSkipFields("APIResource", "ID")),
 		Resolver:    fetchTreasuryOutboundTransfers,
 
 		Columns: []schema.Column{

--- a/plugins/source/stripe/resources/services/treasury/treasury_received_credits.go
+++ b/plugins/source/stripe/resources/services/treasury/treasury_received_credits.go
@@ -13,7 +13,7 @@ func TreasuryReceivedCredits() *schema.Table {
 	return &schema.Table{
 		Name:        "stripe_treasury_received_credits",
 		Description: `https://stripe.com/docs/api/treasury_received_credits`,
-		Transform:   transformers.TransformWithStruct(&stripe.TreasuryReceivedCredit{}, client.SharedTransformers(transformers.WithSkipFields("APIResource", "ID"))...),
+		Transform:   client.TransformWithStruct(&stripe.TreasuryReceivedCredit{}, transformers.WithSkipFields("APIResource", "ID")),
 		Resolver:    fetchTreasuryReceivedCredits,
 
 		Columns: []schema.Column{

--- a/plugins/source/stripe/resources/services/treasury/treasury_received_debits.go
+++ b/plugins/source/stripe/resources/services/treasury/treasury_received_debits.go
@@ -13,7 +13,7 @@ func TreasuryReceivedDebits() *schema.Table {
 	return &schema.Table{
 		Name:        "stripe_treasury_received_debits",
 		Description: `https://stripe.com/docs/api/treasury_received_debits`,
-		Transform:   transformers.TransformWithStruct(&stripe.TreasuryReceivedDebit{}, client.SharedTransformers(transformers.WithSkipFields("APIResource", "ID"))...),
+		Transform:   client.TransformWithStruct(&stripe.TreasuryReceivedDebit{}, transformers.WithSkipFields("APIResource", "ID")),
 		Resolver:    fetchTreasuryReceivedDebits,
 
 		Columns: []schema.Column{

--- a/plugins/source/stripe/resources/services/treasury/treasury_transaction_entries.go
+++ b/plugins/source/stripe/resources/services/treasury/treasury_transaction_entries.go
@@ -2,7 +2,6 @@ package treasury
 
 import (
 	"context"
-
 	"fmt"
 	"strconv"
 
@@ -16,7 +15,7 @@ func TreasuryTransactionEntries() *schema.Table {
 	return &schema.Table{
 		Name:        "stripe_treasury_transaction_entries",
 		Description: `https://stripe.com/docs/api/treasury_transaction_entries`,
-		Transform:   transformers.TransformWithStruct(&stripe.TreasuryTransactionEntry{}, client.SharedTransformers(transformers.WithSkipFields("APIResource", "ID"))...),
+		Transform:   client.TransformWithStruct(&stripe.TreasuryTransactionEntry{}, transformers.WithSkipFields("APIResource", "ID")),
 		Resolver:    fetchTreasuryTransactionEntries,
 
 		Columns: []schema.Column{

--- a/plugins/source/stripe/resources/services/treasury/treasury_transactions.go
+++ b/plugins/source/stripe/resources/services/treasury/treasury_transactions.go
@@ -2,7 +2,6 @@ package treasury
 
 import (
 	"context"
-
 	"fmt"
 	"strconv"
 
@@ -16,7 +15,7 @@ func TreasuryTransactions() *schema.Table {
 	return &schema.Table{
 		Name:        "stripe_treasury_transactions",
 		Description: `https://stripe.com/docs/api/treasury_transactions`,
-		Transform:   transformers.TransformWithStruct(&stripe.TreasuryTransaction{}, client.SharedTransformers(transformers.WithSkipFields("APIResource", "ID"))...),
+		Transform:   client.TransformWithStruct(&stripe.TreasuryTransaction{}, transformers.WithSkipFields("APIResource", "ID")),
 		Resolver:    fetchTreasuryTransactions,
 
 		Columns: []schema.Column{

--- a/plugins/source/stripe/resources/services/webhook_endpoints/webhook_endpoints.go
+++ b/plugins/source/stripe/resources/services/webhook_endpoints/webhook_endpoints.go
@@ -13,7 +13,7 @@ func WebhookEndpoints() *schema.Table {
 	return &schema.Table{
 		Name:        "stripe_webhook_endpoints",
 		Description: `https://stripe.com/docs/api/webhook_endpoints`,
-		Transform:   transformers.TransformWithStruct(&stripe.WebhookEndpoint{}, client.SharedTransformers(transformers.WithSkipFields("APIResource", "ID"))...),
+		Transform:   client.TransformWithStruct(&stripe.WebhookEndpoint{}, transformers.WithSkipFields("APIResource", "ID")),
 		Resolver:    fetchWebhookEndpoints,
 
 		Columns: []schema.Column{

--- a/plugins/source/tailscale/client/transformers.go
+++ b/plugins/source/tailscale/client/transformers.go
@@ -8,10 +8,12 @@ import (
 	"github.com/tailscale/tailscale-client-go/tailscale"
 )
 
-func SharedTransformers(others ...transformers.StructTransformerOption) []transformers.StructTransformerOption {
-	return append([]transformers.StructTransformerOption{
-		transformers.WithTypeTransformer(typeTransformer),
-	}, others...)
+var options = []transformers.StructTransformerOption{
+	transformers.WithTypeTransformer(typeTransformer),
+}
+
+func TransformWithStruct(t any, opts ...transformers.StructTransformerOption) schema.Transform {
+	return transformers.TransformWithStruct(t, append(options, opts...)...)
 }
 
 func typeTransformer(field reflect.StructField) (schema.ValueType, error) {

--- a/plugins/source/tailscale/resources/services/device/devices.go
+++ b/plugins/source/tailscale/resources/services/device/devices.go
@@ -15,7 +15,7 @@ func Devices() *schema.Table {
 		Description:          `https://github.com/tailscale/tailscale/blob/main/api.md#tailnet-devices-get`,
 		Resolver:             fetchDevices,
 		PostResourceResolver: postDeviceFetch,
-		Transform:            transformers.TransformWithStruct(&tailscale.Device{}, client.SharedTransformers(transformers.WithPrimaryKeys("ID"))...),
+		Transform:            client.TransformWithStruct(&tailscale.Device{}, transformers.WithPrimaryKeys("ID")),
 		Columns: []schema.Column{
 			{
 				Name:     "tailnet",

--- a/plugins/source/tailscale/resources/services/key/keys.go
+++ b/plugins/source/tailscale/resources/services/key/keys.go
@@ -15,7 +15,7 @@ func Keys() *schema.Table {
 		Description:         `https://github.com/tailscale/tailscale/blob/main/api.md#keys`,
 		Resolver:            fetchKeys,
 		PreResourceResolver: getKey,
-		Transform:           transformers.TransformWithStruct(&tailscale.Key{}, client.SharedTransformers(transformers.WithPrimaryKeys("ID"))...),
+		Transform:           client.TransformWithStruct(&tailscale.Key{}, transformers.WithPrimaryKeys("ID")),
 		Columns: []schema.Column{
 			{
 				Name:     "tailnet",

--- a/plugins/source/vercel/client/transformers.go
+++ b/plugins/source/vercel/client/transformers.go
@@ -8,10 +8,12 @@ import (
 	"github.com/cloudquery/plugin-sdk/transformers"
 )
 
-func SharedTransformers() []transformers.StructTransformerOption {
-	return []transformers.StructTransformerOption{
-		transformers.WithTypeTransformer(typeTransformer),
-	}
+var options = []transformers.StructTransformerOption{
+	transformers.WithTypeTransformer(typeTransformer),
+}
+
+func TransformWithStruct(t any, opts ...transformers.StructTransformerOption) schema.Transform {
+	return transformers.TransformWithStruct(t, append(options, opts...)...)
 }
 
 func typeTransformer(field reflect.StructField) (schema.ValueType, error) {

--- a/plugins/source/vercel/resources/services/deployment/deployment_checks.go
+++ b/plugins/source/vercel/resources/services/deployment/deployment_checks.go
@@ -4,14 +4,13 @@ import (
 	"github.com/cloudquery/cloudquery/plugins/source/vercel/client"
 	"github.com/cloudquery/cloudquery/plugins/source/vercel/internal/vercel"
 	"github.com/cloudquery/plugin-sdk/schema"
-	"github.com/cloudquery/plugin-sdk/transformers"
 )
 
 func DeploymentChecks() *schema.Table {
 	return &schema.Table{
 		Name:          "vercel_deployment_checks",
 		Resolver:      fetchDeploymentChecks,
-		Transform:     transformers.TransformWithStruct(&vercel.DeploymentCheck{}, client.SharedTransformers()...),
+		Transform:     client.TransformWithStruct(&vercel.DeploymentCheck{}),
 		Multiplex:     client.TeamMultiplex,
 		IsIncremental: true,
 		Columns: []schema.Column{

--- a/plugins/source/vercel/resources/services/deployment/deployments.go
+++ b/plugins/source/vercel/resources/services/deployment/deployments.go
@@ -4,14 +4,13 @@ import (
 	"github.com/cloudquery/cloudquery/plugins/source/vercel/client"
 	"github.com/cloudquery/cloudquery/plugins/source/vercel/internal/vercel"
 	"github.com/cloudquery/plugin-sdk/schema"
-	"github.com/cloudquery/plugin-sdk/transformers"
 )
 
 func Deployments() *schema.Table {
 	return &schema.Table{
 		Name:          "vercel_deployments",
 		Resolver:      fetchDeployments,
-		Transform:     transformers.TransformWithStruct(&vercel.Deployment{}, client.SharedTransformers()...),
+		Transform:     client.TransformWithStruct(&vercel.Deployment{}),
 		Multiplex:     client.TeamMultiplex,
 		IsIncremental: true,
 		Columns: []schema.Column{

--- a/plugins/source/vercel/resources/services/domain/domain_records.go
+++ b/plugins/source/vercel/resources/services/domain/domain_records.go
@@ -4,14 +4,13 @@ import (
 	"github.com/cloudquery/cloudquery/plugins/source/vercel/client"
 	"github.com/cloudquery/cloudquery/plugins/source/vercel/internal/vercel"
 	"github.com/cloudquery/plugin-sdk/schema"
-	"github.com/cloudquery/plugin-sdk/transformers"
 )
 
 func DomainRecords() *schema.Table {
 	return &schema.Table{
 		Name:          "vercel_domain_records",
 		Resolver:      fetchDomainRecords,
-		Transform:     transformers.TransformWithStruct(&vercel.DomainRecord{}, client.SharedTransformers()...),
+		Transform:     client.TransformWithStruct(&vercel.DomainRecord{}),
 		Multiplex:     client.TeamMultiplex,
 		IsIncremental: true,
 		Columns: []schema.Column{

--- a/plugins/source/vercel/resources/services/domain/domains.go
+++ b/plugins/source/vercel/resources/services/domain/domains.go
@@ -4,14 +4,13 @@ import (
 	"github.com/cloudquery/cloudquery/plugins/source/vercel/client"
 	"github.com/cloudquery/cloudquery/plugins/source/vercel/internal/vercel"
 	"github.com/cloudquery/plugin-sdk/schema"
-	"github.com/cloudquery/plugin-sdk/transformers"
 )
 
 func Domains() *schema.Table {
 	return &schema.Table{
 		Name:          "vercel_domains",
 		Resolver:      fetchDomains,
-		Transform:     transformers.TransformWithStruct(&vercel.Domain{}, client.SharedTransformers()...),
+		Transform:     client.TransformWithStruct(&vercel.Domain{}),
 		Multiplex:     client.TeamMultiplex,
 		IsIncremental: true,
 		Columns: []schema.Column{

--- a/plugins/source/vercel/resources/services/project/project_envs.go
+++ b/plugins/source/vercel/resources/services/project/project_envs.go
@@ -4,14 +4,13 @@ import (
 	"github.com/cloudquery/cloudquery/plugins/source/vercel/client"
 	"github.com/cloudquery/cloudquery/plugins/source/vercel/internal/vercel"
 	"github.com/cloudquery/plugin-sdk/schema"
-	"github.com/cloudquery/plugin-sdk/transformers"
 )
 
 func ProjectEnvs() *schema.Table {
 	return &schema.Table{
 		Name:          "vercel_project_envs",
 		Resolver:      fetchProjectEnvs,
-		Transform:     transformers.TransformWithStruct(&vercel.ProjectEnv{}, client.SharedTransformers()...),
+		Transform:     client.TransformWithStruct(&vercel.ProjectEnv{}),
 		Multiplex:     client.TeamMultiplex,
 		IsIncremental: true,
 		Columns: []schema.Column{

--- a/plugins/source/vercel/resources/services/project/projects.go
+++ b/plugins/source/vercel/resources/services/project/projects.go
@@ -4,14 +4,13 @@ import (
 	"github.com/cloudquery/cloudquery/plugins/source/vercel/client"
 	"github.com/cloudquery/cloudquery/plugins/source/vercel/internal/vercel"
 	"github.com/cloudquery/plugin-sdk/schema"
-	"github.com/cloudquery/plugin-sdk/transformers"
 )
 
 func Projects() *schema.Table {
 	return &schema.Table{
 		Name:          "vercel_projects",
 		Resolver:      fetchProjects,
-		Transform:     transformers.TransformWithStruct(&vercel.Project{}, client.SharedTransformers()...),
+		Transform:     client.TransformWithStruct(&vercel.Project{}),
 		Multiplex:     client.TeamMultiplex,
 		IsIncremental: true,
 		Columns: []schema.Column{

--- a/plugins/source/vercel/resources/services/team/team_members.go
+++ b/plugins/source/vercel/resources/services/team/team_members.go
@@ -4,14 +4,13 @@ import (
 	"github.com/cloudquery/cloudquery/plugins/source/vercel/client"
 	"github.com/cloudquery/cloudquery/plugins/source/vercel/internal/vercel"
 	"github.com/cloudquery/plugin-sdk/schema"
-	"github.com/cloudquery/plugin-sdk/transformers"
 )
 
 func TeamMembers() *schema.Table {
 	return &schema.Table{
 		Name:          "vercel_team_members",
 		Resolver:      fetchTeamMembers,
-		Transform:     transformers.TransformWithStruct(&vercel.TeamMember{}, client.SharedTransformers()...),
+		Transform:     client.TransformWithStruct(&vercel.TeamMember{}),
 		IsIncremental: true,
 		Columns: []schema.Column{
 			{

--- a/plugins/source/vercel/resources/services/team/teams.go
+++ b/plugins/source/vercel/resources/services/team/teams.go
@@ -4,14 +4,13 @@ import (
 	"github.com/cloudquery/cloudquery/plugins/source/vercel/client"
 	"github.com/cloudquery/cloudquery/plugins/source/vercel/internal/vercel"
 	"github.com/cloudquery/plugin-sdk/schema"
-	"github.com/cloudquery/plugin-sdk/transformers"
 )
 
 func Teams() *schema.Table {
 	return &schema.Table{
 		Name:          "vercel_teams",
 		Resolver:      fetchTeams,
-		Transform:     transformers.TransformWithStruct(&vercel.Team{}, client.SharedTransformers()...),
+		Transform:     client.TransformWithStruct(&vercel.Team{}),
 		IsIncremental: true,
 		Columns: []schema.Column{
 			{


### PR DESCRIPTION
Sometimes we have default transformer options (e.g., type & resolver transformers).
We use them like this:
```go
schema.Table{
  Transform: transformers.TransformWithStruct(&someStruct, append(client.DefaultOptions, a,b,c)...),
}
```

However, it’ll be much easier to do the following instead:
- in the client package define the following func
  ```go
  func TransformWithStruct(t any, opts ...transformers.StructTransformerOption) schema.Transform {
    return transformers.TransformWithStruct(t, append(options, opts...)...)
  }
  ```
- And replace resource transform calls to `client.TransformWithStruct(t, a, b, c)`

This PR does exactly this.