### PR TITLE
fix: MSSQL migrations

### DIFF
--- a/plugins/destination/mssql/queries/tables_test.go
+++ b/plugins/destination/mssql/queries/tables_test.go
@@ -1,6 +1,7 @@
 package queries
 
 import (
+	"regexp"
 	"testing"
 
 	"github.com/cloudquery/plugin-sdk/schema"
@@ -11,14 +12,14 @@ func TestCreateTable(t *testing.T) {
 	const (
 		schemaName = "cq"
 		expected   = `CREATE TABLE [cq].[table_name] (
-  [_cq_id] uniqueidentifier UNIQUE NOT NULL,
-  [_cq_parent_id] uniqueidentifier,
-  [_cq_source_name] nvarchar(4000),
-  [_cq_sync_time] datetime2,
-  [extra_col] float NOT NULL
-  CONSTRAINT [table_name_cqpk] PRIMARY KEY (
-  [extra_col]
-  )
+[_cq_id] uniqueidentifier UNIQUE NOT NULL,
+[_cq_parent_id] uniqueidentifier,
+[_cq_source_name] nvarchar(4000),
+[_cq_sync_time] datetime2,
+[extra_col] float NOT NULL
+	CONSTRAINT [table_name_cqpk] PRIMARY KEY (
+		[extra_col]
+	)
 );`
 	)
 
@@ -40,5 +41,38 @@ func TestCreateTable(t *testing.T) {
 		true,
 	)
 
-	require.Equal(t, expected, query)
+	require.Equal(t, normalizeSpaces(expected), normalizeSpaces(query))
+}
+
+func TestCreateTableNoPk(t *testing.T) {
+	const (
+		schemaName = "cq"
+		expected   = `CREATE TABLE [cq].[table_name] (
+[_cq_id] uniqueidentifier UNIQUE NOT NULL,
+[_cq_parent_id] uniqueidentifier,
+[_cq_source_name] nvarchar(4000),
+[_cq_sync_time] datetime2
+);`
+	)
+
+	query := CreateTable(schemaName,
+		&schema.Table{
+			Name: "table_name",
+			Columns: schema.ColumnList{
+				schema.CqIDColumn,
+				schema.CqParentIDColumn,
+				schema.CqSourceNameColumn,
+				schema.CqSyncTimeColumn,
+			},
+		},
+		true,
+	)
+
+	require.Equal(t, normalizeSpaces(expected), normalizeSpaces(query))
+}
+
+// Replaces all space/tab/newline sequences with a single space
+func normalizeSpaces(str string) string {
+	re := regexp.MustCompile(`\s+`)
+	return re.ReplaceAllString(str, " ")
 }

--- a/plugins/destination/mssql/queries/templates/create_table.sql.tpl
+++ b/plugins/destination/mssql/queries/templates/create_table.sql.tpl
@@ -1,8 +1,10 @@
 CREATE TABLE {{.Table}} (
 {{with .Definitions}}{{template "col_defs.sql.tpl" .}}{{end}}
 {{- with .PrimaryKey}}
-  CONSTRAINT {{.Name}} PRIMARY KEY (
-{{template "col_names.sql.tpl" .Columns}}
+  {{- if ne (len .Columns) 0}}
+    CONSTRAINT {{.Name}} PRIMARY KEY (
+      {{template "col_names.sql.tpl" .Columns}}
+    )
+  {{- end}}
 {{- end}}
-  )
 );


### PR DESCRIPTION
Change normalization code to be analog to postgresql's migration code

Fixes failing any 2 consecutive links, even when there is no schema-change at all:

```
Loading spec(s) from .
Starting migration with 1 tables for: gcp (v8.4.2) -> [mssql (v3.0.3)]
Error: failed to sync v1 source gcp: failed to migrate source gcp (v8.4.2) on destination mssql (v3.0.3) : failed to call Migrate: rpc error: code = Unknown desc = tables gcp_compute_networks with changes [[column: self_link, type: update, current: self_link:TypeString:PK, previous: self_link:TypeString:PK:NotNull]] require force migration. use 'migrate_mode: forced'
```