### PR TITLE
feat(workflows): Move `validate-release` step checks to job level

### DIFF
--- a/.github/workflows/cli.yml
+++ b/.github/workflows/cli.yml
@@ -74,6 +74,7 @@ jobs:
         if: matrix.os == 'ubuntu-latest'
         run: test "$(git status -s ../website/pages/docs/reference/cli/*.md | wc -l)" -eq 0
   validate-release:
+    if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
     timeout-minutes: 30
     needs: [resolve-runner]
     runs-on: ${{ needs.resolve-runner.outputs.runner }}
@@ -81,10 +82,8 @@ jobs:
       CGO_ENABLED: 0
     steps:
       - name: Checkout
-        if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
         uses: actions/checkout@v3
       - uses: actions/cache@v3
-        if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
         with:
           path: |
             ~/.cache/go-build
@@ -93,19 +92,16 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-go-1.19.5-release-cache-cli
       - name: Set up Go
-        if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
         uses: actions/setup-go@v3
         with:
           go-version-file: cli/go.mod
       - name: Install GoReleaser
-        if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
         uses: goreleaser/goreleaser-action@v3
         with:
           distribution: goreleaser-pro
           version: latest
           install-only: true
       - name: Run GoReleaser Dry-Run
-        if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
         run: goreleaser release --snapshot --clean --skip-validate --skip-publish --skip-sign -f ./cli/.goreleaser.yaml
         env:
           GORELEASER_KEY: ${{ secrets.GORELEASER_KEY }}

--- a/.github/workflows/dest_azblob.yml
+++ b/.github/workflows/dest_azblob.yml
@@ -49,16 +49,15 @@ jobs:
           AZURE_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
           AZURE_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
   validate-release:
+    if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
     timeout-minutes: 30
     runs-on: ubuntu-latest
     env:
       CGO_ENABLED: 0
     steps:
       - name: Checkout
-        if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
         uses: actions/checkout@v3
       - uses: actions/cache@v3
-        if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
         with:
           path: |
             ~/.cache/go-build
@@ -67,19 +66,16 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-go-1.19.5-release-cache-plugins-destination-azblob
       - name: Set up Go
-        if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
         uses: actions/setup-go@v3
         with:
           go-version-file: plugins/destination/azblob/go.mod
       - name: Install GoReleaser
-        if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
         uses: goreleaser/goreleaser-action@v3
         with:
           distribution: goreleaser-pro
           version: latest
           install-only: true
       - name: Run GoReleaser Dry-Run
-        if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
         run: goreleaser release --snapshot --clean --skip-validate --skip-publish --skip-sign -f ./plugins/destination/azblob/.goreleaser.yaml
         env:
           GORELEASER_KEY: ${{ secrets.GORELEASER_KEY }}

--- a/.github/workflows/dest_bigquery.yml
+++ b/.github/workflows/dest_bigquery.yml
@@ -59,14 +59,13 @@ jobs:
           BIGQUERY_PROJECT_ID: ${{ secrets.BIGQUERY_TEST_PROJECT_ID }}
           BIGQUERY_DATASET_ID: ${{ secrets.BIGQUERY_TEST_DATASET_ID }}
   validate-release:
+    if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
     timeout-minutes: 30
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
         uses: actions/checkout@v3
       - uses: actions/cache@v3
-        if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
         with:
           path: |
             ~/.cache/go-build
@@ -75,19 +74,16 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-go-1.19.5-release-cache-plugins-destination-bigquery
       - name: Set up Go
-        if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
         uses: actions/setup-go@v3
         with:
           go-version-file: plugins/destination/bigquery/go.mod
       - name: Install GoReleaser
-        if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
         uses: goreleaser/goreleaser-action@v3
         with:
           distribution: goreleaser-pro
           version: latest
           install-only: true
       - name: Run GoReleaser Dry-Run
-        if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
         run: goreleaser release --snapshot --clean --skip-validate --skip-publish --skip-sign -f ./plugins/destination/bigquery/.goreleaser.yaml
         env:
           GORELEASER_KEY: ${{ secrets.GORELEASER_KEY }}

--- a/.github/workflows/dest_clickhouse.yml
+++ b/.github/workflows/dest_clickhouse.yml
@@ -69,16 +69,15 @@ jobs:
         CQ_DEST_CH_TEST_CONN: "clickhouse://${{ env.DB_USER }}:${{ env.DB_PASSWORD }}@localhost:9000/${{ env.DB_NAME }}"
       run:  make test
   validate-release:
+    if:   startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
     timeout-minutes: 30
     runs-on:         ubuntu-latest
     env:
       CGO_ENABLED: 0
     steps:
     - name: Checkout
-      if:   startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
       uses: actions/checkout@v3
     - uses: actions/cache@v3
-      if:   startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
       with:
         path:         |
                       ~/.cache/go-build
@@ -87,19 +86,16 @@ jobs:
         restore-keys: |
                       ${{ runner.os }}-go-1.19.4-release-cache-plugins-destination-clickhouse
     - name: Set up Go
-      if:   startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
       uses: actions/setup-go@v3
       with:
         go-version-file: plugins/destination/clickhouse/go.mod
     - name: Install GoReleaser
-      if:   startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
       uses: goreleaser/goreleaser-action@v3
       with:
         distribution: goreleaser-pro
         version:      latest
         install-only: true
     - name: Run GoReleaser Dry-Run
-      if:   startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
       run:  goreleaser release --snapshot --rm-dist --skip-validate --skip-publish --skip-sign -f ./plugins/destination/clickhouse/.goreleaser.yaml
       env:
         GORELEASER_KEY: ${{ secrets.GORELEASER_KEY }}

--- a/.github/workflows/dest_csv.yml
+++ b/.github/workflows/dest_csv.yml
@@ -45,16 +45,15 @@ jobs:
       - name: Test
         run: make test
   validate-release:
+    if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
     timeout-minutes: 30
     runs-on: ubuntu-latest
     env:
       CGO_ENABLED: 0
     steps:
       - name: Checkout
-        if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
         uses: actions/checkout@v3
       - uses: actions/cache@v3
-        if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
         with:
           path: |
             ~/.cache/go-build
@@ -63,19 +62,16 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-go-1.19.5-release-cache-plugins-destination-csv
       - name: Set up Go
-        if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
         uses: actions/setup-go@v3
         with:
           go-version-file: plugins/destination/csv/go.mod
       - name: Install GoReleaser
-        if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
         uses: goreleaser/goreleaser-action@v3
         with:
           distribution: goreleaser-pro
           version: latest
           install-only: true
       - name: Run GoReleaser Dry-Run
-        if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
         run: goreleaser release --snapshot --clean --skip-validate --skip-publish --skip-sign -f ./plugins/destination/csv/.goreleaser.yaml
         env:
           GORELEASER_KEY: ${{ secrets.GORELEASER_KEY }}

--- a/.github/workflows/dest_duckdb.yml
+++ b/.github/workflows/dest_duckdb.yml
@@ -45,6 +45,7 @@ jobs:
       - name: Test
         run: make test
   validate-release:
+    if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
     timeout-minutes: 30
     runs-on: ubuntu-latest
     container:
@@ -53,10 +54,8 @@ jobs:
         CGO_ENABLED: 1
     steps:
       - name: Checkout
-        if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
         uses: actions/checkout@v3
       - uses: actions/cache@v3
-        if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
         with:
           path: |
             ~/.cache/go-build
@@ -65,19 +64,16 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-go-1.19.5-release-cache-plugins-destination-duckdb
       - name: Set up Go
-        if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
         uses: actions/setup-go@v3
         with:
           go-version-file: plugins/destination/duckdb/go.mod
       - name: Install GoReleaser
-        if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
         uses: goreleaser/goreleaser-action@v3
         with:
           distribution: goreleaser-pro
           version: latest
           install-only: true
       - name: Run GoReleaser Dry-Run
-        if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
         run: goreleaser release --snapshot --clean --skip-validate --skip-publish --skip-sign -f ./plugins/destination/duckdb/.goreleaser.yaml
         env:
           GORELEASER_KEY: ${{ secrets.GORELEASER_KEY }}

--- a/.github/workflows/dest_elasticsearch.yml
+++ b/.github/workflows/dest_elasticsearch.yml
@@ -59,14 +59,13 @@ jobs:
       - name: Test
         run: make test
   validate-release:
+    if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
     timeout-minutes: 30
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
         uses: actions/checkout@v3
       - uses: actions/cache@v3
-        if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
         with:
           path: |
             ~/.cache/go-build
@@ -75,19 +74,16 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-go-1.19.4-release-cache-plugins-destination-elasticsearch
       - name: Set up Go
-        if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
         uses: actions/setup-go@v3
         with:
           go-version-file: plugins/destination/elasticsearch/go.mod
       - name: Install GoReleaser
-        if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
         uses: goreleaser/goreleaser-action@v3
         with:
           distribution: goreleaser-pro
           version: latest
           install-only: true
       - name: Run GoReleaser Dry-Run
-        if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
         run: goreleaser release --snapshot --rm-dist --skip-validate --skip-publish --skip-sign -f ./plugins/destination/elasticsearch/.goreleaser.yaml
         env:
           GORELEASER_KEY: ${{ secrets.GORELEASER_KEY }}

--- a/.github/workflows/dest_file.yml
+++ b/.github/workflows/dest_file.yml
@@ -47,16 +47,15 @@ jobs:
       - name: Test file plugin
         run: make test
   validate-release:
+    if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
     timeout-minutes: 30
     runs-on: ubuntu-latest
     env:
       CGO_ENABLED: 0
     steps:
       - name: Checkout
-        if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
         uses: actions/checkout@v3
       - uses: actions/cache@v3
-        if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
         with:
           path: |
             ~/.cache/go-build
@@ -65,19 +64,16 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-go-1.19.5-release-cache-plugins-destination-file
       - name: Set up Go
-        if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
         uses: actions/setup-go@v3
         with:
           go-version-file: plugins/destination/file/go.mod
       - name: Install GoReleaser
