### PR TITLE
fix(ci-broken-links): Exclude twitter

### DIFF
--- a/.github/workflows/broken_links.yml
+++ b/.github/workflows/broken_links.yml
@@ -86,5 +86,6 @@ jobs:
             --exclude returngis.net \
             --exclude plausible.io \
             --exclude localhost \
+            --exclude twitter.com \
             ${{ steps.vercel.outputs.url }} \
             | grep -v '───OK───' | grep -v '──SKIP──' | grep -v '0 broken'


### PR DESCRIPTION
<!-- 🎉 Thank you for making CloudQuery awesome by submitting a PR 🎉 -->

#### Summary

Looks like Twitter started failing our broken links checker https://github.com/cloudquery/cloudquery/actions/runs/4795606927/jobs/8530378774#step:7:42

<!--
Use the following steps to ensure your PR is ready to be reviewed

- [ ] Read the [contribution guidelines](../blob/main/CONTRIBUTING.md) 🧑‍🎓
- [ ] Run `make lint` to ensure the proposed changes follow the coding style 🚨 (install golangci-lint [here](https://golangci-lint.run/usage/install/#local-installation))
- [ ] Run `make test` to ensure the proposed changes pass the tests 🧪
- [ ] If changing a source plugin run `make gen` to ensure docs are up to date 📝
- [ ] Ensure the status checks below are successful ✅
--->
