### PR TITLE
fix(postgresql): Ensure all table names are escaped

### DIFF
--- a/plugins/source/postgresql/client/cdc.go
+++ b/plugins/source/postgresql/client/cdc.go
@@ -20,7 +20,7 @@ func (c *Client) tablesWithPks() []string {
 	var tables []string
 	for _, table := range c.Tables {
 		if len(table.PrimaryKeys()) > 0 {
-			tables = append(tables, table.Name)
+			tables = append(tables, pgx.Identifier{table.Name}.Sanitize())
 		}
 	}
 	return tables

--- a/plugins/source/postgresql/resources/plugin/plugin_test.go
+++ b/plugins/source/postgresql/resources/plugin/plugin_test.go
@@ -329,7 +329,8 @@ func TestPluginCDC(t *testing.T) {
 		Path:         "cloudquery/postgresql",
 		Version:      "vdevelopment",
 		Destinations: []string{"test"},
-		Tables:       []string{"user"},
+		// use a reserved keyword as table name to validate escaping
+		Tables: []string{"user"},
 		Spec: &client.Spec{
 			ConnectionString: getTestConnectionString() + "&replication=database",
 			PgxLogLevel:      client.LogLevelTrace,


### PR DESCRIPTION
<!-- 🎉 Thank you for making CloudQuery awesome by submitting a PR 🎉 -->

#### Summary

user reported unable to sync postgresql table named `user` (which is a pg reserved word). This PR adds sanitization to table names to ensure all identifiers are properly handled