-        if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
         uses: goreleaser/goreleaser-action@v3
         with:
           distribution: goreleaser-pro
           version: latest
           install-only: true
       - name: Run GoReleaser Dry-Run
-        if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
         run: goreleaser release --snapshot --clean --skip-validate --skip-publish --skip-sign -f ./plugins/destination/file/.goreleaser.yaml
         env:
           GORELEASER_KEY: ${{ secrets.GORELEASER_KEY }}

--- a/.github/workflows/dest_firehose.yml
+++ b/.github/workflows/dest_firehose.yml
@@ -54,16 +54,15 @@ jobs:
       # - name: Test firehose plugin
       #   run: make test
   validate-release:
+    if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
     timeout-minutes: 30
     runs-on: ubuntu-latest
     env:
       CGO_ENABLED: 0
     steps:
       - name: Checkout
-        if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
         uses: actions/checkout@v3
       - uses: actions/cache@v3
-        if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
         with:
           path: |
             ~/.cache/go-build
@@ -72,19 +71,16 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-go-1.19.4-release-cache-plugins-destination-firehose
       - name: Set up Go
-        if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
         uses: actions/setup-go@v3
         with:
           go-version-file: plugins/destination/firehose/go.mod
       - name: Install GoReleaser
-        if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
         uses: goreleaser/goreleaser-action@v3
         with:
           distribution: goreleaser-pro
           version: latest
           install-only: true
       - name: Run GoReleaser Dry-Run
-        if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
         run: goreleaser release --snapshot --rm-dist --skip-validate --skip-publish --skip-sign -f ./plugins/destination/firehose/.goreleaser.yaml
         env:
           GORELEASER_KEY: ${{ secrets.GORELEASER_KEY }}

--- a/.github/workflows/dest_gcs.yml
+++ b/.github/workflows/dest_gcs.yml
@@ -53,16 +53,15 @@ jobs:
       - name: Test file plugin
         run: make test
   validate-release:
+    if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
     timeout-minutes: 30
     runs-on: ubuntu-latest
     env:
       CGO_ENABLED: 0
     steps:
       - name: Checkout
-        if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
         uses: actions/checkout@v3
       - uses: actions/cache@v3
-        if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
         with:
           path: |
             ~/.cache/go-build
@@ -71,19 +70,16 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-go-1.19.5-release-cache-plugins-destination-gcs
       - name: Set up Go
-        if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
         uses: actions/setup-go@v3
         with:
           go-version-file: plugins/destination/gcs/go.mod
       - name: Install GoReleaser
-        if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
         uses: goreleaser/goreleaser-action@v3
         with:
           distribution: goreleaser-pro
           version: latest
           install-only: true
       - name: Run GoReleaser Dry-Run
-        if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
         run: goreleaser release --snapshot --clean --skip-validate --skip-publish --skip-sign -f ./plugins/destination/gcs/.goreleaser.yaml
         env:
           GORELEASER_KEY: ${{ secrets.GORELEASER_KEY }}

--- a/.github/workflows/dest_gremlin.yml
+++ b/.github/workflows/dest_gremlin.yml
@@ -50,16 +50,15 @@ jobs:
       - name: Test Gremlin
         run: make test
   validate-release:
+    if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
     timeout-minutes: 30
     runs-on: ubuntu-latest
     env:
       CGO_ENABLED: 0
     steps:
       - name: Checkout
-        if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
         uses: actions/checkout@v3
       - uses: actions/cache@v3
-        if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
         with:
           path: |
             ~/.cache/go-build
@@ -68,19 +67,16 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-go-1.19.5-release-cache-plugins-destination-gremlin
       - name: Set up Go
-        if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
         uses: actions/setup-go@v3
         with:
           go-version-file: plugins/destination/gremlin/go.mod
       - name: Install GoReleaser
-        if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
         uses: goreleaser/goreleaser-action@v3
         with:
           distribution: goreleaser-pro
           version: latest
           install-only: true
       - name: Run GoReleaser Dry-Run
-        if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
         run: goreleaser release --snapshot --clean --skip-validate --skip-publish --skip-sign -f ./plugins/destination/gremlin/.goreleaser.yaml
         env:
           GORELEASER_KEY: ${{ secrets.GORELEASER_KEY }}

--- a/.github/workflows/dest_kafka.yml
+++ b/.github/workflows/dest_kafka.yml
@@ -47,16 +47,15 @@ jobs:
       - name: Test
         run: make test
   validate-release:
+    if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
     timeout-minutes: 30
     runs-on: ubuntu-latest
     env:
       CGO_ENABLED: 0
     steps:
       - name: Checkout
-        if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
         uses: actions/checkout@v3
       - uses: actions/cache@v3
-        if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
         with:
           path: |
             ~/.cache/go-build
@@ -65,19 +64,16 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-go-1.19.5-release-cache-plugins-destination-kafka
       - name: Set up Go
-        if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
         uses: actions/setup-go@v3
         with:
           go-version-file: plugins/destination/kafka/go.mod
       - name: Install GoReleaser
-        if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
         uses: goreleaser/goreleaser-action@v3
         with:
           distribution: goreleaser-pro
           version: latest
           install-only: true
       - name: Run GoReleaser Dry-Run
-        if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
         run: goreleaser release --snapshot --clean --skip-validate --skip-publish --skip-sign -f ./plugins/destination/kafka/.goreleaser.yaml
         env:
           GORELEASER_KEY: ${{ secrets.GORELEASER_KEY }}

--- a/.github/workflows/dest_meilisearch.yml
+++ b/.github/workflows/dest_meilisearch.yml
@@ -66,16 +66,15 @@ jobs:
         CQ_DEST_MEILI_TEST_API_KEY: ${{ env.MEILI_MASTER_KEY }}
       run:  make test
   validate-release:
+    if:   startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
     timeout-minutes: 30
     runs-on:         ubuntu-latest
     env:
       CGO_ENABLED: 0
     steps:
     - name: Checkout
-      if:   startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
       uses: actions/checkout@v3
     - uses: actions/cache@v3
-      if:   startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
       with:
         path:         |
                       ~/.cache/go-build
@@ -84,19 +83,16 @@ jobs:
         restore-keys: |
                       ${{ runner.os }}-go-1.19.4-release-cache-plugins-destination-meilisearch
     - name: Set up Go
-      if:   startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
       uses: actions/setup-go@v3
       with:
         go-version-file: plugins/destination/meilisearch/go.mod
     - name: Install GoReleaser
-      if:   startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
       uses: goreleaser/goreleaser-action@v3
       with:
         distribution: goreleaser-pro
         version:      latest
         install-only: true
     - name: Run GoReleaser Dry-Run
-      if:   startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
       run:  goreleaser release --snapshot --rm-dist --skip-validate --skip-publish --skip-sign -f ./plugins/destination/meilisearch/.goreleaser.yaml
       env:
         GORELEASER_KEY: ${{ secrets.GORELEASER_KEY }}

--- a/.github/workflows/dest_mongodb.yml
+++ b/.github/workflows/dest_mongodb.yml
@@ -48,16 +48,15 @@ jobs:
       - name: Test
         run: make test
   validate-release:
+    if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
     timeout-minutes: 30
     runs-on: ubuntu-latest
     env:
       CGO_ENABLED: 0
     steps:
       - name: Checkout
-        if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
         uses: actions/checkout@v3
       - uses: actions/cache@v3
-        if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
         with:
           path: |
             ~/.cache/go-build
@@ -66,19 +65,16 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-go-1.19.5-release-cache-plugins-destination-mongodb
       - name: Set up Go
-        if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
         uses: actions/setup-go@v3
         with:
           go-version-file: plugins/destination/mongodb/go.mod
       - name: Install GoReleaser
-        if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
         uses: goreleaser/goreleaser-action@v3
         with:
           distribution: goreleaser-pro
           version: latest
           install-only: true
       - name: Run GoReleaser Dry-Run
-        if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
         run: goreleaser release --snapshot --clean --skip-validate --skip-publish --skip-sign -f ./plugins/destination/mongodb/.goreleaser.yaml
         env:
           GORELEASER_KEY: ${{ secrets.GORELEASER_KEY }}

--- a/.github/workflows/dest_mssql.yml
+++ b/.github/workflows/dest_mssql.yml
@@ -73,16 +73,15 @@ jobs:
     - name: Test Microsoft SQL
       run:  make test
   validate-release:
+    if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
     timeout-minutes: 30
     runs-on:         ubuntu-latest
     env:
       CGO_ENABLED: 0
     steps:
     - name: Checkout
-      if:   startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
       uses: actions/checkout@v3
     - uses: actions/cache@v3
-      if:   startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
       with:
         path:         |
                       ~/.cache/go-build
@@ -91,19 +90,16 @@ jobs:
         restore-keys: |
                       ${{ runner.os }}-go-1.19.5-release-cache-plugins-destination-mssql
     - name: Set up Go
-      if:   startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
       uses: actions/setup-go@v3
       with:
         go-version-file: plugins/destination/mssql/go.mod
     - name: Install GoReleaser
-      if:   startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
       uses: goreleaser/goreleaser-action@v3
       with:
         distribution: goreleaser-pro
         version:      latest
         install-only: true
     - name: Run GoReleaser Dry-Run
-      if:   startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
       run:  goreleaser release --snapshot --clean --skip-validate --skip-publish --skip-sign -f ./plugins/destination/mssql/.goreleaser.yaml
       env:
         GORELEASER_KEY: ${{ secrets.GORELEASER_KEY }}

--- a/.github/workflows/dest_mysql.yml
+++ b/.github/workflows/dest_mysql.yml
@@ -58,16 +58,15 @@ jobs:
       - name: Test MySQL
         run: make test
   validate-release:
+    if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
     timeout-minutes: 30
     runs-on: ubuntu-latest
     env:
       CGO_ENABLED: 0
     steps:
       - name: Checkout
-        if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
         uses: actions/checkout@v3
       - uses: actions/cache@v3
-        if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
         with:
           path: |
             ~/.cache/go-build
@@ -76,19 +75,16 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-go-1.19.5-release-cache-plugins-destination-mysql
       - name: Set up Go
