### PR TITLE
chore(website): Update meta.json for CQ comparison pages

### DIFF
--- a/website/pages/docs/cq-vs-others/_meta.json
+++ b/website/pages/docs/cq-vs-others/_meta.json
@@ -1,8 +1,9 @@
 {
   "overview": "Overview",
-  "fivetran": "CloudQuery vs Fivetran",
   "airbyte": "CloudQuery vs Airbyte",
   "aws-config": "CloudQuery vs AWS Config",
+  "cloudsploit": "CloudQuery vs CloudSploit",
+  "fivetran": "CloudQuery vs Fivetran",
   "google-cloud-asset-inventory": "CloudQuery vs Google Cloud Asset Inventory",
   "cspms": "CloudQuery vs CSPMs (Cloud Security Posture Management)",
   "steampipe": "CloudQuery vs Steampipe"


### PR DESCRIPTION
Fixes title of the `CloudQuery vs CloudSploit` page in the sidebar