### PR TITLE
fix(ci): Filter out duplicates in `wait-for-required-workflows`

### DIFF
--- a/.github/workflows/dest_clickhouse.yml
+++ b/.github/workflows/dest_clickhouse.yml
@@ -14,7 +14,7 @@ on:
 
 jobs:
   plugins-destination-clickhouse:
-    name:            plugins/destination/clickhouse
+    name: "plugins/destination/clickhouse"
     runs-on:         ubuntu-latest
     timeout-minutes: 30
     env:

--- a/.github/workflows/dest_meilisearch.yml
+++ b/.github/workflows/dest_meilisearch.yml
@@ -14,7 +14,7 @@ on:
 
 jobs:
   plugins-destination-meilisearch:
-    name:            plugins/destination/meilisearch
+    name: "plugins/destination/meilisearch"
     runs-on:         ubuntu-latest
     timeout-minutes: 30
     env:

--- a/.github/workflows/dest_mssql.yml
+++ b/.github/workflows/dest_mssql.yml
@@ -14,7 +14,7 @@ on:
 
 jobs:
   plugins-destination-mssql:
-    name:            "plugins/destination/mssql"
+    name: "plugins/destination/mssql"
     runs-on:         ubuntu-latest
     timeout-minutes: 30
     env:

--- a/.github/workflows/wait_for_required_workflows.yml
+++ b/.github/workflows/wait_for_required_workflows.yml
@@ -78,7 +78,11 @@ jobs:
                 status: 'completed',
                 per_page: 100
               })
-              const runs = checkRuns.map(({ id, name, conclusion }) => ({ id, name, conclusion }))
+
+              // filter as sometimes we can see duplicates (1st page fetch -> new check finished -> 2nd page fetch)
+              const rawRuns = checkRuns.map(({ id, name, conclusion }) => ({ id, name, conclusion }))
+              const runs = rawRuns.filter((element, index) => rawRuns.indexOf(element) === index)
+
               console.log(`Got the following check runs: ${JSON.stringify(runs)}`)
               const matchingRuns = runs.filter(({ name }) => actions.includes(name))
               const failedRuns = matchingRuns.filter(({ conclusion }) => conclusion !== 'success')


### PR DESCRIPTION
Follow-up from #9793 