### PR TITLE
fix(linux-quickstart): Update sync command to use local binary

### DIFF
--- a/website/components/mdx/_configure-authenticate-provider.mdx
+++ b/website/components/mdx/_configure-authenticate-provider.mdx
@@ -1,0 +1,6 @@
+## Authenticate with the Cloud Provider
+
+CloudQuery uses similar authentication methods to the official SDKs of each cloud provider.
+The AWS authentication guide is located [here](https://github.com/cloudquery/cloudquery/blob/main/plugins/source/aws/README.md).
+
+You can find authentication for other plugins in their corresponding [READMEs](https://github.com/cloudquery/cloudquery/tree/main/plugins/source).

--- a/website/components/mdx/_configure-destination.mdx
+++ b/website/components/mdx/_configure-destination.mdx
@@ -1,0 +1,54 @@
+import { Callout } from 'nextra-theme-docs';
+
+## Configure Destination Plugin
+
+Destination plugins define where you will be syncing your data to (See: [available destinations](/docs/plugins/destinations/overview)).
+
+For example, let's configure the [PostgreSQL](https://github.com/cloudquery/cloudquery/tree/main/plugins/destination/postgresql) destination plugin
+(See all available versions [here](https://github.com/cloudquery/cloudquery/releases?q=plugins-destination-postgresql&expanded=true)).
+Create a file in a new directory `cloudquery-config/postgresql.yml`: 
+
+```yaml copy
+kind: destination
+spec:
+  ## Required. name of the plugin.
+  ## This is an alias so it should be unique if you have a number of postgresql destination plugins.
+  name: "postgresql"
+
+  ## Optional. Where to search for the plugin. Default: "github". Options: "github", "local", "grpc".
+  # registry: "github"
+
+  ## Path for the plugin.
+  ## If registry is "github" path should be "repo/name"
+  ## If registry is "local", path is path to binary. If "grpc" then it should be address of the plugin (usually useful in debug).
+  path: "cloudquery/postgresql"
+
+  ## Required. Must be a specific version starting with v, e.g. v1.2.3
+  ## checkout latest versions here https://github.com/cloudquery/cloudquery/releases?q=plugins-destination-postgresql&expanded=true
+  version: "VERSION_DESTINATION_POSTGRESQL"
+
+  ## Optional. Default: "overwrite-delete-stale". Available: "overwrite-delete-stale", "overwrite", "append". 
+  ##  Not all modes are supported by all plugins, so make sure to check the plugin documentation for more details.
+  write_mode: "overwrite-delete-stale" # overwrite-delete-stale, overwrite, append
+
+  spec:
+    ## plugin-specific configuration for PostgreSQL.
+    ## See all available options here: https://github.com/cloudquery/cloudquery/tree/main/plugins/destination/postgresql#postgresql-spec
+
+    ## Required. Connection string to your PostgreSQL instance
+    ## In production it is highly recommended to use environment variable expansion
+    ## connection_string: ${PG_CONNECTION_STRING}
+    connection_string: "postgresql://postgres:pass@localhost:5432/postgres?sslmode=disable"
+```
+
+- All general options for destination spec you can find under [references/destination-spec](/docs/reference/destination-spec).
+- All options for `postgresql` destination plugin spec you can find [here](https://github.com/cloudquery/cloudquery/tree/main/plugins/destination/postgresql#postgresql-spec)
+
+For a list of all available destination plugin spec options, see [Destination Spec Reference](/docs/reference/destination-spec).
+
+<Callout>
+
+If you have multiple destination plugins (or running multiple cloudquery instances in parallel), it's required
+that every plugin configuration has a unique `name` (e.g. `postgres1`, `postgres2`, …).
+
+</Callout>

--- a/website/components/mdx/_configure-done.mdx
+++ b/website/components/mdx/_configure-done.mdx
@@ -1,0 +1,4 @@
+You should see a spinner with number of resources synced and the time it took to sync.
+Once the sync is done you can query the data via the database directly.
+
+Note: All logs are written by default to `cloudquery.log` so you can easily see if any APIs failed and analyse those further.

--- a/website/components/mdx/_configure-linux.mdx
+++ b/website/components/mdx/_configure-linux.mdx
@@ -2,7 +2,7 @@ import ConfigureDestination from './_configure-destination.mdx';
 import ConfigureSource from './_configure-source.mdx';
 import ConfigureAuthenticateProvider from './_configure-authenticate-provider.mdx';
 import ConfigureStartSyncing from './_configure-start-syncing.mdx';
-import ConfigureSyncCommand from './_configure-sync-command.mdx';
+import ConfigureSyncCommandUnixPrecompiled from './_configure-sync-command-unix-precompiled.mdx';
 import ConfigureDone from './_configure-done.mdx';
 
 <ConfigureDestination />
@@ -13,6 +13,6 @@ import ConfigureDone from './_configure-done.mdx';
 
 <ConfigureStartSyncing />
 
-<ConfigureSyncCommand />
+<ConfigureSyncCommandUnixPrecompiled />
 
 <ConfigureDone />

--- a/website/components/mdx/_configure-source.mdx
+++ b/website/components/mdx/_configure-source.mdx
@@ -1,0 +1,54 @@
+import { Callout } from 'nextra-theme-docs';
+
+## Configure Source Plugin
+
+Source plugins define the APIs you want to sync from (See [available sources](/docs/plugins/sources/overview)).
+
+For example, let's configure the [AWS](https://github.com/cloudquery/cloudquery/tree/main/plugins/source/aws) source plugin.
+Create an `aws.yml` file in your `cloudquery-config` directory:
+
+```yaml copy
+kind: source
+spec:
+  ## Required. name of the plugin to use.
+  ## This should be unique if you have number of aws plugins.
+  name: "aws"
+  ## Optional. Where to search for the plugin. Default: "github". Options: "github", "local", "grpc"
+  # registry: "github"
+
+  ## Path for the plugin.
+  ## If registry is "github" path should be "repo/name"
+  ## If registry is "local", path is path to binary. If "grpc" then it should be address of the plugin (usually useful in debug).
+  path: "cloudquery/aws"
+
+  ## Required. Must be a specific version starting with v, e.g. v1.2.3
+  ## checkout latest versions here https://github.com/cloudquery/cloudquery/releases?q=plugins-source-aws&expanded=true
+  version: "VERSION_SOURCE_AWS"
+
+  ## Optional. Default: ["*"] - all tables. We recommend to specify specific tables that you need to sync as this
+  ## will reduce the amount of data synced and improve performance.
+  ## See all tables: https://github.com/cloudquery/cloudquery/blob/main/plugins/source/aws/docs/tables/README.md
+  # tables: ["*"]
+
+  ## Required. all destinations you want to sync data to.
+  destinations: ["postgresql"]
+
+  spec:
+    ## Optional. plugin specific configuration
+    ## By default will use the current aws credentials available (just like AWS CLI)
+    ## See all available options here: https://github.com/cloudquery/cloudquery/blob/main/plugins/source/aws/docs/configuration.md
+```
+
+- All general options for source spec you can find under [references/source-spec](/docs/reference/source-spec).
+- All options for `aws` source plugin spec you can find [here](https://github.com/cloudquery/cloudquery/blob/main/plugins/source/aws/docs/configuration.md)
+
+<Callout>
+
+If you have multiple source plugins (or running multiple cloudquery instances in parallel), it's required
+that every plugin configuration has a unique `name` (e.g. `aws1`, `aws2`, …).
+
+Running multiple plugins with the same name can cause unexpected behavior (e.g. empty tables). 
+
+You can read more [here](/docs/advanced-topics/running-cloudquery-in-parallel).
+
+</Callout>

--- a/website/components/mdx/_configure-start-syncing.mdx
+++ b/website/components/mdx/_configure-start-syncing.mdx
@@ -1,0 +1,6 @@
+
+## Start Syncing
+
+Now you can start syncing the data from your source plugins to the specified destinations.
+
+You can sync the by specifying a directory with the configuration files or specify files directly

--- a/website/components/mdx/_configure-sync-command-unix-precompiled.mdx
+++ b/website/components/mdx/_configure-sync-command-unix-precompiled.mdx
@@ -1,0 +1,5 @@
+```bash copy
+./cloudquery sync ./cloudquery-config
+
+# or ./cloudquery sync cloudquery-config/aws.yml cloudquery-config/postgresql.yml
+```

--- a/website/components/mdx/_configure-sync-command.mdx
+++ b/website/components/mdx/_configure-sync-command.mdx
@@ -1,0 +1,5 @@
+```bash copy
+cloudquery sync ./cloudquery-config
+
+# or cloudquery sync cloudquery-config/aws.yml cloudquery-config/postgresql.yml
+```

--- a/website/pages/docs/quickstart/linux.mdx
+++ b/website/pages/docs/quickstart/linux.mdx
@@ -4,7 +4,7 @@ title: Quickstart - Linux
 
 import Intro from '../../../components/mdx/_intro.mdx'
 import DownloadSection from '../../../components/mdx/_download-linux.mdx'
-import ConfigureSection from '../../../components/mdx/_configure.mdx'
+import ConfigureSection from '../../../components/mdx/_configure-linux.mdx'
 
 <Intro />
 <DownloadSection />


### PR DESCRIPTION
<!-- 🎉 Thank you for making CloudQuery awesome by submitting a PR 🎉 -->

#### Summary

Fixes https://github.com/cloudquery/cloudquery/issues/8943.

This seems like a lot of changes, but it mostly breaks `_configure.mdx` into multiple components so we can have `_configure.mdx` and `_configure-linux.mdx`. The latter uses a different sync command component that has `./cloudquery sync` instead of `cloudquery sync` (notice the `./` prefix).

There's some follow up to do here for MacOS quick start (and also for the integrations page), to switch from `cloudquery` to `./cloudquery` and back when someone clicks the corresponding table (i.e. `cloudquery` for Homebrew and `./cloudquery` for precompiled binary). 

<!--
Use the following steps to ensure your PR is ready to be reviewed

- [ ] Read the [contribution guidelines](../blob/main/CONTRIBUTING.md) 🧑‍🎓
- [ ] Run `make lint` to ensure the proposed changes follow the coding style 🚨 (install golangci-lint [here](https://golangci-lint.run/usage/install/#local-installation))
- [ ] Run `make test` to ensure the proposed changes pass the tests 🧪
- [ ] If changing a source plugin run `make gen` to ensure docs are up to date 📝
- [ ] Ensure the status checks below are successful ✅
--->
