### PR TITLE
feat(aws): Parallelize resolution of `aws_iot_policies`

### DIFF
--- a/plugins/source/aws/resources/services/iot/policies.go
+++ b/plugins/source/aws/resources/services/iot/policies.go
@@ -14,11 +14,12 @@ import (
 func Policies() *schema.Table {
 	tableName := "aws_iot_policies"
 	return &schema.Table{
-		Name:        tableName,
-		Description: `https://docs.aws.amazon.com/iot/latest/apireference/API_Policy.html`,
-		Resolver:    fetchIotPolicies,
-		Transform:   transformers.TransformWithStruct(&types.Policy{}),
-		Multiplex:   client.ServiceAccountRegionMultiplexer(tableName, "iot"),
+		Name:                tableName,
+		Description:         `https://docs.aws.amazon.com/iot/latest/apireference/API_Policy.html`,
+		Resolver:            fetchIotPolicies,
+		PreResourceResolver: getPolicy,
+		Transform:           transformers.TransformWithStruct(&types.Policy{}),
+		Multiplex:           client.ServiceAccountRegionMultiplexer(tableName, "iot"),
 		Columns: []schema.Column{
 			client.DefaultAccountIDColumn(false),
 			client.DefaultRegionColumn(false),
@@ -52,22 +53,25 @@ func fetchIotPolicies(ctx context.Context, meta schema.ClientMeta, parent *schem
 		if err != nil {
 			return err
 		}
-
-		for _, s := range page.Policies {
-			// TODO: Handle resolution in parallel with PreResourceResolver
-			profile, err := svc.GetPolicy(ctx, &iot.GetPolicyInput{
-				PolicyName: s.PolicyName,
-			}, func(options *iot.Options) {
-				options.Region = cl.Region
-			})
-			if err != nil {
-				return err
-			}
-			res <- profile
-		}
+		res <- page.Policies
 	}
 	return nil
 }
+
+func getPolicy(ctx context.Context, meta schema.ClientMeta, resource *schema.Resource) error {
+	cl := meta.(*client.Client)
+	svc := cl.Services().Iot
+
+	output, err := svc.GetPolicy(ctx, &iot.GetPolicyInput{
+		PolicyName: resource.Item.(types.Policy).PolicyName,
+	})
+	if err != nil {
+		return err
+	}
+	resource.Item = output
+	return nil
+}
+
 func ResolveIotPolicyTags(ctx context.Context, meta schema.ClientMeta, resource *schema.Resource, c schema.Column) error {
 	cl := meta.(*client.Client)
 	svc := cl.Services().Iot


### PR DESCRIPTION
<!-- 🎉 Thank you for making CloudQuery awesome by submitting a PR 🎉 -->

#### Summary

Use `PreResourceResolver` to call `GetPolicy` rather than calling sequentially