### PR TITLE
fix: Use the correct path for test file

### DIFF
--- a/plugins/destination/s3/client/client.go
+++ b/plugins/destination/s3/client/client.go
@@ -66,7 +66,7 @@ func New(ctx context.Context, logger zerolog.Logger, spec specs.Destination) (de
 	timeNow := time.Now().UTC()
 	if _, err := c.uploader.Upload(ctx, &s3.PutObjectInput{
 		Bucket: aws.String(c.pluginSpec.Bucket),
-		Key:    aws.String(replacePathVariables(spec.Path, "TEST_TABLE", "TEST_UUID", timeNow)),
+		Key:    aws.String(replacePathVariables(c.pluginSpec.Path, "TEST_TABLE", "TEST_UUID", timeNow)),
 		Body:   bytes.NewReader([]byte("")),
 	}); err != nil {
 		return nil, fmt.Errorf("failed to write test file to S3: %w", err)


### PR DESCRIPTION
#### Summary

When using the S3 destination plugin, cloudquery failed with an Access Denied error around the test file despite correct permissions.

Beforehand the code used the plugins path (i.e. cloudquery/s3). That means it doesn't actually test the correct permissions. It should use the output path that is provided by the user.

<!--
Use the following steps to ensure your PR is ready to be reviewed

- [ ] Read the [contribution guidelines](../blob/main/CONTRIBUTING.md) 🧑‍🎓
- [ ] Run `make lint` to ensure the proposed changes follow the coding style 🚨 (install golangci-lint [here](https://golangci-lint.run/usage/install/#local-installation))
- [ ] Run `make test` to ensure the proposed changes pass the tests 🧪
- [ ] If changing a source plugin run `make gen` to ensure docs are up to date 📝
- [ ] Ensure the status checks below are successful ✅
--->
