### PR TITLE
fix(aws): Remove Resource Specific Parallelization For S3 to use only the SDK parallelization 

### DIFF
--- a/plugins/source/aws/resources/services/s3/bucket_grants.go
+++ b/plugins/source/aws/resources/services/s3/bucket_grants.go
@@ -2,6 +2,7 @@ package s3
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/aws/aws-sdk-go-v2/service/s3"
 	"github.com/aws/aws-sdk-go-v2/service/s3/types"
@@ -64,4 +65,18 @@ func fetchS3BucketGrants(ctx context.Context, meta schema.ClientMeta, parent *sc
 	}
 	res <- aclOutput.Grants
 	return nil
+}
+
+func resolveBucketGranteeID(_ context.Context, _ schema.ClientMeta, resource *schema.Resource, c schema.Column) error {
+	grantee := resource.Item.(types.Grant).Grantee
+	switch grantee.Type {
+	case types.TypeCanonicalUser:
+		return resource.Set(c.Name, *grantee.ID)
+	case types.TypeAmazonCustomerByEmail:
+		return resource.Set(c.Name, *grantee.EmailAddress)
+	case types.TypeGroup:
+		return resource.Set(c.Name, *grantee.URI)
+	default:
+		return fmt.Errorf("unsupported grantee type %q", grantee.Type)
+	}
 }


### PR DESCRIPTION
<!-- 🎉 Thank you for making CloudQuery awesome by submitting a PR 🎉 -->

#### Summary

Was trying to look into an issue with S3 ACL Pks and removed this refactor from my investigation code. Removed all custom/resource specific parallelization to rely solely on the SDK provided parallelization 