### PR TITLE
fix(aws): Replace more manual pagination with Paginator objects

### DIFF
--- a/plugins/source/aws/resources/services/appstream/applications.go
+++ b/plugins/source/aws/resources/services/appstream/applications.go
@@ -41,6 +41,7 @@ func fetchAppstreamApplications(ctx context.Context, meta schema.ClientMeta, par
 	var input appstream.DescribeApplicationsInput
 	c := meta.(*client.Client)
 	svc := c.Services().Appstream
+
 	for {
 		response, err := svc.DescribeApplications(ctx, &input)
 		if err != nil {

--- a/plugins/source/aws/resources/services/appstream/applications.go
+++ b/plugins/source/aws/resources/services/appstream/applications.go
@@ -41,7 +41,6 @@ func fetchAppstreamApplications(ctx context.Context, meta schema.ClientMeta, par
 	var input appstream.DescribeApplicationsInput
 	c := meta.(*client.Client)
 	svc := c.Services().Appstream
-
 	for {
 		response, err := svc.DescribeApplications(ctx, &input)
 		if err != nil {

--- a/plugins/source/aws/resources/services/config/conformance_packs.go
+++ b/plugins/source/aws/resources/services/config/conformance_packs.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 
-	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/configservice"
 	"github.com/aws/aws-sdk-go-v2/service/configservice/types"
 	"github.com/aws/smithy-go"
@@ -44,22 +43,18 @@ func fetchConfigConformancePacks(ctx context.Context, meta schema.ClientMeta, pa
 	c := meta.(*client.Client)
 	config := configservice.DescribeConformancePacksInput{}
 	var ae smithy.APIError
-	for {
-		resp, err := c.Services().Configservice.DescribeConformancePacks(ctx, &config)
-
+	configService := c.Services().Configservice
+	paginator := configservice.NewDescribeConformancePacksPaginator(configService, &config)
+	for paginator.HasMorePages() {
+		page, err := paginator.NextPage(ctx)
 		// This is a workaround until this bug is fixed = https://github.com/aws/aws-sdk-go-v2/issues/1539
 		if (c.Region == "af-south-1" || c.Region == "ap-northeast-3") && errors.As(err, &ae) && ae.ErrorCode() == "AccessDeniedException" {
 			return nil
 		}
-
 		if err != nil {
 			return err
 		}
-		res <- resp.ConformancePackDetails
-		if aws.ToString(resp.NextToken) == "" {
-			break
-		}
-		config.NextToken = resp.NextToken
+		res <- page.ConformancePackDetails
 	}
 	return nil
 }

--- a/plugins/source/aws/resources/services/ec2/byoip_cidrs.go
+++ b/plugins/source/aws/resources/services/ec2/byoip_cidrs.go
@@ -34,9 +34,6 @@ func ByoipCidrs() *schema.Table {
 }
 
 func fetchEc2ByoipCidrs(ctx context.Context, meta schema.ClientMeta, parent *schema.Resource, res chan<- any) error {
-	config := ec2.DescribeByoipCidrsInput{
-		MaxResults: aws.Int32(100),
-	}
 
 	c := meta.(*client.Client)
 	// DescribeByoipCidrs does not work in next regions, so we ignore them.
@@ -47,16 +44,16 @@ func fetchEc2ByoipCidrs(ctx context.Context, meta schema.ClientMeta, parent *sch
 		return nil
 	}
 	svc := c.Services().Ec2
-	for {
-		response, err := svc.DescribeByoipCidrs(ctx, &config)
+	config := ec2.DescribeByoipCidrsInput{
+		MaxResults: aws.Int32(100),
+	}
+	paginator := ec2.NewDescribeByoipCidrsPaginator(svc, &config)
+	for paginator.HasMorePages() {
+		page, err := paginator.NextPage(ctx)
 		if err != nil {
 			return err
 		}
-		res <- response.ByoipCidrs
-		if aws.ToString(response.NextToken) == "" {
-			break
-		}
-		config.NextToken = response.NextToken
+		res <- page.ByoipCidrs
 	}
 	return nil
 }

--- a/plugins/source/aws/resources/services/ec2/byoip_cidrs.go
+++ b/plugins/source/aws/resources/services/ec2/byoip_cidrs.go
@@ -34,7 +34,6 @@ func ByoipCidrs() *schema.Table {
 }
 
 func fetchEc2ByoipCidrs(ctx context.Context, meta schema.ClientMeta, parent *schema.Resource, res chan<- any) error {
-
 	c := meta.(*client.Client)
 	// DescribeByoipCidrs does not work in next regions, so we ignore them.
 	if _, ok := map[string]struct{}{

--- a/plugins/source/aws/resources/services/ecs/cluster_tasks.go
+++ b/plugins/source/aws/resources/services/ecs/cluster_tasks.go
@@ -51,30 +51,25 @@ func fetchEcsClusterTasks(ctx context.Context, meta schema.ClientMeta, parent *s
 	config := ecs.ListTasksInput{
 		Cluster: cluster.ClusterArn,
 	}
-	for {
-		listTasks, err := svc.ListTasks(ctx, &config)
+	paginator := ecs.NewListTasksPaginator(svc, &config)
+	for paginator.HasMorePages() {
+		page, err := paginator.NextPage(ctx)
 		if err != nil {
 			return err
 		}
-		if len(listTasks.TaskArns) == 0 {
-			return nil
+		if len(page.TaskArns) == 0 {
+			continue
 		}
 		describeServicesInput := ecs.DescribeTasksInput{
 			Cluster: cluster.ClusterArn,
-			Tasks:   listTasks.TaskArns,
+			Tasks:   page.TaskArns,
 			Include: []types.TaskField{types.TaskFieldTags},
 		}
 		describeTasks, err := svc.DescribeTasks(ctx, &describeServicesInput)
 		if err != nil {
 			return err
 		}
-
 		res <- describeTasks.Tasks
-
-		if aws.ToString(listTasks.NextToken) == "" {
-			break
-		}
-		config.NextToken = listTasks.NextToken
 	}
 	return nil
 }

--- a/plugins/source/aws/resources/services/elasticsearch/domains.go
+++ b/plugins/source/aws/resources/services/elasticsearch/domains.go
@@ -95,8 +95,8 @@ func resolveAuthorizedPrincipals(ctx context.Context, meta schema.ClientMeta, re
 	input := &elasticsearchservice.ListVpcEndpointAccessInput{
 		DomainName: resource.Item.(*types.ElasticsearchDomainStatus).DomainName,
 	}
-
 	var principals []types.AuthorizedPrincipal
+
 	for {
 		out, err := svc.ListVpcEndpointAccess(ctx, input)
 		if err != nil {

--- a/plugins/source/aws/resources/services/elasticsearch/domains.go
+++ b/plugins/source/aws/resources/services/elasticsearch/domains.go
@@ -95,8 +95,8 @@ func resolveAuthorizedPrincipals(ctx context.Context, meta schema.ClientMeta, re
 	input := &elasticsearchservice.ListVpcEndpointAccessInput{
 		DomainName: resource.Item.(*types.ElasticsearchDomainStatus).DomainName,
 	}
-	var principals []types.AuthorizedPrincipal
 
+	var principals []types.AuthorizedPrincipal
 	for {
 		out, err := svc.ListVpcEndpointAccess(ctx, input)
 		if err != nil {

--- a/plugins/source/aws/resources/services/guardduty/detector_ipsets.go
+++ b/plugins/source/aws/resources/services/guardduty/detector_ipsets.go
@@ -3,7 +3,6 @@ package guardduty
 import (
 	"context"
 
-	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/guardduty"
 	"github.com/cloudquery/cloudquery/plugins/source/aws/client"
 	"github.com/cloudquery/cloudquery/plugins/source/aws/resources/services/guardduty/models"
@@ -41,18 +40,15 @@ func fetchDetectorIPSets(ctx context.Context, meta schema.ClientMeta, parent *sc
 	config := &guardduty.ListIPSetsInput{
 		DetectorId: &detector.Id,
 	}
-	for {
-		output, err := svc.ListIPSets(ctx, config)
+	paginator := guardduty.NewListIPSetsPaginator(svc, config)
+	for paginator.HasMorePages() {
+		page, err := paginator.NextPage(ctx)
 		if err != nil {
 			return err
 		}
-		res <- output.IpSetIds
-
-		if aws.ToString(output.NextToken) == "" {
-			return nil
-		}
-		config.NextToken = output.NextToken
+		res <- page.IpSetIds
 	}
+	return nil
 }
 
 func getDetectorIPSet(ctx context.Context, meta schema.ClientMeta, resource *schema.Resource) error {

--- a/plugins/source/aws/resources/services/guardduty/detector_members.go
+++ b/plugins/source/aws/resources/services/guardduty/detector_members.go
@@ -38,15 +38,13 @@ func fetchDetectorMembers(ctx context.Context, meta schema.ClientMeta, parent *s
 	c := meta.(*client.Client)
 	svc := c.Services().Guardduty
 	config := &guardduty.ListMembersInput{DetectorId: aws.String(detector.Id)}
-	for {
-		output, err := svc.ListMembers(ctx, config)
+	paginator := guardduty.NewListMembersPaginator(svc, config)
+	for paginator.HasMorePages() {
+		page, err := paginator.NextPage(ctx)
 		if err != nil {
 			return err
 		}
-		res <- output.Members
-		if aws.ToString(output.NextToken) == "" {
-			return nil
-		}
-		config.NextToken = output.NextToken
+		res <- page.Members
 	}
+	return nil
 }

--- a/plugins/source/aws/resources/services/guardduty/detector_publishing_destinations.go
+++ b/plugins/source/aws/resources/services/guardduty/detector_publishing_destinations.go
@@ -38,15 +38,13 @@ func fetchGuarddutyDetectorPublishingDestinations(ctx context.Context, meta sche
 	c := meta.(*client.Client)
 	svc := c.Services().Guardduty
 	config := &guardduty.ListPublishingDestinationsInput{DetectorId: aws.String(detector.Id)}
-	for {
-		output, err := svc.ListPublishingDestinations(ctx, config)
+	paginator := guardduty.NewListPublishingDestinationsPaginator(svc, config)
+	for paginator.HasMorePages() {
+		page, err := paginator.NextPage(ctx)
 		if err != nil {
 			return err
 		}
-		res <- output.Destinations
-		if aws.ToString(output.NextToken) == "" {
-			return nil
-		}
-		config.NextToken = output.NextToken
+		res <- page.Destinations
 	}
+	return nil
 }

--- a/plugins/source/aws/resources/services/guardduty/detector_threat_intel_sets.go
+++ b/plugins/source/aws/resources/services/guardduty/detector_threat_intel_sets.go
@@ -38,17 +38,15 @@ func fetchDetectorThreatIntelSets(ctx context.Context, meta schema.ClientMeta, p
 	c := meta.(*client.Client)
 	svc := c.Services().Guardduty
 	config := &guardduty.ListThreatIntelSetsInput{DetectorId: aws.String(detector.Id)}
-	for {
-		output, err := svc.ListThreatIntelSets(ctx, config)
+	paginator := guardduty.NewListThreatIntelSetsPaginator(svc, config)
+	for paginator.HasMorePages() {
+		page, err := paginator.NextPage(ctx)
 		if err != nil {
 			return err
 		}
-		res <- output.ThreatIntelSetIds
-		if aws.ToString(output.NextToken) == "" {
-			return nil
-		}
-		config.NextToken = output.NextToken
+		res <- page.ThreatIntelSetIds
 	}
+	return nil
 }
 
 func getDetectorThreatIntelSet(ctx context.Context, meta schema.ClientMeta, resource *schema.Resource) error {

--- a/plugins/source/aws/resources/services/iam/last_accessed_details.go
+++ b/plugins/source/aws/resources/services/iam/last_accessed_details.go
@@ -132,7 +132,6 @@ func fetchLastAccessedDetails(ctx context.Context, meta schema.ClientMeta, arn *
 		JobId:    jobId,
 		MaxItems: aws.Int32(1000),
 	}
-
 	for {
 		details, err := svc.GetServiceLastAccessedDetails(ctx, &config)
 		if err != nil {

--- a/plugins/source/aws/resources/services/iam/last_accessed_details.go
+++ b/plugins/source/aws/resources/services/iam/last_accessed_details.go
@@ -132,6 +132,7 @@ func fetchLastAccessedDetails(ctx context.Context, meta schema.ClientMeta, arn *
 		JobId:    jobId,
 		MaxItems: aws.Int32(1000),
 	}
+
 	for {
 		details, err := svc.GetServiceLastAccessedDetails(ctx, &config)
 		if err != nil {

--- a/plugins/source/aws/resources/services/lambda/function_aliases.go
+++ b/plugins/source/aws/resources/services/lambda/function_aliases.go
@@ -51,9 +51,9 @@ func fetchLambdaFunctionAliases(ctx context.Context, meta schema.ClientMeta, par
 	config := lambda.ListAliasesInput{
 		FunctionName: p.Configuration.FunctionName,
 	}
-
-	for {
-		output, err := svc.ListAliases(ctx, &config)
+	paginator := lambda.NewListAliasesPaginator(svc, &config)
+	for paginator.HasMorePages() {
+		page, err := paginator.NextPage(ctx)
 		if err != nil {
 			return err
 		}
@@ -63,12 +63,7 @@ func fetchLambdaFunctionAliases(ctx context.Context, meta schema.ClientMeta, par
 			}
 			return err
 		}
-		res <- output.Aliases
-
-		if output.NextMarker == nil {
-			break
-		}
-		config.Marker = output.NextMarker
+		res <- page.Aliases
 	}
 	return nil
 }

--- a/plugins/source/aws/resources/services/lambda/function_concurrency_configs.go
+++ b/plugins/source/aws/resources/services/lambda/function_concurrency_configs.go
@@ -41,20 +41,16 @@ func fetchLambdaFunctionConcurrencyConfigs(ctx context.Context, meta schema.Clie
 	config := lambda.ListProvisionedConcurrencyConfigsInput{
 		FunctionName: p.Configuration.FunctionName,
 	}
-
-	for {
-		output, err := svc.ListProvisionedConcurrencyConfigs(ctx, &config)
+	paginator := lambda.NewListProvisionedConcurrencyConfigsPaginator(svc, &config)
+	for paginator.HasMorePages() {
+		page, err := paginator.NextPage(ctx)
 		if err != nil {
 			if cl.IsNotFoundError(err) {
 				return nil
 			}
 			return err
 		}
-		res <- output.ProvisionedConcurrencyConfigs
-		if output.NextMarker == nil {
-			break
-		}
-		config.Marker = output.NextMarker
+		res <- page.ProvisionedConcurrencyConfigs
 	}
 	return nil
 }

--- a/plugins/source/aws/resources/services/lambda/function_event_invoke_configs.go
+++ b/plugins/source/aws/resources/services/lambda/function_event_invoke_configs.go
@@ -39,20 +39,16 @@ func fetchLambdaFunctionEventInvokeConfigs(ctx context.Context, meta schema.Clie
 	config := lambda.ListFunctionEventInvokeConfigsInput{
 		FunctionName: p.Configuration.FunctionName,
 	}
-
-	for {
-		output, err := svc.ListFunctionEventInvokeConfigs(ctx, &config)
+	paginator := lambda.NewListFunctionEventInvokeConfigsPaginator(svc, &config)
+	for paginator.HasMorePages() {
+		page, err := paginator.NextPage(ctx)
 		if err != nil {
 			if cl.IsNotFoundError(err) {
 				return nil
 			}
 			return err
 		}
-		res <- output.FunctionEventInvokeConfigs
-		if output.NextMarker == nil {
-			break
-		}
-		config.Marker = output.NextMarker
+		res <- page.FunctionEventInvokeConfigs
 	}
 	return nil
 }

--- a/plugins/source/aws/resources/services/lambda/function_event_source_mappings.go
+++ b/plugins/source/aws/resources/services/lambda/function_event_source_mappings.go
@@ -41,19 +41,16 @@ func fetchLambdaFunctionEventSourceMappings(ctx context.Context, meta schema.Cli
 	config := lambda.ListEventSourceMappingsInput{
 		FunctionName: p.Configuration.FunctionName,
 	}
-	for {
-		output, err := svc.ListEventSourceMappings(ctx, &config)
+	paginator := lambda.NewListEventSourceMappingsPaginator(svc, &config)
+	for paginator.HasMorePages() {
+		page, err := paginator.NextPage(ctx)
 		if err != nil {
 			if cl.IsNotFoundError(err) {
 				return nil
 			}
 			return err
 		}
-		res <- output.EventSourceMappings
-		if output.NextMarker == nil {
-			break
-		}
-		config.Marker = output.NextMarker
+		res <- page.EventSourceMappings
 	}
 	return nil
 }

--- a/plugins/source/aws/resources/services/lambda/function_versions.go
+++ b/plugins/source/aws/resources/services/lambda/function_versions.go
@@ -40,20 +40,16 @@ func fetchLambdaFunctionVersions(ctx context.Context, meta schema.ClientMeta, pa
 	config := lambda.ListVersionsByFunctionInput{
 		FunctionName: p.Configuration.FunctionName,
 	}
-
-	for {
-		output, err := svc.ListVersionsByFunction(ctx, &config)
+	paginator := lambda.NewListVersionsByFunctionPaginator(svc, &config)
+	for paginator.HasMorePages() {
+		page, err := paginator.NextPage(ctx)
 		if err != nil {
 			if meta.(*client.Client).IsNotFoundError(err) {
 				return nil
 			}
 			return err
 		}
-		res <- output.Versions
-		if output.NextMarker == nil {
-			break
-		}
-		config.Marker = output.NextMarker
+		res <- page.Versions
 	}
 	return nil
 }

--- a/plugins/source/aws/resources/services/lambda/layers.go
+++ b/plugins/source/aws/resources/services/lambda/layers.go
@@ -63,17 +63,13 @@ func fetchLambdaLayerVersions(ctx context.Context, meta schema.ClientMeta, paren
 	config := lambda.ListLayerVersionsInput{
 		LayerName: p.LayerName,
 	}
-
-	for {
-		output, err := svc.ListLayerVersions(ctx, &config)
+	paginator := lambda.NewListLayerVersionsPaginator(svc, &config)
+	for paginator.HasMorePages() {
+		page, err := paginator.NextPage(ctx)
 		if err != nil {
 			return err
 		}
-		res <- output.LayerVersions
-		if output.NextMarker == nil {
-			break
-		}
-		config.Marker = output.NextMarker
+		res <- page.LayerVersions
 	}
 	return nil
 }

--- a/plugins/source/aws/resources/services/quicksight/folders.go
+++ b/plugins/source/aws/resources/services/quicksight/folders.go
@@ -33,7 +33,7 @@ func fetchQuicksightFolders(ctx context.Context, meta schema.ClientMeta, parent 
 		AwsAccountId: aws.String(cl.AccountID),
 	}
 	var ae smithy.APIError
-
+	// No paginator available
 	for {
 		out, err := svc.ListFolders(ctx, &input)
 		if err != nil {

--- a/plugins/source/aws/resources/services/quicksight/group_members.go
+++ b/plugins/source/aws/resources/services/quicksight/group_members.go
@@ -42,6 +42,7 @@ func fetchQuicksightGroupMembers(ctx context.Context, meta schema.ClientMeta, pa
 		Namespace:    aws.String(defaultNamespace),
 		GroupName:    item.GroupName,
 	}
+	// No paginator available
 	for {
 		out, err := svc.ListGroupMemberships(ctx, &input)
 		if err != nil {

--- a/plugins/source/aws/resources/services/quicksight/users.go
+++ b/plugins/source/aws/resources/services/quicksight/users.go
@@ -33,7 +33,7 @@ func fetchQuicksightUsers(ctx context.Context, meta schema.ClientMeta, parent *s
 		Namespace:    aws.String(defaultNamespace),
 	}
 	var ae smithy.APIError
-
+	// No paginator available
 	for {
 		out, err := svc.ListUsers(ctx, &input)
 		if err != nil {

--- a/plugins/source/aws/resources/services/ram/resource_share_invitations.go
+++ b/plugins/source/aws/resources/services/ram/resource_share_invitations.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/ram"
 	"github.com/aws/aws-sdk-go-v2/service/ram/types"
 	"github.com/cloudquery/cloudquery/plugins/source/aws/client"
@@ -47,17 +46,13 @@ func fetchRamResourceShareInvitations(ctx context.Context, meta schema.ClientMet
 	var input ram.GetResourceShareInvitationsInput = getResourceShareInvitationsInput()
 	c := meta.(*client.Client)
 	svc := c.Services().Ram
-	for {
-		response, err := svc.GetResourceShareInvitations(ctx, &input)
+	paginator := ram.NewGetResourceShareInvitationsPaginator(svc, &input)
+	for paginator.HasMorePages() {
+		page, err := paginator.NextPage(ctx)
 		if err != nil {
 			return err
 		}
-		res <- response.ResourceShareInvitations
-
-		if aws.ToString(response.NextToken) == "" {
-			break
-		}
-		input.NextToken = response.NextToken
+		res <- page.ResourceShareInvitations
 	}
 	return nil
 }

--- a/plugins/source/aws/resources/services/rds/cluster_parameter_groups.go
+++ b/plugins/source/aws/resources/services/rds/cluster_parameter_groups.go
@@ -3,7 +3,6 @@ package rds
 import (
 	"context"
 
-	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/rds"
 	"github.com/aws/aws-sdk-go-v2/service/rds/types"
 	"github.com/cloudquery/cloudquery/plugins/source/aws/client"
@@ -63,16 +62,13 @@ func fetchRdsClusterParameterGroupParameters(ctx context.Context, meta schema.Cl
 	svc := cl.Services().Rds
 	g := parent.Item.(types.DBClusterParameterGroup)
 	input := rds.DescribeDBClusterParametersInput{DBClusterParameterGroupName: g.DBClusterParameterGroupName}
-	for {
-		output, err := svc.DescribeDBClusterParameters(ctx, &input)
+	paginator := rds.NewDescribeDBClusterParametersPaginator(svc, &input)
+	for paginator.HasMorePages() {
+		page, err := paginator.NextPage(ctx)
 		if err != nil {
 			return err
 		}
-		res <- output.Parameters
-		if aws.ToString(output.Marker) == "" {
-			break
-		}
-		input.Marker = output.Marker
+		res <- page.Parameters
 	}
 	return nil
 }

--- a/plugins/source/aws/resources/services/rds/cluster_snapshots.go
+++ b/plugins/source/aws/resources/services/rds/cluster_snapshots.go
@@ -3,7 +3,6 @@ package rds
 import (
 	"context"
 
-	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/rds"
 	"github.com/aws/aws-sdk-go-v2/service/rds/types"
 	"github.com/cloudquery/cloudquery/plugins/source/aws/client"
@@ -48,16 +47,13 @@ func fetchRdsClusterSnapshots(ctx context.Context, meta schema.ClientMeta, paren
 	c := meta.(*client.Client)
 	svc := c.Services().Rds
 	var input rds.DescribeDBClusterSnapshotsInput
-	for {
-		output, err := svc.DescribeDBClusterSnapshots(ctx, &input)
+	paginator := rds.NewDescribeDBClusterSnapshotsPaginator(svc, &input)
+	for paginator.HasMorePages() {
+		page, err := paginator.NextPage(ctx)
 		if err != nil {
 			return nil
 		}
-		res <- output.DBClusterSnapshots
-		if aws.ToString(output.Marker) == "" {
-			break
-		}
-		input.Marker = output.Marker
+		res <- page.DBClusterSnapshots
 	}
 	return nil
 }

--- a/plugins/source/aws/resources/services/rds/clusters.go
+++ b/plugins/source/aws/resources/services/rds/clusters.go
@@ -3,7 +3,6 @@ package rds
 import (
 	"context"
 
-	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/rds"
 	"github.com/aws/aws-sdk-go-v2/service/rds/types"
 	"github.com/cloudquery/cloudquery/plugins/source/aws/client"
@@ -46,16 +45,13 @@ func fetchRdsClusters(ctx context.Context, meta schema.ClientMeta, parent *schem
 	var config rds.DescribeDBClustersInput
 	c := meta.(*client.Client)
 	svc := c.Services().Rds
-	for {
-		response, err := svc.DescribeDBClusters(ctx, &config)
+	paginator := rds.NewDescribeDBClustersPaginator(svc, &config)
+	for paginator.HasMorePages() {
+		page, err := paginator.NextPage(ctx)
 		if err != nil {
 			return err
 		}
-		res <- response.DBClusters
-		if aws.ToString(response.Marker) == "" {
-			break
-		}
-		config.Marker = response.Marker
+		res <- page.DBClusters
 	}
 	return nil
 }

--- a/plugins/source/aws/resources/services/rds/db_parameter_groups.go
+++ b/plugins/source/aws/resources/services/rds/db_parameter_groups.go
@@ -3,7 +3,6 @@ package rds
 import (
 	"context"
 
-	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/rds"
 	"github.com/aws/aws-sdk-go-v2/service/rds/types"
 	"github.com/cloudquery/cloudquery/plugins/source/aws/client"
@@ -47,16 +46,13 @@ func fetchRdsDbParameterGroups(ctx context.Context, meta schema.ClientMeta, pare
 	cl := meta.(*client.Client)
 	svc := cl.Services().Rds
 	var input rds.DescribeDBParameterGroupsInput
-	for {
-		output, err := svc.DescribeDBParameterGroups(ctx, &input)
+	paginator := rds.NewDescribeDBParameterGroupsPaginator(svc, &input)
+	for paginator.HasMorePages() {
+		page, err := paginator.NextPage(ctx)
 		if err != nil {
 			return err
 		}
-		res <- output.DBParameterGroups
-		if aws.ToString(output.Marker) == "" {
-			break
-		}
-		input.Marker = output.Marker
+		res <- page.DBParameterGroups
 	}
 	return nil
 }
@@ -66,8 +62,9 @@ func fetchRdsDbParameterGroupDbParameters(ctx context.Context, meta schema.Clien
 	svc := cl.Services().Rds
 	g := parent.Item.(types.DBParameterGroup)
 	input := rds.DescribeDBParametersInput{DBParameterGroupName: g.DBParameterGroupName}
-	for {
-		output, err := svc.DescribeDBParameters(ctx, &input)
+	paginator := rds.NewDescribeDBParametersPaginator(svc, &input)
+	for paginator.HasMorePages() {
+		page, err := paginator.NextPage(ctx)
 		if err != nil {
 			if client.IsAWSError(err, "DBParameterGroupNotFound") {
 				cl.Logger().Warn().Err(err).Msg("received DBParameterGroupNotFound on DescribeDBParameters")
@@ -75,11 +72,7 @@ func fetchRdsDbParameterGroupDbParameters(ctx context.Context, meta schema.Clien
 			}
 			return err
 		}
-		res <- output.Parameters
-		if aws.ToString(output.Marker) == "" {
-			break
-		}
-		input.Marker = output.Marker
+		res <- page.Parameters
 	}
 	return nil
 }

--- a/plugins/source/aws/resources/services/rds/db_proxies.go
+++ b/plugins/source/aws/resources/services/rds/db_proxies.go
@@ -3,7 +3,6 @@ package rds
 import (
 	"context"
 
-	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/rds"
 	"github.com/aws/aws-sdk-go-v2/service/rds/types"
 	"github.com/cloudquery/cloudquery/plugins/source/aws/client"
@@ -43,16 +42,13 @@ func fetchDbProxies(ctx context.Context, meta schema.ClientMeta, parent *schema.
 	c := meta.(*client.Client)
 	svc := c.Services().Rds
 	input := rds.DescribeDBProxiesInput{}
-	for {
-		output, err := svc.DescribeDBProxies(ctx, &input)
+	paginator := rds.NewDescribeDBProxiesPaginator(svc, &input)
+	for paginator.HasMorePages() {
+		page, err := paginator.NextPage(ctx)
 		if err != nil {
 			return err
 		}
-		res <- output.DBProxies
-		if aws.ToString(output.Marker) == "" {
-			break
-		}
-		input.Marker = output.Marker
+		res <- page.DBProxies
 	}
 	return nil
 }

--- a/plugins/source/aws/resources/services/rds/db_security_groups.go
+++ b/plugins/source/aws/resources/services/rds/db_security_groups.go
@@ -3,7 +3,6 @@ package rds
 import (
 	"context"
 
-	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/rds"
 	"github.com/aws/aws-sdk-go-v2/service/rds/types"
 	"github.com/cloudquery/cloudquery/plugins/source/aws/client"
@@ -46,16 +45,13 @@ func fetchRdsDbSecurityGroups(ctx context.Context, meta schema.ClientMeta, paren
 	cl := meta.(*client.Client)
 	svc := cl.Services().Rds
 	var input rds.DescribeDBSecurityGroupsInput
-	for {
-		output, err := svc.DescribeDBSecurityGroups(ctx, &input)
+	paginator := rds.NewDescribeDBSecurityGroupsPaginator(svc, &input)
+	for paginator.HasMorePages() {
+		page, err := paginator.NextPage(ctx)
 		if err != nil {
 			return err
 		}
-		res <- output.DBSecurityGroups
-		if aws.ToString(output.Marker) == "" {
-			break
-		}
-		input.Marker = output.Marker
+		res <- page.DBSecurityGroups
 	}
 	return nil
 }

--- a/plugins/source/aws/resources/services/rds/db_snapshots.go
+++ b/plugins/source/aws/resources/services/rds/db_snapshots.go
@@ -3,7 +3,6 @@ package rds
 import (
 	"context"
 
-	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/rds"
 	"github.com/aws/aws-sdk-go-v2/service/rds/types"
 	"github.com/cloudquery/cloudquery/plugins/source/aws/client"
@@ -48,16 +47,13 @@ func fetchRdsDbSnapshots(ctx context.Context, meta schema.ClientMeta, parent *sc
 	c := meta.(*client.Client)
 	svc := c.Services().Rds
 	var input rds.DescribeDBSnapshotsInput
-	for {
-		output, err := svc.DescribeDBSnapshots(ctx, &input)
+	paginator := rds.NewDescribeDBSnapshotsPaginator(svc, &input)
+	for paginator.HasMorePages() {
+		page, err := paginator.NextPage(ctx)
 		if err != nil {
 			return nil
 		}
-		res <- output.DBSnapshots
-		if aws.ToString(output.Marker) == "" {
-			break
-		}
-		input.Marker = output.Marker
+		res <- page.DBSnapshots
 	}
 	return nil
 }

--- a/plugins/source/aws/resources/services/rds/event_subscriptions.go
+++ b/plugins/source/aws/resources/services/rds/event_subscriptions.go
@@ -3,7 +3,6 @@ package rds
 import (
 	"context"
 
-	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/rds"
 	"github.com/aws/aws-sdk-go-v2/service/rds/types"
 	"github.com/cloudquery/cloudquery/plugins/source/aws/client"
@@ -43,16 +42,13 @@ func fetchRdsEventSubscriptions(ctx context.Context, meta schema.ClientMeta, par
 	cl := meta.(*client.Client)
 	svc := cl.Services().Rds
 	var input rds.DescribeEventSubscriptionsInput
-	for {
-		out, err := svc.DescribeEventSubscriptions(ctx, &input)
+	paginator := rds.NewDescribeEventSubscriptionsPaginator(svc, &input)
+	for paginator.HasMorePages() {
+		page, err := paginator.NextPage(ctx)
 		if err != nil {
 			return err
 		}
-		res <- out.EventSubscriptionsList
-		if aws.ToString(out.Marker) == "" {
-			break
-		}
-		input.Marker = out.Marker
+		res <- page.EventSubscriptionsList
 	}
 	return nil
 }

--- a/plugins/source/aws/resources/services/redshift/cluster_parameters.go
+++ b/plugins/source/aws/resources/services/redshift/cluster_parameters.go
@@ -3,7 +3,6 @@ package redshift
 import (
 	"context"
 
-	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/redshift"
 	"github.com/aws/aws-sdk-go-v2/service/redshift/types"
 	"github.com/cloudquery/cloudquery/plugins/source/aws/client"
@@ -51,17 +50,13 @@ func fetchClusterParameters(ctx context.Context, meta schema.ClientMeta, parent 
 	config := redshift.DescribeClusterParametersInput{
 		ParameterGroupName: group.ParameterGroupName,
 	}
-	for {
-		response, err := svc.DescribeClusterParameters(ctx, &config)
+	paginator := redshift.NewDescribeClusterParametersPaginator(svc, &config)
+	for paginator.HasMorePages() {
+		page, err := paginator.NextPage(ctx)
 		if err != nil {
 			return err
 		}
-		res <- response.Parameters
-		if aws.ToString(response.Marker) == "" {
-			break
-		}
-		config.Marker = response.Marker
+		res <- page.Parameters
 	}
-
 	return nil
 }

--- a/plugins/source/aws/resources/services/redshift/clusters.go
+++ b/plugins/source/aws/resources/services/redshift/clusters.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/redshift"
 	"github.com/aws/aws-sdk-go-v2/service/redshift/types"
 	"github.com/cloudquery/cloudquery/plugins/source/aws/client"
@@ -58,16 +57,13 @@ func fetchClusters(ctx context.Context, meta schema.ClientMeta, parent *schema.R
 	var config redshift.DescribeClustersInput
 	c := meta.(*client.Client)
 	svc := c.Services().Redshift
-	for {
-		response, err := svc.DescribeClusters(ctx, &config)
+	paginator := redshift.NewDescribeClustersPaginator(svc, &config)
+	for paginator.HasMorePages() {
+		page, err := paginator.NextPage(ctx)
 		if err != nil {
 			return err
 		}
-		res <- response.Clusters
-		if aws.ToString(response.Marker) == "" {
-			break
-		}
-		config.Marker = response.Marker
+		res <- page.Clusters
 	}
 	return nil
 }

--- a/plugins/source/aws/resources/services/redshift/data_shares.go
+++ b/plugins/source/aws/resources/services/redshift/data_shares.go
@@ -33,16 +33,13 @@ func fetchDataShares(ctx context.Context, meta schema.ClientMeta, parent *schema
 	config := redshift.DescribeDataSharesInput{
 		MaxRecords: aws.Int32(100),
 	}
-	for {
-		response, err := svc.DescribeDataShares(ctx, &config)
+	paginator := redshift.NewDescribeDataSharesPaginator(svc, &config)
+	for paginator.HasMorePages() {
+		page, err := paginator.NextPage(ctx)
 		if err != nil {
 			return err
 		}
-		res <- response.DataShares
-		if aws.ToString(response.Marker) == "" {
-			break
-		}
-		config.Marker = response.Marker
+		res <- page.DataShares
 	}
 
 	return nil

--- a/plugins/source/aws/resources/services/redshift/endpoint_access.go
+++ b/plugins/source/aws/resources/services/redshift/endpoint_access.go
@@ -41,17 +41,13 @@ func fetchEndpointAccess(ctx context.Context, meta schema.ClientMeta, parent *sc
 		ClusterIdentifier: cluster.ClusterIdentifier,
 		MaxRecords:        aws.Int32(100),
 	}
-	for {
-		response, err := svc.DescribeEndpointAccess(ctx, &config)
+	paginator := redshift.NewDescribeEndpointAccessPaginator(svc, &config)
+	for paginator.HasMorePages() {
+		page, err := paginator.NextPage(ctx)
 		if err != nil {
 			return err
 		}
-		res <- response.EndpointAccessList
-		if aws.ToString(response.Marker) == "" {
-			break
-		}
-		config.Marker = response.Marker
+		res <- page.EndpointAccessList
 	}
-
 	return nil
 }

--- a/plugins/source/aws/resources/services/redshift/endpoint_authorization.go
+++ b/plugins/source/aws/resources/services/redshift/endpoint_authorization.go
@@ -42,17 +42,13 @@ func fetchEndpointAuthorization(ctx context.Context, meta schema.ClientMeta, par
 		ClusterIdentifier: cluster.ClusterIdentifier,
 		MaxRecords:        aws.Int32(100),
 	}
-	for {
-		response, err := svc.DescribeEndpointAuthorization(ctx, &config)
+	paginator := redshift.NewDescribeEndpointAuthorizationPaginator(svc, &config)
+	for paginator.HasMorePages() {
+		page, err := paginator.NextPage(ctx)
 		if err != nil {
 			return err
 		}
-		res <- response.EndpointAuthorizationList
-		if aws.ToString(response.Marker) == "" {
-			break
-		}
-		config.Marker = response.Marker
+		res <- page.EndpointAuthorizationList
 	}
-
 	return nil
 }

--- a/plugins/source/aws/resources/services/redshift/event_subscriptions.go
+++ b/plugins/source/aws/resources/services/redshift/event_subscriptions.go
@@ -47,16 +47,13 @@ func fetchEventSubscriptions(ctx context.Context, meta schema.ClientMeta, parent
 	svc := cl.Services().Redshift
 	var params redshift.DescribeEventSubscriptionsInput
 	params.MaxRecords = aws.Int32(100)
-	for {
-		result, err := svc.DescribeEventSubscriptions(ctx, &params)
+	paginator := redshift.NewDescribeEventSubscriptionsPaginator(svc, &params)
+	for paginator.HasMorePages() {
+		page, err := paginator.NextPage(ctx)
 		if err != nil {
 			return err
 		}
-		res <- result.EventSubscriptionsList
-		if aws.ToString(result.Marker) == "" {
-			break
-		}
-		params.Marker = result.Marker
+		res <- page.EventSubscriptionsList
 	}
 	return nil
 }

--- a/plugins/source/aws/resources/services/redshift/events.go
+++ b/plugins/source/aws/resources/services/redshift/events.go
@@ -36,16 +36,13 @@ func fetchEvents(ctx context.Context, meta schema.ClientMeta, parent *schema.Res
 		Duration:   aws.Int32(60 * 24 * 14), // 14 days (maximum)
 		MaxRecords: aws.Int32(100),
 	}
-	for {
-		result, err := svc.DescribeEvents(ctx, &config)
+	paginator := redshift.NewDescribeEventsPaginator(svc, &config)
+	for paginator.HasMorePages() {
+		page, err := paginator.NextPage(ctx)
 		if err != nil {
 			return err
 		}
-		res <- result.Events
-		if aws.ToString(result.Marker) == "" {
-			break
-		}
-		config.Marker = result.Marker
+		res <- page.Events
 	}
 	return nil
 }

--- a/plugins/source/aws/resources/services/redshift/snapshots.go
+++ b/plugins/source/aws/resources/services/redshift/snapshots.go
@@ -52,16 +52,13 @@ func fetchSnapshots(ctx context.Context, meta schema.ClientMeta, parent *schema.
 		ClusterIdentifier: cluster.ClusterIdentifier,
 		MaxRecords:        aws.Int32(100),
 	}
-	for {
-		result, err := svc.DescribeClusterSnapshots(ctx, &params)
+	paginator := redshift.NewDescribeClusterSnapshotsPaginator(svc, &params)
+	for paginator.HasMorePages() {
+		page, err := paginator.NextPage(ctx)
 		if err != nil {
 			return err
 		}
-		res <- result.Snapshots
-		if aws.ToString(result.Marker) == "" {
-			break
-		}
-		params.Marker = result.Marker
+		res <- page.Snapshots
 	}
 	return nil
 }

--- a/plugins/source/aws/resources/services/redshift/subnet_groups.go
+++ b/plugins/source/aws/resources/services/redshift/subnet_groups.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/redshift"
 	"github.com/aws/aws-sdk-go-v2/service/redshift/types"
 	"github.com/cloudquery/cloudquery/plugins/source/aws/client"
@@ -45,16 +44,13 @@ func fetchSubnetGroups(ctx context.Context, meta schema.ClientMeta, parent *sche
 	var config redshift.DescribeClusterSubnetGroupsInput
 	c := meta.(*client.Client)
 	svc := c.Services().Redshift
-	for {
-		response, err := svc.DescribeClusterSubnetGroups(ctx, &config)
+	paginator := redshift.NewDescribeClusterSubnetGroupsPaginator(svc, &config)
+	for paginator.HasMorePages() {
+		page, err := paginator.NextPage(ctx)
 		if err != nil {
 			return err
 		}
-		res <- response.ClusterSubnetGroups
-		if aws.ToString(response.Marker) == "" {
-			break
-		}
-		config.Marker = response.Marker
+		res <- page.ClusterSubnetGroups
 	}
 	return nil
 }

--- a/plugins/source/aws/resources/services/route53/delegation_sets.go
+++ b/plugins/source/aws/resources/services/route53/delegation_sets.go
@@ -38,7 +38,7 @@ func fetchRoute53DelegationSets(ctx context.Context, meta schema.ClientMeta, par
 	var config route53.ListReusableDelegationSetsInput
 	c := meta.(*client.Client)
 	svc := c.Services().Route53
-
+	// no paginator available
 	for {
 		response, err := svc.ListReusableDelegationSets(ctx, &config)
 		if err != nil {

--- a/plugins/source/aws/resources/services/route53/domains.go
+++ b/plugins/source/aws/resources/services/route53/domains.go
@@ -47,18 +47,13 @@ func fetchRoute53Domains(ctx context.Context, meta schema.ClientMeta, parent *sc
 	c := meta.(*client.Client)
 	svc := c.Services().Route53domains
 	var input route53domains.ListDomainsInput
-
-	for {
-		output, err := svc.ListDomains(ctx, &input)
+	paginator := route53domains.NewListDomainsPaginator(svc, &input)
+	for paginator.HasMorePages() {
+		page, err := paginator.NextPage(ctx)
 		if err != nil {
 			return err
 		}
-		res <- output.Domains
-
-		if aws.ToString(output.NextPageMarker) == "" {
-			break
-		}
-		input.Marker = output.NextPageMarker
+		res <- page.Domains
 	}
 	return nil
 }

--- a/plugins/source/aws/resources/services/route53/hosted_zone_query_logging_configs.go
+++ b/plugins/source/aws/resources/services/route53/hosted_zone_query_logging_configs.go
@@ -45,16 +45,13 @@ func fetchRoute53HostedZoneQueryLoggingConfigs(ctx context.Context, meta schema.
 	r := parent.Item.(*models.Route53HostedZoneWrapper)
 	svc := meta.(*client.Client).Services().Route53
 	config := route53.ListQueryLoggingConfigsInput{HostedZoneId: r.Id}
-	for {
-		response, err := svc.ListQueryLoggingConfigs(ctx, &config, func(options *route53.Options) {})
+	paginator := route53.NewListQueryLoggingConfigsPaginator(svc, &config)
+	for paginator.HasMorePages() {
+		page, err := paginator.NextPage(ctx)
 		if err != nil {
 			return err
 		}
-		res <- response.QueryLoggingConfigs
-		if aws.ToString(response.NextToken) == "" {
-			break
-		}
-		config.NextToken = response.NextToken
+		res <- page.QueryLoggingConfigs
 	}
 	return nil
 }

--- a/plugins/source/aws/resources/services/route53/hosted_zone_traffic_policy_instances.go
+++ b/plugins/source/aws/resources/services/route53/hosted_zone_traffic_policy_instances.go
@@ -46,6 +46,7 @@ func fetchRoute53HostedZoneTrafficPolicyInstances(ctx context.Context, meta sche
 	r := parent.Item.(*models.Route53HostedZoneWrapper)
 	config := route53.ListTrafficPolicyInstancesByHostedZoneInput{HostedZoneId: r.Id}
 	svc := meta.(*client.Client).Services().Route53
+	// No paginator available
 	for {
 		response, err := svc.ListTrafficPolicyInstancesByHostedZone(ctx, &config)
 		if err != nil {

--- a/plugins/source/aws/resources/services/route53/traffic_policies.go
+++ b/plugins/source/aws/resources/services/route53/traffic_policies.go
@@ -60,6 +60,7 @@ func fetchRoute53TrafficPolicyVersions(ctx context.Context, meta schema.ClientMe
 	r := parent.Item.(types.TrafficPolicySummary)
 	config := route53.ListTrafficPolicyVersionsInput{Id: r.Id}
 	svc := meta.(*client.Client).Services().Route53
+	// no paginator available
 	for {
 		response, err := svc.ListTrafficPolicyVersions(ctx, &config)
 		if err != nil {

--- a/plugins/source/aws/resources/services/sagemaker/models.go
+++ b/plugins/source/aws/resources/services/sagemaker/models.go
@@ -3,7 +3,6 @@ package sagemaker
 import (
 	"context"
 
-	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/sagemaker"
 	"github.com/aws/aws-sdk-go-v2/service/sagemaker/types"
 	"github.com/cloudquery/cloudquery/plugins/source/aws/client"
@@ -51,18 +50,13 @@ func fetchSagemakerModels(ctx context.Context, meta schema.ClientMeta, _ *schema
 	c := meta.(*client.Client)
 	svc := c.Services().Sagemaker
 	config := sagemaker.ListModelsInput{}
-	for {
-		response, err := svc.ListModels(ctx, &config)
+	paginator := sagemaker.NewListModelsPaginator(svc, &config)
+	for paginator.HasMorePages() {
+		page, err := paginator.NextPage(ctx)
 		if err != nil {
 			return err
 		}
-
-		res <- response.Models
-
-		if aws.ToString(response.NextToken) == "" {
-			break
-		}
-		config.NextToken = response.NextToken
+		res <- page.Models
 	}
 	return nil
 }

--- a/plugins/source/aws/resources/services/sagemaker/notebook_instances.go
+++ b/plugins/source/aws/resources/services/sagemaker/notebook_instances.go
@@ -3,7 +3,6 @@ package sagemaker
 import (
 	"context"
 
-	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/sagemaker"
 	"github.com/aws/aws-sdk-go-v2/service/sagemaker/types"
 	"github.com/cloudquery/cloudquery/plugins/source/aws/client"
@@ -51,18 +50,14 @@ func fetchSagemakerNotebookInstances(ctx context.Context, meta schema.ClientMeta
 	c := meta.(*client.Client)
 	svc := c.Services().Sagemaker
 	config := sagemaker.ListNotebookInstancesInput{}
-	for {
-		response, err := svc.ListNotebookInstances(ctx, &config)
+	paginator := sagemaker.NewListNotebookInstancesPaginator(svc, &config)
+	for paginator.HasMorePages() {
+		page, err := paginator.NextPage(ctx)
 		if err != nil {
 			return err
 		}
 
-		res <- response.NotebookInstances
-
-		if aws.ToString(response.NextToken) == "" {
-			break
-		}
-		config.NextToken = response.NextToken
+		res <- page.NotebookInstances
 	}
 	return nil
 }

--- a/plugins/source/aws/resources/services/savingsplans/savingsplans.go
+++ b/plugins/source/aws/resources/services/savingsplans/savingsplans.go
@@ -39,6 +39,7 @@ func fetchSavingsPlans(ctx context.Context, meta schema.ClientMeta, parent *sche
 	config := savingsplans.DescribeSavingsPlansInput{
 		MaxResults: aws.Int32(1000),
 	}
+	// no paginator available
 	for {
 		response, err := svc.DescribeSavingsPlans(ctx, &config)
 		if err != nil {

--- a/plugins/source/aws/resources/services/servicecatalog/products.go
+++ b/plugins/source/aws/resources/services/servicecatalog/products.go
@@ -3,7 +3,6 @@ package servicecatalog
 import (
 	"context"
 
-	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/servicecatalog"
 	"github.com/aws/aws-sdk-go-v2/service/servicecatalog/types"
 	"github.com/aws/aws-sdk-go-v2/service/servicecatalogappregistry"
@@ -44,18 +43,13 @@ func fetchServicecatalogProducts(ctx context.Context, meta schema.ClientMeta, pa
 	svc := c.Services().Servicecatalog
 
 	listInput := new(servicecatalog.SearchProductsAsAdminInput)
-	for {
-		output, err := svc.SearchProductsAsAdmin(ctx, listInput)
+	paginator := servicecatalog.NewSearchProductsAsAdminPaginator(svc, listInput)
+	for paginator.HasMorePages() {
+		page, err := paginator.NextPage(ctx)
 		if err != nil {
 			return err
 		}
-
-		res <- output.ProductViewDetails
-
-		if aws.ToString(output.NextPageToken) == "" {
-			break
-		}
-		listInput.PageToken = output.NextPageToken
+		res <- page.ProductViewDetails
 	}
 
 	return nil

--- a/plugins/source/aws/resources/services/servicecatalog/provisioned_products.go
+++ b/plugins/source/aws/resources/services/servicecatalog/provisioned_products.go
@@ -3,7 +3,6 @@ package servicecatalog
 import (
 	"context"
 
-	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/servicecatalog"
 	"github.com/aws/aws-sdk-go-v2/service/servicecatalog/types"
 	"github.com/cloudquery/cloudquery/plugins/source/aws/client"
@@ -43,18 +42,13 @@ func fetchServicecatalogProvisionedProducts(ctx context.Context, meta schema.Cli
 	svc := c.Services().Servicecatalog
 
 	listInput := new(servicecatalog.SearchProvisionedProductsInput)
-	for {
-		output, err := svc.SearchProvisionedProducts(ctx, listInput)
+	paginator := servicecatalog.NewSearchProvisionedProductsPaginator(svc, listInput)
+	for paginator.HasMorePages() {
+		page, err := paginator.NextPage(ctx)
 		if err != nil {
 			return err
 		}
-
-		res <- output.ProvisionedProducts
-
-		if aws.ToString(output.NextPageToken) == "" {
-			break
-		}
-		listInput.PageToken = output.NextPageToken
+		res <- page.ProvisionedProducts
 	}
 
 	return nil

--- a/plugins/source/aws/resources/services/shield/protections.go
+++ b/plugins/source/aws/resources/services/shield/protections.go
@@ -3,7 +3,6 @@ package shield
 import (
 	"context"
 
-	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/shield"
 	"github.com/aws/aws-sdk-go-v2/service/shield/types"
 	"github.com/cloudquery/cloudquery/plugins/source/aws/client"
@@ -42,20 +41,16 @@ func fetchShieldProtections(ctx context.Context, meta schema.ClientMeta, parent 
 	c := meta.(*client.Client)
 	svc := c.Services().Shield
 	config := shield.ListProtectionsInput{}
-	for {
-		output, err := svc.ListProtections(ctx, &config)
+	paginator := shield.NewListProtectionsPaginator(svc, &config)
+	for paginator.HasMorePages() {
+		page, err := paginator.NextPage(ctx)
 		if err != nil {
 			if c.IsNotFoundError(err) {
 				return nil
 			}
 			return err
 		}
-		res <- output.Protections
-
-		if aws.ToString(output.NextToken) == "" {
-			break
-		}
-		config.NextToken = output.NextToken
+		res <- page.Protections
 	}
 	return nil
 }

--- a/plugins/source/aws/resources/services/ssm/compliance_summary_items.go
+++ b/plugins/source/aws/resources/services/ssm/compliance_summary_items.go
@@ -40,17 +40,13 @@ func fetchSsmComplianceSummaryItems(ctx context.Context, meta schema.ClientMeta,
 	params := ssm.ListComplianceSummariesInput{
 		MaxResults: aws.Int32(50),
 	}
-	for {
-		output, err := svc.ListComplianceSummaries(ctx, &params)
+	paginator := ssm.NewListComplianceSummariesPaginator(svc, &params)
+	for paginator.HasMorePages() {
+		page, err := paginator.NextPage(ctx)
 		if err != nil {
 			return err
 		}
-		res <- output.ComplianceSummaryItems
-
-		if aws.ToString(output.NextToken) == "" {
-			break
-		}
-		params.NextToken = output.NextToken
+		res <- page.ComplianceSummaryItems
 	}
 	return nil
 }

--- a/plugins/source/aws/resources/services/ssm/document_versions.go
+++ b/plugins/source/aws/resources/services/ssm/document_versions.go
@@ -41,6 +41,7 @@ func fetchSsmDocumentVersions(ctx context.Context, meta schema.ClientMeta, paren
 	params := ssm.ListDocumentVersionsInput{
 		Name: item.Name,
 	}
+	// No paginator
 	for {
 		output, err := svc.ListDocumentVersions(ctx, &params)
 		if err != nil {

--- a/plugins/source/aws/resources/services/ssm/instance_compliance_items.go
+++ b/plugins/source/aws/resources/services/ssm/instance_compliance_items.go
@@ -3,7 +3,6 @@ package ssm
 import (
 	"context"
 
-	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/ssm"
 	"github.com/aws/aws-sdk-go-v2/service/ssm/types"
 	"github.com/cloudquery/cloudquery/plugins/source/aws/client"
@@ -50,16 +49,13 @@ func fetchSsmInstanceComplianceItems(ctx context.Context, meta schema.ClientMeta
 	input := ssm.ListComplianceItemsInput{
 		ResourceIds: []string{*instance.InstanceId},
 	}
-	for {
-		output, err := svc.ListComplianceItems(ctx, &input)
+	paginator := ssm.NewListComplianceItemsPaginator(svc, &input)
+	for paginator.HasMorePages() {
+		page, err := paginator.NextPage(ctx)
 		if err != nil {
 			return err
 		}
-		res <- output.ComplianceItems
-		if aws.ToString(output.NextToken) == "" {
-			break
-		}
-		input.NextToken = output.NextToken
+		res <- page.ComplianceItems
 	}
 	return nil
 }


### PR DESCRIPTION
<!-- 🎉 Thank you for making CloudQuery awesome by submitting a PR 🎉 -->

#### Summary

Rather than handling pagination manually, we should use the paginators that are part of the SDK