### PR TITLE
fix(website): Handle source -> dest integration with the same id

### DIFF
--- a/website/components/pages/IntegrationSourceDestination.tsx
+++ b/website/components/pages/IntegrationSourceDestination.tsx
@@ -19,6 +19,8 @@ export default function Integration({
     destinationAuthentication?: ReactNode;
     syncCommand: ReactNode;
 }) {
+    const sourceFilename = source.id === destination.id ? `source-${source.id}.yaml` : `${source.id}.yaml`;
+    const destinationFilename = source.id === destination.id ? `destination-${destination.id}.yaml` : `${destination.id}.yaml`;
     return <>
         <div className="flex flex-col md:flex-row justify-between px-4 pt-16 pb-8 mx-auto sm:pt-24 lg:px-8 w-auto lg:max-w-7xl">
             <div className="flex flex-col justify-between md:mr-4">
@@ -70,14 +72,14 @@ export default function Integration({
                 {source.kind !== "official" ?
                     <>
                         <p className="mt-4">
-                            {source.name} is a {source.kind} plugin, which means that it is maintained by the {source.kind === "community" ? "CloudQuery community" : source.name + " team"}. Create a file called <code className="text-lg nx-font-bold">{source.id}.yaml</code>, then copy the example and follow the instructions in the <a target="_blank" href={source.href} className="text-blue-500 hover:text-blue-600">{source.name} Plugin Documentation ↗</a> to fit your needs.
+                            {source.name} is a {source.kind} plugin, which means that it is maintained by the {source.kind === "community" ? "CloudQuery community" : source.name + " team"}. Create a file called <code className="text-lg nx-font-bold">{sourceFilename}</code>, then copy the example and follow the instructions in the <a target="_blank" href={source.href} className="text-blue-500 hover:text-blue-600">{source.name} Plugin Documentation ↗</a> to fit your needs.
                         </p>
                     </>
                     :
                     <>
                         <h3 className="mt-4 nx-text-2xl font-extrabold tracking-tight lg:nx-text-3xl xl:nx-text-4xl dark:text-white">Configuration</h3>
                         <p className="mt-4">
-                            Create a file called <code className="text-lg nx-font-bold">{source.id}.yaml</code> and add the following contents:
+                            Create a file called <code className="text-lg nx-font-bold">{sourceFilename}</code> and add the following contents:
                         </p>
                         {sourceConfiguration}
                         <p className="mt-4">
@@ -100,7 +102,7 @@ export default function Integration({
                 {destination.kind !== "official" ?
                     <>
                         <p className="mt-4">
-                            {destination.name} is a {destination.kind} plugin, which means that it is maintained by the {destination.kind === "community" ? "CloudQuery community" : destination.name + " team"}. Create a file called <code className="text-lg nx-font-bold">{destination.id}.yaml</code>, then copy the example and follow the instructions in the <a target="_blank" href={destination.href} className="text-blue-500 hover:text-blue-600">{destination.name} Plugin Documentation ↗</a> to fit your needs.
+                            {destination.name} is a {destination.kind} plugin, which means that it is maintained by the {destination.kind === "community" ? "CloudQuery community" : destination.name + " team"}. Create a file called <code className="text-lg nx-font-bold">{destinationFilename}</code>, then copy the example and follow the instructions in the <a target="_blank" href={destination.href} className="text-blue-500 hover:text-blue-600">{destination.name} Plugin Documentation ↗</a> to fit your needs.
                         </p>
                     </>
                     :
@@ -110,7 +112,7 @@ export default function Integration({
                         </p>
                         <h3 className="mt-4 nx-text-2xl font-extrabold tracking-tight lg:nx-text-3xl xl:nx-text-4xl dark:text-white">Configuration</h3>
                         <p className="mt-4">
-                            Create a file called <code className="text-lg nx-font-bold">{destination.id}.yaml</code> and add the following contents:
+                            Create a file called <code className="text-lg nx-font-bold">{destinationFilename}</code> and add the following contents:
                         </p>
                         {destinationConfiguration}
                         <p className="mt-4">

--- a/website/scripts/prebuild.tsx
+++ b/website/scripts/prebuild.tsx
@@ -175,8 +175,10 @@ import SyncCommand from "../../../components/mdx/plugins/source/${source.id}/${d
     }
     // Write the sync command file
     const syncCommandFilePath = path.join(syncCommandDir, "_sync.mdx");
+    const sourceFilename = source.id === destination.id ? `source-${source.id}.yaml` : `${source.id}.yaml`;
+    const destinationFilename = source.id === destination.id ? `destination-${destination.id}.yaml` : `${destination.id}.yaml`;
     const syncCommandFileContents = "```bash copy\n" +
-        `cloudquery sync ${source.id}.yaml ${destination.id}.yaml\n` +
+        `cloudquery sync ${sourceFilename} ${destinationFilename}\n` +
         "```"
     // Write the contents to the new file
     fs.writeFileSync(syncCommandFilePath, syncCommandFileContents);


### PR DESCRIPTION
<!-- 🎉 Thank you for making CloudQuery awesome by submitting a PR 🎉 -->

#### Summary

Fixes an edge case in our integrations pages where someone selects a source and destination with the same id (e.g. MySQL->MySQL or Postgres->Postgres)

<!--
Use the following steps to ensure your PR is ready to be reviewed

- [ ] Read the [contribution guidelines](../blob/main/CONTRIBUTING.md) 🧑‍🎓
- [ ] Run `make lint` to ensure the proposed changes follow the coding style 🚨 (install golangci-lint [here](https://golangci-lint.run/usage/install/#local-installation))
- [ ] Run `make test` to ensure the proposed changes pass the tests 🧪
- [ ] If changing a source plugin run `make gen` to ensure docs are up to date 📝
- [ ] Ensure the status checks below are successful ✅
--->
