### PR TITLE
feat(workflows): Reuse `validate-release`

### DIFF
--- a/.github/workflows/cli.yml
+++ b/.github/workflows/cli.yml
@@ -74,38 +74,9 @@ jobs:
         if: matrix.os == 'ubuntu-latest'
         run: test "$(git status -s ../website/pages/docs/reference/cli/*.md | wc -l)" -eq 0
   validate-release:
-    timeout-minutes: 30
-    needs: [resolve-runner]
-    runs-on: ${{ needs.resolve-runner.outputs.runner }}
-    env:
-      CGO_ENABLED: 0
-    steps:
-      - name: Checkout
-        if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
-        uses: actions/checkout@v3
-      - uses: actions/cache@v3
-        if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
-        with:
-          path: |
-            ~/.cache/go-build
-            ~/go/pkg/mod
-          key: ${{ runner.os }}-go-1.19.5-release-cache-${{ hashFiles('cli/go.sum') }}
-          restore-keys: |
-            ${{ runner.os }}-go-1.19.5-release-cache-cli
-      - name: Set up Go
-        if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
-        uses: actions/setup-go@v3
-        with:
-          go-version-file: cli/go.mod
-      - name: Install GoReleaser
-        if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
-        uses: goreleaser/goreleaser-action@v3
-        with:
-          distribution: goreleaser-pro
-          version: latest
-          install-only: true
-      - name: Run GoReleaser Dry-Run
-        if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
-        run: goreleaser release --snapshot --clean --skip-validate --skip-publish --skip-sign -f ./cli/.goreleaser.yaml
-        env:
-          GORELEASER_KEY: ${{ secrets.GORELEASER_KEY }}
+    if:   startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
+    needs: [ resolve-runner ]
+    uses: ./.github/workflows/validate_release.yml
+    with:
+      path:   cli
+      runner: ${{ needs.resolve-runner.outputs.runner }}

--- a/.github/workflows/cli.yml
+++ b/.github/workflows/cli.yml
@@ -5,12 +5,14 @@ on:
     paths:
       - "cli/**"
       - ".github/workflows/cli.yml"
+      - .github/workflows/validate_release.yml
   push:
     branches:
       - main
     paths:
       - "cli/**"
       - ".github/workflows/cli.yml"
+      - .github/workflows/validate_release.yml
 
 jobs:
   resolve-runner:

--- a/.github/workflows/dest_azblob.yml
+++ b/.github/workflows/dest_azblob.yml
@@ -5,12 +5,14 @@ on:
     paths:
       - "plugins/destination/azblob/**"
       - ".github/workflows/dest_azblob.yml"
+      - ".github/workflows/validate_release.yml"
   push:
     branches:
       - main
     paths:
       - "plugins/destination/azblob/**"
       - ".github/workflows/dest_azblob.yml"
+      - ".github/workflows/validate_release.yml"
 
 jobs:
   plugins-destination-azblob:

--- a/.github/workflows/dest_azblob.yml
+++ b/.github/workflows/dest_azblob.yml
@@ -49,37 +49,7 @@ jobs:
           AZURE_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
           AZURE_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
   validate-release:
-    timeout-minutes: 30
-    runs-on: ubuntu-latest
-    env:
-      CGO_ENABLED: 0
-    steps:
-      - name: Checkout
-        if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
-        uses: actions/checkout@v3
-      - uses: actions/cache@v3
-        if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
-        with:
-          path: |
-            ~/.cache/go-build
-            ~/go/pkg/mod
-          key: ${{ runner.os }}-go-1.19.5-release-cache-${{ hashFiles('plugins/destination/azblob/go.sum') }}
-          restore-keys: |
-            ${{ runner.os }}-go-1.19.5-release-cache-plugins-destination-azblob
-      - name: Set up Go
-        if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
-        uses: actions/setup-go@v3
-        with:
-          go-version-file: plugins/destination/azblob/go.mod
-      - name: Install GoReleaser
-        if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
-        uses: goreleaser/goreleaser-action@v3
-        with:
-          distribution: goreleaser-pro
-          version: latest
-          install-only: true
-      - name: Run GoReleaser Dry-Run
-        if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
-        run: goreleaser release --snapshot --clean --skip-validate --skip-publish --skip-sign -f ./plugins/destination/azblob/.goreleaser.yaml
-        env:
-          GORELEASER_KEY: ${{ secrets.GORELEASER_KEY }}
+    if:   startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
+    uses: ./.github/workflows/validate_release.yml
+    with:
+      path: plugins/destination/azblob

--- a/.github/workflows/dest_bigquery.yml
+++ b/.github/workflows/dest_bigquery.yml
@@ -5,12 +5,14 @@ on:
     paths:
       - "plugins/destination/bigquery/**"
       - ".github/workflows/dest_bigquery.yml"
+      - ".github/workflows/validate_release.yml"
   push:
     branches:
       - main
     paths:
       - "plugins/destination/bigquery/**"
       - ".github/workflows/dest_bigquery.yml"
+      - ".github/workflows/validate_release.yml"
 
 jobs:
   plugins-destination-bigquery:

--- a/.github/workflows/dest_bigquery.yml
+++ b/.github/workflows/dest_bigquery.yml
@@ -59,35 +59,7 @@ jobs:
           BIGQUERY_PROJECT_ID: ${{ secrets.BIGQUERY_TEST_PROJECT_ID }}
           BIGQUERY_DATASET_ID: ${{ secrets.BIGQUERY_TEST_DATASET_ID }}
   validate-release:
-    timeout-minutes: 30
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
-        uses: actions/checkout@v3
-      - uses: actions/cache@v3
-        if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
-        with:
-          path: |
-            ~/.cache/go-build
-            ~/go/pkg/mod
-          key: ${{ runner.os }}-go-1.19.5-release-cache-${{ hashFiles('plugins/destination/bigquery/go.sum') }}
-          restore-keys: |
-            ${{ runner.os }}-go-1.19.5-release-cache-plugins-destination-bigquery
-      - name: Set up Go
-        if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
-        uses: actions/setup-go@v3
-        with:
-          go-version-file: plugins/destination/bigquery/go.mod
-      - name: Install GoReleaser
-        if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
-        uses: goreleaser/goreleaser-action@v3
-        with:
-          distribution: goreleaser-pro
-          version: latest
-          install-only: true
-      - name: Run GoReleaser Dry-Run
-        if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
-        run: goreleaser release --snapshot --clean --skip-validate --skip-publish --skip-sign -f ./plugins/destination/bigquery/.goreleaser.yaml
-        env:
-          GORELEASER_KEY: ${{ secrets.GORELEASER_KEY }}
+    if:   startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
+    uses: ./.github/workflows/validate_release.yml
+    with:
+      path: plugins/destination/bigquery

