### PR TITLE
feat(gremlin): Add `complete_types` option

### DIFF
--- a/plugins/destination/gremlin/client/spec.go
+++ b/plugins/destination/gremlin/client/spec.go
@@ -25,7 +25,8 @@ type Spec struct {
 	// Connection settings
 	MaxConcurrentConnections int `json:"max_concurrent_connections"`
 
-	NeptuneCompatibility *bool `json:"neptune_compatibility"`
+	// Whether to use all Gremlin types or just a basic subset
+	CompleteTypes bool `json:"complete_types"`
 }
 
 type authMode string
@@ -63,11 +64,6 @@ func (s *Spec) SetDefaults() {
 
 	if s.MaxConcurrentConnections < 1 {
 		s.MaxConcurrentConnections = runtime.NumCPU()
-	}
-
-	if s.NeptuneCompatibility == nil {
-		b := true
-		s.NeptuneCompatibility = &b
 	}
 }
 

--- a/plugins/destination/gremlin/client/spec.go
+++ b/plugins/destination/gremlin/client/spec.go
@@ -24,6 +24,8 @@ type Spec struct {
 
 	// Connection settings
 	MaxConcurrentConnections int `json:"max_concurrent_connections"`
+
+	NeptuneCompatibility *bool `json:"neptune_compatibility"`
 }
 
 type authMode string
@@ -61,6 +63,11 @@ func (s *Spec) SetDefaults() {
 
 	if s.MaxConcurrentConnections < 1 {
 		s.MaxConcurrentConnections = runtime.NumCPU()
+	}
+
+	if s.NeptuneCompatibility == nil {
+		b := true
+		s.NeptuneCompatibility = &b
 	}
 }
 

--- a/plugins/destination/gremlin/client/transformer.go
+++ b/plugins/destination/gremlin/client/transformer.go
@@ -45,7 +45,7 @@ func (c *Client) transformArr(arr arrow.Array, isCQTime bool) []any {
 			}
 			dbArr[i] = a.Value(i).ToTime(a.DataType().(*arrow.TimestampType).Unit).UTC().Format("2006-01-02 15:04:05.999999999")
 		case array.ListLike:
-			if *c.pluginSpec.NeptuneCompatibility {
+			if !c.pluginSpec.CompleteTypes {
 				dbArr[i] = stripNulls(arr.ValueStr(i))
 				continue
 			}

--- a/plugins/destination/gremlin/client/write.go
+++ b/plugins/destination/gremlin/client/write.go
@@ -29,7 +29,7 @@ func (c *Client) WriteTableBatch(ctx context.Context, table *schema.Table, recor
 
 	rows := make([]map[string]any, 0)
 	for _, record := range records {
-		rows = append(rows, transformValues(record, cqTimeIndex)...)
+		rows = append(rows, c.transformValues(record, cqTimeIndex)...)
 	}
 
 	pks := table.PrimaryKeys()

--- a/website/pages/docs/plugins/destinations/gremlin/overview.mdx
+++ b/website/pages/docs/plugins/destinations/gremlin/overview.mdx
@@ -79,6 +79,6 @@ This is the (nested) spec used by the Gremlin destination Plugin.
 
   Maximum number of concurrent connections to the database.
 
-- `neptune_compatibility` (boolean, optional. default: true)
+- `complete_types` (boolean, optional. default: false)
 
-  Whether to enable Neptune type-compatibility mode. This is required for AWS Neptune, but could be disabled for other databases.
+  Whether to use all Gremlin-supported types or just a basic set. Should remain `false` for Neptune compatibility.

--- a/website/pages/docs/plugins/destinations/gremlin/overview.mdx
+++ b/website/pages/docs/plugins/destinations/gremlin/overview.mdx
@@ -78,3 +78,7 @@ This is the (nested) spec used by the Gremlin destination Plugin.
 - `max_concurrent_connections` (integer, optional. default: number of runtime processors)
 
   Maximum number of concurrent connections to the database.
+
+- `neptune_compatibility` (boolean, optional. default: true)
+
+  Whether to enable Neptune type-compatibility mode. This is required for AWS Neptune, but could be disabled for other databases.

--- a/website/pages/docs/plugins/destinations/gremlin/overview.mdx
+++ b/website/pages/docs/plugins/destinations/gremlin/overview.mdx
@@ -81,4 +81,4 @@ This is the (nested) spec used by the Gremlin destination Plugin.
 
 - `complete_types` (boolean, optional. default: false)
 
-  Whether to use all Gremlin-supported types or just a basic set. Should remain `false` for Neptune compatibility.
+  Whether to use all Gremlin-supported types or just a basic set. Should remain `false` for Amazon Neptune compatibility.


### PR DESCRIPTION
Neptune doesn't support list types ([among other things](https://docs.aws.amazon.com/neptune/latest/userguide/access-graph-gremlin-differences.html)) so we need to represent lists as strings.

The option defaults to `false` (assuming we have more Neptune users than Apache TinkerPop users it was worded as such)

Fixes #10839