### PR TITLE
fix: Fix typos in CLI output text and logs

### DIFF
--- a/cli/cmd/sync_v0.go
+++ b/cli/cmd/sync_v0.go
@@ -53,7 +53,7 @@ func syncConnectionV0_2(ctx context.Context, sourceClient *managedsource.Client,
 
 	if !noMigrate {
 		migrateStart := time.Now().UTC()
-		fmt.Printf("Starting migration with for: %s -> %s\n", sourceSpec.VersionString(), destinationStrings)
+		fmt.Printf("Starting migration for: %s -> %s\n", sourceSpec.VersionString(), destinationStrings)
 		for i := range destinationsClients {
 			if _, err := destinationsPbClients[i].Migrate(ctx, &destination.Migrate_Request{
 				Tables: tablesBytes,

--- a/cli/cmd/sync_v1.go
+++ b/cli/cmd/sync_v1.go
@@ -69,7 +69,7 @@ func syncConnectionV1(ctx context.Context, sourceClient *managedsource.Client, d
 
 	if !noMigrate {
 		migrateStart := time.Now().UTC()
-		fmt.Printf("Starting migration with for: %s -> %s\n", sourceSpec.VersionString(), destinationStrings)
+		fmt.Printf("Starting migration for: %s -> %s\n", sourceSpec.VersionString(), destinationStrings)
 		for i := range destinationsClients {
 			if _, err := destinationsPbClients[i].Migrate(ctx, &destination.Migrate_Request{
 				Tables: tablesRes.Tables,

--- a/cli/internal/plugin/manageddestination/plugin.go
+++ b/cli/internal/plugin/manageddestination/plugin.go
@@ -140,7 +140,7 @@ func NewClient(ctx context.Context, spec specs.Destination, opts ...Option) (*Cl
 			),
 		)
 		if err != nil {
-			return nil, fmt.Errorf("failed to dial grpc source plugin at %s: %w", spec.Path, err)
+			return nil, fmt.Errorf("failed to dial grpc destination plugin at %s: %w", spec.Path, err)
 		}
 	case specs.RegistryLocal:
 		if err := c.startLocal(ctx, spec.Path); err != nil {
@@ -233,14 +233,14 @@ func (c *Client) Terminate() error {
 	if c.grpcSocketName != "" {
 		defer func() {
 			if err := os.RemoveAll(c.grpcSocketName); err != nil {
-				c.logger.Error().Err(err).Msg("failed to remove source socket file")
+				c.logger.Error().Err(err).Msg("failed to remove destination socket file")
 			}
 		}()
 	}
 
 	if c.Conn != nil {
 		if err := c.Conn.Close(); err != nil {
-			c.logger.Error().Err(err).Msg("failed to close gRPC connection to source plugin")
+			c.logger.Error().Err(err).Msg("failed to close gRPC connection to destination plugin")
 		}
 		c.Conn = nil
 	}

--- a/cli/internal/plugin/manageddestination/unix.go
+++ b/cli/internal/plugin/manageddestination/unix.go
@@ -17,17 +17,17 @@ func getSysProcAttr() *syscall.SysProcAttr {
 }
 
 func (c *Client) terminateProcess() error {
-	c.logger.Debug().Msg("sending interrupt signal to source plugin")
+	c.logger.Debug().Msg("sending interrupt signal to destination plugin")
 	if err := c.cmd.Process.Signal(os.Interrupt); err != nil {
-		c.logger.Error().Err(err).Msg("failed to send interrupt signal to source plugin")
+		c.logger.Error().Err(err).Msg("failed to send interrupt signal to destination plugin")
 	}
 	timer := time.AfterFunc(5*time.Second, func() {
-		c.logger.Info().Msg("sending kill signal to source plugin")
+		c.logger.Info().Msg("sending kill signal to destination plugin")
 		if err := c.cmd.Process.Kill(); err != nil {
-			c.logger.Error().Err(err).Msg("failed to kill source plugin")
+			c.logger.Error().Err(err).Msg("failed to kill destination plugin")
 		}
 	})
-	c.logger.Info().Msg("waiting for source plugin to terminate")
+	c.logger.Info().Msg("waiting for destination plugin to terminate")
 	st, err := c.cmd.Process.Wait()
 	timer.Stop()
 	if err != nil {
@@ -42,7 +42,7 @@ func (c *Client) terminateProcess() error {
 		if st.ExitCode() == 137 {
 			additionalInfo = " (Out of Memory)"
 		}
-		return fmt.Errorf("source plugin process failed with %s%s", st.String(), additionalInfo)
+		return fmt.Errorf("destination plugin process failed with %s%s", st.String(), additionalInfo)
 	}
 
 	return nil

--- a/cli/internal/plugin/manageddestination/windows.go
+++ b/cli/internal/plugin/manageddestination/windows.go
@@ -16,9 +16,9 @@ func getSysProcAttr() *syscall.SysProcAttr {
 func (c *Client) terminateProcess() error {
 	c.logger.Debug().Msg("sending kill signal to destination plugin")
 	if err := c.cmd.Process.Kill(); err != nil {
-		c.logger.Error().Err(err).Msg("failed to kill source plugin")
+		c.logger.Error().Err(err).Msg("failed to kill destination plugin")
 	}
-	c.logger.Info().Msg("waiting for source plugin to terminate")
+	c.logger.Info().Msg("waiting for destination plugin to terminate")
 	st, err := c.cmd.Process.Wait()
 	if err != nil {
 		return err
@@ -26,7 +26,7 @@ func (c *Client) terminateProcess() error {
 	if !st.Success() {
 		// on windows there is no way to shutdown gracefully via signal. Maybe we can do it via grpc api?
 		// though it is a bit strange to expose api to shutdown a server :thinking?:
-		c.logger.Info().Msgf("source plugin process exited with %s", st.String())
+		c.logger.Info().Msgf("destination plugin process exited with %s", st.String())
 	}
 
 	return nil


### PR DESCRIPTION
- Change text in output message from `with for` to `for`
- Change `source` to `destination` in `manageddestination` package