-        if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
         uses: actions/setup-go@v3
         with:
           go-version-file: plugins/destination/mysql/go.mod
       - name: Install GoReleaser
-        if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
         uses: goreleaser/goreleaser-action@v3
         with:
           distribution: goreleaser-pro
           version: latest
           install-only: true
       - name: Run GoReleaser Dry-Run
-        if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
         run: goreleaser release --snapshot --clean --skip-validate --skip-publish --skip-sign -f ./plugins/destination/mysql/.goreleaser.yaml
         env:
           GORELEASER_KEY: ${{ secrets.GORELEASER_KEY }}

--- a/.github/workflows/dest_neo4j.yml
+++ b/.github/workflows/dest_neo4j.yml
@@ -65,16 +65,15 @@ jobs:
       - name: Test Neo4j
         run: make test
   validate-release:
+    if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
     timeout-minutes: 30
     runs-on: ubuntu-latest
     env:
       CGO_ENABLED: 0
     steps:
       - name: Checkout
-        if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
         uses: actions/checkout@v3
       - uses: actions/cache@v3
-        if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
         with:
           path: |
             ~/.cache/go-build
@@ -83,19 +82,16 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-go-1.19.5-release-cache-plugins-destination-neo4j
       - name: Set up Go
-        if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
         uses: actions/setup-go@v3
         with:
           go-version-file: plugins/destination/neo4j/go.mod
       - name: Install GoReleaser
-        if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
         uses: goreleaser/goreleaser-action@v3
         with:
           distribution: goreleaser-pro
           version: latest
           install-only: true
       - name: Run GoReleaser Dry-Run
-        if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
         run: goreleaser release --snapshot --clean --skip-validate --skip-publish --skip-sign -f ./plugins/destination/neo4j/.goreleaser.yaml
         env:
           GORELEASER_KEY: ${{ secrets.GORELEASER_KEY }}

--- a/.github/workflows/dest_postgresql.yml
+++ b/.github/workflows/dest_postgresql.yml
@@ -70,16 +70,15 @@ jobs:
       - name: Test CockroachDB
         run: CQ_DEST_PG_TEST_CONN="postgresql://root@localhost:26257/postgres?sslmode=disable" make test
   validate-release:
+    if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
     timeout-minutes: 30
     runs-on: ubuntu-latest
     env:
       CGO_ENABLED: 0
     steps:
       - name: Checkout
-        if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
         uses: actions/checkout@v3
       - uses: actions/cache@v3
-        if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
         with:
           path: |
             ~/.cache/go-build
@@ -88,19 +87,16 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-go-1.19.5-release-cache-plugins-destination-postgresql
       - name: Set up Go
-        if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
         uses: actions/setup-go@v3
         with:
           go-version-file: plugins/destination/postgresql/go.mod
       - name: Install GoReleaser
-        if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
         uses: goreleaser/goreleaser-action@v3
         with:
           distribution: goreleaser-pro
           version: latest
           install-only: true
       - name: Run GoReleaser Dry-Run
-        if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
         run: goreleaser release --snapshot --clean --skip-validate --skip-publish --skip-sign -f ./plugins/destination/postgresql/.goreleaser.yaml
         env:
           GORELEASER_KEY: ${{ secrets.GORELEASER_KEY }}

--- a/.github/workflows/dest_s3.yml
+++ b/.github/workflows/dest_s3.yml
@@ -55,16 +55,15 @@ jobs:
       - name: Test s3 plugin
         run: make test
   validate-release:
+    if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
     timeout-minutes: 30
     runs-on: ubuntu-latest
     env:
       CGO_ENABLED: 0
     steps:
       - name: Checkout
-        if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
         uses: actions/checkout@v3
       - uses: actions/cache@v3
-        if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
         with:
           path: |
             ~/.cache/go-build
@@ -73,19 +72,16 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-go-1.19.5-release-cache-plugins-destination-s3
       - name: Set up Go
-        if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
         uses: actions/setup-go@v3
         with:
           go-version-file: plugins/destination/s3/go.mod
       - name: Install GoReleaser
-        if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
         uses: goreleaser/goreleaser-action@v3
         with:
           distribution: goreleaser-pro
           version: latest
           install-only: true
       - name: Run GoReleaser Dry-Run
-        if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
         run: goreleaser release --snapshot --clean --skip-validate --skip-publish --skip-sign -f ./plugins/destination/s3/.goreleaser.yaml
         env:
           GORELEASER_KEY: ${{ secrets.GORELEASER_KEY }}

--- a/.github/workflows/dest_snowflake.yml
+++ b/.github/workflows/dest_snowflake.yml
@@ -47,6 +47,7 @@ jobs:
         env: # Or as an environment variable
           SNOW_TEST_DSN: ${{ secrets.SNOW_TEST_DSN }}
   validate-release:
+    if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
     timeout-minutes: 30
     runs-on: ubuntu-latest
     container:
@@ -55,10 +56,8 @@ jobs:
         CGO_ENABLED: 1
     steps:
       - name: Checkout
-        if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
         uses: actions/checkout@v3
       - uses: actions/cache@v3
-        if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
         with:
           path: |
             ~/.cache/go-build
@@ -67,19 +66,16 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-go-1.19.5-release-cache-plugins-destination-snowflake
       - name: Set up Go
-        if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
         uses: actions/setup-go@v3
         with:
           go-version-file: plugins/destination/snowflake/go.mod
       - name: Install GoReleaser
-        if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
         uses: goreleaser/goreleaser-action@v3
         with:
           distribution: goreleaser-pro
           version: latest
           install-only: true
       - name: Run GoReleaser Dry-Run
-        if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
         run: goreleaser release --snapshot --clean --skip-validate --skip-publish --skip-sign -f ./plugins/destination/snowflake/.goreleaser.yaml
         env:
           GORELEASER_KEY: ${{ secrets.GORELEASER_KEY }}

--- a/.github/workflows/dest_sqlite.yml
+++ b/.github/workflows/dest_sqlite.yml
@@ -45,6 +45,7 @@ jobs:
       - name: Test
         run: make test
   validate-release:
+    if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
     timeout-minutes: 30
     runs-on: ubuntu-latest
     container:
@@ -53,10 +54,8 @@ jobs:
         CGO_ENABLED: 1
     steps:
       - name: Checkout
-        if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
         uses: actions/checkout@v3
       - uses: actions/cache@v3
-        if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
         with:
           path: |
             ~/.cache/go-build
@@ -65,19 +64,16 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-go-1.19.5-release-cache-plugins-destination-sqlite
       - name: Set up Go
-        if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
         uses: actions/setup-go@v3
         with:
           go-version-file: plugins/destination/sqlite/go.mod
       - name: Install GoReleaser
-        if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
         uses: goreleaser/goreleaser-action@v3
         with:
           distribution: goreleaser-pro
           version: latest
           install-only: true
       - name: Run GoReleaser Dry-Run
-        if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
         run: goreleaser release --snapshot --clean --skip-validate --skip-publish --skip-sign -f ./plugins/destination/sqlite/.goreleaser.yaml
         env:
           GORELEASER_KEY: ${{ secrets.GORELEASER_KEY }}

--- a/.github/workflows/dest_test.yml
+++ b/.github/workflows/dest_test.yml
@@ -45,16 +45,15 @@ jobs:
       - name: Test
         run: make test
   validate-release:
+    if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
     timeout-minutes: 30
     runs-on: ubuntu-latest
     env:
       CGO_ENABLED: 0
     steps:
       - name: Checkout
-        if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
         uses: actions/checkout@v3
       - uses: actions/cache@v3
-        if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
         with:
           path: |
             ~/.cache/go-build
@@ -63,19 +62,16 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-go-1.19.5-release-cache-plugins-destination-test
       - name: Set up Go
-        if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
         uses: actions/setup-go@v3
         with:
           go-version-file: plugins/destination/test/go.mod
       - name: Install GoReleaser
-        if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
         uses: goreleaser/goreleaser-action@v3
         with:
           distribution: goreleaser-pro
           version: latest
           install-only: true
       - name: Run GoReleaser Dry-Run
-        if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
         run: goreleaser release --snapshot --clean --skip-validate --skip-publish --skip-sign -f ./plugins/destination/test/.goreleaser.yaml
         env:
           GORELEASER_KEY: ${{ secrets.GORELEASER_KEY }}

--- a/.github/workflows/scaffold.yml
+++ b/.github/workflows/scaffold.yml
@@ -45,16 +45,15 @@ jobs:
       - name: Test
         run: make test
   validate-release:
+    if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
     timeout-minutes: 30
     runs-on: ubuntu-latest
     env:
       CGO_ENABLED: 0
     steps:
       - name: Checkout
-        if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
         uses: actions/checkout@v3
       - uses: actions/cache@v3
-        if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
         with:
           path: |
             ~/.cache/go-build
@@ -63,19 +62,16 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-go-1.19.5-release-cache-scaffold
       - name: Set up Go
-        if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
         uses: actions/setup-go@v3
         with:
           go-version-file: scaffold/go.mod
       - name: Install GoReleaser
-        if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
         uses: goreleaser/goreleaser-action@v3
         with:
           distribution: goreleaser-pro
           version: latest
           install-only: true
       - name: Run GoReleaser Dry-Run
-        if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
         run: goreleaser release --snapshot --clean --skip-validate --skip-publish --skip-sign -f ./scaffold/.goreleaser.yaml
         env:
           GORELEASER_KEY: ${{ secrets.GORELEASER_KEY }}

--- a/.github/workflows/source_alicloud.yml
+++ b/.github/workflows/source_alicloud.yml
@@ -49,16 +49,15 @@ jobs:
       - name: Test
         run: make test
   validate-release:
+    if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
     timeout-minutes: 30
     runs-on: ubuntu-latest
     env:
       CGO_ENABLED: 0
     steps:
       - name: Checkout
-        if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
         uses: actions/checkout@v3
       - uses: actions/cache@v3
-        if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
         with:
           path: |
             ~/.cache/go-build
