### PR TITLE
feat(aws): Store Spec in Client

### DIFF
--- a/plugins/source/aws/client/client.go
+++ b/plugins/source/aws/client/client.go
@@ -150,6 +150,7 @@ func (c *Client) withPartitionAccountIDAndRegion(partition, accountID, region st
 		AutoscalingNamespace: c.AutoscalingNamespace,
 		WAFScope:             c.WAFScope,
 		Backend:              c.Backend,
+		Spec:                 c.Spec,
 	}
 }
 
@@ -163,6 +164,7 @@ func (c *Client) withPartitionAccountIDRegionAndNamespace(partition, accountID, 
 		AutoscalingNamespace: namespace,
 		WAFScope:             c.WAFScope,
 		Backend:              c.Backend,
+		Spec:                 c.Spec,
 	}
 }
 
@@ -176,6 +178,7 @@ func (c *Client) withPartitionAccountIDRegionAndScope(partition, accountID, regi
 		AutoscalingNamespace: c.AutoscalingNamespace,
 		WAFScope:             scope,
 		Backend:              c.Backend,
+		Spec:                 c.Spec,
 	}
 }
 

--- a/plugins/source/aws/client/testing.go
+++ b/plugins/source/aws/client/testing.go
@@ -31,7 +31,8 @@ func AwsMockTestHelper(t *testing.T, table *schema.Table, builder func(*testing.
 		if err := spec.UnmarshalSpec(&awsSpec); err != nil {
 			return nil, fmt.Errorf("failed to unmarshal aws spec: %w", err)
 		}
-		c := NewAwsClient(l, nil)
+		awsSpec.SetDefaults()
+		c := NewAwsClient(l, nil, &awsSpec)
 		c.ServicesManager.InitServicesForPartitionAccountAndRegion("aws", "testAccount", "us-east-1", builder(t, ctrl))
 		c.Partition = "aws"
 		return &c, nil

--- a/plugins/source/aws/resources/services/iam/credential_reports_mock_test.go
+++ b/plugins/source/aws/resources/services/iam/credential_reports_mock_test.go
@@ -54,7 +54,7 @@ func testCredentialReportsWithNilValues(t *testing.T) {
 		ctx := context.Background()
 		ctrl := gomock.NewController(t)
 		services := buildCredentialReportsWithNilValues(ctrl)
-		cl := client.NewAwsClient(zerolog.Logger{}, nil)
+		cl := client.NewAwsClient(zerolog.Logger{}, nil, nil)
 		cl.ServicesManager.InitServicesForPartitionAccountAndRegion("aws", "testAccount", "us-east-1", services)
 		cl.Partition = "aws"
 		cl.Region = "us-east-1"


### PR DESCRIPTION
<!-- 🎉 Thank you for making CloudQuery awesome by submitting a PR 🎉 -->

#### Summary

As a precursor to exposing table level options, the Spec will need to be accessible to the resolvers now in each resolver it can access it via 
```
	cl := meta.(*client.Client)
	cl.Spec.
```