### PR TITLE
fix(azure-consumption): Update Price Sheets next link on new response when paginating

### DIFF
--- a/plugins/source/azure/resources/services/consumption/subscription_price_sheets.go
+++ b/plugins/source/azure/resources/services/consumption/subscription_price_sheets.go
@@ -55,6 +55,7 @@ func fetchSubscriptionPriceSheets(ctx context.Context, meta schema.ClientMeta, p
 			break
 		}
 		allPricesSheets = append(allPricesSheets, paginatedResponse.PriceSheetResult.Properties.Pricesheets...)
+		nextLink = paginatedResponse.PriceSheetResult.Properties.NextLink
 	}
 
 	resp.PriceSheetResult.Properties.Pricesheets = allPricesSheets


### PR DESCRIPTION
<!-- 🎉 Thank you for making CloudQuery awesome by submitting a PR 🎉 -->

#### Summary

There was a bug in the original pagination code I wrote. See https://github.com/Azure/azure-sdk-for-go/issues/20671#issuecomment-1521307978

<!--
Use the following steps to ensure your PR is ready to be reviewed

- [ ] Read the [contribution guidelines](../blob/main/CONTRIBUTING.md) 🧑‍🎓
- [ ] Run `make lint` to ensure the proposed changes follow the coding style 🚨 (install golangci-lint [here](https://golangci-lint.run/usage/install/#local-installation))
- [ ] Run `make test` to ensure the proposed changes pass the tests 🧪
- [ ] If changing a source plugin run `make gen` to ensure docs are up to date 📝
- [ ] Ensure the status checks below are successful ✅
--->
