### PR TITLE
feat(azure-resources): VM Scale Set Network Interfaces

### DIFF
--- a/plugins/source/azure/docs/tables/README.md
+++ b/plugins/source/azure/docs/tables/README.md
@@ -59,6 +59,7 @@
 - [azure_compute_snapshots](../../../../../website/tables/azure/azure_compute_snapshots.md)
 - [azure_compute_ssh_public_keys](../../../../../website/tables/azure/azure_compute_ssh_public_keys.md)
 - [azure_compute_virtual_machine_scale_sets](../../../../../website/tables/azure/azure_compute_virtual_machine_scale_sets.md)
+  - [azure_compute_virtual_machine_scale_set_network_interfaces](../../../../../website/tables/azure/azure_compute_virtual_machine_scale_set_network_interfaces.md)
   - [azure_compute_virtual_machine_scale_set_vms](../../../../../website/tables/azure/azure_compute_virtual_machine_scale_set_vms.md)
 - [azure_compute_virtual_machines](../../../../../website/tables/azure/azure_compute_virtual_machines.md)
   - [azure_compute_virtual_machine_extensions](../../../../../website/tables/azure/azure_compute_virtual_machine_extensions.md)

--- a/plugins/source/azure/resources/services/compute/virtual_machine_scale_set_vm_network_interfaces.go
+++ b/plugins/source/azure/resources/services/compute/virtual_machine_scale_set_vm_network_interfaces.go
@@ -2,16 +2,12 @@ package compute
 
 import (
 	"context"
-	"encoding/json"
-	"net/http"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/compute/armcompute/v4"
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/network/armnetwork/v2"
 	"github.com/cloudquery/cloudquery/plugins/source/azure/client"
-	"github.com/cloudquery/plugin-sdk/faker"
 	"github.com/cloudquery/plugin-sdk/schema"
 	"github.com/cloudquery/plugin-sdk/transformers"
-	"github.com/gorilla/mux"
 )
 
 func virtualMachineScaleSetsNetworkInterfaces() *schema.Table {
@@ -44,29 +40,5 @@ func fetchVirtualMachineScaleSetsNetworkInterfaces(ctx context.Context, meta sch
 		}
 		res <- p.Value
 	}
-	return nil
-}
-
-func createVirtualMachineScaleSetsNetworkInterfaces(router *mux.Router) error {
-	var item armnetwork.InterfacesClientListVirtualMachineScaleSetNetworkInterfacesResponse
-	if err := faker.FakeObject(&item); err != nil {
-		return err
-	}
-
-	emptyStr := ""
-	item.NextLink = &emptyStr
-
-	router.HandleFunc("/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/microsoft.Compute/virtualMachineScaleSets/{virtualMachineScaleSetName}/networkInterfaces", func(w http.ResponseWriter, r *http.Request) {
-		b, err := json.Marshal(&item)
-		if err != nil {
-			http.Error(w, "unable to marshal request: "+err.Error(), http.StatusBadRequest)
-			return
-		}
-		if _, err := w.Write(b); err != nil {
-			http.Error(w, "failed to write", http.StatusBadRequest)
-			return
-		}
-	})
-
 	return nil
 }

