### PR TITLE
fix: Add timestamp type

### DIFF
--- a/plugins/destination/sqlite/client/types.go
+++ b/plugins/destination/sqlite/client/types.go
@@ -16,6 +16,8 @@ func (*Client) arrowTypeToSqliteStr(t arrow.DataType) string {
 		return "real"
 	case arrow.BOOL:
 		return "boolean"
+	case arrow.TIMESTAMP:
+		return "timestamp"
 	default:
 		return "text"
 	}
@@ -33,6 +35,8 @@ func (*Client) arrowTypeToSqlite(t arrow.DataType) arrow.DataType {
 		return arrow.PrimitiveTypes.Float64
 	case arrow.BOOL:
 		return arrow.FixedWidthTypes.Boolean
+	case arrow.TIMESTAMP:
+		return arrow.FixedWidthTypes.Timestamp_us
 	default:
 		return arrow.BinaryTypes.LargeString
 	}
@@ -50,7 +54,9 @@ func (*Client) sqliteTypeToArrowType(t string) arrow.DataType {
 		return arrow.BinaryTypes.LargeBinary
 	case "boolean":
 		return arrow.FixedWidthTypes.Boolean
+	case "timestamp":
+		return arrow.FixedWidthTypes.Timestamp_us
 	default:
-		panic("unknown type")
+		panic("unknown type: " + t)
 	}
 }


### PR DESCRIPTION
<!-- 🎉 Thank you for making CloudQuery awesome by submitting a PR 🎉 -->

#### Summary

Related to https://github.com/koltyakov/cq-source-sharepoint/issues/19#issuecomment-1514954567.

SQLite doesn't have an official `timestamp` type but the Go lib takes care of it, see https://github.com/mattn/go-sqlite3/issues/748.

We had this type in `v1`, see https://github.com/cloudquery/cloudquery/blob/plugins-destination-sqlite-v1.3.6/plugins/destination/sqlite/client/types.go#L58

<!--
Use the following steps to ensure your PR is ready to be reviewed

- [ ] Read the [contribution guidelines](../blob/main/CONTRIBUTING.md) 🧑‍🎓
- [ ] Run `make lint` to ensure the proposed changes follow the coding style 🚨 (install golangci-lint [here](https://golangci-lint.run/usage/install/#local-installation))
- [ ] Run `make test` to ensure the proposed changes pass the tests 🧪
- [ ] If changing a source plugin run `make gen` to ensure docs are up to date 📝
- [ ] Ensure the status checks below are successful ✅
--->
