### PR TITLE
feat(s3): Detect write access without writing

### DIFF
--- a/plugins/destination/s3/client/client.go
+++ b/plugins/destination/s3/client/client.go
@@ -1,16 +1,20 @@
 package client
 
 import (
-	"bytes"
 	"context"
+	"errors"
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/aws/arn"
 	"github.com/aws/aws-sdk-go-v2/config"
 	"github.com/aws/aws-sdk-go-v2/feature/s3/manager"
+	"github.com/aws/aws-sdk-go-v2/service/iam"
+	"github.com/aws/aws-sdk-go-v2/service/iam/types"
 	"github.com/aws/aws-sdk-go-v2/service/s3"
-
+	"github.com/aws/aws-sdk-go-v2/service/sts"
 	"github.com/cloudquery/filetypes/v2"
 	"github.com/cloudquery/plugin-sdk/v2/plugins/destination"
 	"github.com/cloudquery/plugin-sdk/v2/specs"
@@ -63,17 +67,66 @@ func New(ctx context.Context, logger zerolog.Logger, spec specs.Destination) (de
 	c.downloader = manager.NewDownloader(c.s3Client)
 
 	// we want to run this test because we want it to fail early if the bucket is not accessible
-	timeNow := time.Now().UTC()
-	if _, err := c.uploader.Upload(ctx, &s3.PutObjectInput{
-		Bucket: aws.String(c.pluginSpec.Bucket),
-		Key:    aws.String(replacePathVariables(c.pluginSpec.Path, "TEST_TABLE", "TEST_UUID", timeNow)),
-		Body:   bytes.NewReader([]byte("")),
-	}); err != nil {
-		return nil, fmt.Errorf("failed to write test file to S3: %w", err)
+	if err := c.testWriteAccess(ctx, cfg); err != nil {
+		return nil, err
 	}
+
 	return c, nil
 }
 
 func (*Client) Close(ctx context.Context) error {
+	return nil
+}
+
+func (c *Client) testWriteAccess(ctx context.Context, cfg aws.Config) error {
+	stsClient := sts.NewFromConfig(cfg)
+	callerIdentity, err := stsClient.GetCallerIdentity(ctx, &sts.GetCallerIdentityInput{})
+	if err != nil {
+		return err
+	}
+
+	userArn := aws.ToString(callerIdentity.Arn)
+	iamClient := iam.NewFromConfig(cfg)
+
+	userArnParsed, err := arn.Parse(userArn)
+	if err != nil {
+		return err
+	}
+
+	timeNow := time.Now().UTC()
+	bucketArn := arn.ARN{
+		Partition: userArnParsed.Partition,
+		Service:   "s3",
+		Resource: strings.Join([]string{
+			c.pluginSpec.Bucket,
+			replacePathVariables(c.pluginSpec.Path, "TEST_TABLE", "TEST_UUID", timeNow),
+		}, "/"),
+	}.String()
+
+	input := &iam.SimulatePrincipalPolicyInput{
+		PolicySourceArn: &userArn,
+		ActionNames: []string{
+			"s3:PutObject",
+		},
+		ResourceArns: []string{
+			bucketArn,
+		},
+	}
+
+	output, err := iamClient.SimulatePrincipalPolicy(ctx, input)
+	if err != nil {
+		return err
+	}
+
+	anyAllowed := false
+	for _, o := range output.EvaluationResults {
+		if o.EvalDecision == types.PolicyEvaluationDecisionTypeAllowed {
+			anyAllowed = true
+		}
+	}
+	if !anyAllowed {
+		return errors.New("Write access to S3 bucket is not allowed")
+	}
+
 	return nil
 }

--- a/plugins/destination/s3/go.mod
+++ b/plugins/destination/s3/go.mod
@@ -21,6 +21,7 @@ replace github.com/apache/arrow/go/v12 => github.com/cloudquery/arrow/go/v12 v12
 require (
 	github.com/JohnCGriffin/overflow v0.0.0-20211019200055-46fa312c352c // indirect
 	github.com/andybalholm/brotli v1.0.5 // indirect
+	github.com/aws/aws-sdk-go-v2/service/iam v1.19.10 // indirect
 	github.com/goccy/go-json v0.10.2 // indirect
 	github.com/google/flatbuffers v2.0.8+incompatible // indirect
 	github.com/klauspost/asmfmt v1.3.2 // indirect

--- a/plugins/destination/s3/go.sum
+++ b/plugins/destination/s3/go.sum
@@ -60,6 +60,8 @@ github.com/aws/aws-sdk-go-v2/internal/ini v1.3.33 h1:HbH1VjUgrCdLJ+4lnnuLI4iVNRv
 github.com/aws/aws-sdk-go-v2/internal/ini v1.3.33/go.mod h1:zG2FcwjQarWaqXSCGpgcr3RSjZ6dHGguZSppUL0XR7Q=
 github.com/aws/aws-sdk-go-v2/internal/v4a v1.0.24 h1:zsg+5ouVLLbePknVZlUMm1ptwyQLkjjLMWnN+kVs5dA=
 github.com/aws/aws-sdk-go-v2/internal/v4a v1.0.24/go.mod h1:+fFaIjycTmpV6hjmPTbyU9Kp5MI/lA+bbibcAtmlhYA=
+github.com/aws/aws-sdk-go-v2/service/iam v1.19.10 h1:mNCARLwZyWdk7070h4Sb9plb947g8jthPkC+WUmoN30=
+github.com/aws/aws-sdk-go-v2/service/iam v1.19.10/go.mod h1:KeyeWNh9U2iztqp7JsK2PvnAupYWNZFp8A6ItqAQay4=
 github.com/aws/aws-sdk-go-v2/service/internal/accept-encoding v1.9.11 h1:y2+VQzC6Zh2ojtV2LoC0MNwHWc6qXv/j2vrQtlftkdA=
 github.com/aws/aws-sdk-go-v2/service/internal/accept-encoding v1.9.11/go.mod h1:iV4q2hsqtNECrfmlXyord9u4zyuFEJX9eLgLpSPzWA8=
 github.com/aws/aws-sdk-go-v2/service/internal/checksum v1.1.27 h1:qIw7Hg5eJEc1uSxg3hRwAthPAO7NeOd4dPxhaTi0yB0=


### PR DESCRIPTION
Fixes #9839

I first tried creating an `io.Pipe` and starting an upload only to cancel it later, but that was hairier than expected.

Could also just remove this check as suggested in the issue.