### PR TITLE
fix(workflows): Properly use caches in AWS, Azure, GCP, K8s workflows

### DIFF
--- a/.github/workflows/source_aws.yml
+++ b/.github/workflows/source_aws.yml
@@ -141,7 +141,7 @@ jobs:
           go-version-file: plugins/source/aws/go.mod
           cache: true
           cache-dependency-path: plugins/source/aws/go.sum
-          cache-prefix: policies-cache-
+          cache-key-prefix: policies-cache-
       - name: Build
         run: go build .
       - name: Setup CloudQuery

--- a/.github/workflows/source_aws.yml
+++ b/.github/workflows/source_aws.yml
@@ -33,11 +33,12 @@ jobs:
         with:
           fetch-depth: 2
       - name: Set up Go 1.x
-        uses: actions/setup-go@v3
+        uses: erezrokah/setup-go@feat/add_cache_prefix
         with:
           go-version-file: plugins/source/aws/go.mod
           cache: true
           cache-dependency-path: plugins/source/aws/go.sum
+          cache-prefix: test-cache-
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v3
         with:
@@ -135,11 +136,12 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
       - name: Set up Go 1.x
-        uses: actions/setup-go@v3
+        uses: erezrokah/setup-go@feat/add_cache_prefix
         with:
           go-version-file: plugins/source/aws/go.mod
           cache: true
           cache-dependency-path: plugins/source/aws/go.sum
+          cache-prefix: policies-cache-
       - name: Build
         run: go build .
       - name: Setup CloudQuery

--- a/.github/workflows/source_aws.yml
+++ b/.github/workflows/source_aws.yml
@@ -38,7 +38,7 @@ jobs:
           go-version-file: plugins/source/aws/go.mod
           cache: true
           cache-dependency-path: plugins/source/aws/go.sum
-          cache-prefix: test-cache-
+          cache-key-prefix: test-cache-
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v3
         with:

--- a/.github/workflows/source_azure.yml
+++ b/.github/workflows/source_azure.yml
@@ -98,7 +98,7 @@ jobs:
     runs-on: ${{ needs.resolve-runner.outputs.runner }}
     defaults:
       run:
-        working-directory: ./plugins/source/aws
+        working-directory: ./plugins/source/azure
     services:
       postgres:
         image: postgres:11

--- a/.github/workflows/source_azure.yml
+++ b/.github/workflows/source_azure.yml
@@ -35,7 +35,7 @@ jobs:
           go-version-file: plugins/source/azure/go.mod
           cache: true
           cache-dependency-path: plugins/source/azure/go.sum
-          cache-prefix: test-cache-
+          cache-key-prefix: test-cache-
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v3
         with:

--- a/.github/workflows/source_azure.yml
+++ b/.github/workflows/source_azure.yml
@@ -120,9 +120,9 @@ jobs:
       - name: Set up Go 1.x
         uses: erezrokah/setup-go@feat/add_cache_prefix
         with:
-          go-version-file: plugins/source/aws/go.mod
+          go-version-file: plugins/source/azure/go.mod
           cache: true
-          cache-dependency-path: plugins/source/aws/go.sum
+          cache-dependency-path: plugins/source/azure/go.sum
           cache-key-prefix: policies-cache-
       - name: Build
         run: go build .

--- a/.github/workflows/source_azure.yml
+++ b/.github/workflows/source_azure.yml
@@ -30,11 +30,12 @@ jobs:
         with:
           fetch-depth: 2
       - name: Set up Go 1.x
-        uses: actions/setup-go@v3
+        uses: erezrokah/setup-go@feat/add_cache_prefix
         with:
           go-version-file: plugins/source/azure/go.mod
           cache: true
           cache-dependency-path: plugins/source/azure/go.sum
+          cache-prefix: test-cache-
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v3
         with:
@@ -117,11 +118,12 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
       - name: Set up Go 1.x
-        uses: actions/setup-go@v3
+        uses: erezrokah/setup-go@feat/add_cache_prefix
         with:
           go-version-file: plugins/source/aws/go.mod
           cache: true
           cache-dependency-path: plugins/source/aws/go.sum
+          cache-prefix: policies-cache-
       - name: Build
         run: go build .
       - name: Setup CloudQuery

