### PR TITLE
doc: Fix AWS profile link

### DIFF
--- a/website/pages/docs/plugins/sources/aws/configuration.md
+++ b/website/pages/docs/plugins/sources/aws/configuration.md
@@ -112,7 +112,7 @@ This is used to specify one or more accounts to extract information from. Note t
 
 - `local_profile` (string) (default: will use current credentials)
 
-  [Local profile](https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-profiles.html) to use to authenticate this account with.
+  [Local profile](https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-files.html) to use to authenticate this account with.
   Please note this should be set to the name of the profile. For example, with the following credentials file:
 
   ```ini copy


### PR DESCRIPTION
The old link seems to have moved and is now returning 404.