### PR TITLE
doc: Update outdated references to codegen

### DIFF
--- a/website/pages/docs/developers/codegen.md
+++ b/website/pages/docs/developers/codegen.md
@@ -1,8 +1,9 @@
 # Generating resources
 
 Adding resources to a plugins can sometimes be a tedious task, some resources can have more than hundreds of fields and relations, and adding them all can
-take a long time. To remedy this issue, we provide code generation utilities as part of our [plugin-sdk](https://github.com/cloudquery/plugin-sdk). Code generation allows to easily generate more of the boilerplate code for tables from Go code.
+take a long time. To remedy this issue, we provide utilities as part of our [plugin-sdk](https://github.com/cloudquery/plugin-sdk) to automatically infer columns 
+from Go structs. In particular, see the [`transformers.TransformWithStruct()` method](https://github.com/cloudquery/plugin-sdk/blob/main/transformers/struct.go).  
 
 ## Examples
 
-The best example would be to checkout how this is done in our of our official plugins such as [gcp](https://github.com/cloudquery/cloudquery/tree/main/plugins/source/gcp/codegen)
+The best example would be to check out how this is done in our of our official plugins such as [GCP Compute Disks](https://github.com/cloudquery/cloudquery/blob/main/plugins/source/gcp/resources/services/compute/disks.go#L22)


### PR DESCRIPTION
We were still referencing some codegen code that is no longer being used; this updates to reference the latest version which uses struct transformers.