### PR TITLE
fix(stripe): Expand fields on prices

### DIFF
--- a/plugins/source/stripe/codegen/recipes/all.go
+++ b/plugins/source/stripe/codegen/recipes/all.go
@@ -148,6 +148,7 @@ var AllResources = []*Resource{
 	{
 		DataStruct:     &stripe.Price{},
 		StateParamName: createdStateParam,
+		ExpandFields:   []string{"data.currency_options", "data.tiers"},
 	},
 	{
 		DataStruct:     &stripe.Product{},

--- a/plugins/source/stripe/codegen/recipes/recipes.go
+++ b/plugins/source/stripe/codegen/recipes/recipes.go
@@ -34,8 +34,9 @@ type Resource struct {
 	Children []*Resource
 	Parent   *Resource // auto calculated from Children
 
-	ListParams     string // optional
-	StateParamName string // optional *int64 param name. If empty, no state will be persisted. Only if Single is not true.
+	ListParams     string   // optional
+	ExpandFields   []string // optional, fields to expand in list call
+	StateParamName string   // optional *int64 param name. If empty, no state will be persisted. Only if Single is not true.
 }
 
 var (

--- a/plugins/source/stripe/codegen/templates/list.go.tpl
+++ b/plugins/source/stripe/codegen/templates/list.go.tpl
@@ -2,7 +2,7 @@ package {{.Service}}
 
 import (
 	"context"
-{{if .StateParamName}}
+{{- if .StateParamName}}
 	"fmt"
 	"strconv"
 {{end}}
@@ -68,6 +68,12 @@ func fetch{{.TableName | ToPascal}}(ctx context.Context, meta schema.ClientMeta,
 		lp := &stripe.{{.TableName | ToPascal | Singularize}}ListParams{
 {{.ListParams}}
 		}
+
+		{{- if len .ExpandFields}}
+		{{- range .ExpandFields}}
+		lp.AddExpand("{{.}}")
+		{{- end}}
+		{{- end}}
 
 {{if .StateParamName}}
 		const key = "{{.TableName}}"

--- a/plugins/source/stripe/codegen/templates/list.go.tpl
+++ b/plugins/source/stripe/codegen/templates/list.go.tpl
@@ -69,10 +69,8 @@ func fetch{{.TableName | ToPascal}}(ctx context.Context, meta schema.ClientMeta,
 {{.ListParams}}
 		}
 
-		{{- if len .ExpandFields}}
 		{{- range .ExpandFields}}
 		lp.AddExpand("{{.}}")
-		{{- end}}
 		{{- end}}
 
 {{if .StateParamName}}

--- a/plugins/source/stripe/resources/services/prices/prices.go
+++ b/plugins/source/stripe/resources/services/prices/prices.go
@@ -44,6 +44,8 @@ func fetchPrices(ctx context.Context, meta schema.ClientMeta, parent *schema.Res
 	cl := meta.(*client.Client)
 
 	lp := &stripe.PriceListParams{}
+	lp.AddExpand("data.currency_options")
+	lp.AddExpand("data.tiers")
 
 	const key = "prices"
 


### PR DESCRIPTION
<!-- 🎉 Thank you for making CloudQuery awesome by submitting a PR 🎉 -->

#### Summary

Use the [expand parameter](https://stripe.com/docs/api/expanding_objects) to include fields on the `stripe_prices` table.
Other tables might also be affected, it might be worth considering exposing a config option.
