### PR TITLE
feat(s3): Support `{{FORMAT}}` placeholder

### DIFF
--- a/plugins/destination/s3/client/client.go
+++ b/plugins/destination/s3/client/client.go
@@ -69,7 +69,7 @@ func New(ctx context.Context, logger zerolog.Logger, spec specs.Destination) (de
 		timeNow := time.Now().UTC()
 		if _, err := c.uploader.Upload(ctx, &s3.PutObjectInput{
 			Bucket: aws.String(c.pluginSpec.Bucket),
-			Key:    aws.String(replacePathVariables(c.pluginSpec.Path, "TEST_TABLE", "TEST_UUID", timeNow)),
+			Key:    aws.String(replacePathVariables(c.pluginSpec.Path, "TEST_TABLE", "TEST_UUID", c.pluginSpec.Format, timeNow)),
 			Body:   bytes.NewReader([]byte("")),
 		}); err != nil {
 			return nil, fmt.Errorf("failed to write test file to S3: %w", err)

--- a/plugins/destination/s3/client/write.go
+++ b/plugins/destination/s3/client/write.go
@@ -15,19 +15,21 @@ import (
 	"github.com/apache/arrow/go/v13/arrow/memory"
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/s3"
+	"github.com/cloudquery/filetypes/v2"
 	"github.com/cloudquery/plugin-sdk/v2/schema"
 	"github.com/cloudquery/plugin-sdk/v2/types"
 	"github.com/google/uuid"
 )
 
 const (
-	PathVarTable = "{{TABLE}}"
-	PathVarUUID  = "{{UUID}}"
-	YearVar      = "{{YEAR}}"
-	MonthVar     = "{{MONTH}}"
-	DayVar       = "{{DAY}}"
-	HourVar      = "{{HOUR}}"
-	MinuteVar    = "{{MINUTE}}"
+	PathVarFormat = "{{FORMAT}}"
+	PathVarTable  = "{{TABLE}}"
+	PathVarUUID   = "{{UUID}}"
+	YearVar       = "{{YEAR}}"
+	MonthVar      = "{{MONTH}}"
+	DayVar        = "{{DAY}}"
+	HourVar       = "{{HOUR}}"
+	MinuteVar     = "{{MINUTE}}"
 )
 
 var reInvalidJSONKey = regexp.MustCompile(`\W`)
@@ -57,7 +59,7 @@ func (c *Client) WriteTableBatch(ctx context.Context, arrowSchema *arrow.Schema,
 	r := io.Reader(&b)
 	if _, err := c.uploader.Upload(ctx, &s3.PutObjectInput{
 		Bucket: aws.String(c.pluginSpec.Bucket),
-		Key:    aws.String(replacePathVariables(c.pluginSpec.Path, tableName, uuid.NewString(), timeNow)),
+		Key:    aws.String(replacePathVariables(c.pluginSpec.Path, tableName, uuid.NewString(), c.pluginSpec.Format, timeNow)),
 		Body:   r,
 	}); err != nil {
 		return err
@@ -112,8 +114,9 @@ func sanitizeJSONKeysForObject(obj any) {
 	}
 }
 
-func replacePathVariables(specPath, table, fileIdentifier string, t time.Time) string {
+func replacePathVariables(specPath, table, fileIdentifier string, format filetypes.FormatType, t time.Time) string {
 	name := strings.ReplaceAll(specPath, PathVarTable, table)
+	name = strings.ReplaceAll(name, PathVarFormat, string(format))
 	name = strings.ReplaceAll(name, PathVarUUID, fileIdentifier)
 	name = strings.ReplaceAll(name, YearVar, t.Format("2006"))
 	name = strings.ReplaceAll(name, MonthVar, t.Format("01"))

--- a/plugins/destination/s3/client/write_test.go
+++ b/plugins/destination/s3/client/write_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/cloudquery/filetypes/v2"
 	"github.com/google/go-cmp/cmp"
 )
 
@@ -80,6 +81,12 @@ func TestReplacePathVariables(t *testing.T) {
 			expectedPath: "test/test/FAKE-UUID.json",
 		},
 		{
+			inputPath:    "test/test/{{TABLE}}/{{UUID}}.{{FORMAT}}",
+			tableName:    "",
+			uuid:         "FAKE-UUID",
+			expectedPath: "test/test/FAKE-UUID.json",
+		},
+		{
 			inputPath:    "test/test/{{TABLE}}/year={{YEAR}}/month={{MONTH}}/day={{DAY}}/hour={{HOUR}}/minute={{MINUTE}}/{{UUID}}.json",
 			tableName:    "test-table",
 			uuid:         "FAKE-UUID",
@@ -89,7 +96,7 @@ func TestReplacePathVariables(t *testing.T) {
 
 	tm := time.Date(2021, 3, 5, 4, 1, 2, 3, time.UTC)
 	for _, tc := range cases {
-		if diff := cmp.Diff(tc.expectedPath, replacePathVariables(tc.inputPath, tc.tableName, tc.uuid, tm)); diff != "" {
+		if diff := cmp.Diff(tc.expectedPath, replacePathVariables(tc.inputPath, tc.tableName, tc.uuid, filetypes.FormatTypeJSON, tm)); diff != "" {
 			t.Errorf("unexpected Path Substitution (-want +got):\n%s", diff)
 		}
 	}

--- a/website/pages/docs/plugins/destinations/s3/overview.mdx
+++ b/website/pages/docs/plugins/destinations/s3/overview.mdx
@@ -37,12 +37,13 @@ This is the (nested) spec used by the CSV destination Plugin.
 
   Path to where the files will be uploaded in the above bucket. The path supports the following placeholder variables:
 
-  - `{{TABLE}}` will be replaced with the table name,
-  - `{{UUID}}` will be replaced with a random UUID to uniquely identify each file,
-  - `{{YEAR}}` will be replaced with the current year in `YYYY` format,
-  - `{{MONTH}}` will be replaced with the current month in `MM` format,
-  - `{{DAY}}` will be replaced with the current day in `DD` format,
-  - `{{HOUR}}` will be replaced with the current hour in `HH` format, and
+  - `{{TABLE}}` will be replaced with the table name
+  - `{{FORMAT}}` will be replaced with the file format, such as `csv`, `json` or `parquet`
+  - `{{UUID}}` will be replaced with a random UUID to uniquely identify each file
+  - `{{YEAR}}` will be replaced with the current year in `YYYY` format
+  - `{{MONTH}}` will be replaced with the current month in `MM` format
+  - `{{DAY}}` will be replaced with the current day in `DD` format
+  - `{{HOUR}}` will be replaced with the current hour in `HH` format
   - `{{MINUTE}}` will be replaced with the current minute in `mm` format
 
   Note that timestamps are in UTC and will be the current time at the time the file is written, not when the sync started.


### PR DESCRIPTION
file plugin supports `{{FORMAT}}` but looks like we were missing it here.