### PR TITLE
feat(clickhouse)!: Read only plain `ca_cert`

### DIFF
--- a/plugins/destination/clickhouse/client/spec.go
+++ b/plugins/destination/clickhouse/client/spec.go
@@ -3,7 +3,6 @@ package client
 import (
 	"crypto/x509"
 	"fmt"
-	"os"
 
 	"github.com/ClickHouse/clickhouse-go/v2"
 	"github.com/cloudquery/cloudquery/plugins/destination/clickhouse/queries"
@@ -29,16 +28,6 @@ func (s *Spec) Options() (*clickhouse.Options, error) {
 	}
 
 	if tlsConfig := options.TLS; tlsConfig != nil && len(s.CACert) > 0 {
-		// read file
-		caCert, err := os.ReadFile(s.CACert)
-		if err != nil {
-			if !os.IsNotExist(err) {
-				return nil, err
-			}
-			// no such file. treat as plain input
-			caCert = []byte(s.CACert)
-		}
-
 		if tlsConfig.RootCAs == nil {
 			tlsConfig.RootCAs, err = x509.SystemCertPool()
 			if err != nil {
@@ -46,7 +35,7 @@ func (s *Spec) Options() (*clickhouse.Options, error) {
 			}
 		}
 
-		if ok := tlsConfig.RootCAs.AppendCertsFromPEM(caCert); !ok {
+		if ok := tlsConfig.RootCAs.AppendCertsFromPEM([]byte(s.CACert)); !ok {
 			return nil, fmt.Errorf("failed to append \"ca_cert\" value")
 		}
 	}

--- a/website/pages/docs/plugins/destinations/clickhouse/overview.mdx
+++ b/website/pages/docs/plugins/destinations/clickhouse/overview.mdx
@@ -40,11 +40,10 @@ This is the (nested) spec used by the ClickHouse destination plugin.
 
 - `ca_cert` (string, optional. Default: not used)
 
-  If you need to use a custom CA to connect to ClickHouse instance you can use `ca_cert` option.
-  The following values are supported:
-
-  - Path to cert file
-  - CA cert data in plain text (or substituted from environment variable)
+  PEM-encoded certificate authorities.
+  When set, a certificate pool will be created by appending the certificates to the system pool.
+  See [file variable substitution](/docs/advanced-topics/environment-variable-substitution#file-variable-substitution-example)
+  for how to read this value from a file.
 
 - `engine` (optional, structure documented [below](#clickhouse-table-engine). Default: `MergeTree` engine)
 


### PR DESCRIPTION
BEGIN_COMMIT_OVERRIDE
feat(clickhouse)!: Read only plain `ca_cert` value

BREAKING-CHANGE: Stop reading `ca_cert` value as file path. See [file variable substitution](/docs/advanced-topics/environment-variable-substitution#file-variable-substitution-example) for how to read this value from a file.
END_COMMIT_OVERRIDE