--- a/plugins/source/azure/resources/services/compute/virtual_machine_scale_set_vm_network_interfaces.go
+++ b/plugins/source/azure/resources/services/compute/virtual_machine_scale_set_vm_network_interfaces.go
@@ -1,0 +1,72 @@
+package compute
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/compute/armcompute/v4"
+	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/network/armnetwork/v2"
+	"github.com/cloudquery/cloudquery/plugins/source/azure/client"
+	"github.com/cloudquery/plugin-sdk/faker"
+	"github.com/cloudquery/plugin-sdk/schema"
+	"github.com/cloudquery/plugin-sdk/transformers"
+	"github.com/gorilla/mux"
+)
+
+func virtualMachineScaleSetsNetworkInterfaces() *schema.Table {
+	return &schema.Table{
+		Name:        "azure_compute_virtual_machine_scale_set_network_interfaces",
+		Resolver:    fetchVirtualMachineScaleSetsNetworkInterfaces,
+		Description: "https://learn.microsoft.com/en-us/rest/api/virtualnetwork/network-interface-in-vm-ss/list-virtual-machine-scale-set-network-interfaces?tabs=HTTP#networkinterface",
+		Multiplex:   client.SubscriptionMultiplexRegisteredNamespace("azure_compute_virtual_machine_scale_set_network_interfaces", client.Namespacemicrosoft_network),
+		Transform:   transformers.TransformWithStruct(&armnetwork.Interface{}, transformers.WithPrimaryKeys("ID")),
+		Columns:     schema.ColumnList{client.SubscriptionID},
+	}
+}
+
+func fetchVirtualMachineScaleSetsNetworkInterfaces(ctx context.Context, meta schema.ClientMeta, parent *schema.Resource, res chan<- any) error {
+	cl := meta.(*client.Client)
+	scaleSet := parent.Item.(*armcompute.VirtualMachineScaleSet)
+	svc, err := armnetwork.NewInterfacesClient(cl.SubscriptionId, cl.Creds, cl.Options)
+	if err != nil {
+		return err
+	}
+	group, err := client.ParseResourceGroup(*scaleSet.ID)
+	if err != nil {
+		return err
+	}
+	pager := svc.NewListVirtualMachineScaleSetNetworkInterfacesPager(group, *scaleSet.Name, nil)
+	for pager.More() {
+		p, err := pager.NextPage(ctx)
+		if err != nil {
+			return err
+		}
+		res <- p.Value
+	}
+	return nil
+}
+
+func createVirtualMachineScaleSetsNetworkInterfaces(router *mux.Router) error {
+	var item armnetwork.InterfacesClientListVirtualMachineScaleSetNetworkInterfacesResponse
+	if err := faker.FakeObject(&item); err != nil {
+		return err
+	}
+
+	emptyStr := ""
+	item.NextLink = &emptyStr
+
+	router.HandleFunc("/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/microsoft.Compute/virtualMachineScaleSets/{virtualMachineScaleSetName}/networkInterfaces", func(w http.ResponseWriter, r *http.Request) {
+		b, err := json.Marshal(&item)
+		if err != nil {
+			http.Error(w, "unable to marshal request: "+err.Error(), http.StatusBadRequest)
+			return
+		}
+		if _, err := w.Write(b); err != nil {
+			http.Error(w, "failed to write", http.StatusBadRequest)
+			return
+		}
+	})
+
+	return nil
+}

--- a/plugins/source/azure/resources/services/compute/virtual_machine_scale_set_vm_network_interfaces_test.go
+++ b/plugins/source/azure/resources/services/compute/virtual_machine_scale_set_vm_network_interfaces_test.go
@@ -1,0 +1,34 @@
+package compute
+
+import (
+	"encoding/json"
+	"net/http"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/network/armnetwork/v2"
+	"github.com/cloudquery/plugin-sdk/faker"
+	"github.com/gorilla/mux"
+)
+
+func createVirtualMachineScaleSetsNetworkInterfaces(router *mux.Router) error {
+	var item armnetwork.InterfacesClientListVirtualMachineScaleSetNetworkInterfacesResponse
+	if err := faker.FakeObject(&item); err != nil {
+		return err
+	}
+
+	emptyStr := ""
+	item.NextLink = &emptyStr
+
+	router.HandleFunc("/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/microsoft.Compute/virtualMachineScaleSets/{virtualMachineScaleSetName}/networkInterfaces", func(w http.ResponseWriter, r *http.Request) {
+		b, err := json.Marshal(&item)
+		if err != nil {
+			http.Error(w, "unable to marshal request: "+err.Error(), http.StatusBadRequest)
+			return
+		}
+		if _, err := w.Write(b); err != nil {
+			http.Error(w, "failed to write", http.StatusBadRequest)
+			return
+		}
+	})
+
+	return nil
+}

--- a/plugins/source/azure/resources/services/compute/virtual_machine_scale_sets.go
+++ b/plugins/source/azure/resources/services/compute/virtual_machine_scale_sets.go
@@ -19,6 +19,7 @@ func VirtualMachineScaleSets() *schema.Table {
 		Columns:     schema.ColumnList{client.SubscriptionID},
 		Relations: []*schema.Table{
 			VirtualMachineScaleSetsVMs(),
+			virtualMachineScaleSetsNetworkInterfaces(),
 		},
 	}
 }

