### PR TITLE
fix(release-summary): Only run the summary workflow if the PR has 1 commits

### DIFF
--- a/.github/workflows/release_summary.yml
+++ b/.github/workflows/release_summary.yml
@@ -8,7 +8,8 @@ on:
 
 jobs:
   release-summary:
-    if:  startsWith(github.head_ref, 'release-please--branches--main--components--plugins-source')
+    # only run on release-please branches and if there is only one commit to avoid a recursive workflow run
+    if:  startsWith(github.head_ref, 'release-please--branches--main--components--plugins-source') && github.event.pull_request.commits == 1
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repository
@@ -73,12 +74,10 @@ jobs:
             const changelogPath = `plugins/source/${process.env.PLUGIN_NAME}/CHANGELOG.md`
             const changes = process.env.CHANGES.replaceAll('\\n', '\n')
             const currentChangelog = fs.readFileSync(changelogPath, 'utf8')
-            // drop existing summary if it exists
             const title = 'This Release has the Following Changes to Tables'
-            let sliceIndex = currentChangelog.includes(title) ? 2 : 1
             // Move summary after breaking changes if they exist
             const newlyAddedSection = currentChangelog.split("## [")[0]
-            sliceIndex = newlyAddedSection.includes("BREAKING CHANGES") ? sliceIndex + 1 : sliceIndex
+            const sliceIndex = newlyAddedSection.includes("BREAKING CHANGES") ? 2 : 1
             const changelogParts = currentChangelog.split('###')
             const newChangelog = [...changelogParts.slice(0, sliceIndex), ` ${title}\n${changes}\n\n`, ...changelogParts.slice(sliceIndex)].join('###')
             fs.writeFileSync(changelogPath, newChangelog)
@@ -94,11 +93,9 @@ jobs:
             const currentDescription = process.env.PR_BODY
             const changes = process.env.CHANGES.replaceAll('\\n', '\n')
             const currentDescriptionParts = currentDescription.split('###')
-            // drop existing summary if it exists
             const title = 'This Release has the Following Changes to Tables'
-            let sliceIndex = currentDescription.includes(title) ? 2 : 1
             // Move summary after breaking changes if they exist
-            sliceIndex = currentDescription.includes("BREAKING CHANGES") ? sliceIndex + 1 : sliceIndex
+            const sliceIndex = currentDescription.includes("BREAKING CHANGES") ? 2 : 1
             const newDescription = [...currentDescriptionParts.slice(0, sliceIndex), ` ${title}\n${changes}\n\n`, ...currentDescriptionParts.slice(sliceIndex)].join('###')
             await github.rest.pulls.update({
               owner: context.repo.owner,


### PR DESCRIPTION
<!-- 🎉 Thank you for making CloudQuery awesome by submitting a PR 🎉 -->

#### Summary

https://github.com/cloudquery/cloudquery/pull/9260 broken the logic that detects if we already added a summary to a PR to avoid a recursive workflow.

This PR fixes the logic and makes it more robust by looking at number of commits instead of the content of the PR 

<!--
Use the following steps to ensure your PR is ready to be reviewed

- [ ] Read the [contribution guidelines](../blob/main/CONTRIBUTING.md) 🧑‍🎓
- [ ] Run `make lint` to ensure the proposed changes follow the coding style 🚨 (install golangci-lint [here](https://golangci-lint.run/usage/install/#local-installation))
- [ ] Run `make test` to ensure the proposed changes pass the tests 🧪
- [ ] If changing a source plugin run `make gen` to ensure docs are up to date 📝
- [ ] Ensure the status checks below are successful ✅
--->
