### PR TITLE
fix(aws): Only resolve ec2 image launch permissions when the image is owned by the AWS Account

### DIFF
--- a/plugins/source/aws/resources/services/ec2/image_attributes.go
+++ b/plugins/source/aws/resources/services/ec2/image_attributes.go
@@ -11,12 +11,10 @@ import (
 )
 
 func imageAttributesLaunchPermissions() *schema.Table {
-	const tableName = "aws_ec2_image_launch_permissions"
 	return &schema.Table{
-		Name:        tableName,
+		Name:        "aws_ec2_image_launch_permissions",
 		Description: `https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_LaunchPermission.html`,
 		Resolver:    fetchEc2ImageAttributeLaunchPermissions,
-		Multiplex:   client.ServiceAccountRegionMultiplexer(tableName, "ec2"),
 		Transform:   transformers.TransformWithStruct(&types.LaunchPermission{}),
 		Columns: []schema.Column{
 			{

--- a/plugins/source/aws/resources/services/ec2/image_attributes.go
+++ b/plugins/source/aws/resources/services/ec2/image_attributes.go
@@ -3,6 +3,7 @@ package ec2
 import (
 	"context"
 
+	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/ec2"
 	"github.com/aws/aws-sdk-go-v2/service/ec2/types"
 	"github.com/cloudquery/cloudquery/plugins/source/aws/client"
@@ -29,7 +30,9 @@ func imageAttributesLaunchPermissions() *schema.Table {
 func fetchEc2ImageAttributeLaunchPermissions(ctx context.Context, meta schema.ClientMeta, parent *schema.Resource, res chan<- any) error {
 	c := meta.(*client.Client)
 	p := parent.Item.(types.Image)
-
+	if aws.ToString(p.OwnerId) != c.AccountID {
+		return nil
+	}
 	svc := c.Services().Ec2
 	output, err := svc.DescribeImageAttribute(ctx, &ec2.DescribeImageAttributeInput{
 		Attribute: types.ImageAttributeNameLaunchPermission,


### PR DESCRIPTION
<!-- 🎉 Thank you for making CloudQuery awesome by submitting a PR 🎉 -->

#### Summary

Verified that it seems like you can only make this call for images that you own:
``` bash
% aws ec2 describe-images --image-ids ami-0f54834d636a9e96f  --region us-east-1 --query "Images[0].OwnerId"       

"286198878708"

% aws ec2 describe-image-attribute --image-id ami-0f54834d636a9e96f --attribute launchPermission --region us-east-1

An error occurred (AuthFailure) when calling the DescribeImageAttribute operation: Not authorized for image:ami-0f54834d636a9e96f
```

Note `286198878708` is not an account that we own (based on google searches it seems to be an account owned by an AWS Service team