@@ -67,19 +66,16 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-go-1.19.5-release-cache-plugins-source-alicloud
       - name: Set up Go
-        if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
         uses: actions/setup-go@v3
         with:
           go-version-file: plugins/source/alicloud/go.mod
       - name: Install GoReleaser
-        if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
         uses: goreleaser/goreleaser-action@v3
         with:
           distribution: goreleaser-pro
           version: latest
           install-only: true
       - name: Run GoReleaser Dry-Run
-        if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
         run: goreleaser release --snapshot --clean --skip-validate --skip-publish --skip-sign -f ./plugins/source/alicloud/.goreleaser.yaml
         env:
           GORELEASER_KEY: ${{ secrets.GORELEASER_KEY }}

--- a/.github/workflows/source_aws.yml
+++ b/.github/workflows/source_aws.yml
@@ -89,6 +89,7 @@ jobs:
         if: startsWith(github.head_ref, 'release-please--branches--main--components')
         run: cloudquery sync test/sanity.yml --log-console
   validate-release:
+    if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
     timeout-minutes: 60
     needs: [resolve-runner]
     runs-on: ${{ needs.resolve-runner.outputs.runner }}
@@ -96,10 +97,8 @@ jobs:
       CGO_ENABLED: 0
     steps:
       - name: Checkout
-        if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
         uses: actions/checkout@v3
       - uses: actions/cache@v3
-        if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
         with:
           path: |
             ~/.cache/go-build
@@ -108,19 +107,16 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-go-1.19.5-release-cache-plugins-source-aws
       - name: Set up Go
-        if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
         uses: actions/setup-go@v3
         with:
           go-version-file: plugins/source/aws/go.mod
       - name: Install GoReleaser
-        if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
         uses: goreleaser/goreleaser-action@v3
         with:
           distribution: goreleaser-pro
           version: latest
           install-only: true
       - name: Run GoReleaser Dry-Run
-        if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
         run: goreleaser release --timeout 50m --snapshot --clean --skip-validate --skip-publish --skip-sign -f ./plugins/source/aws/.goreleaser.yaml
         env:
           GORELEASER_KEY: ${{ secrets.GORELEASER_KEY }}

--- a/.github/workflows/source_awspricing.yml
+++ b/.github/workflows/source_awspricing.yml
@@ -49,16 +49,15 @@ jobs:
       - name: Test
         run: make test
   validate-release:
+    if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
     timeout-minutes: 30
     runs-on: ubuntu-latest
     env:
       CGO_ENABLED: 0
     steps:
       - name: Checkout
-        if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
         uses: actions/checkout@v3
       - uses: actions/cache@v3
-        if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
         with:
           path: |
             ~/.cache/go-build
@@ -67,19 +66,16 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-go-1.19.5-release-cache-plugins-source-awspricing
       - name: Set up Go
-        if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
         uses: actions/setup-go@v3
         with:
           go-version-file: plugins/source/awspricing/go.mod
       - name: Install GoReleaser
-        if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
         uses: goreleaser/goreleaser-action@v3
         with:
           distribution: goreleaser-pro
           version: latest
           install-only: true
       - name: Run GoReleaser Dry-Run
-        if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
         run: goreleaser release --snapshot --clean --skip-validate --skip-publish --skip-sign -f ./plugins/source/awspricing/.goreleaser.yaml
         env:
           GORELEASER_KEY: ${{ secrets.GORELEASER_KEY }}

--- a/.github/workflows/source_azure.yml
+++ b/.github/workflows/source_azure.yml
@@ -71,6 +71,7 @@ jobs:
       - name: Test
         run: make test
   validate-release:
+    if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
     timeout-minutes: 30
     needs: [resolve-runner]
     runs-on: ${{ needs.resolve-runner.outputs.runner }}
@@ -78,10 +79,8 @@ jobs:
       CGO_ENABLED: 0
     steps:
       - name: Checkout
-        if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
         uses: actions/checkout@v3
       - uses: actions/cache@v3
-        if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
         with:
           path: |
             ~/.cache/go-build
@@ -90,19 +89,16 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-go-1.19.5-release-cache-plugins-source-azure
       - name: Set up Go
-        if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
         uses: actions/setup-go@v3
         with:
           go-version-file: plugins/source/azure/go.mod
       - name: Install GoReleaser
-        if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
         uses: goreleaser/goreleaser-action@v3
         with:
           distribution: goreleaser-pro
           version: latest
           install-only: true
       - name: Run GoReleaser Dry-Run
-        if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
         run: goreleaser release --snapshot --clean --skip-validate --skip-publish --skip-sign -f ./plugins/source/azure/.goreleaser.yaml
         env:
           GORELEASER_KEY: ${{ secrets.GORELEASER_KEY }}

--- a/.github/workflows/source_azuredevops.yml
+++ b/.github/workflows/source_azuredevops.yml
@@ -51,16 +51,15 @@ jobs:
       - name: Test
         run: make test
   validate-release:
+    if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
     timeout-minutes: 30
     runs-on: ubuntu-latest
     env:
       CGO_ENABLED: 0
     steps:
       - name: Checkout
-        if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
         uses: actions/checkout@v3
       - uses: actions/cache@v3
-        if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
         with:
           path: |
             ~/.cache/go-build
@@ -69,19 +68,16 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-go-1.19.5-release-cache-plugins-source-azuredevops
       - name: Set up Go
-        if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
         uses: actions/setup-go@v3
         with:
           go-version-file: plugins/source/azuredevops/go.mod
       - name: Install GoReleaser
-        if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
         uses: goreleaser/goreleaser-action@v3
         with:
           distribution: goreleaser-pro
           version: latest
           install-only: true
       - name: Run GoReleaser Dry-Run
-        if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
         run: goreleaser release --snapshot --clean --skip-validate --skip-publish --skip-sign -f ./plugins/source/azuredevops/.goreleaser.yaml
         env:
           GORELEASER_KEY: ${{ secrets.GORELEASER_KEY }}

--- a/.github/workflows/source_cloudflare.yml
+++ b/.github/workflows/source_cloudflare.yml
@@ -51,16 +51,15 @@ jobs:
       - name: Test
         run: make test
   validate-release:
+    if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
     timeout-minutes: 30
     runs-on: ubuntu-latest
     env:
       CGO_ENABLED: 0
     steps:
       - name: Checkout
-        if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
         uses: actions/checkout@v3
       - uses: actions/cache@v3
-        if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
         with:
           path: |
             ~/.cache/go-build
@@ -69,19 +68,16 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-go-1.19.5-release-cache-plugins-source-cloudflare
       - name: Set up Go
-        if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
         uses: actions/setup-go@v3
         with:
           go-version-file: plugins/source/cloudflare/go.mod
       - name: Install GoReleaser
-        if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
         uses: goreleaser/goreleaser-action@v3
         with:
           distribution: goreleaser-pro
           version: latest
           install-only: true
       - name: Run GoReleaser Dry-Run
-        if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
         run: goreleaser release --snapshot --clean --skip-validate --skip-publish --skip-sign -f ./plugins/source/cloudflare/.goreleaser.yaml
         env:
           GORELEASER_KEY: ${{ secrets.GORELEASER_KEY }}

--- a/.github/workflows/source_datadog.yml
+++ b/.github/workflows/source_datadog.yml
@@ -51,16 +51,15 @@ jobs:
       - name: Test
         run: make test
   validate-release:
+    if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
     timeout-minutes: 45
     runs-on: ubuntu-latest
     env:
       CGO_ENABLED: 0
     steps:
       - name: Checkout
-        if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
         uses: actions/checkout@v3
       - uses: actions/cache@v3
-        if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
         with:
           path: |
             ~/.cache/go-build
@@ -69,19 +68,16 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-go-1.19.5-release-cache-plugins-source-datadog
       - name: Set up Go
-        if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
         uses: actions/setup-go@v3
         with:
           go-version-file: plugins/source/datadog/go.mod
       - name: Install GoReleaser
-        if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
         uses: goreleaser/goreleaser-action@v3
         with:
           distribution: goreleaser-pro
           version: latest
           install-only: true
       - name: Run GoReleaser Dry-Run
-        if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
         run: goreleaser release --snapshot --clean --skip-validate --skip-publish --skip-sign -f ./plugins/source/datadog/.goreleaser.yaml
         env:
           GORELEASER_KEY: ${{ secrets.GORELEASER_KEY }}

--- a/.github/workflows/source_digitalocean.yml
+++ b/.github/workflows/source_digitalocean.yml
@@ -51,16 +51,15 @@ jobs:
       - name: Test
         run: make test
   validate-release:
+    if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
     timeout-minutes: 30
     runs-on: ubuntu-latest
     env:
       CGO_ENABLED: 0
     steps:
       - name: Checkout
-        if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
         uses: actions/checkout@v3
       - uses: actions/cache@v3
-        if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
         with:
           path: |
             ~/.cache/go-build
@@ -69,19 +68,16 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-go-1.19.5-release-cache-plugins-source-digitalocean
       - name: Set up Go
-        if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
         uses: actions/setup-go@v3
         with:
           go-version-file: plugins/source/digitalocean/go.mod
       - name: Install GoReleaser
-        if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
         uses: goreleaser/goreleaser-action@v3
         with:
           distribution: goreleaser-pro
           version: latest
           install-only: true
       - name: Run GoReleaser Dry-Run
-        if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
         run: goreleaser release --snapshot --clean --skip-validate --skip-publish --skip-sign -f ./plugins/source/digitalocean/.goreleaser.yaml
         env:
           GORELEASER_KEY: ${{ secrets.GORELEASER_KEY }}

--- a/.github/workflows/source_facebookmarketing.yml
+++ b/.github/workflows/source_facebookmarketing.yml
@@ -49,16 +49,15 @@ jobs:
       - name: Test
         run: make test
   validate-release:
+    if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
     timeout-minutes: 30
     runs-on: ubuntu-latest
     env:
       CGO_ENABLED: 0
     steps:
       - name: Checkout
-        if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
         uses: actions/checkout@v3
       - uses: actions/cache@v3
