### PR TITLE
fix(aws)!: Change Primary keys for `aws_dynamodb_global_tables` to include `region`

### DIFF
--- a/plugins/source/aws/resources/services/dynamodb/global_tables.go
+++ b/plugins/source/aws/resources/services/dynamodb/global_tables.go
@@ -24,7 +24,7 @@ This table only contains version 2017.11.29 (Legacy) Global Tables. See aws_dyna
 		Transform:           transformers.TransformWithStruct(&types.GlobalTableDescription{}),
 		Columns: []schema.Column{
 			client.DefaultAccountIDColumn(false),
-			client.DefaultRegionColumn(false),
+			client.DefaultRegionColumn(true),
 			{
 				Name:     "arn",
 				Type:     schema.TypeString,

--- a/website/tables/aws/aws_dynamodb_global_tables.md
+++ b/website/tables/aws/aws_dynamodb_global_tables.md
@@ -5,7 +5,7 @@ This table shows data for Amazon DynamoDB Global Tables.
 https://docs.aws.amazon.com/amazondynamodb/latest/APIReference/API_GlobalTableDescription.html
 This table only contains version 2017.11.29 (Legacy) Global Tables. See aws_dynamodb_tables for version 2019.11.21 (Current) Global Tables.
 
-The primary key for this table is **arn**.
+The composite primary key for this table is (**region**, **arn**).
 
 ## Columns
 
@@ -16,7 +16,7 @@ The primary key for this table is **arn**.
 |_cq_id|UUID|
 |_cq_parent_id|UUID|
 |account_id|String|
-|region|String|
+|region (PK)|String|
 |arn (PK)|String|
 |tags|JSON|
 |creation_date_time|Timestamp|


### PR DESCRIPTION
<!-- 🎉 Thank you for making CloudQuery awesome by submitting a PR 🎉 -->

#### Summary

Global tables can span multiple regions, because the ARN does not include a region in it the singular value will be duplicated when resolving multiple regions.

By adding the region to the PK we can ensure the record is unique