### PR TITLE
fix(cli): Truncate SyncTime

### DIFF
--- a/cli/cmd/sync.go
+++ b/cli/cmd/sync.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"fmt"
 	"strings"
+	"time"
 
 	"github.com/google/uuid"
 	"golang.org/x/exp/slices"
@@ -113,4 +114,8 @@ func sync(cmd *cobra.Command, args []string) error {
 	}
 
 	return nil
+}
+
+func getSyncTime() time.Time {
+	return time.Now().UTC().Truncate(time.Microsecond)
 }

--- a/cli/cmd/sync_v0_1.go
+++ b/cli/cmd/sync_v0_1.go
@@ -20,7 +20,7 @@ func syncConnectionV0_1(ctx context.Context, cqDir string, sourceClient *source.
 	for i := range destinationsSpecs {
 		destinationNames[i] = destinationsSpecs[i].Name
 	}
-	syncTime := time.Now().UTC()
+	syncTime := getSyncTime()
 
 	log.Info().Str("source", sourceSpec.Name).Strs("destinations", destinationNames).Time("sync_time", syncTime).Msg("Start sync")
 	defer log.Info().Str("source", sourceSpec.Name).Strs("destinations", destinationNames).Time("sync_time", syncTime).Msg("End sync")

--- a/cli/cmd/sync_v0_2.go
+++ b/cli/cmd/sync_v0_2.go
@@ -20,7 +20,7 @@ func syncConnectionV0_2(ctx context.Context, cqDir string, sourceClient *source.
 	for i := range destinationsSpecs {
 		destinationStrings[i] = destinationsSpecs[i].VersionString()
 	}
-	syncTime := time.Now().UTC()
+	syncTime := getSyncTime()
 
 	log.Info().Str("source", sourceSpec.VersionString()).Strs("destinations", destinationStrings).Time("sync_time", syncTime).Msg("Start sync")
 	defer log.Info().Str("source", sourceSpec.VersionString()).Strs("destinations", destinationStrings).Time("sync_time", syncTime).Msg("End sync")

--- a/cli/cmd/sync_v1.go
+++ b/cli/cmd/sync_v1.go
@@ -53,7 +53,7 @@ func syncConnectionV1(ctx context.Context, cqDir string, sourceSpec specs.Source
 		}
 	}()
 
-	syncTime := time.Now().UTC()
+	syncTime := getSyncTime()
 	destinationStrings := make([]string, len(destinationsSpecs))
 	for i := range destinationsSpecs {
 		destinationStrings[i] = destinationsSpecs[i].VersionString()


### PR DESCRIPTION
Make sure time values are truncated uniformly across all operating systems and in line with the arrow casting.

Could also be done in the SDK: https://github.com/cloudquery/plugin-sdk/pull/825