### PR TITLE
feat(aws): Parallelize resolution of  `aws_iot_billing_groups`

### DIFF
--- a/plugins/source/aws/resources/services/iot/billing_groups.go
+++ b/plugins/source/aws/resources/services/iot/billing_groups.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/iot"
+	"github.com/aws/aws-sdk-go-v2/service/iot/types"
 	"github.com/cloudquery/cloudquery/plugins/source/aws/client"
 	"github.com/cloudquery/plugin-sdk/schema"
 	"github.com/cloudquery/plugin-sdk/transformers"
@@ -13,11 +14,12 @@ import (
 func BillingGroups() *schema.Table {
 	tableName := "aws_iot_billing_groups"
 	return &schema.Table{
-		Name:        tableName,
-		Description: `https://docs.aws.amazon.com/iot/latest/apireference/API_DescribeBillingGroup.html`,
-		Resolver:    fetchIotBillingGroups,
-		Transform:   transformers.TransformWithStruct(&iot.DescribeBillingGroupOutput{}),
-		Multiplex:   client.ServiceAccountRegionMultiplexer(tableName, "iot"),
+		Name:                tableName,
+		Description:         `https://docs.aws.amazon.com/iot/latest/apireference/API_DescribeBillingGroup.html`,
+		Resolver:            fetchIotBillingGroups,
+		PreResourceResolver: getBillingGroup,
+		Transform:           transformers.TransformWithStruct(&iot.DescribeBillingGroupOutput{}),
+		Multiplex:           client.ServiceAccountRegionMultiplexer(tableName, "iot"),
 		Columns: []schema.Column{
 			client.DefaultAccountIDColumn(false),
 			client.DefaultRegionColumn(false),
@@ -56,19 +58,22 @@ func fetchIotBillingGroups(ctx context.Context, meta schema.ClientMeta, parent *
 		if err != nil {
 			return err
 		}
-		// TODO: Handle resolution in parallel with PreResourceResolver
-		for _, g := range page.BillingGroups {
-			group, err := svc.DescribeBillingGroup(ctx, &iot.DescribeBillingGroupInput{
-				BillingGroupName: g.GroupName,
-			}, func(options *iot.Options) {
-				options.Region = c.Region
-			})
-			if err != nil {
-				return err
-			}
-			res <- group
-		}
+		res <- page.BillingGroups
 	}
+	return nil
+}
+
+func getBillingGroup(ctx context.Context, meta schema.ClientMeta, resource *schema.Resource) error {
+	cl := meta.(*client.Client)
+	svc := cl.Services().Iot
+
+	output, err := svc.DescribeBillingGroup(ctx, &iot.DescribeBillingGroupInput{
+		BillingGroupName: resource.Item.(types.GroupNameAndArn).GroupName,
+	})
+	if err != nil {
+		return err
+	}
+	resource.Item = output
 	return nil
 }
 


### PR DESCRIPTION
<!-- 🎉 Thank you for making CloudQuery awesome by submitting a PR 🎉 -->

#### Summary

Use `PreResourceResolver` to call `DescribeBillingGroup` rather than calling sequentially