### PR TITLE
feat(aws): Add rule_ids to wafregional rule_group

### DIFF
--- a/plugins/source/aws/resources/services/wafregional/rule_groups_mock_test.go
+++ b/plugins/source/aws/resources/services/wafregional/rule_groups_mock_test.go
@@ -16,8 +16,16 @@ import (
 func buildRuleGroupsMock(t *testing.T, ctrl *gomock.Controller) client.Services {
 	m := mocks.NewMockWafregionalClient(ctrl)
 
-	var g types.RuleGroup
-	if err := faker.FakeObject(&g); err != nil {
+	tempRuleGroup := types.RuleGroup{}
+	if err := faker.FakeObject(&tempRuleGroup); err != nil {
+		t.Fatal(err)
+	}
+	tempRule := types.ActivatedRule{}
+	if err := faker.FakeObject(&tempRule); err != nil {
+		t.Fatal(err)
+	}
+	var tempTags []types.Tag
+	if err := faker.FakeObject(&tempTags); err != nil {
 		t.Fatal(err)
 	}
 	m.EXPECT().ListRuleGroups(
@@ -26,28 +34,40 @@ func buildRuleGroupsMock(t *testing.T, ctrl *gomock.Controller) client.Services 
 		gomock.Any(),
 	).Return(
 		&wafregional.ListRuleGroupsOutput{
-			RuleGroups: []types.RuleGroupSummary{{RuleGroupId: g.RuleGroupId}},
+			RuleGroups: []types.RuleGroupSummary{{RuleGroupId: tempRuleGroup.RuleGroupId}},
 		},
 		nil,
 	)
 
 	m.EXPECT().GetRuleGroup(
 		gomock.Any(),
-		&wafregional.GetRuleGroupInput{RuleGroupId: g.RuleGroupId},
+		&wafregional.GetRuleGroupInput{RuleGroupId: tempRuleGroup.RuleGroupId},
 		gomock.Any(),
 	).Return(
-		&wafregional.GetRuleGroupOutput{RuleGroup: &g},
+		&wafregional.GetRuleGroupOutput{RuleGroup: &tempRuleGroup},
 		nil,
 	)
+
+	m.EXPECT().ListActivatedRulesInRuleGroup(
+		gomock.Any(),
+		gomock.Any(),
+		gomock.Any(),
+	).Return(&wafregional.ListActivatedRulesInRuleGroupOutput{
+		ActivatedRules: []types.ActivatedRule{tempRule},
+	}, nil)
 
 	m.EXPECT().ListTagsForResource(
 		gomock.Any(),
 		&wafregional.ListTagsForResourceInput{
-			ResourceARN: aws.String(fmt.Sprintf("arn:aws:waf-regional:us-east-1:testAccount:rulegroup/%v", *g.RuleGroupId)),
+			ResourceARN: aws.String(fmt.Sprintf("arn:aws:waf-regional:us-east-1:testAccount:rulegroup/%v", *tempRuleGroup.RuleGroupId)),
 		},
 		gomock.Any(),
 	).Return(
-		&wafregional.ListTagsForResourceOutput{},
+		&wafregional.ListTagsForResourceOutput{
+			TagInfoForResource: &types.TagInfoForResource{
+				TagList: tempTags,
+			},
+		},
 		nil,
 	)
 

--- a/website/tables/aws/aws_wafregional_rule_groups.md
+++ b/website/tables/aws/aws_wafregional_rule_groups.md
@@ -18,6 +18,7 @@ The primary key for this table is **arn**.
 |region|String|
 |arn (PK)|String|
 |tags|JSON|
+|rule_ids|StringArray|
 |rule_group_id|String|
 |metric_name|String|
 |name|String|


### PR DESCRIPTION
#### Summary
SSIA

The implementation is almost same as `waf` one
https://github.com/cloudquery/cloudquery/blob/4d76c37eed0502821f7490a7fe310407b0ef0e4c/plugins/source/aws/resources/services/waf/rule_groups.go#L87-L112


#### Checklist

- [x] Read the [contribution guidelines](../blob/main/CONTRIBUTING.md) 🧑‍🎓
- [x] Run `make lint` to ensure the proposed changes follow the coding style 🚨 (install golangci-lint [here](https://golangci-lint.run/usage/install/#local-installation))
- [x] Run `make test` to ensure the proposed changes pass the tests 🧪
- [x] If changing a source plugin run `make gen` to ensure docs are up to date 📝
- [ ] Ensure the status checks below are successful ✅
