### PR TITLE
feat(workflows): Add reusable workflow files

### DIFF
--- a/.github/workflows/reusable_resolve_runner.yml
+++ b/.github/workflows/reusable_resolve_runner.yml
@@ -1,0 +1,28 @@
+name: Resolve runner
+on:
+  workflow_call:
+    outputs:
+      runner:
+        description: 'Runner to be used (default: "ubuntu-latest")'
+        value:       ${{ jobs.resolve-runner.outputs.runner }}
+
+jobs:
+  resolve-runner:
+    timeout-minutes: 5
+    runs-on:         ubuntu-latest
+    outputs:
+      runner: ${{ steps.resolve.outputs.runner }}
+    steps:
+    - name: Check if should use large runner
+      id:   large-runner
+      # We want to speed runs on the release branch
+      # We allow large runners only in this case to prevent forks from abusing them (it's enforced via runner groups access rules)
+      # IF YOU WANT TO USE A LARGE RUNNER YOU NEED TO ADD THE WORKFLOW TO THE `CloudQuery releases` GROUP IN https://github.com/organizations/cloudquery/settings/actions/runner-groups
+      if:   github.event_name == 'push'
+      run:  |
+            echo "runner=cloudquery-release-runner" >> $GITHUB_OUTPUT
+    - name: Resolve runner
+      id:   resolve
+      run:  |
+            RUNNER=${{ steps.large-runner.outputs.runner }}
+            echo "runner=${RUNNER:-"ubuntu-latest"}" >> $GITHUB_OUTPUT

--- a/.github/workflows/reusable_test_source.yml
+++ b/.github/workflows/reusable_test_source.yml
@@ -41,7 +41,7 @@ jobs:
               ~/.cache/go-build
               ~/Library/Caches/go-build
               ~\AppData\Local\go-build
-        key:  ${{ runner.os }}-go-${{ steps.set-up-go.outputs.go-version }}-source-${{ inputs.plugin }}-${{ hashFiles('plugins/source/${{ inputs.plugin }}/go.sum') }}
+        key:  ${{ runner.os }}-go-${{ steps.set-up-go.outputs.go-version }}-source-${{ inputs.plugin }}-${{ hashFiles(format('plugins/source/{0}/go.sum', inputs.plugin)) }}
     - name: golangci-lint
       uses: golangci/golangci-lint-action@v3
       with:
@@ -70,4 +70,4 @@ jobs:
               ~/.cache/go-build
               ~/Library/Caches/go-build
               ~\AppData\Local\go-build
-        key:  ${{ runner.os }}-go-${{ steps.set-up-go.outputs.go-version }}-source-${{ inputs.plugin }}-${{ hashFiles('plugins/source/${{ inputs.plugin }}/go.sum') }}
+        key:  ${{ runner.os }}-go-${{ steps.set-up-go.outputs.go-version }}-source-${{ inputs.plugin }}-${{ hashFiles(format('plugins/source/{0}/go.sum', inputs.plugin)) }}

--- a/.github/workflows/reusable_test_source.yml
+++ b/.github/workflows/reusable_test_source.yml
@@ -1,0 +1,73 @@
+name: Source plugin test
+
+on:
+  workflow_call:
+    inputs:
+      plugin:
+        description: 'Plugin dir (e.g. "aws")'
+        type:        string
+        required:    true
+      runner:
+        description: 'Runner to be used (default: "ubuntu-latest")'
+        type:        string
+        required:    false
+        default:     'ubuntu-latest'
+
+jobs:
+  test:
+    timeout-minutes: 45
+    permissions:
+      id-token: write
+      contents: read
+    runs-on:         ${{ inputs.runner }}
+    defaults:
+      run:
+        working-directory: ./plugins/source/${{ inputs.plugin }}
+    steps:
+    - uses: actions/checkout@v3
+      with:
+        fetch-depth: 2
+    - name: Set up Go
+      id:   set-up-go
+      uses: actions/setup-go@v3
+      with:
+        go-version-file:       plugins/source/${{ inputs.plugin }}/go.mod
+        cache:                 true
+        cache-dependency-path: plugins/source/${{ inputs.plugin }}/go.sum
+    - name: Restore build cache
+      uses: actions/cache/restore@v3
+      with:
+        path: |
+              ~/.cache/go-build
+              ~/Library/Caches/go-build
+              ~\AppData\Local\go-build
+        key:  ${{ runner.os }}-go-${{ steps.set-up-go.outputs.go-version }}-source-${{ inputs.plugin }}-${{ hashFiles('plugins/source/${{ inputs.plugin }}/go.sum') }}
+    - name: golangci-lint
+      uses: golangci/golangci-lint-action@v3
+      with:
+        version:           v1.52.1
+        working-directory: plugins/source/${{ inputs.plugin }}
+        args:              "--config ../../.golangci.yml"
+        skip-pkg-cache:    true
+        skip-build-cache:  true
+    - name: Get dependencies
+      run:  go get -t -d ./...
+    - name: gen
+      if:   github.event_name == 'pull_request'
+      run:  make gen
+    - name: Fail if generation updated files
+      if:   github.event_name == 'pull_request'
+      run:  test "$(git status -s | wc -l)" -eq 0 || (git status -s; exit 1)
+    - name: Build
+      run:  go build .
+    - name: Test
+      run:  make test
+    - name: Save build cache
+      if:   github.ref == 'refs/heads/main'
+      uses: actions/cache/save@v3
+      with:
+        path: |
+              ~/.cache/go-build
+              ~/Library/Caches/go-build
+              ~\AppData\Local\go-build
+        key:  ${{ runner.os }}-go-${{ steps.set-up-go.outputs.go-version }}-source-${{ inputs.plugin }}-${{ hashFiles('plugins/source/${{ inputs.plugin }}/go.sum') }}