-        if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
         with:
           path: |
             ~/.cache/go-build
@@ -67,19 +66,16 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-go-1.19.5-release-cache-plugins-source-facebookmarketing
       - name: Set up Go
-        if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
         uses: actions/setup-go@v3
         with:
           go-version-file: plugins/source/facebookmarketing/go.mod
       - name: Install GoReleaser
-        if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
         uses: goreleaser/goreleaser-action@v3
         with:
           distribution: goreleaser-pro
           version: latest
           install-only: true
       - name: Run GoReleaser Dry-Run
-        if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
         run: goreleaser release --snapshot --clean --skip-validate --skip-publish --skip-sign -f ./plugins/source/facebookmarketing/.goreleaser.yaml
         env:
           GORELEASER_KEY: ${{ secrets.GORELEASER_KEY }}

--- a/.github/workflows/source_fastly.yml
+++ b/.github/workflows/source_fastly.yml
@@ -51,16 +51,15 @@ jobs:
       - name: Test
         run: make test
   validate-release:
+    if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
     timeout-minutes: 30
     runs-on: ubuntu-latest
     env:
       CGO_ENABLED: 0
     steps:
       - name: Checkout
-        if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
         uses: actions/checkout@v3
       - uses: actions/cache@v3
-        if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
         with:
           path: |
             ~/.cache/go-build
@@ -69,19 +68,16 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-go-1.19.5-release-cache-plugins-source-fastly
       - name: Set up Go
-        if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
         uses: actions/setup-go@v3
         with:
           go-version-file: plugins/source/fastly/go.mod
       - name: Install GoReleaser
-        if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
         uses: goreleaser/goreleaser-action@v3
         with:
           distribution: goreleaser-pro
           version: latest
           install-only: true
       - name: Run GoReleaser Dry-Run
-        if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
         run: goreleaser release --snapshot --clean --skip-validate --skip-publish --skip-sign -f ./plugins/source/fastly/.goreleaser.yaml
         env:
           GORELEASER_KEY: ${{ secrets.GORELEASER_KEY }}

--- a/.github/workflows/source_gandi.yml
+++ b/.github/workflows/source_gandi.yml
@@ -51,16 +51,15 @@ jobs:
       - name: Test
         run: make test
   validate-release:
+    if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
     timeout-minutes: 30
     runs-on: ubuntu-latest
     env:
       CGO_ENABLED: 0
     steps:
       - name: Checkout
-        if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
         uses: actions/checkout@v3
       - uses: actions/cache@v3
-        if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
         with:
           path: |
             ~/.cache/go-build
@@ -69,19 +68,16 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-go-1.19.5-release-cache-plugins-source-gandi
       - name: Set up Go
-        if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
         uses: actions/setup-go@v3
         with:
           go-version-file: plugins/source/gandi/go.mod
       - name: Install GoReleaser
-        if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
         uses: goreleaser/goreleaser-action@v3
         with:
           distribution: goreleaser-pro
           version: latest
           install-only: true
       - name: Run GoReleaser Dry-Run
-        if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
         run: goreleaser release --snapshot --clean --skip-validate --skip-publish --skip-sign -f ./plugins/source/gandi/.goreleaser.yaml
         env:
           GORELEASER_KEY: ${{ secrets.GORELEASER_KEY }}

--- a/.github/workflows/source_gcp.yml
+++ b/.github/workflows/source_gcp.yml
@@ -71,6 +71,7 @@ jobs:
       - name: Test
         run: make test
   validate-release:
+    if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
     timeout-minutes: 30
     needs: [resolve-runner]
     runs-on: ${{ needs.resolve-runner.outputs.runner }}
@@ -78,10 +79,8 @@ jobs:
       CGO_ENABLED: 0
     steps:
       - name: Checkout
-        if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
         uses: actions/checkout@v3
       - uses: actions/cache@v3
-        if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
         with:
           path: |
             ~/.cache/go-build
@@ -90,19 +89,16 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-go-1.19.5-release-cache-plugins-source-gcp
       - name: Set up Go
-        if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
         uses: actions/setup-go@v3
         with:
           go-version-file: plugins/source/gcp/go.mod
       - name: Install GoReleaser
-        if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
         uses: goreleaser/goreleaser-action@v3
         with:
           distribution: goreleaser-pro
           version: latest
           install-only: true
       - name: Run GoReleaser Dry-Run
-        if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
         run: goreleaser release --snapshot --clean --skip-validate --skip-publish --skip-sign -f ./plugins/source/gcp/.goreleaser.yaml
         env:
           GORELEASER_KEY: ${{ secrets.GORELEASER_KEY }}

--- a/.github/workflows/source_github.yml
+++ b/.github/workflows/source_github.yml
@@ -51,16 +51,15 @@ jobs:
       - name: Test
         run: make test
   validate-release:
+    if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
     timeout-minutes: 30
     runs-on: ubuntu-latest
     env:
       CGO_ENABLED: 0
     steps:
       - name: Checkout
-        if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
         uses: actions/checkout@v3
       - uses: actions/cache@v3
-        if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
         with:
           path: |
             ~/.cache/go-build
@@ -69,19 +68,16 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-go-1.19.5-release-cache-plugins-source-github
       - name: Set up Go
-        if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
         uses: actions/setup-go@v3
         with:
           go-version-file: plugins/source/github/go.mod
       - name: Install GoReleaser
-        if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
         uses: goreleaser/goreleaser-action@v3
         with:
           distribution: goreleaser-pro
           version: latest
           install-only: true
       - name: Run GoReleaser Dry-Run
-        if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
         run: goreleaser release --snapshot --clean --skip-validate --skip-publish --skip-sign -f ./plugins/source/github/.goreleaser.yaml
         env:
           GORELEASER_KEY: ${{ secrets.GORELEASER_KEY }}

--- a/.github/workflows/source_gitlab.yml
+++ b/.github/workflows/source_gitlab.yml
@@ -51,16 +51,15 @@ jobs:
       - name: Test
         run: make test
   validate-release:
+    if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
     timeout-minutes: 30
     runs-on: ubuntu-latest
     env:
       CGO_ENABLED: 0
     steps:
       - name: Checkout
-        if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
         uses: actions/checkout@v3
       - uses: actions/cache@v3
-        if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
         with:
           path: |
             ~/.cache/go-build
@@ -69,19 +68,16 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-go-1.19.5-release-cache-plugins-source-github
       - name: Set up Go
-        if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
         uses: actions/setup-go@v3
         with:
           go-version-file: plugins/source/gitlab/go.mod
       - name: Install GoReleaser
-        if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
         uses: goreleaser/goreleaser-action@v3
         with:
           distribution: goreleaser-pro
           version: latest
           install-only: true
       - name: Run GoReleaser Dry-Run
-        if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
         run: goreleaser release --snapshot --clean --skip-validate --skip-publish --skip-sign -f ./plugins/source/gitlab/.goreleaser.yaml
         env:
           GORELEASER_KEY: ${{ secrets.GORELEASER_KEY }}

--- a/.github/workflows/source_googleads.yml
+++ b/.github/workflows/source_googleads.yml
@@ -49,16 +49,15 @@ jobs:
       - name: Test
         run: make test
   validate-release:
+    if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
     timeout-minutes: 30
     runs-on: ubuntu-latest
     env:
       CGO_ENABLED: 0
     steps:
       - name: Checkout
-        if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
         uses: actions/checkout@v3
       - uses: actions/cache@v3
-        if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
         with:
           path: |
             ~/.cache/go-build
@@ -67,19 +66,16 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-go-1.19.5-release-cache-plugins-source-googleads
       - name: Set up Go
-        if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
         uses: actions/setup-go@v3
         with:
           go-version-file: plugins/source/googleads/go.mod
       - name: Install GoReleaser
-        if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
         uses: goreleaser/goreleaser-action@v3
         with:
           distribution: goreleaser-pro
           version: latest
           install-only: true
       - name: Run GoReleaser Dry-Run
-        if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
         run: goreleaser release --snapshot --clean --skip-validate --skip-publish --skip-sign -f ./plugins/source/googleads/.goreleaser.yaml
         env:
           GORELEASER_KEY: ${{ secrets.GORELEASER_KEY }}

--- a/.github/workflows/source_googleanalytics.yml
+++ b/.github/workflows/source_googleanalytics.yml
@@ -49,16 +49,15 @@ jobs:
       - name: Test
         run: make test
   validate-release:
+    if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
     timeout-minutes: 30
     runs-on: ubuntu-latest
     env:
       CGO_ENABLED: 0
     steps:
       - name: Checkout
-        if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
         uses: actions/checkout@v3
       - uses: actions/cache@v3
-        if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
         with:
           path: |
             ~/.cache/go-build
@@ -67,19 +66,16 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-go-1.19.5-release-cache-plugins-source-googleanalytics
       - name: Set up Go
-        if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
         uses: actions/setup-go@v3
         with:
           go-version-file: plugins/source/googleanalytics/go.mod
       - name: Install GoReleaser
-        if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
         uses: goreleaser/goreleaser-action@v3
         with:
           distribution: goreleaser-pro
           version: latest
           install-only: true
       - name: Run GoReleaser Dry-Run
-        if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
         run: goreleaser release --snapshot --clean --skip-validate --skip-publish --skip-sign -f ./plugins/source/googleanalytics/.goreleaser.yaml
         env:
           GORELEASER_KEY: ${{ secrets.GORELEASER_KEY }}

--- a/.github/workflows/source_hackernews.yml
+++ b/.github/workflows/source_hackernews.yml
@@ -49,16 +49,15 @@ jobs:
       - name: Test
         run: make test
   validate-release:
+    if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
     timeout-minutes: 30
     runs-on: ubuntu-latest
     env:
       CGO_ENABLED: 0
     steps:
       - name: Checkout
-        if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
         uses: actions/checkout@v3
       - uses: actions/cache@v3
-        if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
         with:
           path: |
             ~/.cache/go-build
@@ -67,19 +66,16 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-go-1.19.5-release-cache-plugins-source-hackernews
       - name: Set up Go
