### PR TITLE
chore(docs): Consolidate formatting for configs

### DIFF
--- a/website/pages/docs/plugins/destinations/clickhouse/_configuration.mdx
+++ b/website/pages/docs/plugins/destinations/clickhouse/_configuration.mdx
@@ -1,12 +1,11 @@
 ```yaml copy
 kind: destination
 spec:
-  name:       "clickhouse"
-  registry:   "github"
-  path:       "cloudquery/clickhouse"
-  version:    "VERSION_DESTINATION_CLICKHOUSE"
+  name: "clickhouse"
+  registry: "github"
+  path: "cloudquery/clickhouse"
+  version: "VERSION_DESTINATION_CLICKHOUSE"
   write_mode: "append"
-
   spec:
     connection_string: "clickhouse://${CH_USER}:${CH_PASSWORD}@localhost:9000/${CH_DATABASE}"
 ```

--- a/website/pages/docs/plugins/destinations/meilisearch/_configuration.mdx
+++ b/website/pages/docs/plugins/destinations/meilisearch/_configuration.mdx
@@ -3,16 +3,16 @@ The following config will sync data to a Meilisearch instance running on `localh
 ```yaml copy
 kind: destination
 spec:
-  name:       meilisearch
-  path:       cloudquery/meilisearch
-  version:    "VERSION_DESTINATION_MEILISEARCH"
+  name: meilisearch
+  path: cloudquery/meilisearch
+  version: "VERSION_DESTINATION_MEILISEARCH"
   write_mode: "overwrite"
   # batch_size: 1000 # optional
   # batch_size_bytes: 5242880 # optional
   spec:
     # meilisearch plugin spec
     api_key: "<YOUR_MEILISEARCH_API_KEY>"
-    host:    "http://localhost:7700"
+    host: "http://localhost:7700"
     # timeout: 5m # optional
     # ca_cert: "<YOUR_MEILISEARCH_CA_CERT>" # optional
 ```

--- a/website/pages/docs/plugins/destinations/mssql/_configuration.mdx
+++ b/website/pages/docs/plugins/destinations/mssql/_configuration.mdx
@@ -1,10 +1,10 @@
 ```yaml copy
 kind: destination
 spec:
-  name:     "mssql"
+  name: "mssql"
   registry: "github"
-  path:     "cloudquery/mssql"
-  version:  "VERSION_DESTINATION_MSSQL"
+  path: "cloudquery/mssql"
+  version: "VERSION_DESTINATION_MSSQL"
   spec:
     connection_string: "server=localhost;user id=SA;password=yourStrongP@ssword;port=1433;database=cloudquery;"
 ```

--- a/website/pages/docs/plugins/destinations/mysql/_configuration.mdx
+++ b/website/pages/docs/plugins/destinations/mysql/_configuration.mdx
@@ -1,10 +1,10 @@
 ```yaml copy
 kind: destination
 spec:
-  name:     "mysql"
+  name: "mysql"
   registry: "github"
-  path:     "cloudquery/mysql"
-  version:  "VERSION_DESTINATION_MYSQL"
+  path: "cloudquery/mysql"
+  version: "VERSION_DESTINATION_MYSQL"
   spec:
     connection_string: "user:password@/dbname"
 ```

--- a/website/pages/docs/plugins/sources/tailscale/_configuration.mdx
+++ b/website/pages/docs/plugins/sources/tailscale/_configuration.mdx
@@ -2,16 +2,16 @@
 kind: source
 # Common source-plugin configuration
 spec:
-  name:    tailscale
-  path:    cloudquery/tailscale
+  name: tailscale
+  path: cloudquery/tailscale
   version: "VERSION_SOURCE_TAILSCALE"
-  tables: [ "*" ]
-  destinations: [ "DESTINATION_NAME" ]
+  tables: ["*"]
+  destinations: ["DESTINATION_NAME"]
 
   # plugin specific configuration
   spec:
-    client_id:    "<YOUR_CLIENT_ID_HERE>"
+    client_id: "<YOUR_CLIENT_ID_HERE>"
     client_secret: ${CLIENT_SECRET_ENV_VARIABLE}
-    tailnet:      "<YOUR_TAILNET>"
+    tailnet: "<YOUR_TAILNET>"
     endpoint_url: "<YOUR_BASE_URL>"
 ```


### PR DESCRIPTION
Removes some extra spacing present in a few plugin configs, bringing all configs into alignment. 