### PR TITLE
feat(azblob): Update to filetypes v1.6.0

### DIFF
--- a/plugins/destination/azblob/go.mod
+++ b/plugins/destination/azblob/go.mod
@@ -5,13 +5,13 @@ go 1.19
 require (
 	github.com/Azure/azure-sdk-for-go/sdk/azidentity v1.2.2
 	github.com/Azure/azure-sdk-for-go/sdk/storage/azblob v1.0.0
-	github.com/cloudquery/filetypes v1.5.1
+	github.com/cloudquery/filetypes v1.6.0
 	github.com/cloudquery/plugin-sdk v1.43.0
 	github.com/google/uuid v1.3.0
 	github.com/rs/zerolog v1.29.0
 )
 
-replace github.com/apache/arrow/go/v12 => github.com/cloudquery/arrow/go/v12 v12.0.0-20230306072451-b6560ef2e6c1
+replace github.com/apache/arrow/go/v12 => github.com/cloudquery/arrow/go/v12 v12.0.0-20230317130341-c648117570af
 
 require (
 	github.com/andybalholm/brotli v1.0.5 // indirect

--- a/plugins/destination/azblob/go.sum
+++ b/plugins/destination/azblob/go.sum
@@ -169,10 +169,10 @@ github.com/chzyer/logex v1.1.10/go.mod h1:+Ywpsq7O8HXn0nuIou7OrIPyXbp3wmkHB+jjWR
 github.com/chzyer/readline v0.0.0-20180603132655-2972be24d48e/go.mod h1:nSuG5e5PlCu98SY8svDHJxuZscDgtXS6KTTbou5AhLI=
 github.com/chzyer/test v0.0.0-20180213035817-a1ea475d72b1/go.mod h1:Q3SI9o4m/ZMnBNeIyt5eFwwo7qiLfzFZmjNmxjkiQlU=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
-github.com/cloudquery/arrow/go/v12 v12.0.0-20230306072451-b6560ef2e6c1 h1:z37B3z+FV7fMga4toXrY0eWR6tfX/x3qefSmfNsWTb8=
-github.com/cloudquery/arrow/go/v12 v12.0.0-20230306072451-b6560ef2e6c1/go.mod h1:d+tV/eHZZ7Dz7RPrFKtPK02tpr+c9/PEd/zm8mDS9Vg=
-github.com/cloudquery/filetypes v1.5.1 h1:/LtV7yqspVlTZ30+nL/OA7JRZ5SIlXiZeq5V4O6x950=
-github.com/cloudquery/filetypes v1.5.1/go.mod h1:7kCMZzIjNaHX/cfXHwepuFZNx1ra5AkR+aiKo7ujiPg=
+github.com/cloudquery/arrow/go/v12 v12.0.0-20230317130341-c648117570af h1:iK2UwRTmBl9+I41tASIttizlmiY7dH9KmKt7iOiwyOc=
+github.com/cloudquery/arrow/go/v12 v12.0.0-20230317130341-c648117570af/go.mod h1:d+tV/eHZZ7Dz7RPrFKtPK02tpr+c9/PEd/zm8mDS9Vg=
+github.com/cloudquery/filetypes v1.6.0 h1:f+p6345zgFVgFIDgkxm3Raz9RumYp4KHKF504I196/8=
+github.com/cloudquery/filetypes v1.6.0/go.mod h1:PEmKtraGq/7uHHCFtgY9MLONr+ii4q8Cj8uy+pa0Cuo=
 github.com/cloudquery/plugin-sdk v1.43.0 h1:vYycBgKdfDbrW7sp+r5ATxjTVVXU2AMc3x6cPs8DTns=
 github.com/cloudquery/plugin-sdk v1.43.0/go.mod h1:CIv+fgm6siZhReOuMGU/OCBPNRLNY4At2RkC31LRaS0=
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=


### PR DESCRIPTION
Updates the filetypes library to v1.6.0, which now uses Apache Arrow as the underlying CSV implementation.