-        if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
         uses: actions/setup-go@v3
         with:
           go-version-file: plugins/source/hackernews/go.mod
       - name: Install GoReleaser
-        if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
         uses: goreleaser/goreleaser-action@v3
         with:
           distribution: goreleaser-pro
           version: latest
           install-only: true
       - name: Run GoReleaser Dry-Run
-        if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
         run: goreleaser release --snapshot --clean --skip-validate --skip-publish --skip-sign -f ./plugins/source/hackernews/.goreleaser.yaml
         env:
           GORELEASER_KEY: ${{ secrets.GORELEASER_KEY }}

--- a/.github/workflows/source_heroku.yml
+++ b/.github/workflows/source_heroku.yml
@@ -51,16 +51,15 @@ jobs:
       - name: Test
         run: make test
   validate-release:
+    if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
     timeout-minutes: 30
     runs-on: ubuntu-latest
     env:
       CGO_ENABLED: 0
     steps:
       - name: Checkout
-        if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
         uses: actions/checkout@v3
       - uses: actions/cache@v3
-        if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
         with:
           path: |
             ~/.cache/go-build
@@ -69,19 +68,16 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-go-1.19.5-release-cache-plugins-source-heroku
       - name: Set up Go
-        if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
         uses: actions/setup-go@v3
         with:
           go-version-file: plugins/source/heroku/go.mod
       - name: Install GoReleaser
-        if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
         uses: goreleaser/goreleaser-action@v3
         with:
           distribution: goreleaser-pro
           version: latest
           install-only: true
       - name: Run GoReleaser Dry-Run
-        if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
         run: goreleaser release --snapshot --clean --skip-validate --skip-publish --skip-sign -f ./plugins/source/heroku/.goreleaser.yaml
         env:
           GORELEASER_KEY: ${{ secrets.GORELEASER_KEY }}

--- a/.github/workflows/source_homebrew.yml
+++ b/.github/workflows/source_homebrew.yml
@@ -49,16 +49,15 @@ jobs:
       - name: Test
         run: make test
   validate-release:
+    if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
     timeout-minutes: 30
     runs-on: ubuntu-latest
     env:
       CGO_ENABLED: 0
     steps:
       - name: Checkout
-        if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
         uses: actions/checkout@v3
       - uses: actions/cache@v3
-        if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
         with:
           path: |
             ~/.cache/go-build
@@ -67,19 +66,16 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-go-1.19.5-release-cache-plugins-source-homebrew
       - name: Set up Go
-        if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
         uses: actions/setup-go@v3
         with:
           go-version-file: plugins/source/homebrew/go.mod
       - name: Install GoReleaser
-        if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
         uses: goreleaser/goreleaser-action@v3
         with:
           distribution: goreleaser-pro
           version: latest
           install-only: true
       - name: Run GoReleaser Dry-Run
-        if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
         run: goreleaser release --snapshot --clean --skip-validate --skip-publish --skip-sign -f ./plugins/source/homebrew/.goreleaser.yaml
         env:
           GORELEASER_KEY: ${{ secrets.GORELEASER_KEY }}

--- a/.github/workflows/source_hubspot.yml
+++ b/.github/workflows/source_hubspot.yml
@@ -49,16 +49,15 @@ jobs:
       - name: Test
         run: make test
   validate-release:
+    if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
     timeout-minutes: 30
     runs-on: ubuntu-latest
     env:
       CGO_ENABLED: 0
     steps:
       - name: Checkout
-        if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
         uses: actions/checkout@v3
       - uses: actions/cache@v3
-        if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
         with:
           path: |
             ~/.cache/go-build
@@ -67,19 +66,16 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-go-1.19.5-release-cache-plugins-source-hubspot
       - name: Set up Go
-        if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
         uses: actions/setup-go@v3
         with:
           go-version-file: plugins/source/hubspot/go.mod
       - name: Install GoReleaser
-        if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
         uses: goreleaser/goreleaser-action@v3
         with:
           distribution: goreleaser-pro
           version: latest
           install-only: true
       - name: Run GoReleaser Dry-Run
-        if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
         run: goreleaser release --snapshot --clean --skip-validate --skip-publish --skip-sign -f ./plugins/source/hubspot/.goreleaser.yaml
         env:
           GORELEASER_KEY: ${{ secrets.GORELEASER_KEY }}

--- a/.github/workflows/source_k8s.yml
+++ b/.github/workflows/source_k8s.yml
@@ -71,6 +71,7 @@ jobs:
       - name: Test
         run: make test
   validate-release:
+    if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
     timeout-minutes: 30
     needs: [resolve-runner]
     runs-on: ${{ needs.resolve-runner.outputs.runner }}
@@ -78,10 +79,8 @@ jobs:
       CGO_ENABLED: 0
     steps:
       - name: Checkout
-        if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
         uses: actions/checkout@v3
       - uses: actions/cache@v3
-        if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
         with:
           path: |
             ~/.cache/go-build
@@ -90,19 +89,16 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-go-1.19.5-release-cache-plugins-source-k8s
       - name: Set up Go
-        if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
         uses: actions/setup-go@v3
         with:
           go-version-file: plugins/source/k8s/go.mod
       - name: Install GoReleaser
-        if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
         uses: goreleaser/goreleaser-action@v3
         with:
           distribution: goreleaser-pro
           version: latest
           install-only: true
       - name: Run GoReleaser Dry-Run
-        if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
         run: goreleaser release --snapshot --clean --skip-validate --skip-publish --skip-sign -f ./plugins/source/k8s/.goreleaser.yaml
         env:
           GORELEASER_KEY: ${{ secrets.GORELEASER_KEY }}

--- a/.github/workflows/source_launchdarkly.yml
+++ b/.github/workflows/source_launchdarkly.yml
@@ -51,16 +51,15 @@ jobs:
       - name: Test
         run: make test
   validate-release:
+    if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
     timeout-minutes: 30
     runs-on: ubuntu-latest
     env:
       CGO_ENABLED: 0
     steps:
       - name: Checkout
-        if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
         uses: actions/checkout@v3
       - uses: actions/cache@v3
-        if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
         with:
           path: |
             ~/.cache/go-build
@@ -69,19 +68,16 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-go-1.19.5-release-cache-plugins-source-launchdarkly
       - name: Set up Go
-        if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
         uses: actions/setup-go@v3
         with:
           go-version-file: plugins/source/launchdarkly/go.mod
       - name: Install GoReleaser
-        if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
         uses: goreleaser/goreleaser-action@v3
         with:
           distribution: goreleaser-pro
           version: latest
           install-only: true
       - name: Run GoReleaser Dry-Run
-        if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
         run: goreleaser release --snapshot --clean --skip-validate --skip-publish --skip-sign -f ./plugins/source/launchdarkly/.goreleaser.yaml
         env:
           GORELEASER_KEY: ${{ secrets.GORELEASER_KEY }}

--- a/.github/workflows/source_mixpanel.yml
+++ b/.github/workflows/source_mixpanel.yml
@@ -51,16 +51,15 @@ jobs:
       - name: Test
         run: make test
   validate-release:
+    if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
     timeout-minutes: 30
     runs-on: ubuntu-latest
     env:
       CGO_ENABLED: 0
     steps:
       - name: Checkout
-        if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
         uses: actions/checkout@v3
       - uses: actions/cache@v3
-        if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
         with:
           path: |
             ~/.cache/go-build
@@ -69,19 +68,16 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-go-1.19.5-release-cache-plugins-source-mixpanel
       - name: Set up Go
-        if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
         uses: actions/setup-go@v3
         with:
           go-version-file: plugins/source/mixpanel/go.mod
       - name: Install GoReleaser
-        if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
         uses: goreleaser/goreleaser-action@v3
         with:
           distribution: goreleaser-pro
           version: latest
           install-only: true
       - name: Run GoReleaser Dry-Run
-        if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
         run: goreleaser release --snapshot --clean --skip-validate --skip-publish --skip-sign -f ./plugins/source/mixpanel/.goreleaser.yaml
         env:
           GORELEASER_KEY: ${{ secrets.GORELEASER_KEY }}

--- a/.github/workflows/source_mysql.yml
+++ b/.github/workflows/source_mysql.yml
@@ -58,16 +58,15 @@ jobs:
       - name: Test mysql
         run: make test
   validate-release:
+    if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
     timeout-minutes: 30
     runs-on: ubuntu-latest
     env:
       CGO_ENABLED: 0
     steps:
       - name: Checkout
-        if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
         uses: actions/checkout@v3
       - uses: actions/cache@v3
-        if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
         with:
           path: |
             ~/.cache/go-build
@@ -76,19 +75,16 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-go-1.19.5-release-cache-plugins-source-mysql
       - name: Set up Go
-        if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
         uses: actions/setup-go@v3
         with:
           go-version-file: plugins/source/mysql/go.mod
       - name: Install GoReleaser
-        if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
         uses: goreleaser/goreleaser-action@v3
         with:
           distribution: goreleaser-pro
           version: latest
           install-only: true
       - name: Run GoReleaser Dry-Run
-        if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
         run: goreleaser release --snapshot --clean --skip-validate --skip-publish --skip-sign -f ./plugins/source/mysql/.goreleaser.yaml
         env:
           GORELEASER_KEY: ${{ secrets.GORELEASER_KEY }}

--- a/.github/workflows/source_okta.yml
+++ b/.github/workflows/source_okta.yml
@@ -51,16 +51,15 @@ jobs:
       - name: Test
         run: make test
   validate-release:
+    if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
     timeout-minutes: 30
     runs-on: ubuntu-latest
     env:
       CGO_ENABLED: 0
     steps:
       - name: Checkout
-        if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
         uses: actions/checkout@v3
       - uses: actions/cache@v3
-        if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
         with:
           path: |
             ~/.cache/go-build
@@ -69,19 +68,16 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-go-1.19.5-release-cache-plugins-source-okta
       - name: Set up Go
-        if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
         uses: actions/setup-go@v3
         with:
           go-version-file: plugins/source/okta/go.mod
       - name: Install GoReleaser
