### PR TITLE
feat(meilisearch): Use Meilisearch v1.1

### DIFF
--- a/.github/workflows/dest_meilisearch.yml
+++ b/.github/workflows/dest_meilisearch.yml
@@ -24,7 +24,7 @@ jobs:
         working-directory: plugins/destination/meilisearch
     services:
       meilisearch:
-        image:   getmeili/meilisearch:v1.1.0-rc.1
+        image:   getmeili/meilisearch:v1.1.0
         env:
           MEILI_ENV:          development
           MEILI_MASTER_KEY:   ${{ env.MEILI_MASTER_KEY }}

--- a/plugins/destination/meilisearch/client/index.go
+++ b/plugins/destination/meilisearch/client/index.go
@@ -36,12 +36,7 @@ func (c *Client) tablesIndexSchemas(tables schema.Tables) map[string]*indexSchem
 	return res
 }
 
-func (c *Client) getIndexSchema(uid string) (*indexSchema, error) {
-	index, err := c.Meilisearch.GetIndex(uid)
-	if err != nil {
-		return nil, err
-	}
-
+func (c *Client) getIndexSchema(index *meilisearch.Index) (*indexSchema, error) {
 	res := &indexSchema{UID: index.UID, PrimaryKey: index.PrimaryKey}
 
 	attrs, err := index.GetFilterableAttributes()
@@ -66,10 +61,8 @@ func (c *Client) indexes() (map[string]*indexSchema, error) {
 			return nil, err
 		}
 
-		for _, shallow := range resp.Results {
-			// we need to perform GetIndex, as the index returned doesn't have client field initialized
-			// see https://github.com/meilisearch/meilisearch-go/pull/426
-			entry, err := c.getIndexSchema(shallow.UID)
+		for _, index := range resp.Results {
+			entry, err := c.getIndexSchema(&index)
 			if err != nil {
 				return nil, err
 			}

--- a/plugins/destination/meilisearch/docker-compose.yaml
+++ b/plugins/destination/meilisearch/docker-compose.yaml
@@ -1,7 +1,7 @@
 services:
   meilisearch:
     container_name: meilisearch
-    image:          getmeili/meilisearch:v1.1.0-rc.1
+    image:          getmeili/meilisearch:v1.1.0
     environment:
     - MEILI_ENV=development
     - MEILI_MASTER_KEY=${MEILI_MASTER_KEY:-test}

--- a/plugins/destination/meilisearch/go.mod
+++ b/plugins/destination/meilisearch/go.mod
@@ -5,7 +5,7 @@ go 1.19
 require (
 	github.com/cloudquery/plugin-sdk v1.44.1
 	github.com/google/uuid v1.3.0
-	github.com/meilisearch/meilisearch-go v0.23.1
+	github.com/meilisearch/meilisearch-go v0.24.0
 	github.com/rs/zerolog v1.29.0
 	github.com/valyala/fasthttp v1.45.0
 	golang.org/x/exp v0.0.0-20230321023759-10a507213a29

--- a/plugins/destination/meilisearch/go.sum
+++ b/plugins/destination/meilisearch/go.sum
@@ -161,8 +161,8 @@ github.com/mattn/go-isatty v0.0.16/go.mod h1:kYGgaQfpe5nmfYZH+SKPsOc2e4SrIfOl2e/
 github.com/mattn/go-isatty v0.0.18 h1:DOKFKCQ7FNG2L1rbrmstDN4QVRdS89Nkh85u68Uwp98=
 github.com/mattn/go-isatty v0.0.18/go.mod h1:W+V8PltTTMOvKvAeJH7IuucS94S2C6jfK/D7dTCTo3Y=
 github.com/mattn/go-runewidth v0.0.14 h1:+xnbZSEeDbOIg5/mE6JF0w6n9duR1l3/WmbinWVwUuU=
-github.com/meilisearch/meilisearch-go v0.23.1 h1:/L8Qo3HaYq20nfvF5yn2L9qysuUaMOwjZGz3M8eXw98=
-github.com/meilisearch/meilisearch-go v0.23.1/go.mod h1:SxuSqDcPBIykjWz1PX+KzsYzArNLSCadQodWs8extS0=
+github.com/meilisearch/meilisearch-go v0.24.0 h1:GTP8LWZmkMYrGgX5BRZdkC2Txyp0mFYLzXYMlVV7cSQ=
+github.com/meilisearch/meilisearch-go v0.24.0/go.mod h1:SxuSqDcPBIykjWz1PX+KzsYzArNLSCadQodWs8extS0=
 github.com/mitchellh/colorstring v0.0.0-20190213212951-d06e56a500db h1:62I3jR2EmQ4l5rM/4FEfDWcRD+abF5XlKShorW5LRoQ=
 github.com/opentracing/opentracing-go v1.1.0/go.mod h1:UkNAQd3GIcIGf0SeVgPpRdFStlNbqXla1AfSYxPUl2o=
 github.com/pingcap/errors v0.11.4 h1:lFuQV/oaUMGcD2tqt+01ROSmJs75VG1ToEOkZIZ4nE4=

--- a/website/pages/docs/plugins/destinations/meilisearch/overview.mdx
+++ b/website/pages/docs/plugins/destinations/meilisearch/overview.mdx
@@ -70,6 +70,6 @@ This is the spec used by the Meilisearch destination plugin.
 ## Underlying library
 
 We use the official [meilisearch-go](https://github.com/meilisearch/meilisearch-go) package.
-It is tested against Meilisearch v1.1.0-rc.1.
+It is tested against Meilisearch v1.1.0.
 Please [open an issue](https://github.com/cloudquery/cloudquery/issues/new/choose)
 if you encounter any problems with this (or another) version.


### PR DESCRIPTION
Follow-up for https://github.com/meilisearch/meilisearch-go/pull/426 finally released in https://github.com/meilisearch/meilisearch-go/pull/427