### PR TITLE
chore: Allocate more memory to Website build

### DIFF
--- a/website/package.json
+++ b/website/package.json
@@ -8,7 +8,7 @@
     "dev": "next",
     "start": "next start",
     "prebuild": "npx tsx ./scripts/prebuild.tsx",
-    "build": "next build",
+    "build": "NODE_OPTIONS=--max-old-space-size=4096 next build",
     "postbuild": "next-sitemap",
     "lint": "next lint"
   },


### PR DESCRIPTION
<!-- 🎉 Thank you for making CloudQuery awesome by submitting a PR 🎉 -->

#### Summary

A test to see if this improves build speed, as the Vercel build container should have 8GB. See https://vercel.com/docs/concepts/limits/overview#build-container-resources

<!--
Use the following steps to ensure your PR is ready to be reviewed

- [ ] Read the [contribution guidelines](../blob/main/CONTRIBUTING.md) 🧑‍🎓
- [ ] Run `make lint` to ensure the proposed changes follow the coding style 🚨 (install golangci-lint [here](https://golangci-lint.run/usage/install/#local-installation))
- [ ] Run `make test` to ensure the proposed changes pass the tests 🧪
- [ ] If changing a source plugin run `make gen` to ensure docs are up to date 📝
- [ ] Ensure the status checks below are successful ✅
--->
