### PR TITLE
fix(aws)!: Change PKs for `aws_sns_subscriptions`

### DIFF
--- a/plugins/source/aws/resources/services/sns/subscriptions.go
+++ b/plugins/source/aws/resources/services/sns/subscriptions.go
@@ -29,9 +29,6 @@ func Subscriptions() *schema.Table {
 				Name:     "arn",
 				Type:     schema.TypeString,
 				Resolver: schema.PathResolver("SubscriptionArn"),
-				CreationOptions: schema.ColumnCreationOptions{
-					PrimaryKey: true,
-				},
 			},
 			{
 				Name:     "delivery_policy",

--- a/plugins/source/aws/resources/services/sns/subscriptions.go
+++ b/plugins/source/aws/resources/services/sns/subscriptions.go
@@ -20,7 +20,7 @@ func Subscriptions() *schema.Table {
 		Description:         `https://docs.aws.amazon.com/sns/latest/api/API_GetSubscriptionAttributes.html`,
 		Resolver:            fetchSnsSubscriptions,
 		PreResourceResolver: getSnsSubscription,
-		Transform:           transformers.TransformWithStruct(&models.Subscription{}),
+		Transform:           transformers.TransformWithStruct(&models.Subscription{}, transformers.WithPrimaryKeys("Owner", "Protocol", "TopicArn", "Endpoint")),
 		Multiplex:           client.ServiceAccountRegionMultiplexer(tableName, "sns"),
 		Columns: []schema.Column{
 			client.DefaultAccountIDColumn(false),

--- a/website/tables/aws/aws_sns_subscriptions.md
+++ b/website/tables/aws/aws_sns_subscriptions.md
@@ -4,7 +4,7 @@ This table shows data for Sns Subscriptions.
 
 https://docs.aws.amazon.com/sns/latest/api/API_GetSubscriptionAttributes.html
 
-The primary key for this table is **arn**.
+The composite primary key for this table is (**endpoint**, **owner**, **protocol**, **topic_arn**).
 
 ## Columns
 
@@ -16,16 +16,16 @@ The primary key for this table is **arn**.
 |_cq_parent_id|UUID|
 |account_id|String|
 |region|String|
-|arn (PK)|String|
+|arn|String|
 |delivery_policy|JSON|
 |effective_delivery_policy|JSON|
 |filter_policy|JSON|
 |redrive_policy|JSON|
-|endpoint|String|
-|owner|String|
-|protocol|String|
+|endpoint (PK)|String|
+|owner (PK)|String|
+|protocol (PK)|String|
 |subscription_arn|String|
-|topic_arn|String|
+|topic_arn (PK)|String|
 |confirmation_was_authenticated|Bool|
 |pending_confirmation|Bool|
 |raw_message_delivery|Bool|


### PR DESCRIPTION
<!-- 🎉 Thank you for making CloudQuery awesome by submitting a PR 🎉 -->

#### Summary

Primary Keys now are `Owner`,`Protocol`, `TopicArn` and `Endpoint`. Have an [open case](https://support.console.aws.amazon.com/support/home?region=us-east-2#/case/?displayId=12408033321&language=en) to see if this can be used instead of SubscriptionARN which only has a value after it is confirmed.