--- a/.github/workflows/dest_clickhouse.yml
+++ b/.github/workflows/dest_clickhouse.yml
@@ -5,12 +5,14 @@ on:
     paths:
     - plugins/destination/clickhouse/**
     - .github/workflows/dest_clickhouse.yml
+    - .github/workflows/validate_release.yml
   push:
     branches:
     - main
     paths:
     - plugins/destination/clickhouse/**
     - .github/workflows/dest_clickhouse.yml
+    - .github/workflows/validate_release.yml
 
 jobs:
   plugins-destination-clickhouse:

--- a/.github/workflows/dest_clickhouse.yml
+++ b/.github/workflows/dest_clickhouse.yml
@@ -69,37 +69,7 @@ jobs:
         CQ_DEST_CH_TEST_CONN: "clickhouse://${{ env.DB_USER }}:${{ env.DB_PASSWORD }}@localhost:9000/${{ env.DB_NAME }}"
       run:  make test
   validate-release:
-    timeout-minutes: 30
-    runs-on:         ubuntu-latest
-    env:
-      CGO_ENABLED: 0
-    steps:
-    - name: Checkout
-      if:   startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
-      uses: actions/checkout@v3
-    - uses: actions/cache@v3
-      if:   startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
-      with:
-        path:         |
-                      ~/.cache/go-build
-                      ~/go/pkg/mod
-        key:          ${{ runner.os }}-go-1.19.4-release-cache-${{ hashFiles('plugins/destination/clickhouse/go.sum') }}
-        restore-keys: |
-                      ${{ runner.os }}-go-1.19.4-release-cache-plugins-destination-clickhouse
-    - name: Set up Go
-      if:   startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
-      uses: actions/setup-go@v3
-      with:
-        go-version-file: plugins/destination/clickhouse/go.mod
-    - name: Install GoReleaser
-      if:   startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
-      uses: goreleaser/goreleaser-action@v3
-      with:
-        distribution: goreleaser-pro
-        version:      latest
-        install-only: true
-    - name: Run GoReleaser Dry-Run
-      if:   startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
-      run:  goreleaser release --snapshot --rm-dist --skip-validate --skip-publish --skip-sign -f ./plugins/destination/clickhouse/.goreleaser.yaml
-      env:
-        GORELEASER_KEY: ${{ secrets.GORELEASER_KEY }}
+    if:   startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
+    uses: ./.github/workflows/validate_release.yml
+    with:
+      path: plugins/destination/clickhouse

--- a/.github/workflows/dest_csv.yml
+++ b/.github/workflows/dest_csv.yml
@@ -45,37 +45,7 @@ jobs:
       - name: Test
         run: make test
   validate-release:
-    timeout-minutes: 30
-    runs-on: ubuntu-latest
-    env:
-      CGO_ENABLED: 0
-    steps:
-      - name: Checkout
-        if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
-        uses: actions/checkout@v3
-      - uses: actions/cache@v3
-        if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
-        with:
-          path: |
-            ~/.cache/go-build
-            ~/go/pkg/mod
-          key: ${{ runner.os }}-go-1.19.5-release-cache-${{ hashFiles('plugins/destination/csv/go.sum') }}
-          restore-keys: |
-            ${{ runner.os }}-go-1.19.5-release-cache-plugins-destination-csv
-      - name: Set up Go
-        if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
-        uses: actions/setup-go@v3
-        with:
-          go-version-file: plugins/destination/csv/go.mod
-      - name: Install GoReleaser
-        if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
-        uses: goreleaser/goreleaser-action@v3
-        with:
-          distribution: goreleaser-pro
-          version: latest
-          install-only: true
-      - name: Run GoReleaser Dry-Run
-        if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
-        run: goreleaser release --snapshot --clean --skip-validate --skip-publish --skip-sign -f ./plugins/destination/csv/.goreleaser.yaml
-        env:
-          GORELEASER_KEY: ${{ secrets.GORELEASER_KEY }}
+    if:   startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
+    uses: ./.github/workflows/validate_release.yml
+    with:
+      path: plugins/destination/csv

--- a/.github/workflows/dest_csv.yml
+++ b/.github/workflows/dest_csv.yml
@@ -5,12 +5,14 @@ on:
     paths:
       - "plugins/destination/csv/**"
       - ".github/workflows/dest_csv.yml"
+      - .github/workflows/validate_release.yml
   push:
     branches:
       - main
     paths:
       - "plugins/destination/csv/**"
       - ".github/workflows/dest_csv.yml"
+      - .github/workflows/validate_release.yml
 
 jobs:
   plugins-destination-csv:

--- a/.github/workflows/dest_duckdb.yml
+++ b/.github/workflows/dest_duckdb.yml
@@ -5,12 +5,14 @@ on:
     paths:
       - "plugins/destination/duckdb/**"
       - ".github/workflows/dest_duckdb.yml"
+      - .github/workflows/validate_release_cgo.yml
   push:
     branches:
       - main
     paths:
       - "plugins/destination/duckdb/**"
       - ".github/workflows/dest_duckdb.yml"
+      - .github/workflows/validate_release_cgo.yml
 
 jobs:
   plugins-destination-duckdb:

--- a/.github/workflows/dest_duckdb.yml
+++ b/.github/workflows/dest_duckdb.yml
@@ -45,39 +45,7 @@ jobs:
       - name: Test
         run: make test
   validate-release:
-    timeout-minutes: 30
-    runs-on: ubuntu-latest
-    container:
-      image: ghcr.io/cloudquery/golang-cross:v10.0.0
-      env:
-        CGO_ENABLED: 1
-    steps:
-      - name: Checkout
-        if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
-        uses: actions/checkout@v3
-      - uses: actions/cache@v3
-        if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
-        with:
-          path: |
-            ~/.cache/go-build
-            ~/go/pkg/mod
-          key: ${{ runner.os }}-go-1.19.5-release-cache-${{ hashFiles('plugins/destination/duckdb/go.sum') }}
-          restore-keys: |
-            ${{ runner.os }}-go-1.19.5-release-cache-plugins-destination-duckdb
-      - name: Set up Go
-        if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
-        uses: actions/setup-go@v3
-        with:
-          go-version-file: plugins/destination/duckdb/go.mod
-      - name: Install GoReleaser
-        if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
-        uses: goreleaser/goreleaser-action@v3
-        with:
-          distribution: goreleaser-pro
-          version: latest
-          install-only: true
-      - name: Run GoReleaser Dry-Run
-        if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
-        run: goreleaser release --snapshot --clean --skip-validate --skip-publish --skip-sign -f ./plugins/destination/duckdb/.goreleaser.yaml
-        env:
-          GORELEASER_KEY: ${{ secrets.GORELEASER_KEY }}
+    if:   startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
+    uses: ./.github/workflows/validate_release_cgo.yml
+    with:
+      path: plugins/destination/duckdb

--- a/.github/workflows/dest_elasticsearch.yml
+++ b/.github/workflows/dest_elasticsearch.yml
@@ -5,12 +5,14 @@ on:
     paths:
       - "plugins/destination/elasticsearch/**"
       - ".github/workflows/dest_elasticsearch.yml"
+      - .github/workflows/validate_release.yml
   push:
     branches:
       - main
     paths:
       - "plugins/destination/elasticsearch/**"
       - ".github/workflows/dest_elasticsearch.yml"
+      - .github/workflows/validate_release.yml
 
 jobs:
   plugins-destination-elasticsearch:

--- a/.github/workflows/dest_elasticsearch.yml
+++ b/.github/workflows/dest_elasticsearch.yml
@@ -59,35 +59,7 @@ jobs:
       - name: Test
         run: make test
   validate-release:
-    timeout-minutes: 30
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
-        uses: actions/checkout@v3
-      - uses: actions/cache@v3
-        if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
-        with:
-          path: |
-            ~/.cache/go-build
-            ~/go/pkg/mod
-          key: ${{ runner.os }}-go-1.19.4-release-cache-${{ hashFiles('plugins/destination/elasticsearch/go.sum') }}
-          restore-keys: |
-            ${{ runner.os }}-go-1.19.4-release-cache-plugins-destination-elasticsearch
-      - name: Set up Go
-        if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
-        uses: actions/setup-go@v3
-        with:
-          go-version-file: plugins/destination/elasticsearch/go.mod
-      - name: Install GoReleaser
-        if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
-        uses: goreleaser/goreleaser-action@v3
-        with:
-          distribution: goreleaser-pro
-          version: latest
-          install-only: true
-      - name: Run GoReleaser Dry-Run
-        if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
-        run: goreleaser release --snapshot --rm-dist --skip-validate --skip-publish --skip-sign -f ./plugins/destination/elasticsearch/.goreleaser.yaml
-        env:
-          GORELEASER_KEY: ${{ secrets.GORELEASER_KEY }}
+    if:   startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
+    uses: ./.github/workflows/validate_release.yml
+    with:
+      path: plugins/destination/elasticsearch

--- a/.github/workflows/dest_file.yml
+++ b/.github/workflows/dest_file.yml
@@ -6,6 +6,7 @@ on:
       - "plugins/destination/filetypes/**"
       - "plugins/destination/file/**"
       - ".github/workflows/dest_file.yml"
+      - .github/workflows/validate_release.yml
   push:
     branches:
       - main
@@ -13,6 +14,7 @@ on:
       - "plugins/destination/filetypes/**"
       - "plugins/destination/file/**"
       - ".github/workflows/dest_file.yml"
+      - .github/workflows/validate_release.yml
 
 jobs:
   plugins-destination-file:

--- a/.github/workflows/dest_file.yml
+++ b/.github/workflows/dest_file.yml
@@ -47,37 +47,7 @@ jobs:
       - name: Test file plugin
         run: make test
   validate-release:
-    timeout-minutes: 30
-    runs-on: ubuntu-latest
-    env:
-      CGO_ENABLED: 0
-    steps:
-      - name: Checkout
-        if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
-        uses: actions/checkout@v3
-      - uses: actions/cache@v3
-        if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
-        with:
-          path: |
-            ~/.cache/go-build
-            ~/go/pkg/mod
-          key: ${{ runner.os }}-go-1.19.5-release-cache-${{ hashFiles('plugins/destination/file/go.sum') }}
-          restore-keys: |
-            ${{ runner.os }}-go-1.19.5-release-cache-plugins-destination-file
-      - name: Set up Go
-        if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
-        uses: actions/setup-go@v3
-        with:
-          go-version-file: plugins/destination/file/go.mod
-      - name: Install GoReleaser
-        if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
-        uses: goreleaser/goreleaser-action@v3
-        with:
-          distribution: goreleaser-pro
-          version: latest
-          install-only: true
-      - name: Run GoReleaser Dry-Run
-        if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
-        run: goreleaser release --snapshot --clean --skip-validate --skip-publish --skip-sign -f ./plugins/destination/file/.goreleaser.yaml
-        env:
-          GORELEASER_KEY: ${{ secrets.GORELEASER_KEY }}
+    if:   startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
+    uses: ./.github/workflows/validate_release.yml
+    with:
+      path: plugins/destination/file

--- a/.github/workflows/dest_firehose.yml
+++ b/.github/workflows/dest_firehose.yml
@@ -5,12 +5,14 @@ on:
     paths:
       - "plugins/destination/firehose/**"
       - ".github/workflows/dest_firehose.yml"
+      - .github/workflows/validate_release.yml
   push:
     branches:
       - main
     paths:
       - "plugins/destination/firehose/**"
       - ".github/workflows/dest_firehose.yml"
+      - .github/workflows/validate_release.yml
 
 jobs:
   plugins-destination-firehose:

--- a/.github/workflows/dest_firehose.yml
+++ b/.github/workflows/dest_firehose.yml
@@ -54,37 +54,7 @@ jobs:
       # - name: Test firehose plugin
       #   run: make test
   validate-release:
-    timeout-minutes: 30
-    runs-on: ubuntu-latest
-    env:
-      CGO_ENABLED: 0
-    steps:
-      - name: Checkout
-        if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
-        uses: actions/checkout@v3
-      - uses: actions/cache@v3
-        if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
-        with:
-          path: |
-            ~/.cache/go-build
-            ~/go/pkg/mod
-          key: ${{ runner.os }}-go-1.19.4-release-cache-${{ hashFiles('plugins/destination/firehose/go.sum') }}
-          restore-keys: |
-            ${{ runner.os }}-go-1.19.4-release-cache-plugins-destination-firehose
-      - name: Set up Go
-        if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
-        uses: actions/setup-go@v3
-        with:
-          go-version-file: plugins/destination/firehose/go.mod
-      - name: Install GoReleaser
-        if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
-        uses: goreleaser/goreleaser-action@v3
-        with:
-          distribution: goreleaser-pro
-          version: latest
-          install-only: true
-      - name: Run GoReleaser Dry-Run
-        if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
-        run: goreleaser release --snapshot --rm-dist --skip-validate --skip-publish --skip-sign -f ./plugins/destination/firehose/.goreleaser.yaml
-        env:
-          GORELEASER_KEY: ${{ secrets.GORELEASER_KEY }}
+    if:   startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
+    uses: ./.github/workflows/validate_release.yml
+    with:
+      path: plugins/destination/firehose

--- a/.github/workflows/dest_gcs.yml
+++ b/.github/workflows/dest_gcs.yml
@@ -5,12 +5,14 @@ on:
     paths:
       - "plugins/destination/gcs/**"
       - ".github/workflows/dest_gcs.yml"
+      - .github/workflows/validate_release.yml
   push:
     branches:
       - main
     paths:
       - "plugins/destination/gcs/**"
       - ".github/workflows/dest_gcs.yml"
+      - .github/workflows/validate_release.yml
 
 jobs:
   plugins-destination-gcs:

--- a/.github/workflows/dest_gcs.yml
+++ b/.github/workflows/dest_gcs.yml
@@ -53,37 +53,7 @@ jobs:
       - name: Test file plugin
         run: make test
   validate-release:
-    timeout-minutes: 30
-    runs-on: ubuntu-latest
-    env:
-      CGO_ENABLED: 0
-    steps:
-      - name: Checkout
-        if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
-        uses: actions/checkout@v3
-      - uses: actions/cache@v3
-        if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
-        with:
-          path: |
-            ~/.cache/go-build
-            ~/go/pkg/mod
-          key: ${{ runner.os }}-go-1.19.5-release-cache-${{ hashFiles('plugins/destination/gcs/go.sum') }}
-          restore-keys: |
-            ${{ runner.os }}-go-1.19.5-release-cache-plugins-destination-gcs
-      - name: Set up Go
-        if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
-        uses: actions/setup-go@v3
-        with:
-          go-version-file: plugins/destination/gcs/go.mod
-      - name: Install GoReleaser
-        if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
-        uses: goreleaser/goreleaser-action@v3
-        with:
-          distribution: goreleaser-pro
-          version: latest
-          install-only: true
-      - name: Run GoReleaser Dry-Run
-        if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
-        run: goreleaser release --snapshot --clean --skip-validate --skip-publish --skip-sign -f ./plugins/destination/gcs/.goreleaser.yaml
-        env:
-          GORELEASER_KEY: ${{ secrets.GORELEASER_KEY }}
+    if:   startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
+    uses: ./.github/workflows/validate_release.yml
+    with:
+      path: plugins/destination/gcs

--- a/.github/workflows/dest_gremlin.yml
+++ b/.github/workflows/dest_gremlin.yml
@@ -50,37 +50,7 @@ jobs:
       - name: Test Gremlin
         run: make test
   validate-release:
-    timeout-minutes: 30
-    runs-on: ubuntu-latest
-    env:
-      CGO_ENABLED: 0
-    steps:
-      - name: Checkout
-        if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
-        uses: actions/checkout@v3
-      - uses: actions/cache@v3
-        if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
-        with:
-          path: |
-            ~/.cache/go-build
-            ~/go/pkg/mod
-          key: ${{ runner.os }}-go-1.19.5-release-cache-${{ hashFiles('plugins/destination/gremlin/go.sum') }}
-          restore-keys: |
-            ${{ runner.os }}-go-1.19.5-release-cache-plugins-destination-gremlin
-      - name: Set up Go
-        if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
-        uses: actions/setup-go@v3
-        with:
-          go-version-file: plugins/destination/gremlin/go.mod
-      - name: Install GoReleaser
-        if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
-        uses: goreleaser/goreleaser-action@v3
-        with:
-          distribution: goreleaser-pro
-          version: latest
-          install-only: true
-      - name: Run GoReleaser Dry-Run
-        if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
-        run: goreleaser release --snapshot --clean --skip-validate --skip-publish --skip-sign -f ./plugins/destination/gremlin/.goreleaser.yaml
-        env:
-          GORELEASER_KEY: ${{ secrets.GORELEASER_KEY }}
+    if:   startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
+    uses: ./.github/workflows/validate_release.yml
+    with:
+      path: plugins/destination/gremlin

--- a/.github/workflows/dest_gremlin.yml
+++ b/.github/workflows/dest_gremlin.yml
@@ -5,12 +5,14 @@ on:
     paths:
       - "plugins/destination/gremlin/**"
       - ".github/workflows/dest_gremlin.yml"
+      - .github/workflows/validate_release.yml
   push:
     branches:
       - main
     paths:
       - "plugins/destination/gremlin/**"
       - ".github/workflows/dest_gremlin.yml"
+      - .github/workflows/validate_release.yml
 
 jobs:
   plugins-destination-gremlin:

--- a/.github/workflows/dest_kafka.yml
+++ b/.github/workflows/dest_kafka.yml
@@ -47,37 +47,7 @@ jobs:
       - name: Test
         run: make test
   validate-release:
-    timeout-minutes: 30
-    runs-on: ubuntu-latest
-    env:
-      CGO_ENABLED: 0
-    steps:
-      - name: Checkout
-        if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
-        uses: actions/checkout@v3
-      - uses: actions/cache@v3
-        if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
-        with:
-          path: |
-            ~/.cache/go-build
-            ~/go/pkg/mod
-          key: ${{ runner.os }}-go-1.19.5-release-cache-${{ hashFiles('plugins/destination/kafka/go.sum') }}
-          restore-keys: |
-            ${{ runner.os }}-go-1.19.5-release-cache-plugins-destination-kafka
-      - name: Set up Go
-        if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
-        uses: actions/setup-go@v3
-        with:
-          go-version-file: plugins/destination/kafka/go.mod
-      - name: Install GoReleaser
-        if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
-        uses: goreleaser/goreleaser-action@v3
-        with:
-          distribution: goreleaser-pro
-          version: latest
-          install-only: true
-      - name: Run GoReleaser Dry-Run
-        if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
-        run: goreleaser release --snapshot --clean --skip-validate --skip-publish --skip-sign -f ./plugins/destination/kafka/.goreleaser.yaml
-        env:
-          GORELEASER_KEY: ${{ secrets.GORELEASER_KEY }}
+    if:   startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
+    uses: ./.github/workflows/validate_release.yml
+    with:
+      path: plugins/destination/kafka

--- a/.github/workflows/dest_kafka.yml
+++ b/.github/workflows/dest_kafka.yml
@@ -5,12 +5,14 @@ on:
     paths:
       - "plugins/destination/kafka/**"
       - ".github/workflows/dest_kafka.yml"
+      - .github/workflows/validate_release.yml
   push:
     branches:
       - main
     paths:
       - "plugins/destination/kafka/**"
       - ".github/workflows/dest_kafka.yml"
+      - .github/workflows/validate_release.yml
 
 jobs:
   plugins-destination-kafka:

--- a/.github/workflows/dest_meilisearch.yml
+++ b/.github/workflows/dest_meilisearch.yml
@@ -66,37 +66,7 @@ jobs:
         CQ_DEST_MEILI_TEST_API_KEY: ${{ env.MEILI_MASTER_KEY }}
       run:  make test
   validate-release:
-    timeout-minutes: 30
-    runs-on:         ubuntu-latest
-    env:
-      CGO_ENABLED: 0
-    steps:
-    - name: Checkout
-      if:   startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
-      uses: actions/checkout@v3
-    - uses: actions/cache@v3
-      if:   startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
-      with:
-        path:         |
-                      ~/.cache/go-build
-                      ~/go/pkg/mod
-        key:          ${{ runner.os }}-go-1.19.4-release-cache-${{ hashFiles('plugins/destination/meilisearch/go.sum') }}
-        restore-keys: |
-                      ${{ runner.os }}-go-1.19.4-release-cache-plugins-destination-meilisearch
-    - name: Set up Go
-      if:   startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
-      uses: actions/setup-go@v3
-      with:
-        go-version-file: plugins/destination/meilisearch/go.mod
-    - name: Install GoReleaser
-      if:   startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
-      uses: goreleaser/goreleaser-action@v3
-      with:
-        distribution: goreleaser-pro
-        version:      latest
-        install-only: true
-    - name: Run GoReleaser Dry-Run
-      if:   startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
-      run:  goreleaser release --snapshot --rm-dist --skip-validate --skip-publish --skip-sign -f ./plugins/destination/meilisearch/.goreleaser.yaml
-      env:
-        GORELEASER_KEY: ${{ secrets.GORELEASER_KEY }}
+    if:   startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
+    uses: ./.github/workflows/validate_release.yml
+    with:
+      path: plugins/destination/meilisearch

--- a/.github/workflows/dest_meilisearch.yml
+++ b/.github/workflows/dest_meilisearch.yml
@@ -5,12 +5,14 @@ on:
     paths:
     - plugins/destination/meilisearch/**
     - .github/workflows/dest_meilisearch.yml
+    - .github/workflows/validate_release.yml
   push:
     branches:
     - main
     paths:
     - plugins/destination/meilisearch/**
     - .github/workflows/dest_meilisearch.yml
+    - .github/workflows/validate_release.yml
 
 jobs:
   plugins-destination-meilisearch:

--- a/.github/workflows/dest_mongodb.yml
+++ b/.github/workflows/dest_mongodb.yml
@@ -5,12 +5,14 @@ on:
     paths:
       - "plugins/destination/mongodb/**"
       - ".github/workflows/dest_mongodb.yml"
+      - .github/workflows/validate_release.yml
   push:
     branches:
       - main
     paths:
       - "plugins/destination/mongodb/**"
       - ".github/workflows/dest_mongodb.yml"
+      - .github/workflows/validate_release.yml
 
 jobs:
   plugins-destination-mongodb:

--- a/.github/workflows/dest_mongodb.yml
+++ b/.github/workflows/dest_mongodb.yml
@@ -48,37 +48,7 @@ jobs:
       - name: Test
         run: make test
   validate-release:
-    timeout-minutes: 30
-    runs-on: ubuntu-latest
-    env:
-      CGO_ENABLED: 0
-    steps:
-      - name: Checkout
-        if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
-        uses: actions/checkout@v3
-      - uses: actions/cache@v3
-        if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
-        with:
-          path: |
-            ~/.cache/go-build
-            ~/go/pkg/mod
-          key: ${{ runner.os }}-go-1.19.5-release-cache-${{ hashFiles('plugins/destination/mongodb/go.sum') }}
-          restore-keys: |
-            ${{ runner.os }}-go-1.19.5-release-cache-plugins-destination-mongodb
-      - name: Set up Go
-        if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
-        uses: actions/setup-go@v3
-        with:
-          go-version-file: plugins/destination/mongodb/go.mod
-      - name: Install GoReleaser
-        if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
-        uses: goreleaser/goreleaser-action@v3
-        with:
-          distribution: goreleaser-pro
-          version: latest
-          install-only: true
-      - name: Run GoReleaser Dry-Run
-        if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
-        run: goreleaser release --snapshot --clean --skip-validate --skip-publish --skip-sign -f ./plugins/destination/mongodb/.goreleaser.yaml
-        env:
-          GORELEASER_KEY: ${{ secrets.GORELEASER_KEY }}
+    if:   startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
+    uses: ./.github/workflows/validate_release.yml
+    with:
+      path: plugins/destination/mongodb

--- a/.github/workflows/dest_mssql.yml
+++ b/.github/workflows/dest_mssql.yml
@@ -73,37 +73,7 @@ jobs:
     - name: Test Microsoft SQL
       run:  make test
   validate-release:
-    timeout-minutes: 30
-    runs-on:         ubuntu-latest
-    env:
-      CGO_ENABLED: 0
-    steps:
-    - name: Checkout
-      if:   startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
-      uses: actions/checkout@v3
-    - uses: actions/cache@v3
-      if:   startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
-      with:
-        path:         |
-                      ~/.cache/go-build
-                      ~/go/pkg/mod
-        key:          ${{ runner.os }}-go-1.19.5-release-cache-${{ hashFiles('plugins/destination/mssql/go.sum') }}
-        restore-keys: |
-                      ${{ runner.os }}-go-1.19.5-release-cache-plugins-destination-mssql
-    - name: Set up Go
-      if:   startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
-      uses: actions/setup-go@v3
-      with:
-        go-version-file: plugins/destination/mssql/go.mod
-    - name: Install GoReleaser
-      if:   startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
-      uses: goreleaser/goreleaser-action@v3
-      with:
-        distribution: goreleaser-pro
-        version:      latest
-        install-only: true
-    - name: Run GoReleaser Dry-Run
-      if:   startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
-      run:  goreleaser release --snapshot --clean --skip-validate --skip-publish --skip-sign -f ./plugins/destination/mssql/.goreleaser.yaml
-      env:
-        GORELEASER_KEY: ${{ secrets.GORELEASER_KEY }}
+    if:   startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
+    uses: ./.github/workflows/validate_release.yml
+    with:
+      path: plugins/destination/mssql

--- a/.github/workflows/dest_mssql.yml
+++ b/.github/workflows/dest_mssql.yml
@@ -5,12 +5,14 @@ on:
     paths:
     - "plugins/destination/mssql/**"
     - ".github/workflows/dest_mssql.yml"
+    - .github/workflows/validate_release.yml
   push:
     branches:
     - main
     paths:
     - "plugins/destination/mssql/**"
     - ".github/workflows/dest_mssql.yml"
+    - .github/workflows/validate_release.yml
 
 jobs:
   plugins-destination-mssql:

--- a/.github/workflows/dest_mysql.yml
+++ b/.github/workflows/dest_mysql.yml
@@ -5,12 +5,14 @@ on:
     paths:
       - "plugins/destination/mysql/**"
       - ".github/workflows/dest_mysql.yml"
+      - .github/workflows/validate_release.yml
   push:
     branches:
       - main
     paths:
       - "plugins/destination/mysql/**"
       - ".github/workflows/dest_mysql.yml"
+      - .github/workflows/validate_release.yml
 
 jobs:
   plugins-destination-mysql:

--- a/.github/workflows/dest_mysql.yml
+++ b/.github/workflows/dest_mysql.yml
@@ -58,37 +58,7 @@ jobs:
       - name: Test MySQL
         run: make test
   validate-release:
-    timeout-minutes: 30
-    runs-on: ubuntu-latest
-    env:
-      CGO_ENABLED: 0
-    steps:
-      - name: Checkout
-        if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
-        uses: actions/checkout@v3
-      - uses: actions/cache@v3
-        if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
-        with:
-          path: |
-            ~/.cache/go-build
-            ~/go/pkg/mod
-          key: ${{ runner.os }}-go-1.19.5-release-cache-${{ hashFiles('plugins/destination/mysql/go.sum') }}
-          restore-keys: |
-            ${{ runner.os }}-go-1.19.5-release-cache-plugins-destination-mysql
-      - name: Set up Go
-        if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
-        uses: actions/setup-go@v3
-        with:
-          go-version-file: plugins/destination/mysql/go.mod
-      - name: Install GoReleaser
-        if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
-        uses: goreleaser/goreleaser-action@v3
-        with:
-          distribution: goreleaser-pro
-          version: latest
-          install-only: true
-      - name: Run GoReleaser Dry-Run
-        if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
-        run: goreleaser release --snapshot --clean --skip-validate --skip-publish --skip-sign -f ./plugins/destination/mysql/.goreleaser.yaml
-        env:
-          GORELEASER_KEY: ${{ secrets.GORELEASER_KEY }}
+    if:   startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
+    uses: ./.github/workflows/validate_release.yml
+    with:
+      path: plugins/destination/mysql

--- a/.github/workflows/dest_neo4j.yml
+++ b/.github/workflows/dest_neo4j.yml
@@ -65,37 +65,7 @@ jobs:
       - name: Test Neo4j
         run: make test
   validate-release:
-    timeout-minutes: 30
-    runs-on: ubuntu-latest
-    env:
-      CGO_ENABLED: 0
-    steps:
-      - name: Checkout
-        if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
-        uses: actions/checkout@v3
-      - uses: actions/cache@v3
-        if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
-        with:
-          path: |
-            ~/.cache/go-build
-            ~/go/pkg/mod
-          key: ${{ runner.os }}-go-1.19.5-release-cache-${{ hashFiles('plugins/destination/neo4j/go.sum') }}
-          restore-keys: |
-            ${{ runner.os }}-go-1.19.5-release-cache-plugins-destination-neo4j
-      - name: Set up Go
-        if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
-        uses: actions/setup-go@v3
-        with:
-          go-version-file: plugins/destination/neo4j/go.mod
-      - name: Install GoReleaser
-        if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
-        uses: goreleaser/goreleaser-action@v3
-        with:
-          distribution: goreleaser-pro
-          version: latest
-          install-only: true
-      - name: Run GoReleaser Dry-Run
-        if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
-        run: goreleaser release --snapshot --clean --skip-validate --skip-publish --skip-sign -f ./plugins/destination/neo4j/.goreleaser.yaml
-        env:
-          GORELEASER_KEY: ${{ secrets.GORELEASER_KEY }}
+    if:   startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
+    uses: ./.github/workflows/validate_release.yml
+    with:
+      path: plugins/destination/neo4j

--- a/.github/workflows/dest_neo4j.yml
+++ b/.github/workflows/dest_neo4j.yml
@@ -5,12 +5,14 @@ on:
     paths:
       - "plugins/destination/neo4j/**"
       - ".github/workflows/dest_neo4j.yml"
+      - .github/workflows/validate_release.yml
   push:
     branches:
       - main
     paths:
       - "plugins/destination/neo4j/**"
       - ".github/workflows/dest_neo4j.yml"
+      - .github/workflows/validate_release.yml
 
 jobs:
   plugins-destination-neo4j:

--- a/.github/workflows/dest_postgresql.yml
+++ b/.github/workflows/dest_postgresql.yml
@@ -5,12 +5,14 @@ on:
     paths:
       - "plugins/destination/postgresql/**"
       - ".github/workflows/dest_postgresql.yml"
+      - .github/workflows/validate_release.yml
   push:
     branches:
       - main
     paths:
       - "plugins/destination/postgresql/**"
       - ".github/workflows/dest_postgresql.yml"
+      - .github/workflows/validate_release.yml
 
 jobs:
   plugins-destination-postgresql:

--- a/.github/workflows/dest_postgresql.yml
+++ b/.github/workflows/dest_postgresql.yml
@@ -70,37 +70,7 @@ jobs:
       - name: Test CockroachDB
         run: CQ_DEST_PG_TEST_CONN="postgresql://root@localhost:26257/postgres?sslmode=disable" make test
   validate-release:
-    timeout-minutes: 30
-    runs-on: ubuntu-latest
-    env:
-      CGO_ENABLED: 0
-    steps:
-      - name: Checkout
-        if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
-        uses: actions/checkout@v3
-      - uses: actions/cache@v3
-        if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
-        with:
-          path: |
-            ~/.cache/go-build
-            ~/go/pkg/mod
-          key: ${{ runner.os }}-go-1.19.5-release-cache-${{ hashFiles('plugins/destination/postgresql/go.sum') }}
-          restore-keys: |
-            ${{ runner.os }}-go-1.19.5-release-cache-plugins-destination-postgresql
-      - name: Set up Go
-        if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
-        uses: actions/setup-go@v3
-        with:
-          go-version-file: plugins/destination/postgresql/go.mod
-      - name: Install GoReleaser
-        if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
-        uses: goreleaser/goreleaser-action@v3
-        with:
-          distribution: goreleaser-pro
-          version: latest
-          install-only: true
-      - name: Run GoReleaser Dry-Run
-        if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
-        run: goreleaser release --snapshot --clean --skip-validate --skip-publish --skip-sign -f ./plugins/destination/postgresql/.goreleaser.yaml
-        env:
-          GORELEASER_KEY: ${{ secrets.GORELEASER_KEY }}
+    if:   startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
+    uses: ./.github/workflows/validate_release.yml
+    with:
+      path: plugins/destination/postgresql

--- a/.github/workflows/dest_s3.yml
+++ b/.github/workflows/dest_s3.yml
@@ -55,37 +55,7 @@ jobs:
       - name: Test s3 plugin
         run: make test
   validate-release:
-    timeout-minutes: 30
-    runs-on: ubuntu-latest
-    env:
-      CGO_ENABLED: 0
-    steps:
-      - name: Checkout
-        if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
-        uses: actions/checkout@v3
-      - uses: actions/cache@v3
-        if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
-        with:
-          path: |
-            ~/.cache/go-build
-            ~/go/pkg/mod
-          key: ${{ runner.os }}-go-1.19.5-release-cache-${{ hashFiles('plugins/destination/s3/go.sum') }}
-          restore-keys: |
-            ${{ runner.os }}-go-1.19.5-release-cache-plugins-destination-s3
-      - name: Set up Go
-        if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
-        uses: actions/setup-go@v3
-        with:
-          go-version-file: plugins/destination/s3/go.mod
-      - name: Install GoReleaser
-        if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
-        uses: goreleaser/goreleaser-action@v3
-        with:
-          distribution: goreleaser-pro
-          version: latest
-          install-only: true
-      - name: Run GoReleaser Dry-Run
-        if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
-        run: goreleaser release --snapshot --clean --skip-validate --skip-publish --skip-sign -f ./plugins/destination/s3/.goreleaser.yaml
-        env:
-          GORELEASER_KEY: ${{ secrets.GORELEASER_KEY }}
+    if:   startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
+    uses: ./.github/workflows/validate_release.yml
+    with:
+      path: plugins/destination/s3

--- a/.github/workflows/dest_s3.yml
+++ b/.github/workflows/dest_s3.yml
@@ -6,6 +6,7 @@ on:
       - "plugins/destination/filetypes/**"
       - "plugins/destination/s3/**"
       - ".github/workflows/dest_s3.yml"
+      - .github/workflows/validate_release.yml
   push:
     branches:
       - main
@@ -13,6 +14,7 @@ on:
       - "plugins/destination/filetypes/**"
       - "plugins/destination/s3/**"
       - ".github/workflows/dest_s3.yml"
+      - .github/workflows/validate_release.yml
 
 jobs:
   plugins-destination-s3:

--- a/.github/workflows/dest_snowflake.yml
+++ b/.github/workflows/dest_snowflake.yml
@@ -5,12 +5,14 @@ on:
     paths:
       - "plugins/destination/snowflake/**"
       - ".github/workflows/dest_snowflake.yml"
+      - .github/workflows/validate_release_cgo.yml
   push:
     branches:
       - main
     paths:
       - "plugins/destination/snowflake/**"
       - ".github/workflows/dest_snowflake.yml"
+      - .github/workflows/validate_release_cgo.yml
 
 jobs:
   plugins-destination-snowflake:

--- a/.github/workflows/dest_snowflake.yml
+++ b/.github/workflows/dest_snowflake.yml
@@ -47,39 +47,7 @@ jobs:
         env: # Or as an environment variable
           SNOW_TEST_DSN: ${{ secrets.SNOW_TEST_DSN }}
   validate-release:
-    timeout-minutes: 30
-    runs-on: ubuntu-latest
-    container:
-      image: ghcr.io/cloudquery/golang-cross:v10.0.0
-      env:
-        CGO_ENABLED: 1
-    steps:
-      - name: Checkout
-        if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
-        uses: actions/checkout@v3
-      - uses: actions/cache@v3
-        if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
-        with:
-          path: |
-            ~/.cache/go-build
-            ~/go/pkg/mod
-          key: ${{ runner.os }}-go-1.19.5-release-cache-${{ hashFiles('plugins/destination/snowflake/go.sum') }}
-          restore-keys: |
-            ${{ runner.os }}-go-1.19.5-release-cache-plugins-destination-snowflake
-      - name: Set up Go
-        if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
-        uses: actions/setup-go@v3
-        with:
-          go-version-file: plugins/destination/snowflake/go.mod
-      - name: Install GoReleaser
-        if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
-        uses: goreleaser/goreleaser-action@v3
-        with:
-          distribution: goreleaser-pro
-          version: latest
-          install-only: true
-      - name: Run GoReleaser Dry-Run
-        if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
-        run: goreleaser release --snapshot --clean --skip-validate --skip-publish --skip-sign -f ./plugins/destination/snowflake/.goreleaser.yaml
-        env:
-          GORELEASER_KEY: ${{ secrets.GORELEASER_KEY }}
+    if:   startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
+    uses: ./.github/workflows/validate_release_cgo.yml
+    with:
+      path: plugins/destination/snowflake

--- a/.github/workflows/dest_sqlite.yml
+++ b/.github/workflows/dest_sqlite.yml
@@ -5,12 +5,14 @@ on:
     paths:
       - "plugins/destination/sqlite/**"
       - ".github/workflows/dest_sqlite.yml"
+      - .github/workflows/validate_release_cgo.yml
   push:
     branches:
       - main
     paths:
       - "plugins/destination/sqlite/**"
       - ".github/workflows/dest_sqlite.yml"
+      - .github/workflows/validate_release_cgo.yml
 
 jobs:
   plugins-destination-sqlite:

--- a/.github/workflows/dest_sqlite.yml
+++ b/.github/workflows/dest_sqlite.yml
@@ -45,39 +45,7 @@ jobs:
       - name: Test
         run: make test
   validate-release:
-    timeout-minutes: 30
-    runs-on: ubuntu-latest
-    container:
-      image: ghcr.io/cloudquery/golang-cross:v10.0.0
-      env:
-        CGO_ENABLED: 1
-    steps:
-      - name: Checkout
-        if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
-        uses: actions/checkout@v3
-      - uses: actions/cache@v3
-        if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
-        with:
-          path: |
-            ~/.cache/go-build
-            ~/go/pkg/mod
-          key: ${{ runner.os }}-go-1.19.5-release-cache-${{ hashFiles('plugins/destination/sqlite/go.sum') }}
-          restore-keys: |
-            ${{ runner.os }}-go-1.19.5-release-cache-plugins-destination-sqlite
-      - name: Set up Go
-        if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
-        uses: actions/setup-go@v3
-        with:
-          go-version-file: plugins/destination/sqlite/go.mod
-      - name: Install GoReleaser
-        if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
-        uses: goreleaser/goreleaser-action@v3
-        with:
-          distribution: goreleaser-pro
-          version: latest
-          install-only: true
-      - name: Run GoReleaser Dry-Run
-        if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
-        run: goreleaser release --snapshot --clean --skip-validate --skip-publish --skip-sign -f ./plugins/destination/sqlite/.goreleaser.yaml
-        env:
-          GORELEASER_KEY: ${{ secrets.GORELEASER_KEY }}
+    if:   startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
+    uses: ./.github/workflows/validate_release_cgo.yml
+    with:
+      path: plugins/destination/sqlite

--- a/.github/workflows/dest_test.yml
+++ b/.github/workflows/dest_test.yml
@@ -45,37 +45,7 @@ jobs:
       - name: Test
         run: make test
   validate-release:
-    timeout-minutes: 30
-    runs-on: ubuntu-latest
-    env:
-      CGO_ENABLED: 0
-    steps:
-      - name: Checkout
-        if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
-        uses: actions/checkout@v3
-      - uses: actions/cache@v3
-        if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
-        with:
-          path: |
-            ~/.cache/go-build
-            ~/go/pkg/mod
-          key: ${{ runner.os }}-go-1.19.5-release-cache-${{ hashFiles('plugins/destination/test/go.sum') }}
-          restore-keys: |
-            ${{ runner.os }}-go-1.19.5-release-cache-plugins-destination-test
-      - name: Set up Go
-        if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
-        uses: actions/setup-go@v3
-        with:
-          go-version-file: plugins/destination/test/go.mod
-      - name: Install GoReleaser
-        if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
-        uses: goreleaser/goreleaser-action@v3
-        with:
-          distribution: goreleaser-pro
-          version: latest
-          install-only: true
-      - name: Run GoReleaser Dry-Run
-        if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
-        run: goreleaser release --snapshot --clean --skip-validate --skip-publish --skip-sign -f ./plugins/destination/test/.goreleaser.yaml
-        env:
-          GORELEASER_KEY: ${{ secrets.GORELEASER_KEY }}
+    if:   startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
+    uses: ./.github/workflows/validate_release.yml
+    with:
+      path: plugins/destination/test

--- a/.github/workflows/dest_test.yml
+++ b/.github/workflows/dest_test.yml
@@ -5,12 +5,14 @@ on:
     paths:
       - "plugins/destination/test/**"
       - ".github/workflows/dest_test.yml"
+      - .github/workflows/validate_release.yml
   push:
     branches:
       - main
     paths:
       - "plugins/destination/test/**"
       - ".github/workflows/dest_test.yml"
+      - .github/workflows/validate_release.yml
 
 jobs:
   plugins-destination-test:

--- a/.github/workflows/scaffold.yml
+++ b/.github/workflows/scaffold.yml
@@ -5,12 +5,14 @@ on:
     paths:
       - "scaffold/**"
       - ".github/workflows/scaffold.yml"
+      - .github/workflows/validate_release.yml
   push:
     branches:
       - main
     paths:
       - "scaffold/**"
       - ".github/workflows/scaffold.yml"
+      - .github/workflows/validate_release.yml
 
 jobs:
   scaffold:

--- a/.github/workflows/scaffold.yml
+++ b/.github/workflows/scaffold.yml
@@ -45,37 +45,7 @@ jobs:
       - name: Test
         run: make test
   validate-release:
-    timeout-minutes: 30
-    runs-on: ubuntu-latest
-    env:
-      CGO_ENABLED: 0
-    steps:
-      - name: Checkout
-        if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
-        uses: actions/checkout@v3
-      - uses: actions/cache@v3
-        if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
-        with:
-          path: |
-            ~/.cache/go-build
-            ~/go/pkg/mod
-          key: ${{ runner.os }}-go-1.19.5-release-cache-${{ hashFiles('scaffold/go.sum') }}
-          restore-keys: |
-            ${{ runner.os }}-go-1.19.5-release-cache-scaffold
-      - name: Set up Go
-        if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
-        uses: actions/setup-go@v3
-        with:
-          go-version-file: scaffold/go.mod
-      - name: Install GoReleaser
-        if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
-        uses: goreleaser/goreleaser-action@v3
-        with:
-          distribution: goreleaser-pro
-          version: latest
-          install-only: true
-      - name: Run GoReleaser Dry-Run
-        if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
-        run: goreleaser release --snapshot --clean --skip-validate --skip-publish --skip-sign -f ./scaffold/.goreleaser.yaml
-        env:
-          GORELEASER_KEY: ${{ secrets.GORELEASER_KEY }}
+    if:   startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
+    uses: ./.github/workflows/validate_release.yml
+    with:
+      path: scaffold

--- a/.github/workflows/source_alicloud.yml
+++ b/.github/workflows/source_alicloud.yml
@@ -49,37 +49,7 @@ jobs:
       - name: Test
         run: make test
   validate-release:
-    timeout-minutes: 30
-    runs-on: ubuntu-latest
-    env:
-      CGO_ENABLED: 0
-    steps:
-      - name: Checkout
-        if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
-        uses: actions/checkout@v3
-      - uses: actions/cache@v3
-        if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
-        with:
-          path: |
-            ~/.cache/go-build
-            ~/go/pkg/mod
-          key: ${{ runner.os }}-go-1.19.5-release-cache-${{ hashFiles('plugins/source/alicloud/go.sum') }}
-          restore-keys: |
-            ${{ runner.os }}-go-1.19.5-release-cache-plugins-source-alicloud
-      - name: Set up Go
-        if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
-        uses: actions/setup-go@v3
-        with:
-          go-version-file: plugins/source/alicloud/go.mod
-      - name: Install GoReleaser
-        if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
-        uses: goreleaser/goreleaser-action@v3
-        with:
-          distribution: goreleaser-pro
-          version: latest
-          install-only: true
-      - name: Run GoReleaser Dry-Run
-        if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
-        run: goreleaser release --snapshot --clean --skip-validate --skip-publish --skip-sign -f ./plugins/source/alicloud/.goreleaser.yaml
-        env:
-          GORELEASER_KEY: ${{ secrets.GORELEASER_KEY }}
+    if:   startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
+    uses: ./.github/workflows/validate_release.yml
+    with:
+      path: plugins/source/alicloud

--- a/.github/workflows/source_alicloud.yml
+++ b/.github/workflows/source_alicloud.yml
@@ -5,12 +5,14 @@ on:
     paths:
       - "plugins/source/alicloud/**"
       - ".github/workflows/source_alicloud.yml"
+      - .github/workflows/validate_release.yml
   push:
     branches:
       - main
     paths:
       - "plugins/source/alicloud/**"
       - ".github/workflows/source_alicloud.yml"
+      - .github/workflows/validate_release.yml
 
 jobs:
   plugins-source-alicloud:

--- a/.github/workflows/source_aws.yml
+++ b/.github/workflows/source_aws.yml
@@ -5,12 +5,14 @@ on:
     paths:
       - "plugins/source/aws/**"
       - ".github/workflows/source_aws.yml"
+      - .github/workflows/validate_release.yml
   push:
     branches:
       - main
     paths:
       - "plugins/source/aws/**"
       - ".github/workflows/source_aws.yml"
+      - .github/workflows/validate_release.yml
 
 jobs:
   resolve-runner:

--- a/.github/workflows/source_aws.yml
+++ b/.github/workflows/source_aws.yml
@@ -89,41 +89,12 @@ jobs:
         if: startsWith(github.head_ref, 'release-please--branches--main--components')
         run: cloudquery sync test/sanity.yml --log-console
   validate-release:
-    timeout-minutes: 60
-    needs: [resolve-runner]
-    runs-on: ${{ needs.resolve-runner.outputs.runner }}
-    env:
-      CGO_ENABLED: 0
-    steps:
-      - name: Checkout
-        if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
-        uses: actions/checkout@v3
-      - uses: actions/cache@v3
-        if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
-        with:
-          path: |
-            ~/.cache/go-build
-            ~/go/pkg/mod
-          key: ${{ runner.os }}-go-1.19.5-release-cache-${{ hashFiles('plugins/source/aws/go.sum') }}
-          restore-keys: |
-            ${{ runner.os }}-go-1.19.5-release-cache-plugins-source-aws
-      - name: Set up Go
-        if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
-        uses: actions/setup-go@v3
-        with:
-          go-version-file: plugins/source/aws/go.mod
-      - name: Install GoReleaser
-        if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
-        uses: goreleaser/goreleaser-action@v3
-        with:
-          distribution: goreleaser-pro
-          version: latest
-          install-only: true
-      - name: Run GoReleaser Dry-Run
-        if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
-        run: goreleaser release --timeout 50m --snapshot --clean --skip-validate --skip-publish --skip-sign -f ./plugins/source/aws/.goreleaser.yaml
-        env:
-          GORELEASER_KEY: ${{ secrets.GORELEASER_KEY }}
+    if:   startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
+    needs: [ resolve-runner ]
+    uses: ./.github/workflows/validate_release.yml
+    with:
+      path:   plugins/source/aws
+      runner: ${{ needs.resolve-runner.outputs.runner }}
   test-policies:
     timeout-minutes: 30
     needs: [resolve-runner]

--- a/.github/workflows/source_awspricing.yml
+++ b/.github/workflows/source_awspricing.yml
@@ -5,12 +5,14 @@ on:
     paths:
       - "plugins/source/awspricing/**"
       - ".github/workflows/source_awspricing.yml"
+      - .github/workflows/validate_release.yml
   push:
     branches:
       - main
     paths:
       - "plugins/source/awspricing/**"
       - ".github/workflows/source_awspricing.yml"
+      - .github/workflows/validate_release.yml
 
 jobs:
   plugins-source-awspricing:

--- a/.github/workflows/source_awspricing.yml
+++ b/.github/workflows/source_awspricing.yml
@@ -49,37 +49,7 @@ jobs:
       - name: Test
         run: make test
   validate-release:
-    timeout-minutes: 30
-    runs-on: ubuntu-latest
-    env:
-      CGO_ENABLED: 0
-    steps:
-      - name: Checkout
-        if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
-        uses: actions/checkout@v3
-      - uses: actions/cache@v3
-        if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
-        with:
-          path: |
-            ~/.cache/go-build
-            ~/go/pkg/mod
-          key: ${{ runner.os }}-go-1.19.5-release-cache-${{ hashFiles('plugins/source/awspricing/go.sum') }}
-          restore-keys: |
-            ${{ runner.os }}-go-1.19.5-release-cache-plugins-source-awspricing
-      - name: Set up Go
-        if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
-        uses: actions/setup-go@v3
-        with:
-          go-version-file: plugins/source/awspricing/go.mod
-      - name: Install GoReleaser
-        if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
-        uses: goreleaser/goreleaser-action@v3
-        with:
-          distribution: goreleaser-pro
-          version: latest
-          install-only: true
-      - name: Run GoReleaser Dry-Run
-        if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
-        run: goreleaser release --snapshot --clean --skip-validate --skip-publish --skip-sign -f ./plugins/source/awspricing/.goreleaser.yaml
-        env:
-          GORELEASER_KEY: ${{ secrets.GORELEASER_KEY }}
+    if:   startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
+    uses: ./.github/workflows/validate_release.yml
+    with:
+      path: plugins/source/awspricing

--- a/.github/workflows/source_azure.yml
+++ b/.github/workflows/source_azure.yml
@@ -71,41 +71,12 @@ jobs:
       - name: Test
         run: make test
   validate-release:
-    timeout-minutes: 30
-    needs: [resolve-runner]
-    runs-on: ${{ needs.resolve-runner.outputs.runner }}
-    env:
-      CGO_ENABLED: 0
-    steps:
-      - name: Checkout
-        if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
-        uses: actions/checkout@v3
-      - uses: actions/cache@v3
-        if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
-        with:
-          path: |
-            ~/.cache/go-build
-            ~/go/pkg/mod
-          key: ${{ runner.os }}-go-1.19.5-release-cache-${{ hashFiles('plugins/source/azure/go.sum') }}
-          restore-keys: |
-            ${{ runner.os }}-go-1.19.5-release-cache-plugins-source-azure
-      - name: Set up Go
-        if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
-        uses: actions/setup-go@v3
-        with:
-          go-version-file: plugins/source/azure/go.mod
-      - name: Install GoReleaser
-        if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
-        uses: goreleaser/goreleaser-action@v3
-        with:
-          distribution: goreleaser-pro
-          version: latest
-          install-only: true
-      - name: Run GoReleaser Dry-Run
-        if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
-        run: goreleaser release --snapshot --clean --skip-validate --skip-publish --skip-sign -f ./plugins/source/azure/.goreleaser.yaml
-        env:
-          GORELEASER_KEY: ${{ secrets.GORELEASER_KEY }}
+    if:   startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
+    needs: [ resolve-runner ]
+    uses: ./.github/workflows/validate_release.yml
+    with:
+      path:   plugins/source/azure
+      runner: ${{ needs.resolve-runner.outputs.runner }}
   test-policies:
     timeout-minutes: 30
     needs: [ resolve-runner ]

--- a/.github/workflows/source_azure.yml
+++ b/.github/workflows/source_azure.yml
@@ -5,12 +5,14 @@ on:
     paths:
       - "plugins/source/azure/**"
       - ".github/workflows/source_azure.yml"
+      - .github/workflows/validate_release.yml
   push:
     branches:
       - main
     paths:
       - "plugins/source/azure/**"
       - ".github/workflows/source_azure.yml"
+      - .github/workflows/validate_release.yml
 
 jobs:
   resolve-runner:

--- a/.github/workflows/source_azuredevops.yml
+++ b/.github/workflows/source_azuredevops.yml
@@ -51,37 +51,7 @@ jobs:
       - name: Test
         run: make test
   validate-release:
-    timeout-minutes: 30
-    runs-on: ubuntu-latest
-    env:
-      CGO_ENABLED: 0
-    steps:
-      - name: Checkout
-        if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
-        uses: actions/checkout@v3
-      - uses: actions/cache@v3
-        if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
-        with:
-          path: |
-            ~/.cache/go-build
-            ~/go/pkg/mod
-          key: ${{ runner.os }}-go-1.19.5-release-cache-${{ hashFiles('plugins/source/azuredevops/go.sum') }}
-          restore-keys: |
-            ${{ runner.os }}-go-1.19.5-release-cache-plugins-source-azuredevops
-      - name: Set up Go
-        if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
-        uses: actions/setup-go@v3
-        with:
-          go-version-file: plugins/source/azuredevops/go.mod
-      - name: Install GoReleaser
-        if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
-        uses: goreleaser/goreleaser-action@v3
-        with:
-          distribution: goreleaser-pro
-          version: latest
-          install-only: true
-      - name: Run GoReleaser Dry-Run
-        if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
-        run: goreleaser release --snapshot --clean --skip-validate --skip-publish --skip-sign -f ./plugins/source/azuredevops/.goreleaser.yaml
-        env:
-          GORELEASER_KEY: ${{ secrets.GORELEASER_KEY }}
+    if:   startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
+    uses: ./.github/workflows/validate_release.yml
+    with:
+      path: plugins/source/azuredevops

--- a/.github/workflows/source_azuredevops.yml
+++ b/.github/workflows/source_azuredevops.yml
@@ -5,12 +5,14 @@ on:
     paths:
       - "plugins/source/azuredevops/**"
       - ".github/workflows/source_azuredevops.yml"
+      - .github/workflows/validate_release.yml
   push:
     branches:
       - main
     paths:
       - "plugins/source/azuredevops/**"
       - ".github/workflows/source_azuredevops.yml"
+      - .github/workflows/validate_release.yml
 
 jobs:
   plugins-source-azuredevops:

--- a/.github/workflows/source_cloudflare.yml
+++ b/.github/workflows/source_cloudflare.yml
@@ -5,12 +5,14 @@ on:
     paths:
       - "plugins/source/cloudflare/**"
       - ".github/workflows/source_cloudflare.yml"
+      - .github/workflows/validate_release.yml
   push:
     branches:
       - main
     paths:
       - "plugins/source/cloudflare/**"
       - ".github/workflows/source_cloudflare.yml"
+      - .github/workflows/validate_release.yml
 
 jobs:
   plugins-source-cloudflare:

--- a/.github/workflows/source_cloudflare.yml
+++ b/.github/workflows/source_cloudflare.yml
@@ -51,37 +51,7 @@ jobs:
       - name: Test
         run: make test
   validate-release:
-    timeout-minutes: 30
-    runs-on: ubuntu-latest
-    env:
-      CGO_ENABLED: 0
-    steps:
-      - name: Checkout
-        if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
-        uses: actions/checkout@v3
-      - uses: actions/cache@v3
-        if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
-        with:
-          path: |
-            ~/.cache/go-build
-            ~/go/pkg/mod
-          key: ${{ runner.os }}-go-1.19.5-release-cache-${{ hashFiles('plugins/source/cloudflare/go.sum') }}
-          restore-keys: |
-            ${{ runner.os }}-go-1.19.5-release-cache-plugins-source-cloudflare
-      - name: Set up Go
-        if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
-        uses: actions/setup-go@v3
-        with:
-          go-version-file: plugins/source/cloudflare/go.mod
-      - name: Install GoReleaser
-        if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
-        uses: goreleaser/goreleaser-action@v3
-        with:
-          distribution: goreleaser-pro
-          version: latest
-          install-only: true
-      - name: Run GoReleaser Dry-Run
-        if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
-        run: goreleaser release --snapshot --clean --skip-validate --skip-publish --skip-sign -f ./plugins/source/cloudflare/.goreleaser.yaml
-        env:
-          GORELEASER_KEY: ${{ secrets.GORELEASER_KEY }}
+    if:   startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
+    uses: ./.github/workflows/validate_release.yml
+    with:
+      path: plugins/source/cloudflare

--- a/.github/workflows/source_datadog.yml
+++ b/.github/workflows/source_datadog.yml
@@ -51,37 +51,7 @@ jobs:
       - name: Test
         run: make test
   validate-release:
-    timeout-minutes: 45
-    runs-on: ubuntu-latest
-    env:
-      CGO_ENABLED: 0
-    steps:
-      - name: Checkout
-        if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
-        uses: actions/checkout@v3
-      - uses: actions/cache@v3
-        if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
-        with:
-          path: |
-            ~/.cache/go-build
-            ~/go/pkg/mod
-          key: ${{ runner.os }}-go-1.19.5-release-cache-${{ hashFiles('plugins/source/datadog/go.sum') }}
-          restore-keys: |
-            ${{ runner.os }}-go-1.19.5-release-cache-plugins-source-datadog
-      - name: Set up Go
-        if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
-        uses: actions/setup-go@v3
-        with:
-          go-version-file: plugins/source/datadog/go.mod
-      - name: Install GoReleaser
-        if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
-        uses: goreleaser/goreleaser-action@v3
-        with:
-          distribution: goreleaser-pro
-          version: latest
-          install-only: true
-      - name: Run GoReleaser Dry-Run
-        if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
-        run: goreleaser release --snapshot --clean --skip-validate --skip-publish --skip-sign -f ./plugins/source/datadog/.goreleaser.yaml
-        env:
-          GORELEASER_KEY: ${{ secrets.GORELEASER_KEY }}
+    if:   startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
+    uses: ./.github/workflows/validate_release.yml
+    with:
+      path: plugins/source/datadog

--- a/.github/workflows/source_datadog.yml
+++ b/.github/workflows/source_datadog.yml
@@ -5,12 +5,14 @@ on:
     paths:
       - "plugins/source/datadog/**"
       - ".github/workflows/source_datadog.yml"
+      - .github/workflows/validate_release.yml
   push:
     branches:
       - main
     paths:
       - "plugins/source/datadog/**"
       - ".github/workflows/source_datadog.yml"
+      - .github/workflows/validate_release.yml
 
 jobs:
   plugins-source-datadog:

--- a/.github/workflows/source_digitalocean.yml
+++ b/.github/workflows/source_digitalocean.yml
@@ -51,37 +51,7 @@ jobs:
       - name: Test
         run: make test
   validate-release:
-    timeout-minutes: 30
-    runs-on: ubuntu-latest
-    env:
-      CGO_ENABLED: 0
-    steps:
-      - name: Checkout
-        if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
-        uses: actions/checkout@v3
-      - uses: actions/cache@v3
-        if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
-        with:
-          path: |
-            ~/.cache/go-build
-            ~/go/pkg/mod
-          key: ${{ runner.os }}-go-1.19.5-release-cache-${{ hashFiles('plugins/source/digitalocean/go.sum') }}
-          restore-keys: |
-            ${{ runner.os }}-go-1.19.5-release-cache-plugins-source-digitalocean
-      - name: Set up Go
-        if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
-        uses: actions/setup-go@v3
-        with:
-          go-version-file: plugins/source/digitalocean/go.mod
-      - name: Install GoReleaser
-        if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
-        uses: goreleaser/goreleaser-action@v3
-        with:
-          distribution: goreleaser-pro
-          version: latest
-          install-only: true
-      - name: Run GoReleaser Dry-Run
-        if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
-        run: goreleaser release --snapshot --clean --skip-validate --skip-publish --skip-sign -f ./plugins/source/digitalocean/.goreleaser.yaml
-        env:
-          GORELEASER_KEY: ${{ secrets.GORELEASER_KEY }}
+    if:   startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
+    uses: ./.github/workflows/validate_release.yml
+    with:
+      path: plugins/source/digitalocean

--- a/.github/workflows/source_digitalocean.yml
+++ b/.github/workflows/source_digitalocean.yml
@@ -5,12 +5,14 @@ on:
     paths:
       - "plugins/source/digitalocean/**"
       - ".github/workflows/source_digitalocean.yml"
+      - .github/workflows/validate_release.yml
   push:
     branches:
       - main
     paths:
       - "plugins/source/digitalocean/**"
       - ".github/workflows/source_digitalocean.yml"
+      - .github/workflows/validate_release.yml
 
 jobs:
   plugins-source-digitalocean:

--- a/.github/workflows/source_facebookmarketing.yml
+++ b/.github/workflows/source_facebookmarketing.yml
@@ -5,12 +5,14 @@ on:
     paths:
       - "plugins/source/facebookmarketing/**"
       - ".github/workflows/source_facebookmarketing.yml"
+      - .github/workflows/validate_release.yml
   push:
     branches:
       - main
     paths:
       - "plugins/source/facebookmarketing/**"
       - ".github/workflows/source_facebookmarketing.yml"
+      - .github/workflows/validate_release.yml
 
 jobs:
   plugins-source-facebookmarketing:

--- a/.github/workflows/source_facebookmarketing.yml
+++ b/.github/workflows/source_facebookmarketing.yml
@@ -49,37 +49,7 @@ jobs:
       - name: Test
         run: make test
   validate-release:
-    timeout-minutes: 30
-    runs-on: ubuntu-latest
-    env:
-      CGO_ENABLED: 0
-    steps:
-      - name: Checkout
-        if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
-        uses: actions/checkout@v3
-      - uses: actions/cache@v3
-        if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
-        with:
-          path: |
-            ~/.cache/go-build
-            ~/go/pkg/mod
-          key: ${{ runner.os }}-go-1.19.5-release-cache-${{ hashFiles('plugins/source/facebookmarketing/go.sum') }}
-          restore-keys: |
-            ${{ runner.os }}-go-1.19.5-release-cache-plugins-source-facebookmarketing
-      - name: Set up Go
-        if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
-        uses: actions/setup-go@v3
-        with:
-          go-version-file: plugins/source/facebookmarketing/go.mod
-      - name: Install GoReleaser
-        if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
-        uses: goreleaser/goreleaser-action@v3
-        with:
-          distribution: goreleaser-pro
-          version: latest
-          install-only: true
-      - name: Run GoReleaser Dry-Run
-        if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
-        run: goreleaser release --snapshot --clean --skip-validate --skip-publish --skip-sign -f ./plugins/source/facebookmarketing/.goreleaser.yaml
-        env:
-          GORELEASER_KEY: ${{ secrets.GORELEASER_KEY }}
+    if:   startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
+    uses: ./.github/workflows/validate_release.yml
+    with:
+      path: plugins/source/facebookmarketing

--- a/.github/workflows/source_fastly.yml
+++ b/.github/workflows/source_fastly.yml
@@ -5,12 +5,14 @@ on:
     paths:
       - "plugins/source/fastly/**"
       - ".github/workflows/source_fastly.yml"
+      - .github/workflows/validate_release.yml
   push:
     branches:
       - main
     paths:
       - "plugins/source/fastly/**"
       - ".github/workflows/source_fastly.yml"
+      - .github/workflows/validate_release.yml
 
 jobs:
   plugins-source-fastly:

--- a/.github/workflows/source_fastly.yml
+++ b/.github/workflows/source_fastly.yml
@@ -51,37 +51,7 @@ jobs:
       - name: Test
         run: make test
   validate-release:
-    timeout-minutes: 30
-    runs-on: ubuntu-latest
-    env:
-      CGO_ENABLED: 0
-    steps:
-      - name: Checkout
-        if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
-        uses: actions/checkout@v3
-      - uses: actions/cache@v3
-        if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
-        with:
-          path: |
-            ~/.cache/go-build
-            ~/go/pkg/mod
-          key: ${{ runner.os }}-go-1.19.5-release-cache-${{ hashFiles('plugins/source/fastly/go.sum') }}
-          restore-keys: |
-            ${{ runner.os }}-go-1.19.5-release-cache-plugins-source-fastly
-      - name: Set up Go
-        if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
-        uses: actions/setup-go@v3
-        with:
-          go-version-file: plugins/source/fastly/go.mod
-      - name: Install GoReleaser
-        if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
-        uses: goreleaser/goreleaser-action@v3
-        with:
-          distribution: goreleaser-pro
-          version: latest
-          install-only: true
-      - name: Run GoReleaser Dry-Run
-        if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
-        run: goreleaser release --snapshot --clean --skip-validate --skip-publish --skip-sign -f ./plugins/source/fastly/.goreleaser.yaml
-        env:
-          GORELEASER_KEY: ${{ secrets.GORELEASER_KEY }}
+    if:   startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
+    uses: ./.github/workflows/validate_release.yml
+    with:
+      path: plugins/source/fastly

--- a/.github/workflows/source_gandi.yml
+++ b/.github/workflows/source_gandi.yml
@@ -5,12 +5,14 @@ on:
     paths:
       - "plugins/source/gandi/**"
       - ".github/workflows/source_gandi.yml"
+      - .github/workflows/validate_release.yml
   push:
     branches:
       - main
     paths:
       - "plugins/source/gandi/**"
       - ".github/workflows/source_gandi.yml"
+      - .github/workflows/validate_release.yml
 
 jobs:
   plugins-source-gandi:

--- a/.github/workflows/source_gandi.yml
+++ b/.github/workflows/source_gandi.yml
@@ -51,37 +51,7 @@ jobs:
       - name: Test
         run: make test
   validate-release:
-    timeout-minutes: 30
-    runs-on: ubuntu-latest
-    env:
-      CGO_ENABLED: 0
-    steps:
-      - name: Checkout
-        if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
-        uses: actions/checkout@v3
-      - uses: actions/cache@v3
-        if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
-        with:
-          path: |
-            ~/.cache/go-build
-            ~/go/pkg/mod
-          key: ${{ runner.os }}-go-1.19.5-release-cache-${{ hashFiles('plugins/source/gandi/go.sum') }}
-          restore-keys: |
-            ${{ runner.os }}-go-1.19.5-release-cache-plugins-source-gandi
-      - name: Set up Go
-        if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
-        uses: actions/setup-go@v3
-        with:
-          go-version-file: plugins/source/gandi/go.mod
-      - name: Install GoReleaser
-        if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
-        uses: goreleaser/goreleaser-action@v3
-        with:
-          distribution: goreleaser-pro
-          version: latest
-          install-only: true
-      - name: Run GoReleaser Dry-Run
-        if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
-        run: goreleaser release --snapshot --clean --skip-validate --skip-publish --skip-sign -f ./plugins/source/gandi/.goreleaser.yaml
-        env:
-          GORELEASER_KEY: ${{ secrets.GORELEASER_KEY }}
+    if:   startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
+    uses: ./.github/workflows/validate_release.yml
+    with:
+      path: plugins/source/gandi

--- a/.github/workflows/source_gcp.yml
+++ b/.github/workflows/source_gcp.yml
@@ -71,41 +71,12 @@ jobs:
       - name: Test
         run: make test
   validate-release:
-    timeout-minutes: 30
-    needs: [resolve-runner]
-    runs-on: ${{ needs.resolve-runner.outputs.runner }}
-    env:
-      CGO_ENABLED: 0
-    steps:
-      - name: Checkout
-        if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
-        uses: actions/checkout@v3
-      - uses: actions/cache@v3
-        if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
-        with:
-          path: |
-            ~/.cache/go-build
-            ~/go/pkg/mod
-          key: ${{ runner.os }}-go-1.19.5-release-cache-${{ hashFiles('plugins/source/gcp/go.sum') }}
-          restore-keys: |
-            ${{ runner.os }}-go-1.19.5-release-cache-plugins-source-gcp
-      - name: Set up Go
-        if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
-        uses: actions/setup-go@v3
-        with:
-          go-version-file: plugins/source/gcp/go.mod
-      - name: Install GoReleaser
-        if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
-        uses: goreleaser/goreleaser-action@v3
-        with:
-          distribution: goreleaser-pro
-          version: latest
-          install-only: true
-      - name: Run GoReleaser Dry-Run
-        if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
-        run: goreleaser release --snapshot --clean --skip-validate --skip-publish --skip-sign -f ./plugins/source/gcp/.goreleaser.yaml
-        env:
-          GORELEASER_KEY: ${{ secrets.GORELEASER_KEY }}
+    if:   startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
+    needs: [ resolve-runner ]
+    uses: ./.github/workflows/validate_release.yml
+    with:
+      path:   plugins/source/gcp
+      runner: ${{ needs.resolve-runner.outputs.runner }}
   test-policies:
     timeout-minutes: 30
     needs: [resolve-runner]

--- a/.github/workflows/source_gcp.yml
+++ b/.github/workflows/source_gcp.yml
@@ -5,12 +5,14 @@ on:
     paths:
       - "plugins/source/gcp/**"
       - ".github/workflows/source_gcp.yml"
+      - .github/workflows/validate_release.yml
   push:
     branches:
       - main
     paths:
       - "plugins/source/gcp/**"
       - ".github/workflows/source_gcp.yml"
+      - .github/workflows/validate_release.yml
 
 jobs:
   resolve-runner:

--- a/.github/workflows/source_github.yml
+++ b/.github/workflows/source_github.yml
@@ -51,37 +51,7 @@ jobs:
       - name: Test
         run: make test
   validate-release:
-    timeout-minutes: 30
-    runs-on: ubuntu-latest
-    env:
-      CGO_ENABLED: 0
-    steps:
-      - name: Checkout
-        if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
-        uses: actions/checkout@v3
-      - uses: actions/cache@v3
-        if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
-        with:
-          path: |
-            ~/.cache/go-build
-            ~/go/pkg/mod
-          key: ${{ runner.os }}-go-1.19.5-release-cache-${{ hashFiles('plugins/source/github/go.sum') }}
-          restore-keys: |
-            ${{ runner.os }}-go-1.19.5-release-cache-plugins-source-github
-      - name: Set up Go
-        if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
-        uses: actions/setup-go@v3
-        with:
-          go-version-file: plugins/source/github/go.mod
-      - name: Install GoReleaser
-        if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
-        uses: goreleaser/goreleaser-action@v3
-        with:
-          distribution: goreleaser-pro
-          version: latest
-          install-only: true
-      - name: Run GoReleaser Dry-Run
-        if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
-        run: goreleaser release --snapshot --clean --skip-validate --skip-publish --skip-sign -f ./plugins/source/github/.goreleaser.yaml
-        env:
-          GORELEASER_KEY: ${{ secrets.GORELEASER_KEY }}
+    if:   startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
+    uses: ./.github/workflows/validate_release.yml
+    with:
+      path: plugins/source/github

--- a/.github/workflows/source_github.yml
+++ b/.github/workflows/source_github.yml
@@ -5,12 +5,14 @@ on:
     paths:
       - "plugins/source/github/**"
       - ".github/workflows/source_github.yml"
+      - .github/workflows/validate_release.yml
   push:
     branches:
       - main
     paths:
       - "plugins/source/github/**"
       - ".github/workflows/source_github.yml"
+      - .github/workflows/validate_release.yml
 
 jobs:
   plugins-source-github:

--- a/.github/workflows/source_gitlab.yml
+++ b/.github/workflows/source_gitlab.yml
@@ -51,37 +51,7 @@ jobs:
       - name: Test
         run: make test
   validate-release:
-    timeout-minutes: 30
-    runs-on: ubuntu-latest
-    env:
-      CGO_ENABLED: 0
-    steps:
-      - name: Checkout
-        if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
-        uses: actions/checkout@v3
-      - uses: actions/cache@v3
-        if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
-        with:
-          path: |
-            ~/.cache/go-build
-            ~/go/pkg/mod
-          key: ${{ runner.os }}-go-1.19.5-release-cache-${{ hashFiles('plugins/source/gitlab/go.sum') }}
-          restore-keys: |
-            ${{ runner.os }}-go-1.19.5-release-cache-plugins-source-github
-      - name: Set up Go
-        if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
-        uses: actions/setup-go@v3
-        with:
-          go-version-file: plugins/source/gitlab/go.mod
-      - name: Install GoReleaser
-        if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
-        uses: goreleaser/goreleaser-action@v3
-        with:
-          distribution: goreleaser-pro
-          version: latest
-          install-only: true
-      - name: Run GoReleaser Dry-Run
-        if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
-        run: goreleaser release --snapshot --clean --skip-validate --skip-publish --skip-sign -f ./plugins/source/gitlab/.goreleaser.yaml
-        env:
-          GORELEASER_KEY: ${{ secrets.GORELEASER_KEY }}
+    if:   startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
+    uses: ./.github/workflows/validate_release.yml
+    with:
+      path: plugins/source/gitlab

--- a/.github/workflows/source_gitlab.yml
+++ b/.github/workflows/source_gitlab.yml
@@ -5,12 +5,14 @@ on:
     paths:
       - "plugins/source/gitlab/**"
       - ".github/workflows/source_gitlab.yml"
+      - .github/workflows/validate_release.yml
   push:
     branches:
       - main
     paths:
       - "plugins/source/gitlab/**"
       - ".github/workflows/source_gitlab.yml"
+      - .github/workflows/validate_release.yml
 
 jobs:
   plugins-source-github:

--- a/.github/workflows/source_googleads.yml
+++ b/.github/workflows/source_googleads.yml
@@ -49,37 +49,7 @@ jobs:
       - name: Test
         run: make test
   validate-release:
-    timeout-minutes: 30
-    runs-on: ubuntu-latest
-    env:
-      CGO_ENABLED: 0
-    steps:
-      - name: Checkout
-        if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
-        uses: actions/checkout@v3
-      - uses: actions/cache@v3
-        if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
-        with:
-          path: |
-            ~/.cache/go-build
-            ~/go/pkg/mod
-          key: ${{ runner.os }}-go-1.19.5-release-cache-${{ hashFiles('plugins/source/googleads/go.sum') }}
-          restore-keys: |
-            ${{ runner.os }}-go-1.19.5-release-cache-plugins-source-googleads
-      - name: Set up Go
-        if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
-        uses: actions/setup-go@v3
-        with:
-          go-version-file: plugins/source/googleads/go.mod
-      - name: Install GoReleaser
-        if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
-        uses: goreleaser/goreleaser-action@v3
-        with:
-          distribution: goreleaser-pro
-          version: latest
-          install-only: true
-      - name: Run GoReleaser Dry-Run
-        if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
-        run: goreleaser release --snapshot --clean --skip-validate --skip-publish --skip-sign -f ./plugins/source/googleads/.goreleaser.yaml
-        env:
-          GORELEASER_KEY: ${{ secrets.GORELEASER_KEY }}
+    if:   startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
+    uses: ./.github/workflows/validate_release.yml
+    with:
+      path: plugins/source/googleads

--- a/.github/workflows/source_googleads.yml
+++ b/.github/workflows/source_googleads.yml
@@ -5,12 +5,14 @@ on:
     paths:
       - "plugins/source/googleads/**"
       - ".github/workflows/source_googleads.yml"
+      - .github/workflows/validate_release.yml
   push:
     branches:
       - main
     paths:
       - "plugins/source/googleads/**"
       - ".github/workflows/source_googleads.yml"
+      - .github/workflows/validate_release.yml
 
 jobs:
   plugins-source-googleads:

--- a/.github/workflows/source_googleanalytics.yml
+++ b/.github/workflows/source_googleanalytics.yml
@@ -5,12 +5,14 @@ on:
     paths:
       - "plugins/source/googleanalytics/**"
       - ".github/workflows/source_googleanalytics.yml"
+      - .github/workflows/validate_release.yml
   push:
     branches:
       - main
     paths:
       - "plugins/source/googleanalytics/**"
       - ".github/workflows/source_googleanalytics.yml"
+      - .github/workflows/validate_release.yml
 
 jobs:
   plugins-source-googleanalytics:

--- a/.github/workflows/source_googleanalytics.yml
+++ b/.github/workflows/source_googleanalytics.yml
@@ -49,37 +49,7 @@ jobs:
       - name: Test
         run: make test
   validate-release:
-    timeout-minutes: 30
-    runs-on: ubuntu-latest
-    env:
-      CGO_ENABLED: 0
-    steps:
-      - name: Checkout
-        if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
-        uses: actions/checkout@v3
-      - uses: actions/cache@v3
-        if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
-        with:
-          path: |
-            ~/.cache/go-build
-            ~/go/pkg/mod
-          key: ${{ runner.os }}-go-1.19.5-release-cache-${{ hashFiles('plugins/source/googleanalytics/go.sum') }}
-          restore-keys: |
-            ${{ runner.os }}-go-1.19.5-release-cache-plugins-source-googleanalytics
-      - name: Set up Go
-        if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
-        uses: actions/setup-go@v3
-        with:
-          go-version-file: plugins/source/googleanalytics/go.mod
-      - name: Install GoReleaser
-        if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
-        uses: goreleaser/goreleaser-action@v3
-        with:
-          distribution: goreleaser-pro
-          version: latest
-          install-only: true
-      - name: Run GoReleaser Dry-Run
-        if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
-        run: goreleaser release --snapshot --clean --skip-validate --skip-publish --skip-sign -f ./plugins/source/googleanalytics/.goreleaser.yaml
-        env:
-          GORELEASER_KEY: ${{ secrets.GORELEASER_KEY }}
+    if:   startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
+    uses: ./.github/workflows/validate_release.yml
+    with:
+      path: plugins/source/googleanalytics

--- a/.github/workflows/source_hackernews.yml
+++ b/.github/workflows/source_hackernews.yml
@@ -5,12 +5,14 @@ on:
     paths:
       - "plugins/source/hackernews/**"
       - ".github/workflows/source_hackernews.yml"
+      - .github/workflows/validate_release.yml
   push:
     branches:
       - main
     paths:
       - "plugins/source/hackernews/**"
       - ".github/workflows/source_hackernews.yml"
+      - .github/workflows/validate_release.yml
 
 jobs:
   plugins-source-hackernews:

--- a/.github/workflows/source_hackernews.yml
+++ b/.github/workflows/source_hackernews.yml
@@ -49,37 +49,7 @@ jobs:
       - name: Test
         run: make test
   validate-release:
-    timeout-minutes: 30
-    runs-on: ubuntu-latest
-    env:
-      CGO_ENABLED: 0
-    steps:
-      - name: Checkout
-        if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
-        uses: actions/checkout@v3
-      - uses: actions/cache@v3
-        if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
-        with:
-          path: |
-            ~/.cache/go-build
-            ~/go/pkg/mod
-          key: ${{ runner.os }}-go-1.19.5-release-cache-${{ hashFiles('plugins/source/hackernews/go.sum') }}
-          restore-keys: |
-            ${{ runner.os }}-go-1.19.5-release-cache-plugins-source-hackernews
-      - name: Set up Go
-        if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
-        uses: actions/setup-go@v3
-        with:
-          go-version-file: plugins/source/hackernews/go.mod
-      - name: Install GoReleaser
-        if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
-        uses: goreleaser/goreleaser-action@v3
-        with:
-          distribution: goreleaser-pro
-          version: latest
-          install-only: true
-      - name: Run GoReleaser Dry-Run
-        if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
-        run: goreleaser release --snapshot --clean --skip-validate --skip-publish --skip-sign -f ./plugins/source/hackernews/.goreleaser.yaml
-        env:
-          GORELEASER_KEY: ${{ secrets.GORELEASER_KEY }}
+    if:   startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
+    uses: ./.github/workflows/validate_release.yml
+    with:
+      path: plugins/source/hackernews

--- a/.github/workflows/source_heroku.yml
+++ b/.github/workflows/source_heroku.yml
@@ -51,37 +51,7 @@ jobs:
       - name: Test
         run: make test
   validate-release:
-    timeout-minutes: 30
-    runs-on: ubuntu-latest
-    env:
-      CGO_ENABLED: 0
-    steps:
-      - name: Checkout
-        if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
-        uses: actions/checkout@v3
-      - uses: actions/cache@v3
-        if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
-        with:
-          path: |
-            ~/.cache/go-build
-            ~/go/pkg/mod
-          key: ${{ runner.os }}-go-1.19.5-release-cache-${{ hashFiles('plugins/source/heroku/go.sum') }}
-          restore-keys: |
-            ${{ runner.os }}-go-1.19.5-release-cache-plugins-source-heroku
-      - name: Set up Go
-        if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
-        uses: actions/setup-go@v3
-        with:
-          go-version-file: plugins/source/heroku/go.mod
-      - name: Install GoReleaser
-        if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
-        uses: goreleaser/goreleaser-action@v3
-        with:
-          distribution: goreleaser-pro
-          version: latest
-          install-only: true
-      - name: Run GoReleaser Dry-Run
-        if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
-        run: goreleaser release --snapshot --clean --skip-validate --skip-publish --skip-sign -f ./plugins/source/heroku/.goreleaser.yaml
-        env:
-          GORELEASER_KEY: ${{ secrets.GORELEASER_KEY }}
+    if:   startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
+    uses: ./.github/workflows/validate_release.yml
+    with:
+      path: plugins/source/heroku

--- a/.github/workflows/source_heroku.yml
+++ b/.github/workflows/source_heroku.yml
@@ -5,12 +5,14 @@ on:
     paths:
       - "plugins/source/heroku/**"
       - ".github/workflows/source_heroku.yml"
+      - .github/workflows/validate_release.yml
   push:
     branches:
       - main
     paths:
       - "plugins/source/heroku/**"
       - ".github/workflows/source_heroku.yml"
+      - .github/workflows/validate_release.yml
 
 jobs:
   plugins-source-heroku:

--- a/.github/workflows/source_homebrew.yml
+++ b/.github/workflows/source_homebrew.yml
@@ -49,37 +49,7 @@ jobs:
       - name: Test
         run: make test
   validate-release:
-    timeout-minutes: 30
-    runs-on: ubuntu-latest
-    env:
-      CGO_ENABLED: 0
-    steps:
-      - name: Checkout
-        if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
-        uses: actions/checkout@v3
-      - uses: actions/cache@v3
-        if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
-        with:
-          path: |
-            ~/.cache/go-build
-            ~/go/pkg/mod
-          key: ${{ runner.os }}-go-1.19.5-release-cache-${{ hashFiles('plugins/source/homebrew/go.sum') }}
-          restore-keys: |
-            ${{ runner.os }}-go-1.19.5-release-cache-plugins-source-homebrew
-      - name: Set up Go
-        if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
-        uses: actions/setup-go@v3
-        with:
-          go-version-file: plugins/source/homebrew/go.mod
-      - name: Install GoReleaser
-        if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
-        uses: goreleaser/goreleaser-action@v3
-        with:
-          distribution: goreleaser-pro
-          version: latest
-          install-only: true
-      - name: Run GoReleaser Dry-Run
-        if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
-        run: goreleaser release --snapshot --clean --skip-validate --skip-publish --skip-sign -f ./plugins/source/homebrew/.goreleaser.yaml
-        env:
-          GORELEASER_KEY: ${{ secrets.GORELEASER_KEY }}
+    if:   startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
+    uses: ./.github/workflows/validate_release.yml
+    with:
+      path: plugins/source/homebrew

--- a/.github/workflows/source_homebrew.yml
+++ b/.github/workflows/source_homebrew.yml
@@ -5,12 +5,14 @@ on:
     paths:
       - "plugins/source/homebrew/**"
       - ".github/workflows/source_homebrew.yml"
+      - .github/workflows/validate_release.yml
   push:
     branches:
       - main
     paths:
       - "plugins/source/homebrew/**"
       - ".github/workflows/source_homebrew.yml"
+      - .github/workflows/validate_release.yml
 
 jobs:
   plugins-source-homebrew:

--- a/.github/workflows/source_hubspot.yml
+++ b/.github/workflows/source_hubspot.yml
@@ -49,37 +49,7 @@ jobs:
       - name: Test
         run: make test
   validate-release:
-    timeout-minutes: 30
-    runs-on: ubuntu-latest
-    env:
-      CGO_ENABLED: 0
-    steps:
-      - name: Checkout
-        if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
-        uses: actions/checkout@v3
-      - uses: actions/cache@v3
-        if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
-        with:
-          path: |
-            ~/.cache/go-build
-            ~/go/pkg/mod
-          key: ${{ runner.os }}-go-1.19.5-release-cache-${{ hashFiles('plugins/source/hubspot/go.sum') }}
-          restore-keys: |
-            ${{ runner.os }}-go-1.19.5-release-cache-plugins-source-hubspot
-      - name: Set up Go
-        if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
-        uses: actions/setup-go@v3
-        with:
-          go-version-file: plugins/source/hubspot/go.mod
-      - name: Install GoReleaser
-        if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
-        uses: goreleaser/goreleaser-action@v3
-        with:
-          distribution: goreleaser-pro
-          version: latest
-          install-only: true
-      - name: Run GoReleaser Dry-Run
-        if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
-        run: goreleaser release --snapshot --clean --skip-validate --skip-publish --skip-sign -f ./plugins/source/hubspot/.goreleaser.yaml
-        env:
-          GORELEASER_KEY: ${{ secrets.GORELEASER_KEY }}
+    if:   startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
+    uses: ./.github/workflows/validate_release.yml
+    with:
+      path: plugins/source/hubspot

--- a/.github/workflows/source_hubspot.yml
+++ b/.github/workflows/source_hubspot.yml
@@ -5,12 +5,14 @@ on:
     paths:
       - "plugins/source/hubspot/**"
       - ".github/workflows/source_hubspot.yml"
+      - .github/workflows/validate_release.yml
   push:
     branches:
       - main
     paths:
       - "plugins/source/hubspot/**"
       - ".github/workflows/source_hubspot.yml"
+      - .github/workflows/validate_release.yml
 
 jobs:
   plugins-source-hubspot:

--- a/.github/workflows/source_k8s.yml
+++ b/.github/workflows/source_k8s.yml
@@ -71,41 +71,12 @@ jobs:
       - name: Test
         run: make test
   validate-release:
-    timeout-minutes: 30
-    needs: [resolve-runner]
-    runs-on: ${{ needs.resolve-runner.outputs.runner }}
-    env:
-      CGO_ENABLED: 0
-    steps:
-      - name: Checkout
-        if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
-        uses: actions/checkout@v3
-      - uses: actions/cache@v3
-        if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
-        with:
-          path: |
-            ~/.cache/go-build
-            ~/go/pkg/mod
-          key: ${{ runner.os }}-go-1.19.5-release-cache-${{ hashFiles('plugins/source/k8s/go.sum') }}
-          restore-keys: |
-            ${{ runner.os }}-go-1.19.5-release-cache-plugins-source-k8s
-      - name: Set up Go
-        if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
-        uses: actions/setup-go@v3
-        with:
-          go-version-file: plugins/source/k8s/go.mod
-      - name: Install GoReleaser
-        if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
-        uses: goreleaser/goreleaser-action@v3
-        with:
-          distribution: goreleaser-pro
-          version: latest
-          install-only: true
-      - name: Run GoReleaser Dry-Run
-        if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
-        run: goreleaser release --snapshot --clean --skip-validate --skip-publish --skip-sign -f ./plugins/source/k8s/.goreleaser.yaml
-        env:
-          GORELEASER_KEY: ${{ secrets.GORELEASER_KEY }}
+    if:   startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
+    needs: [ resolve-runner ]
+    uses: ./.github/workflows/validate_release.yml
+    with:
+      path:   plugins/source/k8s
+      runner: ${{ needs.resolve-runner.outputs.runner }}
   test-policies:
     timeout-minutes: 30
     needs: [resolve-runner]

--- a/.github/workflows/source_k8s.yml
+++ b/.github/workflows/source_k8s.yml
@@ -5,12 +5,14 @@ on:
     paths:
       - "plugins/source/k8s/**"
       - ".github/workflows/source_k8s.yml"
+      - .github/workflows/validate_release.yml
   push:
     branches:
       - main
     paths:
       - "plugins/source/k8s/**"
       - ".github/workflows/source_k8s.yml"
+      - .github/workflows/validate_release.yml
 
 jobs:
   resolve-runner:

--- a/.github/workflows/source_launchdarkly.yml
+++ b/.github/workflows/source_launchdarkly.yml
@@ -51,37 +51,7 @@ jobs:
       - name: Test
         run: make test
   validate-release:
-    timeout-minutes: 30
-    runs-on: ubuntu-latest
-    env:
-      CGO_ENABLED: 0
-    steps:
-      - name: Checkout
-        if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
-        uses: actions/checkout@v3
-      - uses: actions/cache@v3
-        if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
-        with:
-          path: |
-            ~/.cache/go-build
-            ~/go/pkg/mod
-          key: ${{ runner.os }}-go-1.19.5-release-cache-${{ hashFiles('plugins/source/launchdarkly/go.sum') }}
-          restore-keys: |
-            ${{ runner.os }}-go-1.19.5-release-cache-plugins-source-launchdarkly
-      - name: Set up Go
-        if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
-        uses: actions/setup-go@v3
-        with:
-          go-version-file: plugins/source/launchdarkly/go.mod
-      - name: Install GoReleaser
-        if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
-        uses: goreleaser/goreleaser-action@v3
-        with:
-          distribution: goreleaser-pro
-          version: latest
-          install-only: true
-      - name: Run GoReleaser Dry-Run
-        if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
-        run: goreleaser release --snapshot --clean --skip-validate --skip-publish --skip-sign -f ./plugins/source/launchdarkly/.goreleaser.yaml
-        env:
-          GORELEASER_KEY: ${{ secrets.GORELEASER_KEY }}
+    if:   startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
+    uses: ./.github/workflows/validate_release.yml
+    with:
+      path: plugins/source/launchdarkly

--- a/.github/workflows/source_launchdarkly.yml
+++ b/.github/workflows/source_launchdarkly.yml
@@ -5,12 +5,14 @@ on:
     paths:
       - "plugins/source/launchdarkly/**"
       - ".github/workflows/source_launchdarkly.yml"
+      - .github/workflows/validate_release.yml
   push:
     branches:
       - main
     paths:
       - "plugins/source/launchdarkly/**"
       - ".github/workflows/source_launchdarkly.yml"
+      - .github/workflows/validate_release.yml
 
 jobs:
   plugins-source-launchdarkly:

--- a/.github/workflows/source_mixpanel.yml
+++ b/.github/workflows/source_mixpanel.yml
@@ -51,37 +51,7 @@ jobs:
       - name: Test
         run: make test
   validate-release:
-    timeout-minutes: 30
-    runs-on: ubuntu-latest
-    env:
-      CGO_ENABLED: 0
-    steps:
-      - name: Checkout
-        if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
-        uses: actions/checkout@v3
-      - uses: actions/cache@v3
-        if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
-        with:
-          path: |
-            ~/.cache/go-build
-            ~/go/pkg/mod
-          key: ${{ runner.os }}-go-1.19.5-release-cache-${{ hashFiles('plugins/source/mixpanel/go.sum') }}
-          restore-keys: |
-            ${{ runner.os }}-go-1.19.5-release-cache-plugins-source-mixpanel
-      - name: Set up Go
-        if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
-        uses: actions/setup-go@v3
-        with:
-          go-version-file: plugins/source/mixpanel/go.mod
-      - name: Install GoReleaser
-        if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
-        uses: goreleaser/goreleaser-action@v3
-        with:
-          distribution: goreleaser-pro
-          version: latest
-          install-only: true
-      - name: Run GoReleaser Dry-Run
-        if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
-        run: goreleaser release --snapshot --clean --skip-validate --skip-publish --skip-sign -f ./plugins/source/mixpanel/.goreleaser.yaml
-        env:
-          GORELEASER_KEY: ${{ secrets.GORELEASER_KEY }}
+    if:   startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
+    uses: ./.github/workflows/validate_release.yml
+    with:
+      path: plugins/source/mixpanel

--- a/.github/workflows/source_mixpanel.yml
+++ b/.github/workflows/source_mixpanel.yml
@@ -5,12 +5,14 @@ on:
     paths:
       - "plugins/source/mixpanel/**"
       - ".github/workflows/source_mixpanel.yml"
+      - .github/workflows/validate_release.yml
   push:
     branches:
       - main
     paths:
       - "plugins/source/mixpanel/**"
       - ".github/workflows/source_mixpanel.yml"
+      - .github/workflows/validate_release.yml
 
 jobs:
   plugins-source-mixpanel:

--- a/.github/workflows/source_mysql.yml
+++ b/.github/workflows/source_mysql.yml
@@ -58,37 +58,7 @@ jobs:
       - name: Test mysql
         run: make test
   validate-release:
-    timeout-minutes: 30
-    runs-on: ubuntu-latest
-    env:
-      CGO_ENABLED: 0
-    steps:
-      - name: Checkout
-        if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
-        uses: actions/checkout@v3
-      - uses: actions/cache@v3
-        if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
-        with:
-          path: |
-            ~/.cache/go-build
-            ~/go/pkg/mod
-          key: ${{ runner.os }}-go-1.19.5-release-cache-${{ hashFiles('plugins/source/mysql/go.sum') }}
-          restore-keys: |
-            ${{ runner.os }}-go-1.19.5-release-cache-plugins-source-mysql
-      - name: Set up Go
-        if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
-        uses: actions/setup-go@v3
-        with:
-          go-version-file: plugins/source/mysql/go.mod
-      - name: Install GoReleaser
-        if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
-        uses: goreleaser/goreleaser-action@v3
-        with:
-          distribution: goreleaser-pro
-          version: latest
-          install-only: true
-      - name: Run GoReleaser Dry-Run
-        if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
-        run: goreleaser release --snapshot --clean --skip-validate --skip-publish --skip-sign -f ./plugins/source/mysql/.goreleaser.yaml
-        env:
-          GORELEASER_KEY: ${{ secrets.GORELEASER_KEY }}
+    if:   startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
+    uses: ./.github/workflows/validate_release.yml
+    with:
+      path: plugins/source/mysql

--- a/.github/workflows/source_mysql.yml
+++ b/.github/workflows/source_mysql.yml
@@ -5,12 +5,14 @@ on:
     paths:
       - "plugins/source/mysql/**"
       - ".github/workflows/source_mysql.yml"
+      - .github/workflows/validate_release.yml
   push:
     branches:
       - main
     paths:
       - "plugins/source/mysql/**"
       - ".github/workflows/source_mysql.yml"
+      - .github/workflows/validate_release.yml
 
 jobs:
   plugins-source-mysql:

--- a/.github/workflows/source_okta.yml
+++ b/.github/workflows/source_okta.yml
@@ -51,37 +51,7 @@ jobs:
       - name: Test
         run: make test
   validate-release:
-    timeout-minutes: 30
-    runs-on: ubuntu-latest
-    env:
-      CGO_ENABLED: 0
-    steps:
-      - name: Checkout
-        if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
-        uses: actions/checkout@v3
-      - uses: actions/cache@v3
-        if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
-        with:
-          path: |
-            ~/.cache/go-build
-            ~/go/pkg/mod
-          key: ${{ runner.os }}-go-1.19.5-release-cache-${{ hashFiles('plugins/source/okta/go.sum') }}
-          restore-keys: |
-            ${{ runner.os }}-go-1.19.5-release-cache-plugins-source-okta
-      - name: Set up Go
-        if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
-        uses: actions/setup-go@v3
-        with:
-          go-version-file: plugins/source/okta/go.mod
-      - name: Install GoReleaser
-        if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
-        uses: goreleaser/goreleaser-action@v3
-        with:
-          distribution: goreleaser-pro
-          version: latest
-          install-only: true
-      - name: Run GoReleaser Dry-Run
-        if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
-        run: goreleaser release --snapshot --clean --skip-validate --skip-publish --skip-sign -f ./plugins/source/okta/.goreleaser.yaml
-        env:
-          GORELEASER_KEY: ${{ secrets.GORELEASER_KEY }}
+    if:   startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
+    uses: ./.github/workflows/validate_release.yml
+    with:
+      path: plugins/source/okta

--- a/.github/workflows/source_okta.yml
+++ b/.github/workflows/source_okta.yml
@@ -5,12 +5,14 @@ on:
     paths:
       - "plugins/source/okta/**"
       - ".github/workflows/source_okta.yml"
+      - .github/workflows/validate_release.yml
   push:
     branches:
       - main
     paths:
       - "plugins/source/okta/**"
       - ".github/workflows/source_okta.yml"
+      - .github/workflows/validate_release.yml
 
 jobs:
   plugins-source-okta:

--- a/.github/workflows/source_oracle.yml
+++ b/.github/workflows/source_oracle.yml
@@ -5,12 +5,14 @@ on:
     paths:
       - "plugins/source/oracle/**"
       - ".github/workflows/source_oracle.yml"
+      - .github/workflows/validate_release.yml
   push:
     branches:
       - main
     paths:
       - "plugins/source/oracle/**"
       - ".github/workflows/source_oracle.yml"
+      - .github/workflows/validate_release.yml
 
 jobs:
   plugins-source-oracle:

--- a/.github/workflows/source_oracle.yml
+++ b/.github/workflows/source_oracle.yml
@@ -49,37 +49,7 @@ jobs:
       - name: Test
         run: make test
   validate-release:
-    timeout-minutes: 30
-    runs-on: ubuntu-latest
-    env:
-      CGO_ENABLED: 0
-    steps:
-      - name: Checkout
-        if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
-        uses: actions/checkout@v3
-      - uses: actions/cache@v3
-        if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
-        with:
-          path: |
-            ~/.cache/go-build
-            ~/go/pkg/mod
-          key: ${{ runner.os }}-go-1.19.5-release-cache-${{ hashFiles('plugins/source/oracle/go.sum') }}
-          restore-keys: |
-            ${{ runner.os }}-go-1.19.5-release-cache-plugins-source-oracle
-      - name: Set up Go
-        if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
-        uses: actions/setup-go@v3
-        with:
-          go-version-file: plugins/source/oracle/go.mod
-      - name: Install GoReleaser
-        if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
-        uses: goreleaser/goreleaser-action@v3
-        with:
-          distribution: goreleaser-pro
-          version: latest
-          install-only: true
-      - name: Run GoReleaser Dry-Run
-        if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
-        run: goreleaser release --snapshot --clean --skip-validate --skip-publish --skip-sign -f ./plugins/source/oracle/.goreleaser.yaml
-        env:
-          GORELEASER_KEY: ${{ secrets.GORELEASER_KEY }}
+    if:   startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
+    uses: ./.github/workflows/validate_release.yml
+    with:
+      path: plugins/source/oracle

--- a/.github/workflows/source_pagerduty.yml
+++ b/.github/workflows/source_pagerduty.yml
@@ -51,37 +51,7 @@ jobs:
       - name: Test
         run: make test
   validate-release:
-    timeout-minutes: 30
-    runs-on: ubuntu-latest
-    env:
-      CGO_ENABLED: 0
-    steps:
-      - name: Checkout
-        if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
-        uses: actions/checkout@v3
-      - uses: actions/cache@v3
-        if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
-        with:
-          path: |
-            ~/.cache/go-build
-            ~/go/pkg/mod
-          key: ${{ runner.os }}-go-1.19.5-release-cache-${{ hashFiles('plugins/source/pagerduty/go.sum') }}
-          restore-keys: |
-            ${{ runner.os }}-go-1.19.5-release-cache-plugins-source-pagerduty
-      - name: Set up Go
-        if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
-        uses: actions/setup-go@v3
-        with:
-          go-version-file: plugins/source/pagerduty/go.mod
-      - name: Install GoReleaser
-        if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
-        uses: goreleaser/goreleaser-action@v3
-        with:
-          distribution: goreleaser-pro
-          version: latest
-          install-only: true
-      - name: Run GoReleaser Dry-Run
-        if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
-        run: goreleaser release --snapshot --clean --skip-validate --skip-publish --skip-sign -f ./plugins/source/pagerduty/.goreleaser.yaml
-        env:
-          GORELEASER_KEY: ${{ secrets.GORELEASER_KEY }}
+    if:   startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
+    uses: ./.github/workflows/validate_release.yml
+    with:
+      path: plugins/source/pagerduty

--- a/.github/workflows/source_pagerduty.yml
+++ b/.github/workflows/source_pagerduty.yml
@@ -5,12 +5,14 @@ on:
     paths:
       - "plugins/source/pagerduty/**"
       - ".github/workflows/source_pagerduty.yml"
+      - .github/workflows/validate_release.yml
   push:
     branches:
       - main
     paths:
       - "plugins/source/pagerduty/**"
       - ".github/workflows/source_pagerduty.yml"
+      - .github/workflows/validate_release.yml
 
 jobs:
   plugins-source-pagerduty:

--- a/.github/workflows/source_plausible.yml
+++ b/.github/workflows/source_plausible.yml
@@ -5,12 +5,14 @@ on:
     paths:
       - "plugins/source/plausible/**"
       - ".github/workflows/source_plausible.yml"
+      - .github/workflows/validate_release.yml
   push:
     branches:
       - main
     paths:
       - "plugins/source/plausible/**"
       - ".github/workflows/source_plausible.yml"
+      - .github/workflows/validate_release.yml
 
 jobs:
   plugins-source-plausible:

--- a/.github/workflows/source_plausible.yml
+++ b/.github/workflows/source_plausible.yml
@@ -51,37 +51,7 @@ jobs:
       - name: Test
         run: make test
   validate-release:
-    timeout-minutes: 30
-    runs-on: ubuntu-latest
-    env:
-      CGO_ENABLED: 0
-    steps:
-      - name: Checkout
-        if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
-        uses: actions/checkout@v3
-      - uses: actions/cache@v3
-        if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
-        with:
-          path: |
-            ~/.cache/go-build
-            ~/go/pkg/mod
-          key: ${{ runner.os }}-go-1.19.5-release-cache-${{ hashFiles('plugins/source/plausible/go.sum') }}
-          restore-keys: |
-            ${{ runner.os }}-go-1.19.5-release-cache-plugins-source-plausible
-      - name: Set up Go
-        if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
-        uses: actions/setup-go@v3
-        with:
-          go-version-file: plugins/source/plausible/go.mod
-      - name: Install GoReleaser
-        if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
-        uses: goreleaser/goreleaser-action@v3
-        with:
-          distribution: goreleaser-pro
-          version: latest
-          install-only: true
-      - name: Run GoReleaser Dry-Run
-        if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
-        run: goreleaser release --snapshot --clean --skip-validate --skip-publish --skip-sign -f ./plugins/source/plausible/.goreleaser.yaml
-        env:
-          GORELEASER_KEY: ${{ secrets.GORELEASER_KEY }}
+    if:   startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
+    uses: ./.github/workflows/validate_release.yml
+    with:
+      path: plugins/source/plausible

--- a/.github/workflows/source_postgresql.yml
+++ b/.github/workflows/source_postgresql.yml
@@ -5,12 +5,14 @@ on:
     paths:
       - "plugins/source/postgresql/**"
       - ".github/workflows/source_postgresql.yml"
+      - .github/workflows/validate_release.yml
   push:
     branches:
       - main
     paths:
       - "plugins/source/postgresql/**"
       - ".github/workflows/source_postgresql.yml"
+      - .github/workflows/validate_release.yml
 
 jobs:
   plugins-source-postgresql:

--- a/.github/workflows/source_postgresql.yml
+++ b/.github/workflows/source_postgresql.yml
@@ -51,37 +51,7 @@ jobs:
       - name: Test PostgreSQL
         run: make test
   validate-release:
-    timeout-minutes: 30
-    runs-on: ubuntu-latest
-    env:
-      CGO_ENABLED: 0
-    steps:
-      - name: Checkout
-        if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
-        uses: actions/checkout@v3
-      - uses: actions/cache@v3
-        if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
-        with:
-          path: |
-            ~/.cache/go-build
-            ~/go/pkg/mod
-          key: ${{ runner.os }}-go-1.19.5-release-cache-${{ hashFiles('plugins/source/postgresql/go.sum') }}
-          restore-keys: |
-            ${{ runner.os }}-go-1.19.5-release-cache-plugins-source-postgresql
-      - name: Set up Go
-        if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
-        uses: actions/setup-go@v3
-        with:
-          go-version-file: plugins/source/postgresql/go.mod
-      - name: Install GoReleaser
-        if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
-        uses: goreleaser/goreleaser-action@v3
-        with:
-          distribution: goreleaser-pro
-          version: latest
-          install-only: true
-      - name: Run GoReleaser Dry-Run
-        if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
-        run: goreleaser release --snapshot --clean --skip-validate --skip-publish --skip-sign -f ./plugins/source/postgresql/.goreleaser.yaml
-        env:
-          GORELEASER_KEY: ${{ secrets.GORELEASER_KEY }}
+    if:   startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
+    uses: ./.github/workflows/validate_release.yml
+    with:
+      path: plugins/source/postgresql

--- a/.github/workflows/source_salesforce.yml
+++ b/.github/workflows/source_salesforce.yml
@@ -51,37 +51,7 @@ jobs:
       - name: Test
         run: make test
   validate-release:
-    timeout-minutes: 30
-    runs-on: ubuntu-latest
-    env:
-      CGO_ENABLED: 0
-    steps:
-      - name: Checkout
-        if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
-        uses: actions/checkout@v3
-      - uses: actions/cache@v3
-        if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
-        with:
-          path: |
-            ~/.cache/go-build
-            ~/go/pkg/mod
-          key: ${{ runner.os }}-go-1.19.5-release-cache-${{ hashFiles('plugins/source/salesforce/go.sum') }}
-          restore-keys: |
-            ${{ runner.os }}-go-1.19.5-release-cache-plugins-source-salesforce
-      - name: Set up Go
-        if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
-        uses: actions/setup-go@v3
-        with:
-          go-version-file: plugins/source/salesforce/go.mod
-      - name: Install GoReleaser
-        if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
-        uses: goreleaser/goreleaser-action@v3
-        with:
-          distribution: goreleaser-pro
-          version: latest
-          install-only: true
-      - name: Run GoReleaser Dry-Run
-        if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
-        run: goreleaser release --snapshot --clean --skip-validate --skip-publish --skip-sign -f ./plugins/source/salesforce/.goreleaser.yaml
-        env:
-          GORELEASER_KEY: ${{ secrets.GORELEASER_KEY }}
+    if:   startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
+    uses: ./.github/workflows/validate_release.yml
+    with:
+      path: plugins/source/salesforce

--- a/.github/workflows/source_salesforce.yml
+++ b/.github/workflows/source_salesforce.yml
@@ -5,12 +5,14 @@ on:
     paths:
       - "plugins/source/salesforce/**"
       - ".github/workflows/source_salesforce.yml"
+      - .github/workflows/validate_release.yml
   push:
     branches:
       - main
     paths:
       - "plugins/source/salesforce/**"
       - ".github/workflows/source_salesforce.yml"
+      - .github/workflows/validate_release.yml
 
 jobs:
   plugins-source-salesforce:

--- a/.github/workflows/source_shopify.yml
+++ b/.github/workflows/source_shopify.yml
@@ -51,37 +51,7 @@ jobs:
       - name: Test
         run: make test
   validate-release:
-    timeout-minutes: 30
-    runs-on: ubuntu-latest
-    env:
-      CGO_ENABLED: 0
-    steps:
-      - name: Checkout
-        if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
-        uses: actions/checkout@v3
-      - uses: actions/cache@v3
-        if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
-        with:
-          path: |
-            ~/.cache/go-build
-            ~/go/pkg/mod
-          key: ${{ runner.os }}-go-1.19.5-release-cache-${{ hashFiles('plugins/source/shopify/go.sum') }}
-          restore-keys: |
-            ${{ runner.os }}-go-1.19.5-release-cache-plugins-source-shopify
-      - name: Set up Go
-        if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
-        uses: actions/setup-go@v3
-        with:
-          go-version-file: plugins/source/shopify/go.mod
-      - name: Install GoReleaser
-        if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
-        uses: goreleaser/goreleaser-action@v3
-        with:
-          distribution: goreleaser-pro
-          version: latest
-          install-only: true
-      - name: Run GoReleaser Dry-Run
-        if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
-        run: goreleaser release --snapshot --clean --skip-validate --skip-publish --skip-sign -f ./plugins/source/shopify/.goreleaser.yaml
-        env:
-          GORELEASER_KEY: ${{ secrets.GORELEASER_KEY }}
+    if:   startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
+    uses: ./.github/workflows/validate_release.yml
+    with:
+      path: plugins/source/shopify

--- a/.github/workflows/source_shopify.yml
+++ b/.github/workflows/source_shopify.yml
@@ -5,12 +5,14 @@ on:
     paths:
       - "plugins/source/shopify/**"
       - ".github/workflows/source_shopify.yml"
+      - .github/workflows/validate_release.yml
   push:
     branches:
       - main
     paths:
       - "plugins/source/shopify/**"
       - ".github/workflows/source_shopify.yml"
+      - .github/workflows/validate_release.yml
 
 jobs:
   plugins-source-shopify:

--- a/.github/workflows/source_slack.yml
+++ b/.github/workflows/source_slack.yml
@@ -51,37 +51,7 @@ jobs:
       - name: Test
         run: make test
   validate-release:
-    timeout-minutes: 30
-    runs-on: ubuntu-latest
-    env:
-      CGO_ENABLED: 0
-    steps:
-      - name: Checkout
-        if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
-        uses: actions/checkout@v3
-      - uses: actions/cache@v3
-        if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
-        with:
-          path: |
-            ~/.cache/go-build
-            ~/go/pkg/mod
-          key: ${{ runner.os }}-go-1.19.5-release-cache-${{ hashFiles('plugins/source/slack/go.sum') }}
-          restore-keys: |
-            ${{ runner.os }}-go-1.19.5-release-cache-plugins-source-slack
-      - name: Set up Go
-        if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
-        uses: actions/setup-go@v3
-        with:
-          go-version-file: plugins/source/slack/go.mod
-      - name: Install GoReleaser
-        if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
-        uses: goreleaser/goreleaser-action@v3
-        with:
-          distribution: goreleaser-pro
-          version: latest
-          install-only: true
-      - name: Run GoReleaser Dry-Run
-        if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
-        run: goreleaser release --snapshot --clean --skip-validate --skip-publish --skip-sign -f ./plugins/source/slack/.goreleaser.yaml
-        env:
-          GORELEASER_KEY: ${{ secrets.GORELEASER_KEY }}
+    if:   startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
+    uses: ./.github/workflows/validate_release.yml
+    with:
+      path: plugins/source/slack

--- a/.github/workflows/source_slack.yml
+++ b/.github/workflows/source_slack.yml
@@ -5,12 +5,14 @@ on:
     paths:
       - "plugins/source/slack/**"
       - ".github/workflows/source_slack.yml"
+      - .github/workflows/validate_release.yml
   push:
     branches:
       - main
     paths:
       - "plugins/source/slack/**"
       - ".github/workflows/source_slack.yml"
+      - .github/workflows/validate_release.yml
 
 jobs:
   plugins-source-slack:

--- a/.github/workflows/source_snyk.yml
+++ b/.github/workflows/source_snyk.yml
@@ -5,12 +5,14 @@ on:
     paths:
       - "plugins/source/snyk/**"
       - ".github/workflows/source_snyk.yml"
+      - .github/workflows/validate_release.yml
   push:
     branches:
       - main
     paths:
       - "plugins/source/snyk/**"
       - ".github/workflows/source_snyk.yml"
+      - .github/workflows/validate_release.yml
 
 jobs:
   plugins-source-snyk:

--- a/.github/workflows/source_snyk.yml
+++ b/.github/workflows/source_snyk.yml
@@ -49,37 +49,7 @@ jobs:
       - name: Test
         run: make test
   validate-release:
-    timeout-minutes: 30
-    runs-on: ubuntu-latest
-    env:
-      CGO_ENABLED: 0
-    steps:
-      - name: Checkout
-        if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
-        uses: actions/checkout@v3
-      - uses: actions/cache@v3
-        if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
-        with:
-          path: |
-            ~/.cache/go-build
-            ~/go/pkg/mod
-          key: ${{ runner.os }}-go-1.19.5-release-cache-${{ hashFiles('plugins/source/snyk/go.sum') }}
-          restore-keys: |
-            ${{ runner.os }}-go-1.19.5-release-cache-plugins-source-snyk
-      - name: Set up Go
-        if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
-        uses: actions/setup-go@v3
-        with:
-          go-version-file: plugins/source/snyk/go.mod
-      - name: Install GoReleaser
-        if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
-        uses: goreleaser/goreleaser-action@v3
-        with:
-          distribution: goreleaser-pro
-          version: latest
-          install-only: true
-      - name: Run GoReleaser Dry-Run
-        if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
-        run: goreleaser release --snapshot --clean --skip-validate --skip-publish --skip-sign -f ./plugins/source/snyk/.goreleaser.yaml
-        env:
-          GORELEASER_KEY: ${{ secrets.GORELEASER_KEY }}
+    if:   startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
+    uses: ./.github/workflows/validate_release.yml
+    with:
+      path: plugins/source/snyk

--- a/.github/workflows/source_stripe.yml
+++ b/.github/workflows/source_stripe.yml
@@ -49,37 +49,7 @@ jobs:
       - name: Test
         run: make test
   validate-release:
-    timeout-minutes: 30
-    runs-on: ubuntu-latest
-    env:
-      CGO_ENABLED: 0
-    steps:
-      - name: Checkout
-        if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
-        uses: actions/checkout@v3
-      - uses: actions/cache@v3
-        if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
-        with:
-          path: |
-            ~/.cache/go-build
-            ~/go/pkg/mod
-          key: ${{ runner.os }}-go-1.19.5-release-cache-${{ hashFiles('plugins/source/stripe/go.sum') }}
-          restore-keys: |
-            ${{ runner.os }}-go-1.19.5-release-cache-plugins-source-stripe
-      - name: Set up Go
-        if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
-        uses: actions/setup-go@v3
-        with:
-          go-version-file: plugins/source/stripe/go.mod
-      - name: Install GoReleaser
-        if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
-        uses: goreleaser/goreleaser-action@v3
-        with:
-          distribution: goreleaser-pro
-          version: latest
-          install-only: true
-      - name: Run GoReleaser Dry-Run
-        if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
-        run: goreleaser release --snapshot --clean --skip-validate --skip-publish --skip-sign -f ./plugins/source/stripe/.goreleaser.yaml
-        env:
-          GORELEASER_KEY: ${{ secrets.GORELEASER_KEY }}
+    if:   startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
+    uses: ./.github/workflows/validate_release.yml
+    with:
+      path: plugins/source/stripe

--- a/.github/workflows/source_stripe.yml
+++ b/.github/workflows/source_stripe.yml
@@ -5,12 +5,14 @@ on:
     paths:
       - "plugins/source/stripe/**"
       - ".github/workflows/source_stripe.yml"
+      - .github/workflows/validate_release.yml
   push:
     branches:
       - main
     paths:
       - "plugins/source/stripe/**"
       - ".github/workflows/source_stripe.yml"
+      - .github/workflows/validate_release.yml
 
 jobs:
   plugins-source-stripe:

--- a/.github/workflows/source_tailscale.yml
+++ b/.github/workflows/source_tailscale.yml
@@ -5,12 +5,14 @@ on:
     paths:
       - "plugins/source/tailscale/**"
       - ".github/workflows/source_tailscale.yml"
+      - .github/workflows/validate_release.yml
   push:
     branches:
       - main
     paths:
       - "plugins/source/tailscale/**"
       - ".github/workflows/source_tailscale.yml"
+      - .github/workflows/validate_release.yml
 
 jobs:
   plugins-source-tailscale:

--- a/.github/workflows/source_tailscale.yml
+++ b/.github/workflows/source_tailscale.yml
@@ -51,37 +51,7 @@ jobs:
       - name: Test
         run: make test
   validate-release:
-    timeout-minutes: 30
-    runs-on: ubuntu-latest
-    env:
-      CGO_ENABLED: 0
-    steps:
-      - name: Checkout
-        if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
-        uses: actions/checkout@v3
-      - uses: actions/cache@v3
-        if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
-        with:
-          path: |
-            ~/.cache/go-build
-            ~/go/pkg/mod
-          key: ${{ runner.os }}-go-1.19.5-release-cache-${{ hashFiles('plugins/source/tailscale/go.sum') }}
-          restore-keys: |
-            ${{ runner.os }}-go-1.19.5-release-cache-plugins-source-tailscale
-      - name: Set up Go
-        if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
-        uses: actions/setup-go@v3
-        with:
-          go-version-file: plugins/source/tailscale/go.mod
-      - name: Install GoReleaser
-        if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
-        uses: goreleaser/goreleaser-action@v3
-        with:
-          distribution: goreleaser-pro
-          version: latest
-          install-only: true
-      - name: Run GoReleaser Dry-Run
-        if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
-        run: goreleaser release --snapshot --clean --skip-validate --skip-publish --skip-sign -f ./plugins/source/tailscale/.goreleaser.yaml
-        env:
-          GORELEASER_KEY: ${{ secrets.GORELEASER_KEY }}
+    if:   startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
+    uses: ./.github/workflows/validate_release.yml
+    with:
+      path: plugins/source/tailscale

--- a/.github/workflows/source_terraform.yml
+++ b/.github/workflows/source_terraform.yml
@@ -51,37 +51,7 @@ jobs:
       - name: Test
         run: make test
   validate-release:
-    timeout-minutes: 30
-    runs-on: ubuntu-latest
-    env:
-      CGO_ENABLED: 0
-    steps:
-      - name: Checkout
-        if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
-        uses: actions/checkout@v3
-      - uses: actions/cache@v3
-        if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
-        with:
-          path: |
-            ~/.cache/go-build
-            ~/go/pkg/mod
-          key: ${{ runner.os }}-go-1.19.5-release-cache-${{ hashFiles('plugins/source/terraform/go.sum') }}
-          restore-keys: |
-            ${{ runner.os }}-go-1.19.5-release-cache-plugins-source-terraform
-      - name: Set up Go
-        if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
-        uses: actions/setup-go@v3
-        with:
-          go-version-file: plugins/source/terraform/go.mod
-      - name: Install GoReleaser
-        if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
-        uses: goreleaser/goreleaser-action@v3
-        with:
-          distribution: goreleaser-pro
-          version: latest
-          install-only: true
-      - name: Run GoReleaser Dry-Run
-        if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
-        run: goreleaser release --snapshot --clean --skip-validate --skip-publish --skip-sign -f ./plugins/source/terraform/.goreleaser.yaml
-        env:
-          GORELEASER_KEY: ${{ secrets.GORELEASER_KEY }}
+    if:   startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
+    uses: ./.github/workflows/validate_release.yml
+    with:
+      path: plugins/source/terraform

--- a/.github/workflows/source_terraform.yml
+++ b/.github/workflows/source_terraform.yml
@@ -5,12 +5,14 @@ on:
     paths:
       - "plugins/source/terraform/**"
       - ".github/workflows/source_terraform.yml"
+      - .github/workflows/validate_release.yml
   push:
     branches:
       - main
     paths:
       - "plugins/source/terraform/**"
       - ".github/workflows/source_terraform.yml"
+      - .github/workflows/validate_release.yml
 
 jobs:
   plugins-source-terraform:

--- a/.github/workflows/source_test.yml
+++ b/.github/workflows/source_test.yml
@@ -5,12 +5,14 @@ on:
     paths:
       - "plugins/source/test/**"
       - ".github/workflows/source_test.yml"
+      - .github/workflows/validate_release.yml
   push:
     branches:
       - main
     paths:
       - "plugins/source/test/**"
       - ".github/workflows/source_test.yml"
+      - .github/workflows/validate_release.yml
 
 jobs:
   plugins-source-test:

--- a/.github/workflows/source_test.yml
+++ b/.github/workflows/source_test.yml
@@ -51,37 +51,7 @@ jobs:
       - name: Test
         run: make test
   validate-release:
-    timeout-minutes: 30
-    runs-on: ubuntu-latest
-    env:
-      CGO_ENABLED: 0
-    steps:
-      - name: Checkout
-        if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
-        uses: actions/checkout@v3
-      - uses: actions/cache@v3
-        if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
-        with:
-          path: |
-            ~/.cache/go-build
-            ~/go/pkg/mod
-          key: ${{ runner.os }}-go-1.19.5-release-cache-${{ hashFiles('plugins/source/test/go.sum') }}
-          restore-keys: |
-            ${{ runner.os }}-go-1.19.5-release-cache-plugins-source-test
-      - name: Set up Go
-        if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
-        uses: actions/setup-go@v3
-        with:
-          go-version-file: plugins/source/test/go.mod
-      - name: Install GoReleaser
-        if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
-        uses: goreleaser/goreleaser-action@v3
-        with:
-          distribution: goreleaser-pro
-          version: latest
-          install-only: true
-      - name: Run GoReleaser Dry-Run
-        if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
-        run: goreleaser release --snapshot --clean --skip-validate --skip-publish --skip-sign -f ./plugins/source/test/.goreleaser.yaml
-        env:
-          GORELEASER_KEY: ${{ secrets.GORELEASER_KEY }}
+    if:   startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
+    uses: ./.github/workflows/validate_release.yml
+    with:
+      path: plugins/source/test

--- a/.github/workflows/source_vercel.yml
+++ b/.github/workflows/source_vercel.yml
@@ -5,12 +5,14 @@ on:
     paths:
       - "plugins/source/vercel/**"
       - ".github/workflows/source_vercel.yml"
+      - .github/workflows/validate_release.yml
   push:
     branches:
       - main
     paths:
       - "plugins/source/vercel/**"
       - ".github/workflows/source_vercel.yml"
+      - .github/workflows/validate_release.yml
 
 jobs:
   plugins-source-vercel:

--- a/.github/workflows/source_vercel.yml
+++ b/.github/workflows/source_vercel.yml
@@ -51,37 +51,7 @@ jobs:
       - name: Test
         run: make test
   validate-release:
-    timeout-minutes: 30
-    runs-on: ubuntu-latest
-    env:
-      CGO_ENABLED: 0
-    steps:
-      - name: Checkout
-        if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
-        uses: actions/checkout@v3
-      - uses: actions/cache@v3
-        if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
-        with:
-          path: |
-            ~/.cache/go-build
-            ~/go/pkg/mod
-          key: ${{ runner.os }}-go-1.19.5-release-cache-${{ hashFiles('plugins/source/vercel/go.sum') }}
-          restore-keys: |
-            ${{ runner.os }}-go-1.19.5-release-cache-plugins-source-vercel
-      - name: Set up Go
-        if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
-        uses: actions/setup-go@v3
-        with:
-          go-version-file: plugins/source/vercel/go.mod
-      - name: Install GoReleaser
-        if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
-        uses: goreleaser/goreleaser-action@v3
-        with:
-          distribution: goreleaser-pro
-          version: latest
-          install-only: true
-      - name: Run GoReleaser Dry-Run
-        if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
-        run: goreleaser release --snapshot --clean --skip-validate --skip-publish --skip-sign -f ./plugins/source/vercel/.goreleaser.yaml
-        env:
-          GORELEASER_KEY: ${{ secrets.GORELEASER_KEY }}
+    if:   startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
+    uses: ./.github/workflows/validate_release.yml
+    with:
+      path: plugins/source/vercel

--- a/.github/workflows/validate_release.yml
+++ b/.github/workflows/validate_release.yml
@@ -22,7 +22,6 @@ jobs:
   validate-release:
     # this if check is left here as a precautionary measure, as the proper way to do it is in the caller workflow
     if:              startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
-    name:            Validate release
     timeout-minutes: 60
     runs-on:         ${{ inputs.runner }}
     env:

--- a/.github/workflows/validate_release.yml
+++ b/.github/workflows/validate_release.yml
@@ -33,13 +33,6 @@ jobs:
            echo "dashed=$(echo ${{ inputs.path }} | tr '/' '-')" >> $GITHUB_OUTPUT
     - name: Checkout
       uses: actions/checkout@v3
-    - name: Set up Go
-      id:   set-up-go
-      uses: actions/setup-go@v3
-      with:
-        go-version-file:       ${{ inputs.path }}/go.mod
-        cache:                 true
-        cache-dependency-path: ${{ inputs.path }}/go.sum
     - uses: actions/cache@v3
       with:
         path:         |
@@ -49,6 +42,13 @@ jobs:
         # actually, this value is never ever saved, but left for consistency (renaming cache keys os out of scope)
         restore-keys: |
                       ${{ runner.os }}-go-1.19.5-release-cache-${{ steps.dash-path.outputs.dashed }}
+    - name: Set up Go
+      id:   set-up-go
+      uses: actions/setup-go@v3
+      with:
+        go-version-file:       ${{ inputs.path }}/go.mod
+        cache:                 true
+        cache-dependency-path: ${{ inputs.path }}/go.sum
     - name: Install GoReleaser
       uses: goreleaser/goreleaser-action@v3
       with:

--- a/.github/workflows/validate_release.yml
+++ b/.github/workflows/validate_release.yml
@@ -1,0 +1,69 @@
+name: Validate release
+
+on:
+  workflow_call:
+    inputs:
+      path:
+        description: 'Go mod directory (e.g. "plugins/source/aws", "plugins/destination/csv", "cli")'
+        type:        string
+        required:    true
+      runner:
+        description: 'Runner to be used (default: "ubuntu-latest")'
+        type:        string
+        required:    false
+        default:     'ubuntu-latest'
+      CGO_ENABLED:
+        description: 'CGO_ENABLED value to be used (default: 0)'
+        type:        number
+        required:    false
+        default:     0
+
+jobs:
+  validate-release:
+    # this if check is left here as a precautionary measure, as the proper way to do it is in the caller workflow
+    if:              startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
+    name:            Validate release
+    timeout-minutes: 60
+    runs-on:         ${{ inputs.runner }}
+    env:
+      CGO_ENABLED: 0
+    steps:
+    - id:  dash-path
+      run: |
+           echo "dashed=$(echo ${{ inputs.path }} | tr '/' '-')" >> $GITHUB_OUTPUT
+    - name: Checkout
+      uses: actions/checkout@v3
+    - name: Set up Go
+      id:   set-up-go
+      uses: actions/setup-go@v3
+      with:
+        go-version-file:       ${{ inputs.path }}/go.mod
+        cache:                 true
+        cache-dependency-path: ${{ inputs.path }}/go.sum
+    - uses: actions/cache@v3
+      with:
+        path:         |
+                      ~/.cache/go-build
+                      ~/go/pkg/mod
+        key:          ${{ runner.os }}-go-1.19.5-release-cache-${{ hashFiles(format('{0}/go.sum', inputs.path)) }}
+        # actually, this value is never ever saved, but left for consistency (renaming cache keys os out of scope)
+        restore-keys: |
+                      ${{ runner.os }}-go-1.19.5-release-cache-${{ steps.dash-path.outputs.dashed }}
+    - name: Install GoReleaser
+      uses: goreleaser/goreleaser-action@v3
+      with:
+        distribution: goreleaser-pro
+        version:      latest
+        install-only: true
+    - name: Run GoReleaser Dry-Run
+      run:  >
+            goreleaser release
+            --timeout 50m
+            --snapshot
+            --clean
+            --skip-validate
+            --skip-publish
+            --skip-sign
+            -f ${{ inputs.path }}/.goreleaser.yaml
+      env:
+        GORELEASER_KEY: ${{ secrets.GORELEASER_KEY }}

--- a/.github/workflows/validate_release_cgo.yml
+++ b/.github/workflows/validate_release_cgo.yml
@@ -17,7 +17,6 @@ jobs:
   validate-release:
     # this if check is left here as a precautionary measure, as the proper way to do it is in the caller workflow
     if:              startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
-    name:            Validate release (with cgo enabled)
     timeout-minutes: 60
     runs-on:         ${{ inputs.runner }}
     container:

--- a/.github/workflows/validate_release_cgo.yml
+++ b/.github/workflows/validate_release_cgo.yml
@@ -30,13 +30,6 @@ jobs:
            echo "dashed=$(echo ${{ inputs.path }} | tr '/' '-')" >> $GITHUB_OUTPUT
     - name: Checkout
       uses: actions/checkout@v3
-    - name: Set up Go
-      id:   set-up-go
-      uses: actions/setup-go@v3
-      with:
-        go-version-file:       ${{ inputs.path }}/go.mod
-        cache:                 true
-        cache-dependency-path: ${{ inputs.path }}/go.sum
     - uses: actions/cache@v3
       with:
         path:         |
@@ -46,6 +39,13 @@ jobs:
         # actually, this value is never ever saved, but left for consistency (renaming cache keys os out of scope)
         restore-keys: |
                       ${{ runner.os }}-go-1.19.5-release-cache-${{ steps.dash-path.outputs.dashed }}
+    - name: Set up Go
+      id:   set-up-go
+      uses: actions/setup-go@v3
+      with:
+        go-version-file:       ${{ inputs.path }}/go.mod
+        cache:                 true
+        cache-dependency-path: ${{ inputs.path }}/go.sum
     - name: Install GoReleaser
       uses: goreleaser/goreleaser-action@v3
       with:

--- a/.github/workflows/validate_release_cgo.yml
+++ b/.github/workflows/validate_release_cgo.yml
@@ -1,0 +1,66 @@
+name: Validate release (with cgo enabled)
+
+on:
+  workflow_call:
+    inputs:
+      path:
+        description: 'Go mod directory (e.g. "plugins/source/aws", "plugins/destination/csv", "cli")'
+        type:        string
+        required:    true
+      runner:
+        description: 'Runner to be used (default: "ubuntu-latest")'
+        type:        string
+        required:    false
+        default:     'ubuntu-latest'
+
+jobs:
+  validate-release:
+    # this if check is left here as a precautionary measure, as the proper way to do it is in the caller workflow
+    if:              startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
+    name:            Validate release (with cgo enabled)
+    timeout-minutes: 60
+    runs-on:         ${{ inputs.runner }}
+    container:
+      image: ghcr.io/cloudquery/golang-cross:v10.0.0
+      env:
+        CGO_ENABLED: 1
+    steps:
+    - id:  dash-path
+      run: |
+           echo "dashed=$(echo ${{ inputs.path }} | tr '/' '-')" >> $GITHUB_OUTPUT
+    - name: Checkout
+      uses: actions/checkout@v3
+    - name: Set up Go
+      id:   set-up-go
+      uses: actions/setup-go@v3
+      with:
+        go-version-file:       ${{ inputs.path }}/go.mod
+        cache:                 true
+        cache-dependency-path: ${{ inputs.path }}/go.sum
+    - uses: actions/cache@v3
+      with:
+        path:         |
+                      ~/.cache/go-build
+                      ~/go/pkg/mod
+        key:          ${{ runner.os }}-go-1.19.5-release-cache-${{ hashFiles(format('{0}/go.sum', inputs.path)) }}
+        # actually, this value is never ever saved, but left for consistency (renaming cache keys os out of scope)
+        restore-keys: |
+                      ${{ runner.os }}-go-1.19.5-release-cache-${{ steps.dash-path.outputs.dashed }}
+    - name: Install GoReleaser
+      uses: goreleaser/goreleaser-action@v3
+      with:
+        distribution: goreleaser-pro
+        version:      latest
+        install-only: true
+    - name: Run GoReleaser Dry-Run
+      run:  >
+            goreleaser release
+            --timeout 50m
+            --snapshot
+            --clean
+            --skip-validate
+            --skip-publish
+            --skip-sign
+            -f ${{ inputs.path }}/.goreleaser.yaml
+      env:
+        GORELEASER_KEY: ${{ secrets.GORELEASER_KEY }}

--- a/.github/workflows/wait_for_required_workflows.yml
+++ b/.github/workflows/wait_for_required_workflows.yml
@@ -18,10 +18,12 @@ jobs:
       - uses: actions/github-script@v6
         env:
           FILES: ${{ steps.changed-files.outputs.all }}
+          CAN_SKIP: validate-release
         with:
           script: |
             const fs = require("fs");
             const files = process.env.FILES.split(' ')
+            const can_skip = process.env.CAN_SKIP.split(' ')
             console.log(files)
             if (files.length >= 300) {
               // This is a GitHub limitation https://github.com/cloudquery/cloudquery/issues/2688
@@ -81,7 +83,7 @@ jobs:
               const runs = checkRuns.map(({ name, conclusion }) => ({ name, conclusion }))
               console.log(`Got the following check runs: ${JSON.stringify(runs)}`)
               const matchingRuns = runs.filter(({ name }) => actions.includes(name))
-              const failedRuns = matchingRuns.filter(({ conclusion }) => conclusion !== 'success')
+              const failedRuns = matchingRuns.filter(({ name, conclusion }) => !(conclusion == 'success' || (can_skip.includes(name) && conclusion == 'skipped')))
               if (failedRuns.length > 0) {
                 throw new Error(`The following required workflows failed: ${failedRuns.map(({ name }) => name).join(", ")}`)
               }

--- a/.github/workflows/wait_for_required_workflows.yml
+++ b/.github/workflows/wait_for_required_workflows.yml
@@ -18,7 +18,8 @@ jobs:
       - uses: actions/github-script@v6
         env:
           FILES: ${{ steps.changed-files.outputs.all }}
-          CAN_SKIP: validate-release
+          CAN_SKIP: >-
+            validate-release
         with:
           script: |
             const fs = require("fs");


### PR DESCRIPTION
This builds on top of ideas from #9668 and can safely replace it.

`wait-for-required-workflows` change is required to make it wait for skipped jobs, too