### PR TITLE
fix(website): Increase largePageDataBytes

### DIFF
--- a/website/next.config.mjs
+++ b/website/next.config.mjs
@@ -113,6 +113,8 @@ export default withNextra({
   reactStrictMode: true,
   experimental: {
     legacyBrowsers: false,
+    // default is 128KB
+    largePageDataBytes: 512 * 1000,
   },
   env: {
     VERCEL_GIT_REPO_OWNER: process.env.VERCEL_GIT_REPO_OWNER,


### PR DESCRIPTION
<!-- 🎉 Thank you for making CloudQuery awesome by submitting a PR 🎉 -->

#### Summary

Our Website build logs are flooded with warnings regarding page size data as we exceed the default threshold. See https://nextjs.org/docs/messages/large-page-data and https://vercel.com/cloudquery/cloudquery-web/6EioYEoajvT1ViUiFnko47S4sd9m.

I think this is related to https://github.com/cloudquery/cloudquery/pull/9138 as we return Markdown content from `getStaticProps` so we trigger the warning (only on production builds).

I suggest we ignore it for now and accept the tradeoff of the faster build times 

<!--
Use the following steps to ensure your PR is ready to be reviewed

- [ ] Read the [contribution guidelines](../blob/main/CONTRIBUTING.md) 🧑‍🎓
- [ ] Run `make lint` to ensure the proposed changes follow the coding style 🚨 (install golangci-lint [here](https://golangci-lint.run/usage/install/#local-installation))
- [ ] Run `make test` to ensure the proposed changes pass the tests 🧪
- [ ] If changing a source plugin run `make gen` to ensure docs are up to date 📝
- [ ] Ensure the status checks below are successful ✅
--->
