### PR TITLE
feat(okta): Enable SDK Debug Logs

### DIFF
--- a/plugins/source/okta/client/client.go
+++ b/plugins/source/okta/client/client.go
@@ -56,6 +56,7 @@ func Configure(_ context.Context, logger zerolog.Logger, srcSpec specs.Source, _
 		okta.WithRateLimitMaxBackOff(int64(spec.RateLimit.MaxBackoff/time.Second)), // this param takes int64 of seconds
 		okta.WithRateLimitMaxRetries(spec.RateLimit.MaxRetries),
 	)
+	cf.Debug = oktaSpec.Debug
 	c := okta.NewAPIClient(cf)
 
 	return New(logger, srcSpec, c), nil

--- a/plugins/source/okta/client/client.go
+++ b/plugins/source/okta/client/client.go
@@ -56,7 +56,7 @@ func Configure(_ context.Context, logger zerolog.Logger, srcSpec specs.Source, _
 		okta.WithRateLimitMaxBackOff(int64(spec.RateLimit.MaxBackoff/time.Second)), // this param takes int64 of seconds
 		okta.WithRateLimitMaxRetries(spec.RateLimit.MaxRetries),
 	)
-	cf.Debug = oktaSpec.Debug
+	cf.Debug = spec.Debug
 	c := okta.NewAPIClient(cf)
 
 	return New(logger, srcSpec, c), nil

--- a/plugins/source/okta/client/spec.go
+++ b/plugins/source/okta/client/spec.go
@@ -11,6 +11,7 @@ type (
 		Token     string     `json:"token,omitempty"`
 		Domain    string     `json:"domain,omitempty"`
 		RateLimit *RateLimit `json:"rate_limit,omitempty"`
+		Debug     bool       `json:"debug,omitempty"`
 	}
 	RateLimit struct {
 		MaxBackoff time.Duration `json:"max_backoff,omitempty"`

--- a/website/pages/docs/plugins/sources/okta/overview.mdx
+++ b/website/pages/docs/plugins/sources/okta/overview.mdx
@@ -32,6 +32,14 @@ The following example sets up the Okta plugin, and connects it to a postgresql d
   Token for Okta API access.
   You can set this with an `OKTA_API_TOKEN` environment variable.
 
+- `debug` (`bool`, optional. Default: `false`)
+
+  Enables debug logs within the Okta SDK.
+  <Callout type="warning">
+    This feature will result in sensitive information being logged!
+  </Callout>
+
+
 - `rate_limit` ([Rate limit](#rate-limit-spec) spec, optional. Default: see [rate limit](#rate-limit-spec) spec defaults)
 
   Rate limit configuration.


### PR DESCRIPTION
<!-- 🎉 Thank you for making CloudQuery awesome by submitting a PR 🎉 -->

#### Summary

Users have no visibility into the requests that CQ is making, which makes debugging nearly impossible. This PR allows users to see all of the requests being made