### PR TITLE
fix(aws)!: Update Primary Key for `aws_ec2_ebs_snapshots` and value of `arn`

### DIFF
--- a/plugins/source/aws/policies/queries/ec2/ebs_snapshot_permissions_check.sql
+++ b/plugins/source/aws/policies/queries/ec2/ebs_snapshot_permissions_check.sql
@@ -1,6 +1,6 @@
 insert into aws_policy_results
 WITH snapshot_access_groups AS (
-    SELECT account_id,
+    SELECT owner_id AS account_id,
            region,
            snapshot_id,
            JSONB_ARRAY_ELEMENTS(attribute->'CreateVolumePermissions') ->> 'Group' AS "group",

--- a/plugins/source/aws/resources/services/ec2/ebs_snapshots.go
+++ b/plugins/source/aws/resources/services/ec2/ebs_snapshots.go
@@ -64,6 +64,12 @@ func fetchEc2EbsSnapshots(ctx context.Context, meta schema.ClientMeta, parent *s
 
 func resolveEbsSnapshotAttribute(ctx context.Context, meta schema.ClientMeta, resource *schema.Resource, c schema.Column) error {
 	r := resource.Item.(types.Snapshot)
+	cl := meta.(*client.Client)
+
+	if aws.ToString(r.OwnerId) != cl.AccountID {
+		return nil
+	}
+
 	svc := meta.(*client.Client).Services().Ec2
 	output, err := svc.DescribeSnapshotAttribute(ctx, &ec2.DescribeSnapshotAttributeInput{
 		Attribute:  types.SnapshotAttributeNameCreateVolumePermission,

--- a/plugins/source/aws/resources/services/ec2/ebs_snapshots_mock_test.go
+++ b/plugins/source/aws/resources/services/ec2/ebs_snapshots_mock_test.go
@@ -3,6 +3,7 @@ package ec2
 import (
 	"testing"
 
+	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/ec2"
 	"github.com/aws/aws-sdk-go-v2/service/ec2/types"
 	"github.com/cloudquery/cloudquery/plugins/source/aws/client"
@@ -23,10 +24,12 @@ func buildEc2EbsSnapshots(t *testing.T, ctrl *gomock.Controller) client.Services
 	if err != nil {
 		t.Fatal(err)
 	}
+	s.OwnerId = aws.String("testAccount")
 	m.EXPECT().DescribeSnapshots(gomock.Any(), gomock.Any(), gomock.Any()).Return(
 		&ec2.DescribeSnapshotsOutput{
 			Snapshots: []types.Snapshot{s},
 		}, nil)
+
 	m.EXPECT().DescribeSnapshotAttribute(gomock.Any(), gomock.Any(), gomock.Any()).Return(
 		&ec2.DescribeSnapshotAttributeOutput{
 			CreateVolumePermissions: []types.CreateVolumePermission{sa},

--- a/website/tables/aws/aws_ec2_ebs_snapshots.md
+++ b/website/tables/aws/aws_ec2_ebs_snapshots.md
@@ -3,8 +3,9 @@
 This table shows data for Amazon Elastic Compute Cloud (EC2) Amazon Elastic Block Store (EBS) Snapshots.
 
 https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_Snapshot.html
+The 'request_account_id' columns are added to show the account where the request was made from.
 
-The primary key for this table is **arn**.
+The composite primary key for this table is (**request_account_id**, **arn**).
 
 ## Columns
 
@@ -14,7 +15,7 @@ The primary key for this table is **arn**.
 |_cq_sync_time|Timestamp|
 |_cq_id|UUID|
 |_cq_parent_id|UUID|
-|account_id|String|
+|request_account_id (PK)|String|
 |region|String|
 |arn (PK)|String|
 |attribute|JSON|


### PR DESCRIPTION
<!-- 🎉 Thank you for making CloudQuery awesome by submitting a PR 🎉 -->

#### Summary

BEGIN_COMMIT_OVERRIDE
fix(aws)!: Change AccountID in the Arn to be `OwnerID` instead of AccountID that made the request

fix(aws): Only fetch Snapshot Attributes if the Snapshot is owned by the account making the request

fix(aws)!: Change the primary key to include the `request_account_id` to be able to handle shared snapshots

END_COMMIT_OVERRIDE