### PR TITLE
fix(resources)!: Don't list billing and enrollment accounts per subscription

### DIFF
--- a/plugins/source/azure/resources/services/billing/accounts.go
+++ b/plugins/source/azure/resources/services/billing/accounts.go
@@ -14,9 +14,7 @@ func Accounts() *schema.Table {
 		Name:        "azure_billing_accounts",
 		Resolver:    fetchAccounts,
 		Description: "https://learn.microsoft.com/en-us/rest/api/billing/2020-05-01/billing-accounts/list?tabs=HTTP#billingaccount",
-		Multiplex:   client.SubscriptionMultiplexRegisteredNamespace("azure_billing_accounts", client.Namespacemicrosoft_billing),
 		Transform:   transformers.TransformWithStruct(&armbilling.Account{}, transformers.WithPrimaryKeys("ID")),
-		Columns:     schema.ColumnList{client.SubscriptionID},
 	}
 }
 

--- a/plugins/source/azure/resources/services/billing/enrollment_accounts.go
+++ b/plugins/source/azure/resources/services/billing/enrollment_accounts.go
@@ -14,9 +14,7 @@ func EnrollmentAccounts() *schema.Table {
 		Name:        "azure_billing_enrollment_accounts",
 		Resolver:    fetchEnrollmentAccounts,
 		Description: "https://pkg.go.dev/github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/billing/armbilling@v0.5.0#EnrollmentAccountSummary",
-		Multiplex:   client.SubscriptionMultiplexRegisteredNamespace("azure_billing_enrollment_accounts", client.Namespacemicrosoft_billing),
 		Transform:   transformers.TransformWithStruct(&armbilling.EnrollmentAccountSummary{}, transformers.WithPrimaryKeys("ID")),
-		Columns:     schema.ColumnList{client.SubscriptionID},
 	}
 }
 

--- a/website/tables/azure/azure_billing_accounts.md
+++ b/website/tables/azure/azure_billing_accounts.md
@@ -14,7 +14,6 @@ The primary key for this table is **id**.
 |_cq_sync_time|Timestamp|
 |_cq_id|UUID|
 |_cq_parent_id|UUID|
-|subscription_id|String|
 |properties|JSON|
 |id (PK)|String|
 |name|String|

--- a/website/tables/azure/azure_billing_enrollment_accounts.md
+++ b/website/tables/azure/azure_billing_enrollment_accounts.md
@@ -14,7 +14,6 @@ The primary key for this table is **id**.
 |_cq_sync_time|Timestamp|
 |_cq_id|UUID|
 |_cq_parent_id|UUID|
-|subscription_id|String|
 |properties|JSON|
 |id (PK)|String|
 |name|String|


### PR DESCRIPTION
<!-- 🎉 Thank you for making CloudQuery awesome by submitting a PR 🎉 -->

#### Summary

Related to https://github.com/cloudquery/cloudquery/issues/8929 (as to list consumption data we need to use a billing account ID as a scope).

Billing and enrollment accounts are not tied to a subscription so we shouldn't multiplex over those, and also remove the subscription ID column (hence the breaking change).

BEGIN_COMMIT_OVERRIDE
fix(resources): Don't list billing and enrollment accounts per subscription

BREAKING-CHANGE: Remove `subscription_id` column from `azure_billing_enrollment_accounts` and `azure_billing_accounts` tables.

END_COMMIT_OVERRIDE

<!--
Use the following steps to ensure your PR is ready to be reviewed

- [ ] Read the [contribution guidelines](../blob/main/CONTRIBUTING.md) 🧑‍🎓
- [ ] Run `make lint` to ensure the proposed changes follow the coding style 🚨 (install golangci-lint [here](https://golangci-lint.run/usage/install/#local-installation))
- [ ] Run `make test` to ensure the proposed changes pass the tests 🧪
- [ ] If changing a source plugin run `make gen` to ensure docs are up to date 📝
- [ ] Ensure the status checks below are successful ✅
--->
