### PR TITLE
chore(ci): Log check run ID to detect duplicates

### DIFF
--- a/.github/workflows/wait_for_required_workflows.yml
+++ b/.github/workflows/wait_for_required_workflows.yml
@@ -78,7 +78,7 @@ jobs:
                 status: 'completed',
                 per_page: 100
               })
-              const runs = checkRuns.map(({ name, conclusion }) => ({ name, conclusion }))
+              const runs = checkRuns.map(({ id, name, conclusion }) => ({ id, name, conclusion }))
               console.log(`Got the following check runs: ${JSON.stringify(runs)}`)
               const matchingRuns = runs.filter(({ name }) => actions.includes(name))
               const failedRuns = matchingRuns.filter(({ conclusion }) => conclusion !== 'success')


### PR DESCRIPTION
<!-- 🎉 Thank you for making CloudQuery awesome by submitting a PR 🎉 -->

#### Summary

Related to https://github.com/cloudquery/cloudquery/pull/9736#issuecomment-1501606356. We've seen cases were apparently the GitHub JS SDK returns duplicate check runs, so adding a log for the ID to see what's up.

<!--
Use the following steps to ensure your PR is ready to be reviewed

- [ ] Read the [contribution guidelines](../blob/main/CONTRIBUTING.md) 🧑‍🎓
- [ ] Run `make lint` to ensure the proposed changes follow the coding style 🚨 (install golangci-lint [here](https://golangci-lint.run/usage/install/#local-installation))
- [ ] Run `make test` to ensure the proposed changes pass the tests 🧪
- [ ] If changing a source plugin run `make gen` to ensure docs are up to date 📝
- [ ] Ensure the status checks below are successful ✅
--->
