### PR TITLE
fix: Add region criteria to inner join

### DIFF
--- a/plugins/source/aws/policies/queries/cloudtrail/enabled_in_all_regions.sql
+++ b/plugins/source/aws/policies/queries/cloudtrail/enabled_in_all_regions.sql
@@ -17,3 +17,4 @@ from aws_cloudtrail_trails
 inner join
     aws_cloudtrail_trail_event_selectors on
         aws_cloudtrail_trails.arn = aws_cloudtrail_trail_event_selectors.trail_arn
+        and aws_cloudtrail_trails.region = aws_cloudtrail_trail_event_selectors.region

--- a/plugins/source/aws/policies/queries/cloudtrail/enabled_in_all_regions.sql
+++ b/plugins/source/aws/policies/queries/cloudtrail/enabled_in_all_regions.sql
@@ -18,3 +18,4 @@ inner join
     aws_cloudtrail_trail_event_selectors on
         aws_cloudtrail_trails.arn = aws_cloudtrail_trail_event_selectors.trail_arn
         and aws_cloudtrail_trails.region = aws_cloudtrail_trail_event_selectors.region
+        and aws_cloudtrail_trails.account_id = aws_cloudtrail_trail_event_selectors.account_id


### PR DESCRIPTION
#### Summary

This PR addresses inadequate criteria in the inner join of the policy query that checks whether AWS CloudTrail is enabled in all regions, [enabled_in_all_regions.sql](https://github.com/cloudquery/cloudquery/blob/main/plugins/source/aws/policies/queries/cloudtrail/enabled_in_all_regions.sql)

Specifically, the fix handles the situation of a single global CloudTrail in a target AWS account by adding `region` criteria to the `inner join`. It also corrects the results when an Organization-wide CloudTrail is in place, by adding `account_id` criteria to the `inner join`.

This bug is identified in #10245. 
