### PR TITLE
feat(website-azure): Update Azure docs to skip some tables, remove concurrency

### DIFF
--- a/website/pages/docs/plugins/sources/azure/_configuration.mdx
+++ b/website/pages/docs/plugins/sources/azure/_configuration.mdx
@@ -6,9 +6,10 @@ spec:
   path: "cloudquery/azure"
   version: "VERSION_SOURCE_AZURE"
   destinations: ["DESTINATION_NAME"]
-  # For the Azure plugin we recommend a lower concurrency setting than the default to avoid hitting memory limits
-  # See more in https://www.cloudquery.io/docs/advanced-topics/performance-tuning#tune-concurrency
-  concurrency: 1000
+
+  # for accounts with many subscriptions, we recommend creating separate configurations for the tables below
+  # as they can consume a lot of memory and time. See more here https://github.com/cloudquery/cloudquery/issues/9269
+  skip_tables: ["azure_compute_skus", "azure_*_definitions","azure_authorization_role_assignments"]
 
   spec:
     # Azure Spec section


### PR DESCRIPTION
<!-- 🎉 Thank you for making CloudQuery awesome by submitting a PR 🎉 -->

#### Summary

A follow up to https://github.com/cloudquery/cloudquery/pull/9355, and related to https://github.com/cloudquery/cloudquery/issues/9269#issuecomment-1482441047.

Since we recommend the env variables auth method we can remove the `concurrency` setting from the docs, as with variables auth it should not be needed, unless syncing the `["azure_compute_skus", "azure_*_definitions","azure_authorization_role_assignments"]`, which this PR adds to `skip_tables`.

<!--
Use the following steps to ensure your PR is ready to be reviewed

- [ ] Read the [contribution guidelines](../blob/main/CONTRIBUTING.md) 🧑‍🎓
- [ ] Run `make lint` to ensure the proposed changes follow the coding style 🚨 (install golangci-lint [here](https://golangci-lint.run/usage/install/#local-installation))
- [ ] Run `make test` to ensure the proposed changes pass the tests 🧪
- [ ] If changing a source plugin run `make gen` to ensure docs are up to date 📝
- [ ] Ensure the status checks below are successful ✅
--->