-        if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
         uses: goreleaser/goreleaser-action@v3
         with:
           distribution: goreleaser-pro
           version: latest
           install-only: true
       - name: Run GoReleaser Dry-Run
-        if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
         run: goreleaser release --snapshot --clean --skip-validate --skip-publish --skip-sign -f ./plugins/source/okta/.goreleaser.yaml
         env:
           GORELEASER_KEY: ${{ secrets.GORELEASER_KEY }}

--- a/.github/workflows/source_oracle.yml
+++ b/.github/workflows/source_oracle.yml
@@ -49,16 +49,15 @@ jobs:
       - name: Test
         run: make test
   validate-release:
+    if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
     timeout-minutes: 30
     runs-on: ubuntu-latest
     env:
       CGO_ENABLED: 0
     steps:
       - name: Checkout
-        if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
         uses: actions/checkout@v3
       - uses: actions/cache@v3
-        if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
         with:
           path: |
             ~/.cache/go-build
@@ -67,19 +66,16 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-go-1.19.5-release-cache-plugins-source-oracle
       - name: Set up Go
-        if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
         uses: actions/setup-go@v3
         with:
           go-version-file: plugins/source/oracle/go.mod
       - name: Install GoReleaser
-        if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
         uses: goreleaser/goreleaser-action@v3
         with:
           distribution: goreleaser-pro
           version: latest
           install-only: true
       - name: Run GoReleaser Dry-Run
-        if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
         run: goreleaser release --snapshot --clean --skip-validate --skip-publish --skip-sign -f ./plugins/source/oracle/.goreleaser.yaml
         env:
           GORELEASER_KEY: ${{ secrets.GORELEASER_KEY }}

--- a/.github/workflows/source_pagerduty.yml
+++ b/.github/workflows/source_pagerduty.yml
@@ -51,16 +51,15 @@ jobs:
       - name: Test
         run: make test
   validate-release:
+    if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
     timeout-minutes: 30
     runs-on: ubuntu-latest
     env:
       CGO_ENABLED: 0
     steps:
       - name: Checkout
-        if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
         uses: actions/checkout@v3
       - uses: actions/cache@v3
-        if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
         with:
           path: |
             ~/.cache/go-build
@@ -69,19 +68,16 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-go-1.19.5-release-cache-plugins-source-pagerduty
       - name: Set up Go
-        if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
         uses: actions/setup-go@v3
         with:
           go-version-file: plugins/source/pagerduty/go.mod
       - name: Install GoReleaser
-        if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
         uses: goreleaser/goreleaser-action@v3
         with:
           distribution: goreleaser-pro
           version: latest
           install-only: true
       - name: Run GoReleaser Dry-Run
-        if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
         run: goreleaser release --snapshot --clean --skip-validate --skip-publish --skip-sign -f ./plugins/source/pagerduty/.goreleaser.yaml
         env:
           GORELEASER_KEY: ${{ secrets.GORELEASER_KEY }}

--- a/.github/workflows/source_plausible.yml
+++ b/.github/workflows/source_plausible.yml
@@ -51,16 +51,15 @@ jobs:
       - name: Test
         run: make test
   validate-release:
+    if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
     timeout-minutes: 30
     runs-on: ubuntu-latest
     env:
       CGO_ENABLED: 0
     steps:
       - name: Checkout
-        if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
         uses: actions/checkout@v3
       - uses: actions/cache@v3
-        if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
         with:
           path: |
             ~/.cache/go-build
@@ -69,19 +68,16 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-go-1.19.5-release-cache-plugins-source-plausible
       - name: Set up Go
-        if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
         uses: actions/setup-go@v3
         with:
           go-version-file: plugins/source/plausible/go.mod
       - name: Install GoReleaser
-        if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
         uses: goreleaser/goreleaser-action@v3
         with:
           distribution: goreleaser-pro
           version: latest
           install-only: true
       - name: Run GoReleaser Dry-Run
-        if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
         run: goreleaser release --snapshot --clean --skip-validate --skip-publish --skip-sign -f ./plugins/source/plausible/.goreleaser.yaml
         env:
           GORELEASER_KEY: ${{ secrets.GORELEASER_KEY }}

--- a/.github/workflows/source_postgresql.yml
+++ b/.github/workflows/source_postgresql.yml
@@ -51,16 +51,15 @@ jobs:
       - name: Test PostgreSQL
         run: make test
   validate-release:
+    if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
     timeout-minutes: 30
     runs-on: ubuntu-latest
     env:
       CGO_ENABLED: 0
     steps:
       - name: Checkout
-        if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
         uses: actions/checkout@v3
       - uses: actions/cache@v3
-        if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
         with:
           path: |
             ~/.cache/go-build
@@ -69,19 +68,16 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-go-1.19.5-release-cache-plugins-source-postgresql
       - name: Set up Go
-        if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
         uses: actions/setup-go@v3
         with:
           go-version-file: plugins/source/postgresql/go.mod
       - name: Install GoReleaser
-        if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
         uses: goreleaser/goreleaser-action@v3
         with:
           distribution: goreleaser-pro
           version: latest
           install-only: true
       - name: Run GoReleaser Dry-Run
-        if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
         run: goreleaser release --snapshot --clean --skip-validate --skip-publish --skip-sign -f ./plugins/source/postgresql/.goreleaser.yaml
         env:
           GORELEASER_KEY: ${{ secrets.GORELEASER_KEY }}

--- a/.github/workflows/source_salesforce.yml
+++ b/.github/workflows/source_salesforce.yml
@@ -51,16 +51,15 @@ jobs:
       - name: Test
         run: make test
   validate-release:
+    if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
     timeout-minutes: 30
     runs-on: ubuntu-latest
     env:
       CGO_ENABLED: 0
     steps:
       - name: Checkout
-        if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
         uses: actions/checkout@v3
       - uses: actions/cache@v3
-        if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
         with:
           path: |
             ~/.cache/go-build
@@ -69,19 +68,16 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-go-1.19.5-release-cache-plugins-source-salesforce
       - name: Set up Go
-        if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
         uses: actions/setup-go@v3
         with:
           go-version-file: plugins/source/salesforce/go.mod
       - name: Install GoReleaser
-        if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
         uses: goreleaser/goreleaser-action@v3
         with:
           distribution: goreleaser-pro
           version: latest
           install-only: true
       - name: Run GoReleaser Dry-Run
-        if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
         run: goreleaser release --snapshot --clean --skip-validate --skip-publish --skip-sign -f ./plugins/source/salesforce/.goreleaser.yaml
         env:
           GORELEASER_KEY: ${{ secrets.GORELEASER_KEY }}

--- a/.github/workflows/source_shopify.yml
+++ b/.github/workflows/source_shopify.yml
@@ -51,16 +51,15 @@ jobs:
       - name: Test
         run: make test
   validate-release:
+    if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
     timeout-minutes: 30
     runs-on: ubuntu-latest
     env:
       CGO_ENABLED: 0
     steps:
       - name: Checkout
-        if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
         uses: actions/checkout@v3
       - uses: actions/cache@v3
-        if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
         with:
           path: |
             ~/.cache/go-build
@@ -69,19 +68,16 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-go-1.19.5-release-cache-plugins-source-shopify
       - name: Set up Go
-        if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
         uses: actions/setup-go@v3
         with:
           go-version-file: plugins/source/shopify/go.mod
       - name: Install GoReleaser
-        if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
         uses: goreleaser/goreleaser-action@v3
         with:
           distribution: goreleaser-pro
           version: latest
           install-only: true
       - name: Run GoReleaser Dry-Run
-        if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
         run: goreleaser release --snapshot --clean --skip-validate --skip-publish --skip-sign -f ./plugins/source/shopify/.goreleaser.yaml
         env:
           GORELEASER_KEY: ${{ secrets.GORELEASER_KEY }}

--- a/.github/workflows/source_slack.yml
+++ b/.github/workflows/source_slack.yml
@@ -51,16 +51,15 @@ jobs:
       - name: Test
         run: make test
   validate-release:
+    if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
     timeout-minutes: 30
     runs-on: ubuntu-latest
     env:
       CGO_ENABLED: 0
     steps:
       - name: Checkout
-        if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
         uses: actions/checkout@v3
       - uses: actions/cache@v3
-        if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
         with:
           path: |
             ~/.cache/go-build
@@ -69,19 +68,16 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-go-1.19.5-release-cache-plugins-source-slack
       - name: Set up Go
-        if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
         uses: actions/setup-go@v3
         with:
           go-version-file: plugins/source/slack/go.mod
       - name: Install GoReleaser
-        if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
         uses: goreleaser/goreleaser-action@v3
         with:
           distribution: goreleaser-pro
           version: latest
           install-only: true
       - name: Run GoReleaser Dry-Run
-        if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
         run: goreleaser release --snapshot --clean --skip-validate --skip-publish --skip-sign -f ./plugins/source/slack/.goreleaser.yaml
         env:
           GORELEASER_KEY: ${{ secrets.GORELEASER_KEY }}

--- a/.github/workflows/source_snyk.yml
+++ b/.github/workflows/source_snyk.yml
@@ -49,16 +49,15 @@ jobs:
       - name: Test
         run: make test
   validate-release:
+    if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
     timeout-minutes: 30
     runs-on: ubuntu-latest
     env:
       CGO_ENABLED: 0
     steps:
       - name: Checkout
-        if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
         uses: actions/checkout@v3
       - uses: actions/cache@v3
-        if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
         with:
           path: |
             ~/.cache/go-build
@@ -67,19 +66,16 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-go-1.19.5-release-cache-plugins-source-snyk
       - name: Set up Go
-        if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
         uses: actions/setup-go@v3
         with:
           go-version-file: plugins/source/snyk/go.mod
       - name: Install GoReleaser
-        if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
         uses: goreleaser/goreleaser-action@v3
         with:
           distribution: goreleaser-pro
           version: latest
           install-only: true
       - name: Run GoReleaser Dry-Run