--- a/plugins/source/azure/resources/services/compute/virtual_machine_scale_sets_mock_test.go
+++ b/plugins/source/azure/resources/services/compute/virtual_machine_scale_sets_mock_test.go
@@ -51,7 +51,7 @@ func createVirtualMachineScaleSets(router *mux.Router) error {
 		}
 	})
 
-	return nil
+	return createVirtualMachineScaleSetsNetworkInterfaces(router)
 }
 
 func TestVirtualMachineScaleSets(t *testing.T) {

--- a/website/pages/docs/plugins/sources/azure/tables.md
+++ b/website/pages/docs/plugins/sources/azure/tables.md
@@ -59,6 +59,7 @@
 - [azure_compute_snapshots](tables/azure_compute_snapshots)
 - [azure_compute_ssh_public_keys](tables/azure_compute_ssh_public_keys)
 - [azure_compute_virtual_machine_scale_sets](tables/azure_compute_virtual_machine_scale_sets)
+  - [azure_compute_virtual_machine_scale_set_network_interfaces](tables/azure_compute_virtual_machine_scale_set_network_interfaces)
   - [azure_compute_virtual_machine_scale_set_vms](tables/azure_compute_virtual_machine_scale_set_vms)
 - [azure_compute_virtual_machines](tables/azure_compute_virtual_machines)
   - [azure_compute_virtual_machine_extensions](tables/azure_compute_virtual_machine_extensions)

--- a/website/tables/azure/azure_compute_virtual_machine_scale_set_network_interfaces.md
+++ b/website/tables/azure/azure_compute_virtual_machine_scale_set_network_interfaces.md
@@ -1,0 +1,29 @@
+# Table: azure_compute_virtual_machine_scale_set_network_interfaces
+
+This table shows data for Azure Compute Virtual Machine Scale Set Network Interfaces.
+
+https://learn.microsoft.com/en-us/rest/api/virtualnetwork/network-interface-in-vm-ss/list-virtual-machine-scale-set-network-interfaces?tabs=HTTP#networkinterface
+
+The primary key for this table is **id**.
+
+## Relations
+
+This table depends on [azure_compute_virtual_machine_scale_sets](azure_compute_virtual_machine_scale_sets).
+
+## Columns
+
+| Name          | Type          |
+| ------------- | ------------- |
+|_cq_source_name|String|
+|_cq_sync_time|Timestamp|
+|_cq_id|UUID|
+|_cq_parent_id|UUID|
+|subscription_id|String|
+|extended_location|JSON|
+|id (PK)|String|
+|location|String|
+|properties|JSON|
+|tags|JSON|
+|etag|String|
+|name|String|
+|type|String|

--- a/website/tables/azure/azure_compute_virtual_machine_scale_sets.md
+++ b/website/tables/azure/azure_compute_virtual_machine_scale_sets.md
@@ -9,6 +9,7 @@ The primary key for this table is **id**.
 ## Relations
 
 The following tables depend on azure_compute_virtual_machine_scale_sets:
+  - [azure_compute_virtual_machine_scale_set_network_interfaces](azure_compute_virtual_machine_scale_set_network_interfaces)
   - [azure_compute_virtual_machine_scale_set_vms](azure_compute_virtual_machine_scale_set_vms)
 
 ## Columns


### PR DESCRIPTION
<!-- 🎉 Thank you for making CloudQuery awesome by submitting a PR 🎉 -->

#### Summary

Fixes https://github.com/cloudquery/cloudquery/issues/9258.

The API to list VM Scale Set Network Interfaces is on the `armnetwork` module and not on the `armcompute` module

<!--
Use the following steps to ensure your PR is ready to be reviewed

- [ ] Read the [contribution guidelines](../blob/main/CONTRIBUTING.md) 🧑‍🎓
- [ ] Run `make lint` to ensure the proposed changes follow the coding style 🚨 (install golangci-lint [here](https://golangci-lint.run/usage/install/#local-installation))
- [ ] Run `make test` to ensure the proposed changes pass the tests 🧪
- [ ] If changing a source plugin run `make gen` to ensure docs are up to date 📝
- [ ] Ensure the status checks below are successful ✅
--->
