### PR TITLE
fix(aws): Handle Cloudfront Regions in different partitions

### DIFF
--- a/plugins/source/aws/client/account.go
+++ b/plugins/source/aws/client/account.go
@@ -91,7 +91,7 @@ func (c *Client) setupAWSAccount(ctx context.Context, logger zerolog.Logger, aws
 	svcsDetails[len(account.Regions)] = svcsDetail{
 		partition: iamArn.Partition,
 		accountId: *output.Account,
-		svcs:      initServices(cloudfrontScopeRegion, awsCfg),
+		svcs:      initServices(awscloudfrontScopeRegion, awsCfg),
 	}
 	return svcsDetails, nil
 }

--- a/plugins/source/aws/client/account.go
+++ b/plugins/source/aws/client/account.go
@@ -91,7 +91,7 @@ func (c *Client) setupAWSAccount(ctx context.Context, logger zerolog.Logger, aws
 	svcsDetails[len(account.Regions)] = svcsDetail{
 		partition: iamArn.Partition,
 		accountId: *output.Account,
-		svcs:      initServices(awscloudfrontScopeRegion, awsCfg),
+		svcs:      initServices(awsCloudfrontScopeRegion, awsCfg),
 	}
 	return svcsDetails, nil
 }

--- a/plugins/source/aws/client/account.go
+++ b/plugins/source/aws/client/account.go
@@ -88,10 +88,18 @@ func (c *Client) setupAWSAccount(ctx context.Context, logger zerolog.Logger, aws
 		}
 	}
 
+	var cloudfrontRegion string
+	switch iamArn.Partition {
+	case "aws":
+		cloudfrontRegion = awsCloudfrontScopeRegion
+	case "aws-cn":
+		cloudfrontRegion = awsCnCloudfrontScopeRegion
+	}
+
 	svcsDetails[len(account.Regions)] = svcsDetail{
 		partition: iamArn.Partition,
 		accountId: *output.Account,
-		svcs:      initServices(awsCloudfrontScopeRegion, awsCfg),
+		svcs:      initServices(cloudfrontRegion, awsCfg),
 	}
 	return svcsDetails, nil
 }

--- a/plugins/source/aws/client/client.go
+++ b/plugins/source/aws/client/client.go
@@ -52,9 +52,11 @@ type ServicesManager struct {
 }
 
 const (
-	defaultRegion         = "us-east-1"
-	defaultVar            = "default"
-	cloudfrontScopeRegion = defaultRegion
+	defaultRegion               = "us-east-1"
+	defaultVar                  = "default"
+	awsCloudfrontScopeRegion    = defaultRegion
+	awsGovCloudfrontScopeRegion = "us-gov-east-1"
+	awsCnCloudfrontScopeRegion  = "cn-north-1"
 )
 
 var errInvalidRegion = errors.New("region wildcard \"*\" is only supported as first argument")
@@ -169,6 +171,16 @@ func (c *Client) withPartitionAccountIDRegionAndNamespace(partition, accountID, 
 }
 
 func (c *Client) withPartitionAccountIDRegionAndScope(partition, accountID, region string, scope wafv2types.Scope) *Client {
+	if region == "" {
+		switch partition {
+		case "aws":
+			region = awsCloudfrontScopeRegion
+		case "aws-us-gov":
+			region = awsGovCloudfrontScopeRegion
+		case "aws-cn":
+			region = awsCnCloudfrontScopeRegion
+		}
+	}
 	return &Client{
 		Partition:            partition,
 		ServicesManager:      c.ServicesManager,

--- a/plugins/source/aws/client/client.go
+++ b/plugins/source/aws/client/client.go
@@ -52,11 +52,10 @@ type ServicesManager struct {
 }
 
 const (
-	defaultRegion               = "us-east-1"
-	defaultVar                  = "default"
-	awsCloudfrontScopeRegion    = defaultRegion
-	awsGovCloudfrontScopeRegion = "us-gov-east-1"
-	awsCnCloudfrontScopeRegion  = "cn-north-1"
+	defaultRegion              = "us-east-1"
+	defaultVar                 = "default"
+	awsCloudfrontScopeRegion   = defaultRegion
+	awsCnCloudfrontScopeRegion = "cn-north-1"
 )
 
 var errInvalidRegion = errors.New("region wildcard \"*\" is only supported as first argument")
@@ -171,16 +170,6 @@ func (c *Client) withPartitionAccountIDRegionAndNamespace(partition, accountID, 
 }
 
 func (c *Client) withPartitionAccountIDRegionAndScope(partition, accountID, region string, scope wafv2types.Scope) *Client {
-	if region == "" {
-		switch partition {
-		case "aws":
-			region = awsCloudfrontScopeRegion
-		case "aws-us-gov":
-			region = awsGovCloudfrontScopeRegion
-		case "aws-cn":
-			region = awsCnCloudfrontScopeRegion
-		}
-	}
 	return &Client{
 		Partition:            partition,
 		ServicesManager:      c.ServicesManager,

--- a/plugins/source/aws/client/multiplexers.go
+++ b/plugins/source/aws/client/multiplexers.go
@@ -119,7 +119,7 @@ func ServiceAccountRegionScopeMultiplexer(table, service string) func(meta schem
 		for partition := range client.ServicesManager.services {
 			for accountID := range client.ServicesManager.services[partition] {
 				// always fetch cloudfront related resources
-				l = append(l, client.withPartitionAccountIDRegionAndScope(partition, accountID, cloudfrontScopeRegion, wafv2types.ScopeCloudfront))
+				l = append(l, client.withPartitionAccountIDRegionAndScope(partition, accountID, "", wafv2types.ScopeCloudfront))
 				for region := range client.ServicesManager.services[partition][accountID] {
 					if !isSupportedServiceForRegion(service, region) {
 						if client.specificRegions {

--- a/plugins/source/aws/client/multiplexers.go
+++ b/plugins/source/aws/client/multiplexers.go
@@ -118,8 +118,14 @@ func ServiceAccountRegionScopeMultiplexer(table, service string) func(meta schem
 		client := meta.(*Client)
 		for partition := range client.ServicesManager.services {
 			for accountID := range client.ServicesManager.services[partition] {
-				// always fetch cloudfront related resources
-				l = append(l, client.withPartitionAccountIDRegionAndScope(partition, accountID, "", wafv2types.ScopeCloudfront))
+				// always fetch cloudfront related resources as long as in aws or aws-cn partition
+				switch partition {
+				case "aws":
+					l = append(l, client.withPartitionAccountIDRegionAndScope(partition, accountID, awsCloudfrontScopeRegion, wafv2types.ScopeCloudfront))
+				case "aws-cn":
+					l = append(l, client.withPartitionAccountIDRegionAndScope(partition, accountID, awsCnCloudfrontScopeRegion, wafv2types.ScopeCloudfront))
+				}
+
 				for region := range client.ServicesManager.services[partition][accountID] {
 					if !isSupportedServiceForRegion(service, region) {
 						if client.specificRegions {


### PR DESCRIPTION
<!-- 🎉 Thank you for making CloudQuery awesome by submitting a PR 🎉 -->

#### Summary

When syncing `aws-cn` the cloudfront region should be set to `cn-north-1`  when partition is `aws-gov` then there is no cloudfront so no reason to set the multiplexer