### PR TITLE
fix(website): Use correct title for MySQL source plugin

### DIFF
--- a/website/pages/docs/plugins/sources/mysql/overview.mdx
+++ b/website/pages/docs/plugins/sources/mysql/overview.mdx
@@ -1,7 +1,7 @@
 ---
 name: MySQL
 ---
-# PostgreSQL Source Plugin
+# MySQL Source Plugin
 
 import { getLatestVersion } from "../../../../../utils/versions";
 import { Badge } from "../../../../../components/Badge";


### PR DESCRIPTION
<!-- 🎉 Thank you for making CloudQuery awesome by submitting a PR 🎉 -->

#### Summary

The title should be `MySQL` and not `PostgreSQL`

<!--
Use the following steps to ensure your PR is ready to be reviewed

- [ ] Read the [contribution guidelines](../blob/main/CONTRIBUTING.md) 🧑‍🎓
- [ ] Run `make lint` to ensure the proposed changes follow the coding style 🚨 (install golangci-lint [here](https://golangci-lint.run/usage/install/#local-installation))
- [ ] Run `make test` to ensure the proposed changes pass the tests 🧪
- [ ] If changing a source plugin run `make gen` to ensure docs are up to date 📝
- [ ] Ensure the status checks below are successful ✅
--->