--- a/.github/workflows/reusable_test_source.yml
+++ b/.github/workflows/reusable_test_source.yml
@@ -41,7 +41,7 @@ jobs:
               ~/.cache/go-build
               ~/Library/Caches/go-build
               ~\AppData\Local\go-build
-        key:  ${{ runner.os }}-go-${{ steps.set-up-go.outputs.go-version }}-source-${{ inputs.plugin }}-${{ hashFiles(plugins/source/${{ inputs.plugin }}/go.sum) }}
+        key:  ${{ runner.os }}-go-${{ steps.set-up-go.outputs.go-version }}-source-${{ inputs.plugin }}-${{ hashFiles('plugins/source/${{ inputs.plugin }}/go.sum') }}
     - name: golangci-lint
       uses: golangci/golangci-lint-action@v3
       with:
@@ -70,4 +70,4 @@ jobs:
               ~/.cache/go-build
               ~/Library/Caches/go-build
               ~\AppData\Local\go-build
-        key:  ${{ runner.os }}-go-${{ steps.set-up-go.outputs.go-version }}-source-${{ inputs.plugin }}-${{ hashFiles(plugins/source/${{ inputs.plugin }}/go.sum) }}
+        key:  ${{ runner.os }}-go-${{ steps.set-up-go.outputs.go-version }}-source-${{ inputs.plugin }}-${{ hashFiles('plugins/source/${{ inputs.plugin }}/go.sum') }}

--- a/.github/workflows/reusable_test_source.yml
+++ b/.github/workflows/reusable_test_source.yml
@@ -37,11 +37,13 @@ jobs:
     - name: Restore build cache
       uses: actions/cache/restore@v3
       with:
-        path: |
-              ~/.cache/go-build
-              ~/Library/Caches/go-build
-              ~\AppData\Local\go-build
-        key:  ${{ runner.os }}-go-${{ steps.set-up-go.outputs.go-version }}-source-${{ inputs.plugin }}-${{ hashFiles(format('plugins/source/{0}/go.sum', inputs.plugin)) }}
+        path:         |
+                      ~/.cache/go-build
+                      ~/Library/Caches/go-build
+                      ~\AppData\Local\go-build
+        key:          source-${{ inputs.plugin }}-${{ runner.os }}-go-${{ steps.set-up-go.outputs.go-version }}-${{ hashFiles(format('plugins/source/{0}/go.sum', inputs.plugin)) }}
+        # no direct cache hit, however, even a partial hit might be beneficial
+        restore-keys: source-${{ inputs.plugin }}-${{ runner.os }}-go-${{ steps.set-up-go.outputs.go-version }}-
     - name: golangci-lint
       uses: golangci/golangci-lint-action@v3
       with:
@@ -70,4 +72,4 @@ jobs:
               ~/.cache/go-build
               ~/Library/Caches/go-build
               ~\AppData\Local\go-build
