### PR TITLE
fix(gcp): Fix typo and condition in the CIS GCP Policy 6.3.6

### DIFF
--- a/plugins/source/gcp/policies/queries/sql/sqlserver_trace_flag_on.sql
+++ b/plugins/source/gcp/policies/queries/sql/sqlserver_trace_flag_on.sql
@@ -11,13 +11,13 @@ SELECT gsi.name                                                                 
        :'execution_time'::timestamp                                                                             AS execution_time,
        :'framework'                                                                                             AS framework,
        :'check_id'                                                                                              AS check_id,
-       'Ensure "3625 (trace flag)" database flag for Cloud SQL SQL Server instance is set to "off" (Automated)' AS title,
+       'Ensure "3625 (trace flag)" database flag for Cloud SQL SQL Server instance is set to "on" (Automated)'  AS title,
        gsi.project_id                                                                                           AS project_id,
        CASE
            WHEN
                        gsi.database_version LIKE 'SQLSERVER%'
                    AND (f->>'value' IS NULL
-                   OR f->>'value' != 'off')
+                   OR f->>'value' != 'on')
                THEN 'fail'
            ELSE 'pass'
            END                                                                                                  AS status


### PR DESCRIPTION
#### Summary
The title, description and remediation of CIS GCP Policy v1.2.0 Section 6.3.6 has an error. It describes 3625 trace flag should be off, but in fact it should be on. The statement is fixed in CIS for GCP v1.3.0. In my opinion, for convenience, this fix should be backported in v1.2.0.