### PR TITLE
fix(website): Bring back plausible.io links

### DIFF
--- a/.github/workflows/broken_links.yml
+++ b/.github/workflows/broken_links.yml
@@ -84,5 +84,6 @@ jobs:
             --exclude work-bench.com \
             --exclude mailchimp.com \
             --exclude returngis.net \
+            --exclude plausible.io \
             ${{ steps.vercel.outputs.url }} \
             | grep -v '───OK───' | grep -v '──SKIP──' | grep -v '0 broken'

--- a/website/pages/docs/plugins/sources/plausible/_authentication.mdx
+++ b/website/pages/docs/plugins/sources/plausible/_authentication.mdx
@@ -1,2 +1,1 @@
-You must have a [Plausible Analytics](https://plausible.io) account and an API key.
-You can find your API key in the Plausible Analytics Settings.
+You must have a [Plausible Analytics](https://plausible.io/sites) account and an API key. You can find your API key in the [Plausible Analytics Settings](https://plausible.io/sites).

--- a/website/pages/docs/plugins/sources/plausible/overview.mdx
+++ b/website/pages/docs/plugins/sources/plausible/overview.mdx
@@ -37,7 +37,7 @@ This is the (nested) spec used by this plugin:
 
 - `api_key` (string, required):
 
-  This is your secret API key which you can obtain for your account by going to your user settings page.
+  This is your secret API key which you can obtain for your account by going to your user settings page [plausible.io/settings](https://plausible.io/settings).
 
 - `period` (string, optional, default: `30d`):
 


### PR DESCRIPTION
<!-- 🎉 Thank you for making CloudQuery awesome by submitting a PR 🎉 -->

#### Summary

It seems these links not working have been a temporary issue with  `plausible.io` or some kind of bot protection, as they work now:
![image](https://user-images.githubusercontent.com/26760571/232286629-e2edac80-222d-447f-a895-a8384351c7bd.png)
![image](https://user-images.githubusercontent.com/26760571/232286635-4982b69b-f927-4b87-9fc3-6abcb6510557.png)

This PR brings back the links and also excludes them from the broken links check as many external sites have some kind of bot protection

<!--
Use the following steps to ensure your PR is ready to be reviewed

- [ ] Read the [contribution guidelines](../blob/main/CONTRIBUTING.md) 🧑‍🎓
- [ ] Run `make lint` to ensure the proposed changes follow the coding style 🚨 (install golangci-lint [here](https://golangci-lint.run/usage/install/#local-installation))
- [ ] Run `make test` to ensure the proposed changes pass the tests 🧪
- [ ] If changing a source plugin run `make gen` to ensure docs are up to date 📝
- [ ] Ensure the status checks below are successful ✅
--->
