### PR TITLE
fix(aws): Fix the case where resrouce_id is null in ECS.2 of foundational policy

### DIFF
--- a/plugins/source/aws/policies/queries/ecs/ecs_services_with_public_ips.sql
+++ b/plugins/source/aws/policies/queries/ecs/ecs_services_with_public_ips.sql
@@ -4,12 +4,11 @@ select
   :'framework' as framework,
   :'check_id' as check_id,
   'Amazon ECS services should not have public IP addresses assigned to them automatically' as title,
-  c.account_id,
-  s.arn as resource_id,
+  account_id,
+  arn as resource_id,
   case when
     network_configuration->'AwsvpcConfiguration'->>'AssignPublicIp' is distinct from 'DISABLED'
     then 'fail'
     else 'pass'
   end as status
-from aws_ecs_clusters c
-     left join aws_ecs_cluster_services s ON c.arn = s.cluster_arn
+from aws_ecs_cluster_services


### PR DESCRIPTION
#### Summary
When I run the query of ECS.2 in foundational policies, I have noticed that resource_id became null if there is no ECS service in a ECS cluster.

Thus, we don't have to use `left join` to detect the rule. Only just seek `aws_ecs_cluster_services` table.