### PR TITLE
fix(ci): Release summary token v2

### DIFF
--- a/.github/workflows/release_summary.yml
+++ b/.github/workflows/release_summary.yml
@@ -15,6 +15,8 @@ jobs:
         uses: actions/checkout@v3
         with:
           fetch-depth: 0
+          # required so the commit triggers workflow runs
+          token: ${{ secrets.GH_CQ_BOT }}
       - name: Get plugin name
         id: plugin
         run: |
@@ -108,8 +110,6 @@ jobs:
       - uses: stefanzweifel/git-auto-commit-action@v4
         if: ${{ steps.get-changes.outputs.result != '' }}
         with:
-          # required so the commit triggers workflow runs
-          token: ${{ secrets.GH_CQ_BOT }}
           commit_message: "chore: Add tables changes to changelog"
           file_pattern: "plugins/source/${{ steps.plugin.outputs.name }}/CHANGELOG.md"
           author: cq-bot <cq-bot@users.noreply.github.com>


### PR DESCRIPTION
<!-- 🎉 Thank you for making CloudQuery awesome by submitting a PR 🎉 -->

#### Summary

My previous fix in https://github.com/cloudquery/cloudquery/pull/9340 was wrong as we need to set the token on the checkout action, see https://github.com/cloudquery/cloudquery/blob/main/.github/workflows/manual_commands_triggers.yml#L30

<!--
Use the following steps to ensure your PR is ready to be reviewed

- [ ] Read the [contribution guidelines](../blob/main/CONTRIBUTING.md) 🧑‍🎓
- [ ] Run `make lint` to ensure the proposed changes follow the coding style 🚨 (install golangci-lint [here](https://golangci-lint.run/usage/install/#local-installation))
- [ ] Run `make test` to ensure the proposed changes pass the tests 🧪
- [ ] If changing a source plugin run `make gen` to ensure docs are up to date 📝
- [ ] Ensure the status checks below are successful ✅
--->
