### PR TITLE
chore(website): Fail prebuild script on duplicate plugin ids

### DIFF
--- a/website/components/pluginData.tsx
+++ b/website/components/pluginData.tsx
@@ -667,14 +667,6 @@ export const UNPUBLISHED_SOURCE_PLUGINS: Plugin[] = [
     logo: "/images/logos/plugins/mssql.svg",
   },
   {
-    name: "MySQL",
-    id: "mysql",
-    href: "https://github.com/cloudquery/cloudquery/issues/8411",
-    kind: "unpublished",
-    category: "databases",
-    logo: "/images/logos/plugins/mysql.svg",
-  },
-  {
     name: "New Relic",
     id: "new-relic",
     href: "https://github.com/cloudquery/cloudquery/issues/9040",

--- a/website/scripts/prebuild.tsx
+++ b/website/scripts/prebuild.tsx
@@ -140,10 +140,17 @@ title: Export data from ${source.name} to ${destination.name}
 }
 
 function generateFiles() {
+    const sources = new Set<string>();
+    const destinations = new Set<string>();
+
     let hasAuthFile = {};
 
     // Loop through each source plugin and generate or copy MDX files
     [...SOURCE_PLUGINS, ...UNPUBLISHED_SOURCE_PLUGINS].forEach((source) => {
+      if (sources.has(source.id)) {
+        throw new Error("Duplicate source id: " + source.id + ". Did you forget to remove an unpublished plugin you implemented?");
+      }
+      sources.add(source.id);
       recreateDirectory(outputDir + "/" + source.id);
 
       const hasConfiguration = copySourceConfigurationFile(source);
@@ -158,6 +165,10 @@ function generateFiles() {
 
     // Loop through each destination plugin and generate or copy MDX files
     DESTINATION_PLUGINS.forEach((destination) => {
+        if (destinations.has(destination.id)) {
+            throw new Error("Duplicate destination id: " + destination.id);
+        }
+        destinations.add(destination.id);
         recreateDirectory(mdxDestinationComponentDir + "/" + destination.id);
 
         const hasConfiguration = copyDestinationConfigurationFile(destination);


### PR DESCRIPTION
<!-- 🎉 Thank you for making CloudQuery awesome by submitting a PR 🎉 -->

#### Summary

I got bit by this in https://github.com/cloudquery/cloudquery/pull/9511, and apparently also `MySQL` but didn't notice.
If we have duplicate IDs the last one takes.

See current integration for MySQL:
https://www.cloudquery.io/integrations/mysql/file
![image](https://user-images.githubusercontent.com/26760571/228596118-1c5231e9-6a76-43b3-a78b-763cb2f2dd40.png)

It should show the example configuration, but it doesn't as it takes the values on the `unpublished` kind.


<!--
Use the following steps to ensure your PR is ready to be reviewed

- [ ] Read the [contribution guidelines](../blob/main/CONTRIBUTING.md) 🧑‍🎓
- [ ] Run `make lint` to ensure the proposed changes follow the coding style 🚨 (install golangci-lint [here](https://golangci-lint.run/usage/install/#local-installation))
- [ ] Run `make test` to ensure the proposed changes pass the tests 🧪
- [ ] If changing a source plugin run `make gen` to ensure docs are up to date 📝
- [ ] Ensure the status checks below are successful ✅
--->
