### PR TITLE
feat(aws): Add AWS EC2 AccountAttributes

### DIFF
--- a/plugins/source/aws/docs/tables/README.md
+++ b/plugins/source/aws/docs/tables/README.md
@@ -136,6 +136,7 @@
 - [aws_dynamodb_tables](../../../../../website/tables/aws/aws_dynamodb_tables.md)
   - [aws_dynamodb_table_continuous_backups](../../../../../website/tables/aws/aws_dynamodb_table_continuous_backups.md)
   - [aws_dynamodb_table_replica_auto_scalings](../../../../../website/tables/aws/aws_dynamodb_table_replica_auto_scalings.md)
+- [aws_ec2_account_attributes](../../../../../website/tables/aws/aws_ec2_account_attributes.md)
 - [aws_ec2_byoip_cidrs](../../../../../website/tables/aws/aws_ec2_byoip_cidrs.md)
 - [aws_ec2_customer_gateways](../../../../../website/tables/aws/aws_ec2_customer_gateways.md)
 - [aws_ec2_dhcp_options](../../../../../website/tables/aws/aws_ec2_dhcp_options.md)

--- a/plugins/source/aws/resources/plugin/tables.go
+++ b/plugins/source/aws/resources/plugin/tables.go
@@ -179,6 +179,7 @@ func tables() []*schema.Table {
 		docdb.PendingMaintenanceActions(),
 		docdb.SubnetGroups(),
 		dynamodb.Tables(),
+		ec2.AccountAttributes(),
 		ec2.AvailabilityZones(),
 		ec2.ByoipCidrs(),
 		ec2.CustomerGateways(),

--- a/plugins/source/aws/resources/services/ec2/account_attributes.go
+++ b/plugins/source/aws/resources/services/ec2/account_attributes.go
@@ -1,0 +1,39 @@
+package ec2
+
+import (
+	"context"
+
+	"github.com/aws/aws-sdk-go-v2/service/ec2"
+	"github.com/aws/aws-sdk-go-v2/service/ec2/types"
+	"github.com/cloudquery/cloudquery/plugins/source/aws/client"
+	"github.com/cloudquery/plugin-sdk/schema"
+	"github.com/cloudquery/plugin-sdk/transformers"
+)
+
+func AccountAttributes() *schema.Table {
+	tableName := "aws_ec2_account_attributes"
+	return &schema.Table{
+		Name:        tableName,
+		Description: `https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_AccountAttribute.html`,
+		Resolver:    fetchAccountAttributes,
+		Multiplex:   client.AccountMultiplex(tableName),
+		Transform:   transformers.TransformWithStruct(&types.AccountAttribute{}, transformers.WithPrimaryKeys("AttributeName")),
+		Columns: []schema.Column{
+			client.DefaultAccountIDColumn(true),
+			{
+				Name:     "partition",
+				Type:     schema.TypeString,
+				Resolver: client.ResolveAWSPartition,
+			},
+		},
+	}
+}
+func fetchAccountAttributes(ctx context.Context, meta schema.ClientMeta, parent *schema.Resource, res chan<- any) error {
+	c := meta.(*client.Client)
+	output, err := c.Services().Ec2.DescribeAccountAttributes(ctx, &ec2.DescribeAccountAttributesInput{})
+	if err != nil {
+		return err
+	}
+	res <- output.AccountAttributes
+	return nil
+}

--- a/plugins/source/aws/resources/services/ec2/account_attributes_mock_test.go
+++ b/plugins/source/aws/resources/services/ec2/account_attributes_mock_test.go
@@ -1,0 +1,32 @@
+package ec2
+
+import (
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/service/ec2"
+	"github.com/aws/aws-sdk-go-v2/service/ec2/types"
+	"github.com/cloudquery/cloudquery/plugins/source/aws/client"
+	"github.com/cloudquery/cloudquery/plugins/source/aws/client/mocks"
+	"github.com/cloudquery/plugin-sdk/faker"
+	"github.com/golang/mock/gomock"
+)
+
+func buildAccountAttributesMock(t *testing.T, ctrl *gomock.Controller) client.Services {
+	m := mocks.NewMockEc2Client(ctrl)
+	ac := types.AccountAttribute{}
+	if err := faker.FakeObject(&ac); err != nil {
+		t.Fatal(err)
+	}
+	m.EXPECT().DescribeAccountAttributes(gomock.Any(), gomock.Any(), gomock.Any()).Return(
+		&ec2.DescribeAccountAttributesOutput{
+			AccountAttributes: []types.AccountAttribute{ac},
+		}, nil)
+
+	return client.Services{
+		Ec2: m,
+	}
+}
+
+func TestAccountAttributes(t *testing.T) {
+	client.AwsMockTestHelper(t, AccountAttributes(), buildAccountAttributesMock, client.TestOptions{})
+}

--- a/website/pages/docs/plugins/sources/aws/tables.md
+++ b/website/pages/docs/plugins/sources/aws/tables.md
@@ -136,6 +136,7 @@
 - [aws_dynamodb_tables](tables/aws_dynamodb_tables)
   - [aws_dynamodb_table_continuous_backups](tables/aws_dynamodb_table_continuous_backups)
   - [aws_dynamodb_table_replica_auto_scalings](tables/aws_dynamodb_table_replica_auto_scalings)
+- [aws_ec2_account_attributes](tables/aws_ec2_account_attributes)
 - [aws_ec2_byoip_cidrs](tables/aws_ec2_byoip_cidrs)
 - [aws_ec2_customer_gateways](tables/aws_ec2_customer_gateways)
 - [aws_ec2_dhcp_options](tables/aws_ec2_dhcp_options)

--- a/website/tables/aws/aws_ec2_account_attributes.md
+++ b/website/tables/aws/aws_ec2_account_attributes.md
@@ -1,0 +1,18 @@
+# Table: aws_ec2_account_attributes
+
+https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_AccountAttribute.html
+
+The composite primary key for this table is (**account_id**, **attribute_name**).
+
+## Columns
+
+| Name          | Type          |
+| ------------- | ------------- |
+|_cq_source_name|String|
+|_cq_sync_time|Timestamp|
+|_cq_id|UUID|
+|_cq_parent_id|UUID|
+|account_id (PK)|String|
+|partition|String|
+|attribute_name (PK)|String|
+|attribute_values|JSON|


### PR DESCRIPTION
<!-- 🎉 Thank you for making CloudQuery awesome by submitting a PR 🎉 -->

#### Summary

Adds support for grabbing data from `Ec2.DescribeAccountAttributes`. Puts data into a new table `aws_ec2_account_attributes`
<!--
Use the following steps to ensure your PR is ready to be reviewed

- [ ] Read the [contribution guidelines](../blob/main/CONTRIBUTING.md) 🧑‍🎓
- [ ] Run `make lint` to ensure the proposed changes follow the coding style 🚨 (install golangci-lint [here](https://golangci-lint.run/usage/install/#local-installation))
- [ ] Run `make test` to ensure the proposed changes pass the tests 🧪
- [ ] If changing a source plugin run `make gen` to ensure docs are up to date 📝
- [ ] Ensure the status checks below are successful ✅
--->
