### PR TITLE
feat: Add GitHub Enterprise support on GitHub source

### DIFF
--- a/plugins/source/github/client/spec.go
+++ b/plugins/source/github/client/spec.go
@@ -3,10 +3,16 @@ package client
 import "fmt"
 
 type Spec struct {
-	AccessToken string        `json:"access_token"`
-	Orgs        []string      `json:"orgs"`
-	Repos       []string      `json:"repos"`
-	AppAuth     []AppAuthSpec `json:"app_auth"`
+	AccessToken        string              `json:"access_token"`
+	Orgs               []string            `json:"orgs"`
+	Repos              []string            `json:"repos"`
+	AppAuth            []AppAuthSpec       `json:"app_auth"`
+	EnterpriseSettings *EnterpriseSettings `json:"enterprise"`
+}
+
+type EnterpriseSettings struct {
+	BaseURL   string `json:"base_url"`
+	UploadURL string `json:"upload_url"`
 }
 
 type AppAuthSpec struct {
@@ -19,6 +25,11 @@ type AppAuthSpec struct {
 func (s *Spec) Validate() error {
 	if s.AccessToken == "" && len(s.AppAuth) == 0 {
 		return fmt.Errorf("missing personal access token or app auth in configuration")
+	}
+	if s.EnterpriseSettings != nil {
+		if err := s.ValidateEnterpriseSettings(); err != nil {
+			return err
+		}
 	}
 	for _, appAuth := range s.AppAuth {
 		if appAuth.Org == "" {
@@ -39,6 +50,18 @@ func (s *Spec) Validate() error {
 			return err
 		}
 	}
+	return nil
+}
+
+func (s *Spec) ValidateEnterpriseSettings() error {
+	if s.EnterpriseSettings.BaseURL == "" {
+		return fmt.Errorf("enterprise base url is empty")
+	}
+
+	if s.EnterpriseSettings.UploadURL == "" {
+		return fmt.Errorf("enterprise upload url is empty")
+	}
+
 	return nil
 }
 

--- a/website/pages/docs/plugins/sources/github/_configuration.mdx
+++ b/website/pages/docs/plugins/sources/github/_configuration.mdx
@@ -20,6 +20,15 @@ spec:
     #   installation_id: <ORG_INSTALLATION_ID> # Installation ID for this org
     orgs: [] # Optional. List of organizations to extract from
     repos: ["cloudquery/cloudquery"] # Optional. List of repositories to extract from
+    ## GitHub Enterprise
+    # In order to enable GHE you have to provide two urls, the base url of the server and the upload url.
+    # Quote from GitHub's client:
+    #   If the base URL does not have the suffix "/api/v3/", it will be added automatically. If the upload URL does not have the suffix "/api/uploads", it will be added automatically.
+    #   Another important thing is that by default, the GitHub Enterprise URL format should be http(s)://[hostname]/api/v3/ or you will always receive the 406 status code. The upload URL format should be http(s)://[hostname]/api/uploads/"
+    # If you are not configuring against an enterprise server please omit the enterprise stanza bellow
+    enterprise:
+        base_url: "http(s)://[your-ghe-hostname]/api/v3/"
+        upload_url: "http(s)://[your-ghe-hostname]/api/uploads/"
 ```
 
 You must specify either `orgs` or `repos` in the configuration. If a repository is specified in both `orgs` and `repos`, it will be extracted only once, and other repositories from that organization will be ignored.


### PR DESCRIPTION
<!-- 🎉 Thank you for making CloudQuery awesome by submitting a PR 🎉 -->

#### Summary

Implements: https://github.com/cloudquery/cloudquery/issues/10696
Adding support for GHE based on the request found [here](https://github.com/cloudquery/cloudquery/issues/10696)

### Tests

Didn't increase the coverage cause the GitHubEnterpriseClient from go-github is basically a duck-type githubClient.
<!--
Use the following steps to ensure your PR is ready to be reviewed

- [ ] Read the [contribution guidelines](../blob/main/CONTRIBUTING.md) 🧑‍🎓
- [ ] Run `make lint` to ensure the proposed changes follow the coding style 🚨 (install golangci-lint [here](https://golangci-lint.run/usage/install/#local-installation))
- [ ] Run `make test` to ensure the proposed changes pass the tests 🧪
- [ ] If changing a source plugin run `make gen` to ensure docs are up to date 📝
- [ ] Ensure the status checks below are successful ✅
--->
