### PR TITLE
fix(mysql-migrate): Properly set `NotNull` when a column is a primary Key

### DIFF
--- a/plugins/destination/mysql/client/migrate.go
+++ b/plugins/destination/mysql/client/migrate.go
@@ -24,8 +24,8 @@ func (c *Client) normalizedTables(tables schema.Tables) schema.Tables {
 			table.Columns.Get(schema.CqIDColumn.Name).CreationOptions.PrimaryKey = true
 		}
 
-		for _, col := range table.Columns {
-			col.CreationOptions.NotNull = col.CreationOptions.NotNull || col.CreationOptions.PrimaryKey
+		for i := range table.Columns {
+			table.Columns[i].CreationOptions.NotNull = table.Columns[i].CreationOptions.NotNull || table.Columns[i].CreationOptions.PrimaryKey
 		}
 
 		normalized = append(normalized, table)

--- a/plugins/destination/mysql/client/migrate.go
+++ b/plugins/destination/mysql/client/migrate.go
@@ -24,8 +24,8 @@ func (c *Client) normalizedTables(tables schema.Tables) schema.Tables {
 			table.Columns.Get(schema.CqIDColumn.Name).CreationOptions.PrimaryKey = true
 		}
 
-		for i := range table.Columns {
-			table.Columns[i].CreationOptions.NotNull = table.Columns[i].CreationOptions.NotNull || table.Columns[i].CreationOptions.PrimaryKey
+		for i, col := range table.Columns {
+			table.Columns[i].CreationOptions.NotNull = col.CreationOptions.NotNull || col.CreationOptions.PrimaryKey
 		}
 
 		normalized = append(normalized, table)


### PR DESCRIPTION
<!-- 🎉 Thank you for making CloudQuery awesome by submitting a PR 🎉 -->

#### Summary

This fixes a bug in the MySQL destination migration where it always required a forced migration since we didn't set the `NotNull` value for primary keys. See original comment https://github.com/cloudquery/cloudquery/pull/8438#discussion_r1118470405

<!--
Use the following steps to ensure your PR is ready to be reviewed

- [ ] Read the [contribution guidelines](../blob/main/CONTRIBUTING.md) 🧑‍🎓
- [ ] Run `make lint` to ensure the proposed changes follow the coding style 🚨 (install golangci-lint [here](https://golangci-lint.run/usage/install/#local-installation))
- [ ] Run `make test` to ensure the proposed changes pass the tests 🧪
- [ ] If changing a source plugin run `make gen` to ensure docs are up to date 📝
- [ ] Ensure the status checks below are successful ✅
--->
