### PR TITLE
fix(ci-release-summary): Set `cq-bot` as commit author

### DIFF
--- a/.github/workflows/release_summary.yml
+++ b/.github/workflows/release_summary.yml
@@ -108,5 +108,8 @@ jobs:
       - uses: stefanzweifel/git-auto-commit-action@v4
         if: ${{ steps.get-changes.outputs.result != '' }}
         with:
+          # required so the commit triggers workflow runs
+          token: ${{ secrets.GH_CQ_BOT }}
           commit_message: "chore: Add tables changes to changelog"
           file_pattern: "plugins/source/${{ steps.plugin.outputs.name }}/CHANGELOG.md"
+          author: cq-bot <cq-bot@users.noreply.github.com>


### PR DESCRIPTION
<!-- 🎉 Thank you for making CloudQuery awesome by submitting a PR 🎉 -->

#### Summary

This is required so the new commit triggers workflow runs (using the default GitHub token won't do that)

<!--
Use the following steps to ensure your PR is ready to be reviewed

- [ ] Read the [contribution guidelines](../blob/main/CONTRIBUTING.md) 🧑‍🎓
- [ ] Run `make lint` to ensure the proposed changes follow the coding style 🚨 (install golangci-lint [here](https://golangci-lint.run/usage/install/#local-installation))
- [ ] Run `make test` to ensure the proposed changes pass the tests 🧪
- [ ] If changing a source plugin run `make gen` to ensure docs are up to date 📝
- [ ] Ensure the status checks below are successful ✅
--->