-        key:  ${{ runner.os }}-go-${{ steps.set-up-go.outputs.go-version }}-source-${{ inputs.plugin }}-${{ hashFiles(format('plugins/source/{0}/go.sum', inputs.plugin)) }}
+        key:  source-${{ inputs.plugin }}-${{ runner.os }}-go-${{ steps.set-up-go.outputs.go-version }}-${{ hashFiles(format('plugins/source/{0}/go.sum', inputs.plugin)) }}

--- a/.github/workflows/reusable_test_source.yml
+++ b/.github/workflows/reusable_test_source.yml
@@ -41,7 +41,7 @@ jobs:
               ~/.cache/go-build
               ~/Library/Caches/go-build
               ~\AppData\Local\go-build
-        key:  ${{ runner.os }}-go-${{ steps.set-up-go.outputs.go-version }}-source-${{ inputs.plugin }}-${{ hashFiles('plugins/source/${{ inputs.plugin }}/go.sum') }}
+        key:  ${{ runner.os }}-go-${{ steps.set-up-go.outputs.go-version }}-source-${{ inputs.plugin }}-${{ hashFiles(plugins/source/${{ inputs.plugin }}/go.sum) }}
     - name: golangci-lint
       uses: golangci/golangci-lint-action@v3
       with:
@@ -70,4 +70,4 @@ jobs:
               ~/.cache/go-build
               ~/Library/Caches/go-build
               ~\AppData\Local\go-build
-        key:  ${{ runner.os }}-go-${{ steps.set-up-go.outputs.go-version }}-source-${{ inputs.plugin }}-${{ hashFiles('plugins/source/${{ inputs.plugin }}/go.sum') }}
+        key:  ${{ runner.os }}-go-${{ steps.set-up-go.outputs.go-version }}-source-${{ inputs.plugin }}-${{ hashFiles(plugins/source/${{ inputs.plugin }}/go.sum) }}

--- a/.github/workflows/reusable_validate_release.yml
+++ b/.github/workflows/reusable_validate_release.yml
@@ -41,7 +41,7 @@ jobs:
               ~/.cache/go-build
               ~/Library/Caches/go-build
               ~\AppData\Local\go-build
-        key:  ${{ runner.os }}-go-${{ steps.set-up-go.outputs.go-version }}-${{ inputs.type }}-${{ inputs.plugin }}-${{ hashFiles('plugins/source/${{ inputs.plugin }}/go.sum') }}
+        key:  ${{ runner.os }}-go-${{ steps.set-up-go.outputs.go-version }}-${{ inputs.type }}-${{ inputs.plugin }}-${{ hashFiles(plugins/source/${{ inputs.plugin }}/go.sum) }}
     - name: Install GoReleaser
       uses: goreleaser/goreleaser-action@v3
       with:

--- a/.github/workflows/reusable_validate_release.yml
+++ b/.github/workflows/reusable_validate_release.yml
@@ -1,0 +1,61 @@
+name: Validate plugin release
+
+on:
+  workflow_call:
+    inputs:
+      plugin:
+        description: 'Plugin dir (e.g. "aws", "postgresql")'
+        type:        string
+        required:    true
+      type:
+        description: 'Plugin type ("source" or "destination")'
+        type:        string
+        required:    true
+      runner:
+        description: 'Runner to be used (default: "ubuntu-latest")'
+        type:        string
+        required:    false
+        default:     'ubuntu-latest'
+
+jobs:
+  validate-release:
+    if:              startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
+    timeout-minutes: 30
+    runs-on:         ${{ inputs.runner }}
+    env:
+      CGO_ENABLED: 0
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v3
+    - name: Set up Go
+      id:   set-up-go
+      with:
+        go-version-file:       plugins/${{ inputs.type }}/${{ inputs.plugin }}/go.mod
+        cache:                 true
+        cache-dependency-path: plugins/${{ inputs.type }}/${{ inputs.plugin }}/go.sum
+    - name: Restore build cache
+      uses: actions/cache/restore@v3
+      with:
+        path: |
+              ~/.cache/go-build
+              ~/Library/Caches/go-build
+              ~\AppData\Local\go-build
+        key:  ${{ runner.os }}-go-${{ steps.set-up-go.outputs.go-version }}-${{ inputs.type }}-${{ inputs.plugin }}-${{ hashFiles('plugins/source/${{ inputs.plugin }}/go.sum') }}
+    - name: Install GoReleaser
+      uses: goreleaser/goreleaser-action@v3
+      with:
+        distribution: goreleaser-pro
+        version:      latest
+        install-only: true
+    - name: Run GoReleaser Dry-Run
+      run:  >
+            goreleaser release
+            --timeout 50m
+            --snapshot
+            --clean
+            --skip-validate
+            --skip-publish
+            --skip-sign
+            -f ./plugins/${{ inputs.type }}/${{ inputs.plugin }}/.goreleaser.yaml
+      env:
+        GORELEASER_KEY: ${{ secrets.GORELEASER_KEY }}

