### PR TITLE
doc: Add basic Cloud Run deployment page

### DIFF
--- a/website/pages/docs/deployment/_meta.json
+++ b/website/pages/docs/deployment/_meta.json
@@ -1,8 +1,9 @@
 {
   "overview": "Overview",
+  "ecs": "Amazon ECS",
   "airflow": "Apache Airflow",
   "docker": "Docker",
-  "ecs": "Amazon ECS",
   "github-actions": "GitHub Actions",
+  "cloud-run": "Google Cloud Run",
   "kestra": "Kestra"
 }

--- a/website/pages/docs/deployment/cloud-run.mdx
+++ b/website/pages/docs/deployment/cloud-run.mdx
@@ -1,0 +1,24 @@
+---
+title: Google Cloud Run
+---
+
+import { Callout } from 'nextra-theme-docs';
+
+# Scheduling CloudQuery Syncs with Google Cloud Run and Cloud Scheduler
+
+[Google Cloud Run](https://cloud.google.com/run) is a managed compute platform that enables you to run stateless containers that are invocable via web requests or Pub/Sub events. It provides a serverless experience for developers to deploy and run highly scalable applications without worrying about the underlying infrastructure. While not a perfect fit for CloudQuery syncs, it provides a relatively simple way to run CloudQuery as a serverless container on Google Cloud. If your use case is more complex but still requires deployment on GCP, you may want to consider deploying to a [Virtual Machine](https://cloud.google.com/compute/docs/instances/create-start-instance), [Cloud Composer](https://cloud.google.com/composer/docs/concepts/overview) or [Google Data Flow](https://cloud.google.com/dataflow) instead.
+
+<Callout type="warning">
+
+Note that [Cloud Run quotas](https://cloud.google.com/run/quotas) impose a 1 hour time limit per execution (i.e. CloudQuery sync)
+
+</Callout>
+
+## Deploying with Cloud Run
+
+See the [cloudquery/cloudrun-example](https://github.com/cloudquery/cloudrun-example) repository for an example Dockerfile and instructions on how to deploy CloudQuery using Cloud Run and Cloud Scheduler. Cloud Run containers must accept incoming connections on a given port (8080 by default). The Docker image above wraps CloudQuery with a small web server that listens for incoming requests and starts a sync whenever a request is received. You should keep the HTTP endpoint private, making it available only to the Cloud Scheduler that triggers the sync on a schedule.
+
+## Improve this Page
+
+If you have successfully deployed CloudQuery with Google Cloud Run and would like to help us improve this guide, please consider [opening a Pull Request](https://github.com/cloudquery/cloudquery/blob/main/website/pages/docs/deployment/cloudrun.mdx).
+


### PR DESCRIPTION
Just a basic page to describe running with Cloud Run and to help people make a decision on how to deploy to GCP; we can expand this over time.