### PR TITLE
fix: Return error instead of panicking

### DIFF
--- a/plugins/destination/postgresql/client/read.go
+++ b/plugins/destination/postgresql/client/read.go
@@ -52,7 +52,7 @@ func (c *Client) reverseTransform(f arrow.Field, bldr array.Builder, val any) er
 	case *array.StringBuilder:
 		va, ok := val.(string)
 		if !ok {
-			panic(fmt.Sprintf("unsupported type %T with builder %T and column %s", val, bldr, f.Name))
+			return fmt.Errorf("unsupported type %T with builder %T and column %s", val, bldr, f.Name)
 		}
 		b.Append(va)
 	case *array.LargeStringBuilder:
@@ -64,7 +64,7 @@ func (c *Client) reverseTransform(f arrow.Field, bldr array.Builder, val any) er
 	case *types.UUIDBuilder:
 		va, ok := val.([16]byte)
 		if !ok {
-			panic(fmt.Sprintf("unsupported type %T with builder %T", val, bldr))
+			return fmt.Errorf("unsupported type %T with builder %T", val, bldr)
 		}
 		u, err := uuid.FromBytes(va[:])
 		if err != nil {
@@ -104,7 +104,7 @@ func (c *Client) reverseTransform(f arrow.Field, bldr array.Builder, val any) er
 	default:
 		v, ok := val.(string)
 		if !ok {
-			panic(fmt.Sprintf("unsupported type %T with builder %T", val, bldr))
+			return fmt.Errorf("unsupported type %T with builder %T", val, bldr)
 		}
 		if err := bldr.AppendValueFromString(v); err != nil {
 			return err


### PR DESCRIPTION
<!-- 🎉 Thank you for making CloudQuery awesome by submitting a PR 🎉 -->

#### Summary

The function returns an error so we could do that instead of panicking (unless there's a specific reason to panic I'm missing)

<!--
Use the following steps to ensure your PR is ready to be reviewed

- [ ] Read the [contribution guidelines](../blob/main/CONTRIBUTING.md) 🧑‍🎓
- [ ] Run `make lint` to ensure the proposed changes follow the coding style 🚨 (install golangci-lint [here](https://golangci-lint.run/usage/install/#local-installation))
- [ ] Run `make test` to ensure the proposed changes pass the tests 🧪
- [ ] If changing a source plugin run `make gen` to ensure docs are up to date 📝
- [ ] Ensure the status checks below are successful ✅
--->
