### PR TITLE
feat!: Add ability to override CSV File options (headers and delimiters)

### DIFF
--- a/plugins/destination/file/client/client_test.go
+++ b/plugins/destination/file/client/client_test.go
@@ -3,6 +3,7 @@ package client
 import (
 	"testing"
 
+	"github.com/cloudquery/filetypes"
 	"github.com/cloudquery/plugin-sdk/plugins/destination"
 	"github.com/cloudquery/plugin-sdk/specs"
 )
@@ -22,8 +23,10 @@ func TestPluginCSV(t *testing.T) {
 		},
 		Spec{
 			Directory: t.TempDir(),
-			Format:    FormatTypeCSV,
-			NoRotate:  true,
+			FileSpec: &filetypes.FileSpec{
+				Format: filetypes.FormatTypeCSV,
+			},
+			NoRotate: true,
 		},
 		destination.PluginTestSuiteTests{
 			SkipOverwrite:             true,
@@ -45,8 +48,10 @@ func TestPluginJSON(t *testing.T) {
 		},
 		Spec{
 			Directory: t.TempDir(),
-			Format:    FormatTypeJSON,
-			NoRotate:  true,
+			FileSpec: &filetypes.FileSpec{
+				Format: filetypes.FormatTypeJSON,
+			},
+			NoRotate: true,
 		},
 		destination.PluginTestSuiteTests{
 			SkipOverwrite:             true,
@@ -68,8 +73,10 @@ func TestPluginParquet(t *testing.T) {
 		},
 		Spec{
 			Directory: t.TempDir(),
-			Format:    FormatTypeParquet,
-			NoRotate:  true,
+			FileSpec: &filetypes.FileSpec{
+				Format: filetypes.FormatTypeParquet,
+			},
+			NoRotate: true,
 		},
 		destination.PluginTestSuiteTests{
 			SkipOverwrite:             true,

--- a/plugins/destination/file/client/read.go
+++ b/plugins/destination/file/client/read.go
@@ -19,5 +19,5 @@ func (c *Client) Read(ctx context.Context, table *schema.Table, sourceName strin
 	}
 	defer f.Close()
 
-	return c.formatClient.Read(f, table, sourceName, res)
+	return c.Client.Read(f, table, sourceName, res)
 }

--- a/plugins/destination/file/client/spec.go
+++ b/plugins/destination/file/client/spec.go
@@ -2,20 +2,14 @@ package client
 
 import (
 	"fmt"
-)
 
-type FormatType string
-
-const (
-	FormatTypeCSV     = "csv"
-	FormatTypeJSON    = "json"
-	FormatTypeParquet = "parquet"
+	"github.com/cloudquery/filetypes"
 )
 
 type Spec struct {
-	Directory string     `json:"directory,omitempty"`
-	Format    FormatType `json:"format,omitempty"`
-	NoRotate  bool       `json:"no_rotate,omitempty"`
+	*filetypes.FileSpec
+	Directory string `json:"directory,omitempty"`
+	NoRotate  bool   `json:"no_rotate,omitempty"`
 }
 
 func (*Spec) SetDefaults() {}

--- a/plugins/destination/file/client/write.go
+++ b/plugins/destination/file/client/write.go
@@ -20,5 +20,5 @@ func (c *Client) WriteTableBatch(ctx context.Context, table *schema.Table, data 
 	}
 	defer f.Close()
 
-	return c.formatClient.WriteTableBatch(f, table, data)
+	return c.Client.WriteTableBatchFile(f, table, data)
 }

--- a/plugins/destination/file/go.mod
+++ b/plugins/destination/file/go.mod
@@ -9,6 +9,8 @@ require (
 	github.com/rs/zerolog v1.29.0
 )
 
+replace github.com/cloudquery/filetypes v1.5.1 => ../../../../filetypes
+
 require (
 	github.com/andybalholm/brotli v1.0.4 // indirect
 	github.com/apache/arrow/go/v12 v12.0.0-20230306000349-d5b3b4737838 // indirect
@@ -24,7 +26,7 @@ require (
 	golang.org/x/tools v0.6.0 // indirect
 )
 
-replace github.com/apache/arrow/go/v12 => github.com/cloudquery/arrow/go/v12 v12.0.0-20230306072451-b6560ef2e6c1
+replace github.com/apache/arrow/go/v12 => github.com/cloudquery/arrow/go/v12 v12.0.0-20230317103356-3818eab063a2
 
 require (
 	github.com/apache/arrow/go/arrow v0.0.0-20200730104253-651201b0f516 // indirect

--- a/plugins/destination/file/go.mod
+++ b/plugins/destination/file/go.mod
@@ -24,6 +24,8 @@ require (
 	golang.org/x/tools v0.6.0 // indirect
 )
 
+replace github.com/apache/arrow/go/v12 => github.com/cloudquery/arrow/go/v12 v12.0.0-20230317130341-c648117570af
+
 require (
 	github.com/apache/arrow/go/arrow v0.0.0-20200730104253-651201b0f516 // indirect
 	github.com/apache/thrift v0.16.0 // indirect

--- a/plugins/destination/file/go.mod
+++ b/plugins/destination/file/go.mod
@@ -3,13 +3,11 @@ module github.com/cloudquery/cloudquery/plugins/destination/file
 go 1.19
 
 require (
-	github.com/cloudquery/filetypes v1.5.1
+	github.com/cloudquery/filetypes v1.6.0
 	github.com/cloudquery/plugin-sdk v1.43.0
 	github.com/google/uuid v1.3.0
 	github.com/rs/zerolog v1.29.0
 )
-
-replace github.com/cloudquery/filetypes v1.5.1 => ../../../../filetypes
 
 require (
 	github.com/andybalholm/brotli v1.0.4 // indirect
@@ -25,8 +23,6 @@ require (
 	golang.org/x/mod v0.8.0 // indirect
 	golang.org/x/tools v0.6.0 // indirect
 )
-
-replace github.com/apache/arrow/go/v12 => github.com/cloudquery/arrow/go/v12 v12.0.0-20230317103356-3818eab063a2
 
 require (
 	github.com/apache/arrow/go/arrow v0.0.0-20200730104253-651201b0f516 // indirect

--- a/plugins/destination/file/go.sum
+++ b/plugins/destination/file/go.sum
@@ -155,8 +155,10 @@ github.com/chzyer/logex v1.1.10/go.mod h1:+Ywpsq7O8HXn0nuIou7OrIPyXbp3wmkHB+jjWR
 github.com/chzyer/readline v0.0.0-20180603132655-2972be24d48e/go.mod h1:nSuG5e5PlCu98SY8svDHJxuZscDgtXS6KTTbou5AhLI=
 github.com/chzyer/test v0.0.0-20180213035817-a1ea475d72b1/go.mod h1:Q3SI9o4m/ZMnBNeIyt5eFwwo7qiLfzFZmjNmxjkiQlU=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
-github.com/cloudquery/arrow/go/v12 v12.0.0-20230317103356-3818eab063a2 h1:cXjcHCHMkwQsbBIsVbWZTZ0Sz4DQATGqLYssc9hLE/s=
-github.com/cloudquery/arrow/go/v12 v12.0.0-20230317103356-3818eab063a2/go.mod h1:d+tV/eHZZ7Dz7RPrFKtPK02tpr+c9/PEd/zm8mDS9Vg=
+github.com/cloudquery/arrow/go/v12 v12.0.0-20230317130341-c648117570af h1:iK2UwRTmBl9+I41tASIttizlmiY7dH9KmKt7iOiwyOc=
+github.com/cloudquery/arrow/go/v12 v12.0.0-20230317130341-c648117570af/go.mod h1:d+tV/eHZZ7Dz7RPrFKtPK02tpr+c9/PEd/zm8mDS9Vg=
+github.com/cloudquery/filetypes v1.6.0 h1:f+p6345zgFVgFIDgkxm3Raz9RumYp4KHKF504I196/8=
+github.com/cloudquery/filetypes v1.6.0/go.mod h1:PEmKtraGq/7uHHCFtgY9MLONr+ii4q8Cj8uy+pa0Cuo=
 github.com/cloudquery/plugin-sdk v1.43.0 h1:vYycBgKdfDbrW7sp+r5ATxjTVVXU2AMc3x6cPs8DTns=
 github.com/cloudquery/plugin-sdk v1.43.0/go.mod h1:CIv+fgm6siZhReOuMGU/OCBPNRLNY4At2RkC31LRaS0=
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=

--- a/plugins/destination/file/go.sum
+++ b/plugins/destination/file/go.sum
@@ -155,10 +155,8 @@ github.com/chzyer/logex v1.1.10/go.mod h1:+Ywpsq7O8HXn0nuIou7OrIPyXbp3wmkHB+jjWR
 github.com/chzyer/readline v0.0.0-20180603132655-2972be24d48e/go.mod h1:nSuG5e5PlCu98SY8svDHJxuZscDgtXS6KTTbou5AhLI=
 github.com/chzyer/test v0.0.0-20180213035817-a1ea475d72b1/go.mod h1:Q3SI9o4m/ZMnBNeIyt5eFwwo7qiLfzFZmjNmxjkiQlU=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
-github.com/cloudquery/arrow/go/v12 v12.0.0-20230306072451-b6560ef2e6c1 h1:z37B3z+FV7fMga4toXrY0eWR6tfX/x3qefSmfNsWTb8=
-github.com/cloudquery/arrow/go/v12 v12.0.0-20230306072451-b6560ef2e6c1/go.mod h1:d+tV/eHZZ7Dz7RPrFKtPK02tpr+c9/PEd/zm8mDS9Vg=
-github.com/cloudquery/filetypes v1.5.1 h1:/LtV7yqspVlTZ30+nL/OA7JRZ5SIlXiZeq5V4O6x950=
-github.com/cloudquery/filetypes v1.5.1/go.mod h1:7kCMZzIjNaHX/cfXHwepuFZNx1ra5AkR+aiKo7ujiPg=
+github.com/cloudquery/arrow/go/v12 v12.0.0-20230317103356-3818eab063a2 h1:cXjcHCHMkwQsbBIsVbWZTZ0Sz4DQATGqLYssc9hLE/s=
+github.com/cloudquery/arrow/go/v12 v12.0.0-20230317103356-3818eab063a2/go.mod h1:d+tV/eHZZ7Dz7RPrFKtPK02tpr+c9/PEd/zm8mDS9Vg=
 github.com/cloudquery/plugin-sdk v1.43.0 h1:vYycBgKdfDbrW7sp+r5ATxjTVVXU2AMc3x6cPs8DTns=
 github.com/cloudquery/plugin-sdk v1.43.0/go.mod h1:CIv+fgm6siZhReOuMGU/OCBPNRLNY4At2RkC31LRaS0=
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=

--- a/website/pages/docs/plugins/destinations/file/overview.mdx
+++ b/website/pages/docs/plugins/destinations/file/overview.mdx
@@ -33,3 +33,16 @@ This is the (nested) spec used by the CSV destination Plugin.
 
   If set to true, the plugin will write to one file per table.
   Otherwise, for every batch a new file will be created with a different `.<UUID>` suffix.
+
+- `format_spec` (map [format_spec](#format_spec)) (optional)
+Optional parameters to change the format of the file
+
+### format_spec
+
+- `delimiter` (string) (optional) (default: `,`)
+
+Character that will be used as want to use as the delimiter if the format type is `csv`
+
+- `skip_header` (bool) (optional) (default: false)
+
+Specifies if the first line of a file should be the headers (when format is `csv`).


### PR DESCRIPTION
Users can now use the following options to change the destination behavior:
1. `skip_header`: default is `false` which will mean the the first row will be the column headers
2. `delimiter`: default value is `,` but user can specify any single character

The underlying implementation for CSV and JSON is also being changed to Apache Arrow through the updated import of the `filetypes` library.