-        if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
         run: goreleaser release --snapshot --clean --skip-validate --skip-publish --skip-sign -f ./plugins/source/snyk/.goreleaser.yaml
         env:
           GORELEASER_KEY: ${{ secrets.GORELEASER_KEY }}

--- a/.github/workflows/source_stripe.yml
+++ b/.github/workflows/source_stripe.yml
@@ -49,16 +49,15 @@ jobs:
       - name: Test
         run: make test
   validate-release:
+    if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
     timeout-minutes: 30
     runs-on: ubuntu-latest
     env:
       CGO_ENABLED: 0
     steps:
       - name: Checkout
-        if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
         uses: actions/checkout@v3
       - uses: actions/cache@v3
-        if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
         with:
           path: |
             ~/.cache/go-build
@@ -67,19 +66,16 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-go-1.19.5-release-cache-plugins-source-stripe
       - name: Set up Go
-        if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
         uses: actions/setup-go@v3
         with:
           go-version-file: plugins/source/stripe/go.mod
       - name: Install GoReleaser
-        if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
         uses: goreleaser/goreleaser-action@v3
         with:
           distribution: goreleaser-pro
           version: latest
           install-only: true
       - name: Run GoReleaser Dry-Run
-        if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
         run: goreleaser release --snapshot --clean --skip-validate --skip-publish --skip-sign -f ./plugins/source/stripe/.goreleaser.yaml
         env:
           GORELEASER_KEY: ${{ secrets.GORELEASER_KEY }}

--- a/.github/workflows/source_tailscale.yml
+++ b/.github/workflows/source_tailscale.yml
@@ -51,16 +51,15 @@ jobs:
       - name: Test
         run: make test
   validate-release:
+    if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
     timeout-minutes: 30
     runs-on: ubuntu-latest
     env:
       CGO_ENABLED: 0
     steps:
       - name: Checkout
-        if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
         uses: actions/checkout@v3
       - uses: actions/cache@v3
-        if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
         with:
           path: |
             ~/.cache/go-build
@@ -69,19 +68,16 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-go-1.19.5-release-cache-plugins-source-tailscale
       - name: Set up Go
-        if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
         uses: actions/setup-go@v3
         with:
           go-version-file: plugins/source/tailscale/go.mod
       - name: Install GoReleaser
-        if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
         uses: goreleaser/goreleaser-action@v3
         with:
           distribution: goreleaser-pro
           version: latest
           install-only: true
       - name: Run GoReleaser Dry-Run
-        if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
         run: goreleaser release --snapshot --clean --skip-validate --skip-publish --skip-sign -f ./plugins/source/tailscale/.goreleaser.yaml
         env:
           GORELEASER_KEY: ${{ secrets.GORELEASER_KEY }}

--- a/.github/workflows/source_terraform.yml
+++ b/.github/workflows/source_terraform.yml
@@ -51,16 +51,15 @@ jobs:
       - name: Test
         run: make test
   validate-release:
+    if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
     timeout-minutes: 30
     runs-on: ubuntu-latest
     env:
       CGO_ENABLED: 0
     steps:
       - name: Checkout
-        if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
         uses: actions/checkout@v3
       - uses: actions/cache@v3
-        if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
         with:
           path: |
             ~/.cache/go-build
@@ -69,19 +68,16 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-go-1.19.5-release-cache-plugins-source-terraform
       - name: Set up Go
-        if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
         uses: actions/setup-go@v3
         with:
           go-version-file: plugins/source/terraform/go.mod
       - name: Install GoReleaser
-        if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
         uses: goreleaser/goreleaser-action@v3
         with:
           distribution: goreleaser-pro
           version: latest
           install-only: true
       - name: Run GoReleaser Dry-Run
-        if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
         run: goreleaser release --snapshot --clean --skip-validate --skip-publish --skip-sign -f ./plugins/source/terraform/.goreleaser.yaml
         env:
           GORELEASER_KEY: ${{ secrets.GORELEASER_KEY }}

--- a/.github/workflows/source_test.yml
+++ b/.github/workflows/source_test.yml
@@ -51,16 +51,15 @@ jobs:
       - name: Test
         run: make test
   validate-release:
+    if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
     timeout-minutes: 30
     runs-on: ubuntu-latest
     env:
       CGO_ENABLED: 0
     steps:
       - name: Checkout
-        if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
         uses: actions/checkout@v3
       - uses: actions/cache@v3
-        if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
         with:
           path: |
             ~/.cache/go-build
@@ -69,19 +68,16 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-go-1.19.5-release-cache-plugins-source-test
       - name: Set up Go
-        if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
         uses: actions/setup-go@v3
         with:
           go-version-file: plugins/source/test/go.mod
       - name: Install GoReleaser
-        if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
         uses: goreleaser/goreleaser-action@v3
         with:
           distribution: goreleaser-pro
           version: latest
           install-only: true
       - name: Run GoReleaser Dry-Run
-        if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
         run: goreleaser release --snapshot --clean --skip-validate --skip-publish --skip-sign -f ./plugins/source/test/.goreleaser.yaml
         env:
           GORELEASER_KEY: ${{ secrets.GORELEASER_KEY }}

--- a/.github/workflows/source_vercel.yml
+++ b/.github/workflows/source_vercel.yml
@@ -51,16 +51,15 @@ jobs:
       - name: Test
         run: make test
   validate-release:
+    if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
     timeout-minutes: 30
     runs-on: ubuntu-latest
     env:
       CGO_ENABLED: 0
     steps:
       - name: Checkout
-        if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
         uses: actions/checkout@v3
       - uses: actions/cache@v3
-        if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
         with:
           path: |
             ~/.cache/go-build
@@ -69,19 +68,16 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-go-1.19.5-release-cache-plugins-source-vercel
       - name: Set up Go
-        if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
         uses: actions/setup-go@v3
         with:
           go-version-file: plugins/source/vercel/go.mod
       - name: Install GoReleaser
-        if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
         uses: goreleaser/goreleaser-action@v3
         with:
           distribution: goreleaser-pro
           version: latest
           install-only: true
       - name: Run GoReleaser Dry-Run
-        if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
         run: goreleaser release --snapshot --clean --skip-validate --skip-publish --skip-sign -f ./plugins/source/vercel/.goreleaser.yaml
         env:
           GORELEASER_KEY: ${{ secrets.GORELEASER_KEY }}

--- a/.github/workflows/wait_for_required_workflows.yml
+++ b/.github/workflows/wait_for_required_workflows.yml
@@ -81,7 +81,7 @@ jobs:
               const runs = checkRuns.map(({ name, conclusion }) => ({ name, conclusion }))
               console.log(`Got the following check runs: ${JSON.stringify(runs)}`)
               const matchingRuns = runs.filter(({ name }) => actions.includes(name))
-              const failedRuns = matchingRuns.filter(({ conclusion }) => conclusion !== 'success')
+              const failedRuns = matchingRuns.filter(({ conclusion }) => conclusion !== 'success' && conclusion !== 'skipped')
               if (failedRuns.length > 0) {
                 throw new Error(`The following required workflows failed: ${failedRuns.map(({ name }) => name).join(", ")}`)
               }

--- a/.github/workflows/wait_for_required_workflows.yml
+++ b/.github/workflows/wait_for_required_workflows.yml
@@ -18,7 +18,7 @@ jobs:
       - uses: actions/github-script@v6
         env:
           FILES: ${{ steps.changed-files.outputs.all }}
-          CAN_SKIP: |
+          CAN_SKIP: >-
             validate-release
         with:
           script: |

--- a/.github/workflows/wait_for_required_workflows.yml
+++ b/.github/workflows/wait_for_required_workflows.yml
@@ -18,13 +18,15 @@ jobs:
       - uses: actions/github-script@v6
         env:
           FILES: ${{ steps.changed-files.outputs.all }}
-          CAN_SKIP: validate-release
+          CAN_SKIP: |
+            validate-release
         with:
           script: |
             const fs = require("fs");
             const files = process.env.FILES.split(' ')
-            const can_skip = process.env.CAN_SKIP.split(' ')
             console.log(files)
+            const can_skip = process.env.CAN_SKIP.split(' ')
+            console.log(can_skip)
             if (files.length >= 300) {
               // This is a GitHub limitation https://github.com/cloudquery/cloudquery/issues/2688
               throw new Error('Too many files changed. Skipping check. Please split your PR into multiple ones.')

--- a/.github/workflows/wait_for_required_workflows.yml
+++ b/.github/workflows/wait_for_required_workflows.yml
@@ -18,10 +18,12 @@ jobs:
       - uses: actions/github-script@v6
         env:
           FILES: ${{ steps.changed-files.outputs.all }}
+          CAN_SKIP: validate-release
         with:
           script: |
             const fs = require("fs");
             const files = process.env.FILES.split(' ')
+            const can_skip = process.env.CAN_SKIP.split(' ')
             console.log(files)
             if (files.length >= 300) {
               // This is a GitHub limitation https://github.com/cloudquery/cloudquery/issues/2688
@@ -81,7 +83,7 @@ jobs:
               const runs = checkRuns.map(({ name, conclusion }) => ({ name, conclusion }))
               console.log(`Got the following check runs: ${JSON.stringify(runs)}`)
               const matchingRuns = runs.filter(({ name }) => actions.includes(name))
-              const failedRuns = matchingRuns.filter(({ conclusion }) => conclusion !== 'success' && conclusion !== 'skipped')
+              const failedRuns = matchingRuns.filter(({ name, conclusion }) => !(conclusion == 'success' || (can_skip.includes(name) && conclusion == 'skipped')))
               if (failedRuns.length > 0) {
                 throw new Error(`The following required workflows failed: ${failedRuns.map(({ name }) => name).join(", ")}`)
               }


### PR DESCRIPTION
Extracted from #9656.
Allows to skip `validate-release` job entirely (not using any runner) while not failing `waif-for-required-workflows`

### Note on `wait-for-required-workflows` change
Instead of skipping every step in `validate-release` job (that still will result in job running) I moved the `if` section to the `job` level, allowing to skip the entire job.
However, this requires `wait-for-required-workflows` to accept the `skipped` status as well.