### PR TITLE
chore(issue-templates): Remove `needs-triage` label from issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,7 +1,7 @@
 name: 🐛 Bug Report
 description: If something isn't working as expected 🤔
 title: "bug: <title>"
-labels: [bug, needs-triage]
+labels: [bug]
 body:
   - type: checkboxes
     attributes:

--- a/.github/ISSUE_TEMPLATE/new_destination_plugin.yml
+++ b/.github/ISSUE_TEMPLATE/new_destination_plugin.yml
@@ -1,7 +1,7 @@
 name: 🔄 New Destination Plugin
 description: Request a new destination plugin
 title: "feat: Add a <plugin-name> destination plugin"
-labels: [new-destination-plugin, needs-triage]
+labels: [new-destination-plugin]
 body:
   - type: textarea
     id: description

--- a/.github/ISSUE_TEMPLATE/new_resource.yml
+++ b/.github/ISSUE_TEMPLATE/new_resource.yml
@@ -1,7 +1,7 @@
 name: ✅ New Resource
 description: Ask to add a new resource to an existing source plugin
 title: "feat: Add <resource-name> to <plugin-name> source plugin"
-labels: [enhancement, resource, needs-triage]
+labels: [enhancement, resource]
 body:
   - type: textarea
     id: description

--- a/.github/ISSUE_TEMPLATE/new_source_plugin.yml
+++ b/.github/ISSUE_TEMPLATE/new_source_plugin.yml
@@ -1,7 +1,7 @@
 name: 🔄 New Source Plugin
 description: Request a new source plugin
 title: "feat: Add a <plugin-name> source plugin"
-labels: [new-source-plugin, needs-triage]
+labels: [new-source-plugin]
 body:
   - type: textarea
     id: description


### PR DESCRIPTION
<!-- 🎉 Thank you for making CloudQuery awesome by submitting a PR 🎉 -->

#### Summary

We already have a triage view that is based on an issue status, so we don't need the labels, see https://github.com/orgs/cloudquery/projects/7/views/11

<!--
Use the following steps to ensure your PR is ready to be reviewed

- [ ] Read the [contribution guidelines](../blob/main/CONTRIBUTING.md) 🧑‍🎓
- [ ] Run `make lint` to ensure the proposed changes follow the coding style 🚨 (install golangci-lint [here](https://golangci-lint.run/usage/install/#local-installation))
- [ ] Run `make test` to ensure the proposed changes pass the tests 🧪
- [ ] If changing a source plugin run `make gen` to ensure docs are up to date 📝
- [ ] Ensure the status checks below are successful ✅
--->
