### PR TITLE
chore: Change behavior for changing ordering

### DIFF
--- a/scripts/table_diff/changes/changes.go
+++ b/scripts/table_diff/changes/changes.go
@@ -8,6 +8,8 @@ import (
 	"strings"
 
 	"github.com/bluekeyes/go-gitdiff/gitdiff"
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
 )
 
 var (
@@ -175,9 +177,9 @@ func getColumnChanges(file *gitdiff.File, table string) (changes []change) {
 			})
 		}
 	}
-
-	// check PK:
-	if len(addedPK) > 0 && len(addedPK) == len(deletedPK) {
+	ordering := func(a, b string) bool { return a < b }
+	diff := cmp.Diff(addedPK, deletedPK, cmpopts.SortSlices(ordering))
+	if len(addedPK) > 0 && diff == "" {
 		// if they are unequal the pk added/removed is correct.
 		changes = append(changes, change{
 			Text: fmt.Sprintf("Table %s: primary key order changed from %s to %s",

--- a/scripts/table_diff/changes/changes_test.go
+++ b/scripts/table_diff/changes/changes_test.go
@@ -189,15 +189,15 @@ func Test_getChanges(t *testing.T) {
 			wantChanges: []change{
 				{
 					Text:     "Table `gcp_resourcemanager_projects`: primary key constraint added to column `name`",
-					Breaking: false,
+					Breaking: true,
 				},
 				{
 					Text:     "Table `gcp_resourcemanager_projects`: primary key constraint added to column `project_id`",
-					Breaking: false,
+					Breaking: true,
 				},
 				{
 					Text:     "Table `gcp_resourcemanager_projects`: primary key constraint removed from column `_cq_id`",
-					Breaking: false,
+					Breaking: true,
 				},
 			},
 		},
@@ -211,15 +211,29 @@ func Test_getChanges(t *testing.T) {
 				},
 				{
 					Text:     "Table `aws_ses_configuration_sets`: primary key constraint removed from column `account_id`",
-					Breaking: false,
+					Breaking: true,
 				},
 				{
 					Text:     "Table `aws_ses_configuration_sets`: primary key constraint removed from column `name`",
-					Breaking: false,
+					Breaking: true,
 				},
 				{
 					Text:     "Table `aws_ses_configuration_sets`: primary key constraint removed from column `region`",
-					Breaking: false,
+					Breaking: true,
+				},
+			},
+		},
+		{
+			name:         "Should mark PK order change as breaking",
+			diffDataFile: "testdata/pr_9677_diff.txt",
+			wantChanges: []change{
+				{
+					Text:     "Table `aws_iam_users`: column `id` removed from table",
+					Breaking: true,
+				},
+				{
+					Text:     "Table `aws_iam_users`: primary key constraint added to column `arn`",
+					Breaking: true,
 				},
 			},
 		},

--- a/scripts/table_diff/changes/testdata/pr_9677_diff.txt
+++ b/scripts/table_diff/changes/testdata/pr_9677_diff.txt
@@ -1,0 +1,24 @@
+diff --git a/website/tables/aws/aws_iam_users.md b/website/tables/aws/aws_iam_users.md
+index bd0e89a9e633..6dea1f5e8277 100644
+--- a/website/tables/aws/aws_iam_users.md
++++ b/website/tables/aws/aws_iam_users.md
+@@ -4,7 +4,7 @@ This table shows data for IAM Users.
+ 
+ https://docs.aws.amazon.com/IAM/latest/APIReference/API_User.html
+ 
+-The composite primary key for this table is (**id**, **account_id**).
++The composite primary key for this table is (**account_id**, **arn**).
+ 
+ ## Relations
+ 
+@@ -25,9 +25,8 @@ The following tables depend on aws_iam_users:
+ |_cq_sync_time|Timestamp|
+ |_cq_id|UUID|
+ |_cq_parent_id|UUID|
+-|arn|String|
+-|id (PK)|String|
+ |account_id (PK)|String|
++|arn (PK)|String|
+ |tags|JSON|
+ |create_date|Timestamp|
+ |path|String|

--- a/scripts/table_diff/go.mod
+++ b/scripts/table_diff/go.mod
@@ -4,6 +4,7 @@ go 1.19
 
 require (
 	github.com/bluekeyes/go-gitdiff v0.7.1
+	github.com/google/go-cmp v0.5.9
 	github.com/stretchr/testify v1.8.2
 )
 

--- a/scripts/table_diff/go.sum
+++ b/scripts/table_diff/go.sum
@@ -3,6 +3,8 @@ github.com/bluekeyes/go-gitdiff v0.7.1/go.mod h1:QpfYYO1E0fTVHVZAZKiRjtSGY9823iC
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/google/go-cmp v0.5.9 h1:O2Tfq5qg4qc4AmwVlvv0oLiVAGB7enBSJ2x2DqQFi38=
+github.com/google/go-cmp v0.5.9/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=


### PR DESCRIPTION
<!-- 🎉 Thank you for making CloudQuery awesome by submitting a PR 🎉 -->

#### Summary

When a table has 2 Primary keys and we replace 1 of them the current implementation marks it as breaking because the order has changed. This PR validates that all of the pks before and after are exactly the same, but just in a different order.
