### PR TITLE
feat(snyk): Add Groups, Group Members, Organization Members and Pending User Provisions

### DIFF
--- a/plugins/source/snyk/client/client.go
+++ b/plugins/source/snyk/client/client.go
@@ -23,7 +23,7 @@ type Client struct {
 
 	Spec           Spec
 	OrganizationID string
-	organizations  []string
+	Organizations  []snyk.Organization
 
 	logger zerolog.Logger
 
@@ -110,12 +110,11 @@ func Configure(ctx context.Context, logger zerolog.Logger, spec specs.Source, _ 
 		backoff = time.Duration(snykSpec.RetryDelaySeconds) * time.Second
 	}
 	c := &Client{
-		Client:        client,
-		Spec:          *snykSpec,
-		logger:        logger,
-		organizations: snykSpec.Organizations,
-		maxRetries:    maxRetries,
-		backoff:       backoff,
+		Client:     client,
+		Spec:       *snykSpec,
+		logger:     logger,
+		maxRetries: maxRetries,
+		backoff:    backoff,
 	}
 
 	return c, c.initOrganizations(ctx)

--- a/plugins/source/snyk/client/multiplexer.go
+++ b/plugins/source/snyk/client/multiplexer.go
@@ -6,14 +6,14 @@ import (
 
 func SingleOrganization(meta schema.ClientMeta) []schema.ClientMeta {
 	client := meta.(*Client)
-	return []schema.ClientMeta{client.WithOrganization(client.organizations[0])}
+	return []schema.ClientMeta{client.WithOrganization(client.Organizations[0].ID)}
 }
 
 func ByOrganization(meta schema.ClientMeta) []schema.ClientMeta {
 	client := meta.(*Client)
-	l := make([]schema.ClientMeta, 0, len(client.organizations))
-	for _, o := range client.organizations {
-		l = append(l, client.WithOrganization(o))
+	l := make([]schema.ClientMeta, 0, len(client.Organizations))
+	for _, o := range client.Organizations {
+		l = append(l, client.WithOrganization(o.ID))
 	}
 	return l
 }
@@ -23,7 +23,7 @@ func (c *Client) WithOrganization(organizationID string) schema.ClientMeta {
 		Client:         c.Client,
 		Spec:           c.Spec,
 		OrganizationID: organizationID,
-		organizations:  c.organizations,
+		Organizations:  c.Organizations,
 		logger:         c.logger.With().Str("organization", organizationID).Logger(),
 		maxRetries:     c.maxRetries,
 		backoff:        c.backoff,

--- a/plugins/source/snyk/client/organizations.go
+++ b/plugins/source/snyk/client/organizations.go
@@ -2,12 +2,10 @@ package client
 
 import (
 	"context"
-
-	"golang.org/x/exp/slices"
 )
 
 func (c *Client) initOrganizations(ctx context.Context) error {
-	if len(c.organizations) > 0 {
+	if len(c.Organizations) > 0 {
 		// already set
 		return nil
 	}
@@ -16,15 +14,15 @@ func (c *Client) initOrganizations(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
-	organizations := make([]string, 0, len(orgs))
-	for _, org := range orgs {
-		organizations = append(organizations, org.ID)
-	}
-
-	c.organizations = organizations
+	c.Organizations = orgs
 	return nil
 }
 
 func (c *Client) WantOrganization(organizationID string) bool {
-	return slices.Contains(c.organizations, organizationID)
+	for _, org := range c.Organizations {
+		if org.ID == organizationID {
+			return true
+		}
+	}
+	return false
 }

--- a/plugins/source/snyk/client/testing.go
+++ b/plugins/source/snyk/client/testing.go
@@ -38,9 +38,14 @@ func MockTestHelper(t *testing.T, table *schema.Table, createService func(*httpr
 		}
 
 		c := &Client{
-			Client:        snykClient,
-			logger:        logger,
-			organizations: []string{"test-org"},
+			Client: snykClient,
+			logger: logger,
+			Organizations: []snyk.Organization{
+				{ID: "test-org-id", Name: "test-org-name", Group: &snyk.Group{
+					ID:   "test-group-id",
+					Name: "test-group-name",
+				}},
+			},
 		}
 		return c, nil
 	}

--- a/plugins/source/snyk/docs/tables/README.md
+++ b/plugins/source/snyk/docs/tables/README.md
@@ -3,8 +3,12 @@
 ## Tables
 
 - [snyk_dependencies](../../../../../website/tables/snyk/snyk_dependencies.md)
+- [snyk_groups](../../../../../website/tables/snyk/snyk_groups.md)
+  - [snyk_group_members](../../../../../website/tables/snyk/snyk_group_members.md)
 - [snyk_integrations](../../../../../website/tables/snyk/snyk_integrations.md)
 - [snyk_organizations](../../../../../website/tables/snyk/snyk_organizations.md)
+  - [snyk_organization_members](../../../../../website/tables/snyk/snyk_organization_members.md)
+  - [snyk_organization_provisions](../../../../../website/tables/snyk/snyk_organization_provisions.md)
 - [snyk_projects](../../../../../website/tables/snyk/snyk_projects.md)
 - [snyk_reporting_issues](../../../../../website/tables/snyk/snyk_reporting_issues.md)
 - [snyk_reporting_latest_issues](../../../../../website/tables/snyk/snyk_reporting_latest_issues.md)

--- a/plugins/source/snyk/go.mod
+++ b/plugins/source/snyk/go.mod
@@ -35,8 +35,10 @@ require (
 replace (
 	// TODO: remove once the changes are merged to upstream
 	github.com/apache/arrow/go/v12 => github.com/cloudquery/arrow/go/v12 v12.0.0-20230411134648-a5b71cd453c8
-	github.com/pavel-snyk/snyk-sdk-go => github.com/cloudquery/snyk-sdk-go v0.4.0
+	// github.com/pavel-snyk/snyk-sdk-go => github.com/cloudquery/snyk-sdk-go v0.4.0
 )
+
+replace github.com/pavel-snyk/snyk-sdk-go => ../../../../snyk-sdk-go
 
 require (
 	github.com/cloudquery/plugin-sdk/v2 v2.4.0

--- a/plugins/source/snyk/go.mod
+++ b/plugins/source/snyk/go.mod
@@ -8,7 +8,6 @@ require (
 	github.com/pavel-snyk/snyk-sdk-go v0.4.1
 	github.com/rs/zerolog v1.29.0
 	github.com/stretchr/testify v1.8.2
-	golang.org/x/exp v0.0.0-20230321023759-10a507213a29
 )
 
 require (
@@ -26,6 +25,7 @@ require (
 	github.com/minio/c2goasm v0.0.0-20190812172519-36a3d3bbc4f3 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/zeebo/xxh3 v1.0.2 // indirect
+	golang.org/x/exp v0.0.0-20230321023759-10a507213a29 // indirect
 	golang.org/x/mod v0.8.0 // indirect
 	golang.org/x/tools v0.6.0 // indirect
 	golang.org/x/xerrors v0.0.0-20220609144429-65e65417b02f // indirect
@@ -35,10 +35,8 @@ require (
 replace (
 	// TODO: remove once the changes are merged to upstream
 	github.com/apache/arrow/go/v12 => github.com/cloudquery/arrow/go/v12 v12.0.0-20230411134648-a5b71cd453c8
-	// github.com/pavel-snyk/snyk-sdk-go => github.com/cloudquery/snyk-sdk-go v0.4.0
+	github.com/pavel-snyk/snyk-sdk-go => github.com/cloudquery/snyk-sdk-go v0.5.0
 )
-
-replace github.com/pavel-snyk/snyk-sdk-go => ../../../../snyk-sdk-go
 
 require (
 	github.com/cloudquery/plugin-sdk/v2 v2.4.0

--- a/plugins/source/snyk/go.sum
+++ b/plugins/source/snyk/go.sum
@@ -49,8 +49,8 @@ github.com/cloudquery/arrow/go/v12 v12.0.0-20230411134648-a5b71cd453c8 h1:v4ST36
 github.com/cloudquery/arrow/go/v12 v12.0.0-20230411134648-a5b71cd453c8/go.mod h1:d+tV/eHZZ7Dz7RPrFKtPK02tpr+c9/PEd/zm8mDS9Vg=
 github.com/cloudquery/plugin-sdk/v2 v2.4.0 h1:uhgzk8U0rugXOenuQe1yi95JTSeVS2ehM9drYO+ZM9M=
 github.com/cloudquery/plugin-sdk/v2 v2.4.0/go.mod h1:/wAbhyQbdIUAMEL+Yo9zkgoBls83xt3ev6jLpJblIoU=
-github.com/cloudquery/snyk-sdk-go v0.4.0 h1:kT7oJN5plhoz+pYXCaUnArExw01UVbY8OnbPLy1U7JA=
-github.com/cloudquery/snyk-sdk-go v0.4.0/go.mod h1:LRL1TRuuM925gnyGp54WtS9p8S4yJMd0oS4JpLg+n7Y=
+github.com/cloudquery/snyk-sdk-go v0.5.0 h1:aDA94/ix7ro4V1qh2mk3/XTaT2j37ETRkOaYUR2pHc8=
+github.com/cloudquery/snyk-sdk-go v0.5.0/go.mod h1:LRL1TRuuM925gnyGp54WtS9p8S4yJMd0oS4JpLg+n7Y=
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
 github.com/cncf/udpa/go v0.0.0-20201120205902-5459f2c99403/go.mod h1:WmhPx2Nbnhtbo57+VJT5O0JRkEi1Wbu0z5j0R8u5Hbk=
 github.com/coreos/go-systemd v0.0.0-20190321100706-95778dfbb74e/go.mod h1:F5haX7vjVVG0kc13fIWeqUViNPyEJxv/OmvnBo0Yme4=

--- a/plugins/source/snyk/resources/plugin/plugin.go
+++ b/plugins/source/snyk/resources/plugin/plugin.go
@@ -3,6 +3,7 @@ package plugin
 import (
 	"github.com/cloudquery/cloudquery/plugins/source/snyk/client"
 	"github.com/cloudquery/cloudquery/plugins/source/snyk/resources/services/dependency"
+	"github.com/cloudquery/cloudquery/plugins/source/snyk/resources/services/group"
 	"github.com/cloudquery/cloudquery/plugins/source/snyk/resources/services/integration"
 	"github.com/cloudquery/cloudquery/plugins/source/snyk/resources/services/organization"
 	"github.com/cloudquery/cloudquery/plugins/source/snyk/resources/services/project"
@@ -20,6 +21,7 @@ func Snyk() *source.Plugin {
 		[]*schema.Table{
 			dependency.Dependencies(),
 			integration.Integrations(),
+			group.Groups(),
 			organization.Organizations(),
 			project.Projects(),
 			reporting.Issues(),

--- a/plugins/source/snyk/resources/services/group/group_members.go
+++ b/plugins/source/snyk/resources/services/group/group_members.go
@@ -1,0 +1,45 @@
+package group
+
+import (
+	"context"
+
+	"github.com/cloudquery/cloudquery/plugins/source/snyk/client"
+	"github.com/cloudquery/plugin-sdk/v2/schema"
+	"github.com/cloudquery/plugin-sdk/v2/transformers"
+	"github.com/pavel-snyk/snyk-sdk-go/snyk"
+)
+
+func groupMembers() *schema.Table {
+	return &schema.Table{
+		Name:        "snyk_group_members",
+		Description: `https://snyk.docs.apiary.io/#reference/groups/group-settings/list-all-members-in-a-group`,
+		Resolver:    fetchGroupMembers,
+		Multiplex:   client.ByOrganization,
+		Transform: transformers.TransformWithStruct(&snyk.GroupMember{},
+			transformers.WithPrimaryKeys("ID"),
+		),
+		Columns: []schema.Column{
+			{
+				Name: "group_id",
+				Type: schema.TypeString,
+				CreationOptions: schema.ColumnCreationOptions{
+					PrimaryKey: true,
+				},
+				Resolver: schema.ParentColumnResolver("id"),
+			},
+		},
+	}
+}
+
+func fetchGroupMembers(ctx context.Context, meta schema.ClientMeta, parent *schema.Resource, res chan<- any) error {
+	c := meta.(*client.Client)
+	groupID := parent.Item.(*snyk.Group).ID
+	result, _, err := c.Groups.ListMembers(ctx, groupID)
+	if err != nil {
+		return err
+	}
+	for _, member := range result {
+		res <- member
+	}
+	return nil
+}

--- a/plugins/source/snyk/resources/services/group/groups.go
+++ b/plugins/source/snyk/resources/services/group/groups.go
@@ -1,0 +1,41 @@
+package group
+
+import (
+	"context"
+
+	"github.com/cloudquery/cloudquery/plugins/source/snyk/client"
+	"github.com/cloudquery/plugin-sdk/v2/schema"
+	"github.com/cloudquery/plugin-sdk/v2/transformers"
+	"github.com/pavel-snyk/snyk-sdk-go/snyk"
+)
+
+func Groups() *schema.Table {
+	return &schema.Table{
+		Name: "snyk_groups",
+		Description: `https://snyk.docs.apiary.io/#reference/organizations/the-snyk-organization-for-a-request/list-all-the-organizations-a-user-belongs-to
+	
+This table lists all groups for the selected organizations. It uses the list organizations endpoint from the Snyk API.`,
+		Resolver:  fetchGroups,
+		Multiplex: client.SingleOrganization,
+		Transform: transformers.TransformWithStruct(&snyk.Group{},
+			transformers.WithPrimaryKeys("ID"),
+		),
+		Relations: []*schema.Table{
+			groupMembers(),
+		},
+	}
+}
+
+func fetchGroups(ctx context.Context, meta schema.ClientMeta, _ *schema.Resource, res chan<- any) error {
+	c := meta.(*client.Client)
+	groups := map[string]*snyk.Group{}
+	for _, org := range c.Organizations {
+		if org.Group != nil {
+			groups[org.Group.ID] = org.Group
+		}
+	}
+	for _, group := range groups {
+		res <- group
+	}
+	return nil
+}

--- a/plugins/source/snyk/resources/services/group/groups_mock_test.go
+++ b/plugins/source/snyk/resources/services/group/groups_mock_test.go
@@ -1,0 +1,43 @@
+package group
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"testing"
+
+	"github.com/cloudquery/cloudquery/plugins/source/snyk/client"
+	"github.com/cloudquery/plugin-sdk/v2/faker"
+	"github.com/julienschmidt/httprouter"
+	"github.com/pavel-snyk/snyk-sdk-go/snyk"
+)
+
+func createGroups(mux *httprouter.Router) error {
+	return createGroupMembers(mux, "test-group-id")
+}
+
+func createGroupMembers(mux *httprouter.Router, groupID string) error {
+	path := fmt.Sprintf("/group/%s/members", groupID)
+	mux.GET(path, func(w http.ResponseWriter, r *http.Request, _ httprouter.Params) {
+		var member snyk.GroupMember
+		if err := faker.FakeObject(&member); err != nil {
+			http.Error(w, "unable to fake object: "+err.Error(), http.StatusBadRequest)
+			return
+		}
+		b, err := json.Marshal([]snyk.GroupMember{member})
+		if err != nil {
+			http.Error(w, "unable to marshal response: "+err.Error(), http.StatusBadRequest)
+			return
+		}
+		if _, err := w.Write(b); err != nil {
+			http.Error(w, "failed to write", http.StatusBadRequest)
+			return
+		}
+	})
+
+	return nil
+}
+
+func TestOrganizations(t *testing.T) {
+	client.MockTestHelper(t, Groups(), createGroups)
+}

--- a/plugins/source/snyk/resources/services/organization/members.go
+++ b/plugins/source/snyk/resources/services/organization/members.go
@@ -1,0 +1,46 @@
+package organization
+
+import (
+	"context"
+
+	"github.com/cloudquery/cloudquery/plugins/source/snyk/client"
+	"github.com/cloudquery/plugin-sdk/v2/schema"
+	"github.com/cloudquery/plugin-sdk/v2/transformers"
+	"github.com/pavel-snyk/snyk-sdk-go/snyk"
+)
+
+func organizationMembers() *schema.Table {
+	return &schema.Table{
+		Name:        "snyk_organization_members",
+		Description: `https://snyk.docs.apiary.io/#reference/organizations/members-in-organization/list-members`,
+		Resolver:    fetchOrganizationMembers,
+		Multiplex:   client.ByOrganization,
+		Transform:   transformers.TransformWithStruct(&snyk.OrganizationMember{}, transformers.WithPrimaryKeys("ID")),
+		Columns: []schema.Column{
+			{
+				Name: "organization_id",
+				Type: schema.TypeString,
+				CreationOptions: schema.ColumnCreationOptions{
+					PrimaryKey: true,
+				},
+				Resolver: schema.ParentColumnResolver("id"),
+			},
+		},
+	}
+}
+
+func fetchOrganizationMembers(ctx context.Context, meta schema.ClientMeta, _ *schema.Resource, res chan<- any) error {
+	c := meta.(*client.Client)
+
+	includeAdmins := true
+	result, _, err := c.Orgs.ListMembers(ctx, c.OrganizationID, includeAdmins)
+	if err != nil {
+		return err
+	}
+
+	for _, member := range result {
+		res <- member
+	}
+
+	return nil
+}

--- a/plugins/source/snyk/resources/services/organization/organizations.go
+++ b/plugins/source/snyk/resources/services/organization/organizations.go
@@ -16,6 +16,10 @@ func Organizations() *schema.Table {
 		Resolver:    fetchOrganizations,
 		Multiplex:   client.SingleOrganization,
 		Transform:   transformers.TransformWithStruct(&snyk.Organization{}, transformers.WithPrimaryKeys("ID")),
+		Relations: []*schema.Table{
+			organizationMembers(),
+			pendingUserProvisions(),
+		},
 	}
 }
 

--- a/plugins/source/snyk/resources/services/organization/organizations_mock_test.go
+++ b/plugins/source/snyk/resources/services/organization/organizations_mock_test.go
@@ -2,6 +2,7 @@ package organization
 
 import (
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"testing"
 
@@ -16,7 +17,7 @@ func createOrganizations(mux *httprouter.Router) error {
 	if err := faker.FakeObject(&organization); err != nil {
 		return err
 	}
-	organization.ID = "test-org"
+	organization.ID = "test-org-id"
 
 	mux.GET("/orgs", func(w http.ResponseWriter, r *http.Request, _ httprouter.Params) {
 		type organizationsRoot struct {
@@ -33,7 +34,63 @@ func createOrganizations(mux *httprouter.Router) error {
 		}
 	})
 
+	createOrganizationMembers(mux)
+	createPendingProvisions(mux)
 	return nil
+}
+
+func createOrganizationMembers(mux *httprouter.Router) {
+	path := fmt.Sprintf("/org/%s/members", "test-org-id")
+	mux.GET(path, func(w http.ResponseWriter, r *http.Request, _ httprouter.Params) {
+		var member snyk.OrganizationMember
+		if err := faker.FakeObject(&member); err != nil {
+			http.Error(w, "unable to fake object: "+err.Error(), http.StatusBadRequest)
+			return
+		}
+		b, err := json.Marshal([]snyk.OrganizationMember{member})
+		if err != nil {
+			http.Error(w, "unable to marshal response: "+err.Error(), http.StatusBadRequest)
+			return
+		}
+		if _, err := w.Write(b); err != nil {
+			http.Error(w, "failed to write", http.StatusBadRequest)
+			return
+		}
+	})
+}
+
+func createPendingProvisions(mux *httprouter.Router) {
+	path := fmt.Sprintf("/org/%s/provision", "test-org-id")
+	requestCount := 0
+	mux.GET(path, func(w http.ResponseWriter, r *http.Request, _ httprouter.Params) {
+		var pp snyk.PendingProvision
+		defer func() { requestCount++ }()
+		if err := faker.FakeObject(&pp); err != nil {
+			http.Error(w, "unable to fake object: "+err.Error(), http.StatusBadRequest)
+			return
+		}
+		var (
+			b   []byte
+			err error
+		)
+		if requestCount == 0 {
+			b, err = json.Marshal([]snyk.PendingProvision{pp})
+			if err != nil {
+				http.Error(w, "unable to marshal response: "+err.Error(), http.StatusBadRequest)
+				return
+			}
+		} else {
+			b, err = json.Marshal([]snyk.PendingProvision{})
+			if err != nil {
+				http.Error(w, "unable to marshal response: "+err.Error(), http.StatusBadRequest)
+				return
+			}
+		}
+		if _, err := w.Write(b); err != nil {
+			http.Error(w, "failed to write", http.StatusBadRequest)
+			return
+		}
+	})
 }
 
 func TestOrganizations(t *testing.T) {

--- a/plugins/source/snyk/resources/services/organization/provisions.go
+++ b/plugins/source/snyk/resources/services/organization/provisions.go
@@ -1,0 +1,57 @@
+package organization
+
+import (
+	"context"
+
+	"github.com/cloudquery/cloudquery/plugins/source/snyk/client"
+	"github.com/cloudquery/plugin-sdk/v2/schema"
+	"github.com/cloudquery/plugin-sdk/v2/transformers"
+	"github.com/pavel-snyk/snyk-sdk-go/snyk"
+)
+
+func pendingUserProvisions() *schema.Table {
+	return &schema.Table{
+		Name:        "snyk_organization_provisions",
+		Description: `https://snyk.docs.apiary.io/#reference/organizations/provision-user/list-pending-user-provisions`,
+		Resolver:    fetchPendingProvisions,
+		Multiplex:   client.ByOrganization,
+		Transform: transformers.TransformWithStruct(&snyk.PendingProvision{},
+			transformers.WithPrimaryKeys("Email", "Created")),
+		Columns: []schema.Column{
+			{
+				Name: "organization_id",
+				Type: schema.TypeString,
+				CreationOptions: schema.ColumnCreationOptions{
+					PrimaryKey: true,
+				},
+				Resolver: schema.ParentColumnResolver("id"),
+			},
+		},
+	}
+}
+
+func fetchPendingProvisions(ctx context.Context, meta schema.ClientMeta, _ *schema.Resource, res chan<- any) error {
+	c := meta.(*client.Client)
+
+	opts := snyk.ListPendingUserProvisionsOptions{
+		Page:    1,
+		PerPage: 1000,
+	}
+
+	for {
+		result, _, err := c.Orgs.ListPendingUserProvisions(ctx, c.OrganizationID, opts)
+		if err != nil {
+			return err
+		}
+
+		for _, prov := range result {
+			res <- prov
+		}
+		if len(result) == 0 {
+			break
+		}
+		opts.Page++
+	}
+
+	return nil
+}

--- a/website/pages/docs/plugins/sources/snyk/tables.md
+++ b/website/pages/docs/plugins/sources/snyk/tables.md
@@ -3,8 +3,12 @@
 ## Tables
 
 - [snyk_dependencies](tables/snyk_dependencies)
+- [snyk_groups](tables/snyk_groups)
+  - [snyk_group_members](tables/snyk_group_members)
 - [snyk_integrations](tables/snyk_integrations)
 - [snyk_organizations](tables/snyk_organizations)
+  - [snyk_organization_members](tables/snyk_organization_members)
+  - [snyk_organization_provisions](tables/snyk_organization_provisions)
 - [snyk_projects](tables/snyk_projects)
 - [snyk_reporting_issues](tables/snyk_reporting_issues)
 - [snyk_reporting_latest_issues](tables/snyk_reporting_latest_issues)

--- a/website/tables/snyk/snyk_group_members.md
+++ b/website/tables/snyk/snyk_group_members.md
@@ -1,0 +1,27 @@
+# Table: snyk_group_members
+
+This table shows data for Snyk Group Members.
+
+https://snyk.docs.apiary.io/#reference/groups/group-settings/list-all-members-in-a-group
+
+The composite primary key for this table is (**group_id**, **id**).
+
+## Relations
+
+This table depends on [snyk_groups](snyk_groups).
+
+## Columns
+
+| Name          | Type          |
+| ------------- | ------------- |
+|_cq_source_name|String|
+|_cq_sync_time|Timestamp|
+|_cq_id|UUID|
+|_cq_parent_id|UUID|
+|group_id (PK)|String|
+|id (PK)|String|
+|name|String|
+|username|String|
+|email|String|
+|orgs|JSON|
+|group_role|String|

--- a/website/tables/snyk/snyk_groups.md
+++ b/website/tables/snyk/snyk_groups.md
@@ -1,16 +1,18 @@
-# Table: snyk_organizations
+# Table: snyk_groups
 
-This table shows data for Snyk Organizations.
+This table shows data for Snyk Groups.
 
 https://snyk.docs.apiary.io/#reference/organizations/the-snyk-organization-for-a-request/list-all-the-organizations-a-user-belongs-to
+
+	
+This table lists all groups for the selected organizations. It uses the list organizations endpoint from the Snyk API.
 
 The primary key for this table is **id**.
 
 ## Relations
 
-The following tables depend on snyk_organizations:
-  - [snyk_organization_members](snyk_organization_members)
-  - [snyk_organization_provisions](snyk_organization_provisions)
+The following tables depend on snyk_groups:
+  - [snyk_group_members](snyk_group_members)
 
 ## Columns
 
@@ -20,8 +22,5 @@ The following tables depend on snyk_organizations:
 |_cq_sync_time|Timestamp|
 |_cq_id|UUID|
 |_cq_parent_id|UUID|
-|group|JSON|
 |id (PK)|String|
 |name|String|
-|slug|String|
-|url|String|

--- a/website/tables/snyk/snyk_organization_members.md
+++ b/website/tables/snyk/snyk_organization_members.md
@@ -1,0 +1,26 @@
+# Table: snyk_organization_members
+
+This table shows data for Snyk Organization Members.
+
+https://snyk.docs.apiary.io/#reference/organizations/members-in-organization/list-members
+
+The composite primary key for this table is (**organization_id**, **id**).
+
+## Relations
+
+This table depends on [snyk_organizations](snyk_organizations).
+
+## Columns
+
+| Name          | Type          |
+| ------------- | ------------- |
+|_cq_source_name|String|
+|_cq_sync_time|Timestamp|
+|_cq_id|UUID|
+|_cq_parent_id|UUID|
+|organization_id (PK)|String|
+|id (PK)|String|
+|username|String|
+|name|String|
+|email|String|
+|role|String|

--- a/website/tables/snyk/snyk_organization_provisions.md
+++ b/website/tables/snyk/snyk_organization_provisions.md
@@ -22,4 +22,4 @@ This table depends on [snyk_organizations](snyk_organizations).
 |email (PK)|String|
 |role|String|
 |role_public_id|String|
-|created (PK)|String|
+|created (PK)|Timestamp|

--- a/website/tables/snyk/snyk_organization_provisions.md
+++ b/website/tables/snyk/snyk_organization_provisions.md
@@ -1,0 +1,25 @@
+# Table: snyk_organization_provisions
+
+This table shows data for Snyk Organization Provisions.
+
+https://snyk.docs.apiary.io/#reference/organizations/provision-user/list-pending-user-provisions
+
+The composite primary key for this table is (**organization_id**, **email**, **created**).
+
+## Relations
+
+This table depends on [snyk_organizations](snyk_organizations).
+
+## Columns
+
+| Name          | Type          |
+| ------------- | ------------- |
+|_cq_source_name|String|
+|_cq_sync_time|Timestamp|
+|_cq_id|UUID|
+|_cq_parent_id|UUID|
+|organization_id (PK)|String|
+|email (PK)|String|
+|role|String|
+|role_public_id|String|
+|created (PK)|String|


### PR DESCRIPTION
Adds 4 new tables to the Snyk plugin: `snyk_groups`, `snyk_group_members`, `snyk_organization_members` and `snyk_organization_provisions`.

- Closes https://github.com/cloudquery/cloudquery/issues/10172
- Closes https://github.com/cloudquery/cloudquery/issues/10173
- Closes https://github.com/cloudquery/cloudquery/issues/10174