### PR TITLE
fix(aws)!: Update Primary Keys for `aws_organizations_accounts`

### DIFF
--- a/plugins/source/aws/resources/services/organizations/accounts.go
+++ b/plugins/source/aws/resources/services/organizations/accounts.go
@@ -13,13 +13,19 @@ import (
 func Accounts() *schema.Table {
 	tableName := "aws_organizations_accounts"
 	return &schema.Table{
-		Name:        tableName,
-		Description: `https://docs.aws.amazon.com/organizations/latest/APIReference/API_Account.html`,
-		Resolver:    fetchOrganizationsAccounts,
-		Transform:   transformers.TransformWithStruct(&types.Account{}, transformers.WithPrimaryKeys("Arn")),
-		Multiplex:   client.ServiceAccountRegionMultiplexer(tableName, "organizations"),
+		Name: tableName,
+		Description: `https://docs.aws.amazon.com/organizations/latest/APIReference/API_Account.html
+The 'request_account_id' column is added to show from where the request was made.`,
+		Resolver:  fetchOrganizationsAccounts,
+		Transform: transformers.TransformWithStruct(&types.Account{}, transformers.WithPrimaryKeys("Arn")),
+		Multiplex: client.ServiceAccountRegionMultiplexer(tableName, "organizations"),
 		Columns: []schema.Column{
-			client.DefaultAccountIDColumn(false),
+			{
+				Name:            "request_account_id",
+				Type:            schema.TypeString,
+				Resolver:        client.ResolveAWSAccount,
+				CreationOptions: schema.ColumnCreationOptions{PrimaryKey: true},
+			},
 			{
 				Name:     "tags",
 				Type:     schema.TypeJSON,

--- a/website/tables/aws/aws_organizations_accounts.md
+++ b/website/tables/aws/aws_organizations_accounts.md
@@ -3,8 +3,9 @@
 This table shows data for Organizations Accounts.
 
 https://docs.aws.amazon.com/organizations/latest/APIReference/API_Account.html
+The 'request_account_id' column is added to show from where the request was made.
 
-The primary key for this table is **arn**.
+The composite primary key for this table is (**request_account_id**, **arn**).
 
 ## Relations
 
@@ -19,7 +20,7 @@ The following tables depend on aws_organizations_accounts:
 |_cq_sync_time|Timestamp|
 |_cq_id|UUID|
 |_cq_parent_id|UUID|
-|account_id|String|
+|request_account_id (PK)|String|
 |tags|JSON|
 |arn (PK)|String|
 |email|String|


### PR DESCRIPTION
<!-- 🎉 Thank you for making CloudQuery awesome by submitting a PR 🎉 -->

#### Summary

Any account in an organization can have access to call `organizations:ListAccounts` this means that if a user is syncing multiple accounts at once you can have duplication without a primary key on the `request_account_id`