--- a/.github/workflows/reusable_validate_release.yml
+++ b/.github/workflows/reusable_validate_release.yml
@@ -41,7 +41,7 @@ jobs:
               ~/.cache/go-build
               ~/Library/Caches/go-build
               ~\AppData\Local\go-build
-        key:  ${{ runner.os }}-go-${{ steps.set-up-go.outputs.go-version }}-${{ inputs.type }}-${{ inputs.plugin }}-${{ hashFiles('plugins/source/${{ inputs.plugin }}/go.sum') }}
+        key:  ${{ runner.os }}-go-${{ steps.set-up-go.outputs.go-version }}-${{ inputs.type }}-${{ inputs.plugin }}-${{ hashFiles(format('plugins/{0}/{1}/go.sum', inputs.type, inputs.plugin)) }}
     - name: Install GoReleaser
       uses: goreleaser/goreleaser-action@v3
       with:

--- a/.github/workflows/reusable_validate_release.yml
+++ b/.github/workflows/reusable_validate_release.yml
@@ -37,11 +37,13 @@ jobs:
     - name: Restore build cache
       uses: actions/cache/restore@v3
       with:
-        path: |
-              ~/.cache/go-build
-              ~/Library/Caches/go-build
-              ~\AppData\Local\go-build
-        key:  ${{ runner.os }}-go-${{ steps.set-up-go.outputs.go-version }}-${{ inputs.type }}-${{ inputs.plugin }}-${{ hashFiles(format('plugins/{0}/{1}/go.sum', inputs.type, inputs.plugin)) }}
+        path:         |
+                      ~/.cache/go-build
+                      ~/Library/Caches/go-build
+                      ~\AppData\Local\go-build
+        key:          ${{ inputs.type }}-${{ inputs.plugin }}-${{ runner.os }}-go-${{ steps.set-up-go.outputs.go-version }}-${{ hashFiles(format('plugins/{0}/{1}/go.sum', inputs.type, inputs.plugin)) }}
+        # no direct cache hit, however, even a partial hit might be beneficial
+        restore-keys: ${{ inputs.type }}-${{ inputs.plugin }}-${{ runner.os }}-go-${{ steps.set-up-go.outputs.go-version }}-
     - name: Install GoReleaser
       uses: goreleaser/goreleaser-action@v3
       with:

--- a/.github/workflows/reusable_validate_release.yml
+++ b/.github/workflows/reusable_validate_release.yml
@@ -29,6 +29,7 @@ jobs:
       uses: actions/checkout@v3
     - name: Set up Go
       id:   set-up-go
+      uses: actions/setup-go@v3
       with:
         go-version-file:       plugins/${{ inputs.type }}/${{ inputs.plugin }}/go.mod
         cache:                 true

--- a/.github/workflows/reusable_validate_release.yml
+++ b/.github/workflows/reusable_validate_release.yml
@@ -41,7 +41,7 @@ jobs:
               ~/.cache/go-build
               ~/Library/Caches/go-build
               ~\AppData\Local\go-build
-        key:  ${{ runner.os }}-go-${{ steps.set-up-go.outputs.go-version }}-${{ inputs.type }}-${{ inputs.plugin }}-${{ hashFiles(plugins/source/${{ inputs.plugin }}/go.sum) }}
+        key:  ${{ runner.os }}-go-${{ steps.set-up-go.outputs.go-version }}-${{ inputs.type }}-${{ inputs.plugin }}-${{ hashFiles('plugins/source/${{ inputs.plugin }}/go.sum') }}
     - name: Install GoReleaser
       uses: goreleaser/goreleaser-action@v3
       with:


### PR DESCRIPTION
Add [reusable workflows](https://docs.github.com/en/actions/using-workflows/reusing-workflows) that will allow us to reuse the common job definitions:
* source plugin tests
  * adds ability to implement #9388 in a single place
* plugin release validation
* runner resolving

Once this part is in the `main` we can switch parts of the workflows to the reusable ones.

Example implementation: #9541 (aws source).