### PR TITLE
fix(aws)!: Add Columns to `aws_ec2_subnets` Primary Key to handle when subnet is shared

### DIFF
--- a/plugins/source/aws/resources/services/ec2/subnets.go
+++ b/plugins/source/aws/resources/services/ec2/subnets.go
@@ -3,7 +3,6 @@ package ec2
 import (
 	"context"
 
-	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/ec2"
 	"github.com/aws/aws-sdk-go-v2/service/ec2/types"
 	"github.com/cloudquery/cloudquery/plugins/source/aws/client"
@@ -14,14 +13,25 @@ import (
 func Subnets() *schema.Table {
 	tableName := "aws_ec2_subnets"
 	return &schema.Table{
-		Name:        tableName,
-		Description: `https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_Subnet.html`,
-		Resolver:    fetchEc2Subnets,
-		Multiplex:   client.ServiceAccountRegionMultiplexer(tableName, "ec2"),
-		Transform:   transformers.TransformWithStruct(&types.Subnet{}),
+		Name: tableName,
+		Description: `https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_Subnet.html
+The 'request_account_id' and 'request_region' columns are added to show from where the request was made.`,
+		Resolver:  fetchEc2Subnets,
+		Multiplex: client.ServiceAccountRegionMultiplexer(tableName, "ec2"),
+		Transform: transformers.TransformWithStruct(&types.Subnet{}),
 		Columns: []schema.Column{
-			client.DefaultAccountIDColumn(false),
-			client.DefaultRegionColumn(false),
+			{
+				Name:            "request_account_id",
+				Type:            schema.TypeString,
+				Resolver:        client.ResolveAWSAccount,
+				CreationOptions: schema.ColumnCreationOptions{PrimaryKey: true},
+			},
+			{
+				Name:            "request_region",
+				Type:            schema.TypeString,
+				Resolver:        client.ResolveAWSRegion,
+				CreationOptions: schema.ColumnCreationOptions{PrimaryKey: true},
+			},
 			{
 				Name:     "arn",
 				Type:     schema.TypeString,
@@ -40,19 +50,14 @@ func Subnets() *schema.Table {
 }
 
 func fetchEc2Subnets(ctx context.Context, meta schema.ClientMeta, parent *schema.Resource, res chan<- any) error {
-	var config ec2.DescribeSubnetsInput
-	c := meta.(*client.Client)
-	svc := c.Services().Ec2
-	for {
-		output, err := svc.DescribeSubnets(ctx, &config)
+	svc := meta.(*client.Client).Services().Ec2
+	paginator := ec2.NewDescribeSubnetsPaginator(svc, &ec2.DescribeSubnetsInput{})
+	for paginator.HasMorePages() {
+		page, err := paginator.NextPage(ctx)
 		if err != nil {
 			return err
 		}
-		res <- output.Subnets
-		if aws.ToString(output.NextToken) == "" {
-			break
-		}
-		config.NextToken = output.NextToken
+		res <- page.Subnets
 	}
 	return nil
 }

--- a/website/tables/aws/aws_ec2_subnets.md
+++ b/website/tables/aws/aws_ec2_subnets.md
@@ -3,8 +3,9 @@
 This table shows data for Amazon Elastic Compute Cloud (EC2) Subnets.
 
 https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_Subnet.html
+The 'request_account_id' and 'request_region' columns are added to show from where the request was made.
 
-The primary key for this table is **arn**.
+The composite primary key for this table is (**request_account_id**, **request_region**, **arn**).
 
 ## Columns
 
@@ -14,8 +15,8 @@ The primary key for this table is **arn**.
 |_cq_sync_time|Timestamp|
 |_cq_id|UUID|
 |_cq_parent_id|UUID|
-|account_id|String|
-|region|String|
+|request_account_id (PK)|String|
+|request_region (PK)|String|
 |arn (PK)|String|
 |tags|JSON|
 |assign_ipv6_address_on_creation|Bool|


### PR DESCRIPTION
<!-- 🎉 Thank you for making CloudQuery awesome by submitting a PR 🎉 -->

#### Summary

Fix primary to handle when it is accessible from multiple accounts via [AWS RAM](https://docs.aws.amazon.com/vpc/latest/userguide/vpc-sharing.html#vpc-sharing-share-subnet)