--- a/.github/workflows/source_azure.yml
+++ b/.github/workflows/source_azure.yml
@@ -123,7 +123,7 @@ jobs:
           go-version-file: plugins/source/aws/go.mod
           cache: true
           cache-dependency-path: plugins/source/aws/go.sum
-          cache-prefix: policies-cache-
+          cache-key-prefix: policies-cache-
       - name: Build
         run: go build .
       - name: Setup CloudQuery

--- a/.github/workflows/source_gcp.yml
+++ b/.github/workflows/source_gcp.yml
@@ -30,11 +30,12 @@ jobs:
         with:
           fetch-depth: 2
       - name: Set up Go 1.x
-        uses: actions/setup-go@v3
+        uses: erezrokah/setup-go@feat/add_cache_prefix
         with:
           go-version-file: plugins/source/gcp/go.mod
           cache: true
           cache-dependency-path: plugins/source/gcp/go.sum
+          cache-prefix: test-cache-
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v3
         with:
@@ -117,11 +118,12 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
       - name: Set up Go 1.x
-        uses: actions/setup-go@v3
+        uses: erezrokah/setup-go@feat/add_cache_prefix
         with:
           go-version-file: plugins/source/gcp/go.mod
           cache: true
           cache-dependency-path: plugins/source/gcp/go.sum
+          cache-prefix: policies-cache-
       - name: Build
         run: go build .
       - name: Setup CloudQuery

--- a/.github/workflows/source_gcp.yml
+++ b/.github/workflows/source_gcp.yml
@@ -35,7 +35,7 @@ jobs:
           go-version-file: plugins/source/gcp/go.mod
           cache: true
           cache-dependency-path: plugins/source/gcp/go.sum
-          cache-prefix: test-cache-
+          cache-key-prefix: test-cache-
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v3
         with:

--- a/.github/workflows/source_gcp.yml
+++ b/.github/workflows/source_gcp.yml
@@ -123,7 +123,7 @@ jobs:
           go-version-file: plugins/source/gcp/go.mod
           cache: true
           cache-dependency-path: plugins/source/gcp/go.sum
-          cache-prefix: policies-cache-
+          cache-key-prefix: policies-cache-
       - name: Build
         run: go build .
       - name: Setup CloudQuery

--- a/.github/workflows/source_k8s.yml
+++ b/.github/workflows/source_k8s.yml
@@ -30,11 +30,12 @@ jobs:
         with:
           fetch-depth: 2
       - name: Set up Go 1.x
-        uses: actions/setup-go@v3
+        uses: erezrokah/setup-go@feat/add_cache_prefix
         with:
           go-version-file: plugins/source/k8s/go.mod
           cache: true
           cache-dependency-path: plugins/source/k8s/go.sum
+          cache-prefix: test-cache-
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v3
         with:
@@ -117,11 +118,12 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
       - name: Set up Go 1.x
-        uses: actions/setup-go@v3
+        uses: erezrokah/setup-go@feat/add_cache_prefix
         with:
           go-version-file: plugins/source/k8s/go.mod
           cache: true
           cache-dependency-path: plugins/source/k8s/go.sum
+          cache-prefix: policies-cache-
       - name: Build
         run: go build .
       - name: Setup CloudQuery

--- a/.github/workflows/source_k8s.yml
+++ b/.github/workflows/source_k8s.yml
@@ -35,7 +35,7 @@ jobs:
           go-version-file: plugins/source/k8s/go.mod
           cache: true
           cache-dependency-path: plugins/source/k8s/go.sum
-          cache-prefix: test-cache-
+          cache-key-prefix: test-cache-
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v3
         with:

--- a/.github/workflows/source_k8s.yml
+++ b/.github/workflows/source_k8s.yml
@@ -123,7 +123,7 @@ jobs:
           go-version-file: plugins/source/k8s/go.mod
           cache: true
           cache-dependency-path: plugins/source/k8s/go.sum
-          cache-prefix: policies-cache-
+          cache-key-prefix: policies-cache-
       - name: Build
         run: go build .
       - name: Setup CloudQuery


### PR DESCRIPTION
Short way instead of #9656.
Closes #9388 