### PR TITLE
fix: Fix case on arn attribute

### DIFF
--- a/plugins/source/aws/policies/queries/iam/hardware_mfa_enabled_for_root.sql
+++ b/plugins/source/aws/policies/queries/iam/hardware_mfa_enabled_for_root.sql
@@ -13,6 +13,6 @@ select
 from aws_iam_credential_reports cr
 left join
     aws_iam_virtual_mfa_devices mfa on
-        mfa.user->>'arn' = cr.arn
+        mfa.user->>'Arn' = cr.arn
 where cr.user = '<root_account>'
 group by mfa.serial_number, cr.mfa_active, cr.arn;


### PR DESCRIPTION
<!-- 🎉 Thank you for making CloudQuery awesome by submitting a PR 🎉 -->

#### Summary

The MFA policy isn't linking any MFA devices to the root user because the case of the Arn attribute is incorrect.

Note that this query doesn't strictly enforce the hardware MFA policy, as it only checks virtual MFA devices. I don't believe there is anyway for CloudQuery to detect hardware MFA devices that are associated with the root user, as the AWS API requires you to be logged in as root to do that.

<!--
Use the following steps to ensure your PR is ready to be reviewed

- [ ] Read the [contribution guidelines](../blob/main/CONTRIBUTING.md) 🧑‍🎓
- [ ] Run `make lint` to ensure the proposed changes follow the coding style 🚨 (install golangci-lint [here](https://golangci-lint.run/usage/install/#local-installation))
- [ ] Run `make test` to ensure the proposed changes pass the tests 🧪
- [ ] If changing a source plugin run `make gen` to ensure docs are up to date 📝
- [ ] Ensure the status checks below are successful ✅
--->
