### PR TITLE
chore(ci): Splitting `wait-for-required-workflows` code

### DIFF
--- a/.github/workflows/scripts/required_actions.js
+++ b/.github/workflows/scripts/required_actions.js
@@ -7,8 +7,6 @@ module.exports = () => {
     }
 
     const fs = require("fs");
-    let now = new Date().getTime()
-    const deadline = now + 60 * 1000 * 50
     const matchesWorkflow = (file, action) => {
         if (!file.startsWith('.github/workflows/')) {
             return false
@@ -28,10 +26,6 @@ module.exports = () => {
     const allComponents = ["cli", "scaffold", ...sources, ...destinations]
     console.log(`All components: ${allComponents.join(", ")}`)
     let actions = allComponents.filter(action => matchesFile(action))
-    if (actions.length === 0) {
-        console.log("No actions to wait for")
-        return
-    }
 
     // Most modules should have a 'validate-release' job
     for (const action of actions) {

--- a/.github/workflows/scripts/required_actions.js
+++ b/.github/workflows/scripts/required_actions.js
@@ -1,0 +1,57 @@
+module.exports = () => {
+    const files = process.env.FILES.split(' ')
+    console.log(files)
+    if (files.length >= 300) {
+        // This is a GitHub limitation https://github.com/cloudquery/cloudquery/issues/2688
+        throw new Error('Too many files changed. Skipping check. Please split your PR into multiple ones.')
+    }
+
+    const fs = require("fs");
+    let now = new Date().getTime()
+    const deadline = now + 60 * 1000 * 50
+    const matchesWorkflow = (file, action) => {
+        if (!file.startsWith('.github/workflows/')) {
+            return false
+        }
+        try {
+            const contents = fs.readFileSync(file, 'utf8');
+            return contents.includes(`name: "${action}"`)
+        } catch {
+            return false
+        }
+    }
+    const matchesFile = (action) => {
+        return files.some(file => file.startsWith(`${action}/`) || matchesWorkflow(file, action))
+    }
+    const sources = fs.readdirSync("plugins/source", {withFileTypes: true}).filter(dirent => dirent.isDirectory()).map(dirent => `plugins/source/${dirent.name}`)
+    const destinations = fs.readdirSync("plugins/destination", {withFileTypes: true}).filter(dirent => dirent.isDirectory()).map(dirent => `plugins/destination/${dirent.name}`)
+    const allComponents = ["cli", "scaffold", ...sources, ...destinations]
+    console.log(`All components: ${allComponents.join(", ")}`)
+    let actions = allComponents.filter(action => matchesFile(action))
+    if (actions.length === 0) {
+        console.log("No actions to wait for")
+        return
+    }
+
+    // Most modules should have a 'validate-release' job
+    for (const action of actions) {
+        actions = [...actions, 'validate-release']
+    }
+
+    // We test the CLI on multiple OSes, so we need to wait for all of them
+    if (actions.includes("cli")) {
+        actions = actions.filter(action => action !== "cli")
+        actions = ["cli (ubuntu-latest)", "cli (windows-latest)", "cli (macos-latest)", ...actions]
+    }
+
+    // Enforce policy tests for AWS,GCP and K8s plugins
+    const pluginsWithPolicyTests = ["plugins/source/aws", "plugins/source/azure", "plugins/source/gcp", "plugins/source/k8s"]
+    for (const plugin of pluginsWithPolicyTests) {
+        if (actions.includes(plugin)) {
+            actions = [...actions, 'test-policies']
+        }
+    }
+
+    console.log(`Required actions: [${actions.join(", ")}]`)
+    return actions
+}

--- a/.github/workflows/scripts/wait_for_required_workflows.js
+++ b/.github/workflows/scripts/wait_for_required_workflows.js
@@ -1,56 +1,6 @@
 module.exports = async ({github, context}) => {
-    const files = process.env.FILES.split(' ')
-    console.log(files)
-    if (files.length >= 300) {
-        // This is a GitHub limitation https://github.com/cloudquery/cloudquery/issues/2688
-        throw new Error('Too many files changed. Skipping check. Please split your PR into multiple ones.')
-    }
-
-    const fs = require("fs");
-    let now = new Date().getTime()
-    const deadline = now + 60 * 1000 * 50
-    const matchesWorkflow = (file, action) => {
-        if (!file.startsWith('.github/workflows/')) {
-            return false
-        }
-        try {
-            const contents = fs.readFileSync(file, 'utf8');
-            return contents.includes(`name: "${action}"`)
-        } catch {
-            return false
-        }
-    }
-    const matchesFile = (action) => {
-        return files.some(file => file.startsWith(`${action}/`) || matchesWorkflow(file, action))
-    }
-    const sources = fs.readdirSync("plugins/source", {withFileTypes: true}).filter(dirent => dirent.isDirectory()).map(dirent => `plugins/source/${dirent.name}`)
-    const destinations = fs.readdirSync("plugins/destination", {withFileTypes: true}).filter(dirent => dirent.isDirectory()).map(dirent => `plugins/destination/${dirent.name}`)
-    const allComponents = ["cli", "scaffold", ...sources, ...destinations]
-    console.log(`All components: ${allComponents.join(", ")}`)
-    let actions = allComponents.filter(action => matchesFile(action))
-    if (actions.length === 0) {
-        console.log("No actions to wait for")
-        return
-    }
-
-// Most modules should have a 'validate-release' job
-    for (const action of actions) {
-        actions = [...actions, 'validate-release']
-    }
-
-// We test the CLI on multiple OSes, so we need to wait for all of them
-    if (actions.includes("cli")) {
-        actions = actions.filter(action => action !== "cli")
-        actions = ["cli (ubuntu-latest)", "cli (windows-latest)", "cli (macos-latest)", ...actions]
-    }
-
-// Enforce policy tests for AWS,GCP and K8s plugins
-    const pluginsWithPolicyTests = ["plugins/source/aws", "plugins/source/azure", "plugins/source/gcp", "plugins/source/k8s"]
-    for (const plugin of pluginsWithPolicyTests) {
-        if (actions.includes(plugin)) {
-            actions = [...actions, 'test-policies']
-        }
-    }
+    const actions = JSON.parse(process.env.ACTIONS)
+    console.log(`Required actions: [${actions.join(", ")}]`)
 
     pendingActions = [...actions]
     console.log(`Waiting for ${pendingActions.join(", ")}`)

--- a/.github/workflows/scripts/wait_for_required_workflows.js
+++ b/.github/workflows/scripts/wait_for_required_workflows.js
@@ -1,9 +1,16 @@
 module.exports = async ({github, context}) => {
     const actions = JSON.parse(process.env.ACTIONS)
+    if (actions.length === 0) {
+        console.log("No actions to wait for")
+        return
+    }
     console.log(`Required actions: [${actions.join(", ")}]`)
 
+    let now = new Date().getTime()
+    const deadline = now + 60 * 1000 * 50
     pendingActions = [...actions]
     console.log(`Waiting for ${pendingActions.join(", ")}`)
+
     while (now <= deadline) {
         const checkRuns = await github.paginate(github.rest.checks.listForRef, {
             owner: 'cloudquery',

--- a/.github/workflows/wait_for_required_workflows.yml
+++ b/.github/workflows/wait_for_required_workflows.yml
@@ -16,8 +16,19 @@ jobs:
         id: changed-files
         uses: Ana06/get-changed-files@v2.2.0
       - uses: actions/github-script@v6
+        name: Define required workflows
+        id: required-workflows
         env:
           FILES: ${{ steps.changed-files.outputs.all }}
+        with:
+          script: |
+            const script = require('.github/workflows/scripts/required_actions.js')
+            return script()
+      - uses: actions/github-script@v6
+        name: Wait for required workflows
+        id: wait
+        env:
+          ACTIONS: ${{steps.required-workflows.outputs.result}}
         with:
           script: |
             const script = require('.github/workflows/scripts/wait_for_required_workflows.js')

--- a/.github/workflows/wait_for_required_workflows.yml
+++ b/.github/workflows/wait_for_required_workflows.yml
@@ -4,7 +4,6 @@ on:
   pull_request:
     branches:
       - main
-      - feat/ci/move-wait-to-js-file # to trigger test
 
 jobs:
   wait_for_required_workflows:

--- a/.github/workflows/wait_for_required_workflows.yml
+++ b/.github/workflows/wait_for_required_workflows.yml
@@ -4,6 +4,7 @@ on:
   pull_request:
     branches:
       - main
+      - feat/ci/move-wait-to-js-file # to trigger test
 
 jobs:
   wait_for_required_workflows:


### PR DESCRIPTION
Split the logic into 2 distinct parts:
1. Define what actions are required to wait for
2. Actual waiting

Extends #10072
Tested by #10119