### PR TITLE
feat(heroku)!: Migrate to Arrow native SDK

### DIFF
--- a/plugins/source/heroku/client/client.go
+++ b/plugins/source/heroku/client/client.go
@@ -6,8 +6,8 @@ import (
 	"fmt"
 
 	"github.com/cloudquery/plugin-pb-go/specs"
-	"github.com/cloudquery/plugin-sdk/v2/plugins/source"
-	"github.com/cloudquery/plugin-sdk/v2/schema"
+	"github.com/cloudquery/plugin-sdk/v3/plugins/source"
+	"github.com/cloudquery/plugin-sdk/v3/schema"
 	heroku "github.com/heroku/heroku-go/v5"
 	"github.com/rs/zerolog"
 )

--- a/plugins/source/heroku/client/testing.go
+++ b/plugins/source/heroku/client/testing.go
@@ -8,8 +8,8 @@ import (
 	"time"
 
 	"github.com/cloudquery/plugin-pb-go/specs"
-	"github.com/cloudquery/plugin-sdk/v2/plugins/source"
-	"github.com/cloudquery/plugin-sdk/v2/schema"
+	"github.com/cloudquery/plugin-sdk/v3/plugins/source"
+	"github.com/cloudquery/plugin-sdk/v3/schema"
 	heroku "github.com/heroku/heroku-go/v5"
 	"github.com/rs/zerolog"
 )

--- a/plugins/source/heroku/go.mod
+++ b/plugins/source/heroku/go.mod
@@ -3,8 +3,9 @@ module github.com/cloudquery/cloudquery/plugins/source/heroku
 go 1.19
 
 require (
+	github.com/apache/arrow/go/v13 v13.0.0-20230509040948-de6c3cd2b604
 	github.com/cloudquery/plugin-pb-go v1.0.8
-	github.com/cloudquery/plugin-sdk/v2 v2.7.0
+	github.com/cloudquery/plugin-sdk/v3 v3.6.4
 	github.com/google/go-cmp v0.5.9
 	github.com/googleapis/gax-go/v2 v2.7.1
 	github.com/heroku/heroku-go/v5 v5.5.0
@@ -22,10 +23,9 @@ require (
 	cloud.google.com/go/compute v1.19.0 // indirect
 	cloud.google.com/go/compute/metadata v0.2.3 // indirect
 	github.com/andybalholm/brotli v1.0.5 // indirect
-	github.com/apache/arrow/go/v13 v13.0.0-20230509040948-de6c3cd2b604 // indirect
 	github.com/apache/thrift v0.16.0 // indirect
 	github.com/cenkalti/backoff v2.2.1+incompatible // indirect
-	github.com/cloudquery/plugin-sdk/v3 v3.6.4 // indirect
+	github.com/cloudquery/plugin-sdk/v2 v2.7.0 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/getsentry/sentry-go v0.20.0 // indirect
 	github.com/ghodss/yaml v1.0.0 // indirect
@@ -47,6 +47,7 @@ require (
 	github.com/minio/asm2plan9s v0.0.0-20200509001527-cdd76441f9d8 // indirect
 	github.com/minio/c2goasm v0.0.0-20190812172519-36a3d3bbc4f3 // indirect
 	github.com/pborman/uuid v1.2.1 // indirect
+	github.com/pierrec/lz4/v4 v4.1.15 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/spf13/cast v1.5.0 // indirect
 	github.com/spf13/cobra v1.6.1 // indirect

--- a/plugins/source/heroku/go.mod
+++ b/plugins/source/heroku/go.mod
@@ -25,6 +25,7 @@ require (
 	github.com/apache/arrow/go/v13 v13.0.0-20230509040948-de6c3cd2b604 // indirect
 	github.com/apache/thrift v0.16.0 // indirect
 	github.com/cenkalti/backoff v2.2.1+incompatible // indirect
+	github.com/cloudquery/plugin-sdk/v3 v3.6.4 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/getsentry/sentry-go v0.20.0 // indirect
 	github.com/ghodss/yaml v1.0.0 // indirect

--- a/plugins/source/heroku/go.sum
+++ b/plugins/source/heroku/go.sum
@@ -59,6 +59,8 @@ github.com/cloudquery/plugin-pb-go v1.0.8 h1:wn3GXhcNItcP+6wUUZuzUFbvdL59liKBO37
 github.com/cloudquery/plugin-pb-go v1.0.8/go.mod h1:vAGA27psem7ZZNAY4a3S9TKuA/JDQWstjKcHPJX91Mc=
 github.com/cloudquery/plugin-sdk/v2 v2.7.0 h1:hRXsdEiaOxJtsn/wZMFQC9/jPfU1MeMK3KF+gPGqm7U=
 github.com/cloudquery/plugin-sdk/v2 v2.7.0/go.mod h1:pAX6ojIW99b/Vg4CkhnsGkRIzNaVEceYMR+Bdit73ug=
+github.com/cloudquery/plugin-sdk/v3 v3.6.4 h1:P4OkS5tJYkv3OqeL60DAVqXXbFQUyPKJ5YDtAgjl9b4=
+github.com/cloudquery/plugin-sdk/v3 v3.6.4/go.mod h1:3JrZXEULmGXpkOukVaRIzaA63d7TJr9Ukp6hemTjbtc=
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
 github.com/cncf/udpa/go v0.0.0-20201120205902-5459f2c99403/go.mod h1:WmhPx2Nbnhtbo57+VJT5O0JRkEi1Wbu0z5j0R8u5Hbk=
 github.com/coreos/go-systemd v0.0.0-20190321100706-95778dfbb74e/go.mod h1:F5haX7vjVVG0kc13fIWeqUViNPyEJxv/OmvnBo0Yme4=

--- a/plugins/source/heroku/go.sum
+++ b/plugins/source/heroku/go.sum
@@ -202,6 +202,7 @@ github.com/pborman/uuid v1.2.0/go.mod h1:X/NO0urCmaxf9VXbdlT7C2Yzkj2IKimNn4k+gtP
 github.com/pborman/uuid v1.2.1 h1:+ZZIw58t/ozdjRaXh/3awHfmWRbzYxJoAdNJxe/3pvw=
 github.com/pborman/uuid v1.2.1/go.mod h1:X/NO0urCmaxf9VXbdlT7C2Yzkj2IKimNn4k+gtPdI/k=
 github.com/pierrec/lz4/v4 v4.1.15 h1:MO0/ucJhngq7299dKLwIMtgTfbkoSPF6AoMYDd8Q4q0=
+github.com/pierrec/lz4/v4 v4.1.15/go.mod h1:gZWDp/Ze/IJXGXf23ltt2EXimqmTUXEy0GFuRQyBid4=
 github.com/pingcap/errors v0.11.4 h1:lFuQV/oaUMGcD2tqt+01ROSmJs75VG1ToEOkZIZ4nE4=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=

--- a/plugins/source/heroku/main.go
+++ b/plugins/source/heroku/main.go
@@ -2,7 +2,7 @@ package main
 
 import (
 	"github.com/cloudquery/cloudquery/plugins/source/heroku/resources/plugin"
-	"github.com/cloudquery/plugin-sdk/v2/serve"
+	"github.com/cloudquery/plugin-sdk/v3/serve"
 )
 
 const sentryDSN = "https://007186e3289a490c9af043fe0f0b3fb2@o1396617.ingest.sentry.io/6765331"

--- a/plugins/source/heroku/resources/plugin/plugin.go
+++ b/plugins/source/heroku/resources/plugin/plugin.go
@@ -3,8 +3,8 @@ package plugin
 import (
 	"github.com/cloudquery/cloudquery/plugins/source/heroku/client"
 	"github.com/cloudquery/cloudquery/plugins/source/heroku/resources/services"
-	"github.com/cloudquery/plugin-sdk/v2/plugins/source"
-	"github.com/cloudquery/plugin-sdk/v2/schema"
+	"github.com/cloudquery/plugin-sdk/v3/plugins/source"
+	"github.com/cloudquery/plugin-sdk/v3/schema"
 )
 
 var (

--- a/plugins/source/heroku/resources/services/account_feature.go
+++ b/plugins/source/heroku/resources/services/account_feature.go
@@ -3,6 +3,8 @@ package services
 import (
 	"context"
 
+	"github.com/apache/arrow/go/v13/arrow"
+
 	"github.com/cloudquery/cloudquery/plugins/source/heroku/client"
 	"github.com/cloudquery/plugin-sdk/v3/schema"
 	"github.com/cloudquery/plugin-sdk/v3/transformers"
@@ -18,12 +20,10 @@ func AccountFeatures() *schema.Table {
 		Transform:   transformers.TransformWithStruct(&heroku.AccountFeature{}),
 		Columns: []schema.Column{
 			{
-				Name:     "id",
-				Type:     schema.TypeString,
-				Resolver: schema.PathResolver("ID"),
-				CreationOptions: schema.ColumnCreationOptions{
-					PrimaryKey: true,
-				},
+				Name:       "id",
+				Type:       arrow.BinaryTypes.String,
+				Resolver:   schema.PathResolver("ID"),
+				PrimaryKey: true,
 			},
 		},
 	}

--- a/plugins/source/heroku/resources/services/account_feature.go
+++ b/plugins/source/heroku/resources/services/account_feature.go
@@ -4,8 +4,8 @@ import (
 	"context"
 
 	"github.com/cloudquery/cloudquery/plugins/source/heroku/client"
-	"github.com/cloudquery/plugin-sdk/v2/schema"
-	"github.com/cloudquery/plugin-sdk/v2/transformers"
+	"github.com/cloudquery/plugin-sdk/v3/schema"
+	"github.com/cloudquery/plugin-sdk/v3/transformers"
 	heroku "github.com/heroku/heroku-go/v5"
 	"github.com/pkg/errors"
 )

--- a/plugins/source/heroku/resources/services/account_feature_mock_test.go
+++ b/plugins/source/heroku/resources/services/account_feature_mock_test.go
@@ -7,7 +7,7 @@ import (
 	"testing"
 
 	"github.com/cloudquery/cloudquery/plugins/source/heroku/client"
-	"github.com/cloudquery/plugin-sdk/v2/faker"
+	"github.com/cloudquery/plugin-sdk/v3/faker"
 	heroku "github.com/heroku/heroku-go/v5"
 	"github.com/julienschmidt/httprouter"
 )

--- a/plugins/source/heroku/resources/services/add_on.go
+++ b/plugins/source/heroku/resources/services/add_on.go
@@ -4,8 +4,8 @@ import (
 	"context"
 
 	"github.com/cloudquery/cloudquery/plugins/source/heroku/client"
-	"github.com/cloudquery/plugin-sdk/v2/schema"
-	"github.com/cloudquery/plugin-sdk/v2/transformers"
+	"github.com/cloudquery/plugin-sdk/v3/schema"
+	"github.com/cloudquery/plugin-sdk/v3/transformers"
 	heroku "github.com/heroku/heroku-go/v5"
 	"github.com/pkg/errors"
 )

--- a/plugins/source/heroku/resources/services/add_on.go
+++ b/plugins/source/heroku/resources/services/add_on.go
@@ -3,6 +3,8 @@ package services
 import (
 	"context"
 
+	"github.com/apache/arrow/go/v13/arrow"
+
 	"github.com/cloudquery/cloudquery/plugins/source/heroku/client"
 	"github.com/cloudquery/plugin-sdk/v3/schema"
 	"github.com/cloudquery/plugin-sdk/v3/transformers"
@@ -18,12 +20,10 @@ func AddOns() *schema.Table {
 		Transform:   transformers.TransformWithStruct(&heroku.AddOn{}),
 		Columns: []schema.Column{
 			{
-				Name:     "id",
-				Type:     schema.TypeString,
-				Resolver: schema.PathResolver("ID"),
-				CreationOptions: schema.ColumnCreationOptions{
-					PrimaryKey: true,
-				},
+				Name:       "id",
+				Type:       arrow.BinaryTypes.String,
+				Resolver:   schema.PathResolver("ID"),
+				PrimaryKey: true,
 			},
 		},
 	}

--- a/plugins/source/heroku/resources/services/add_on_attachment.go
+++ b/plugins/source/heroku/resources/services/add_on_attachment.go
@@ -4,8 +4,8 @@ import (
 	"context"
 
 	"github.com/cloudquery/cloudquery/plugins/source/heroku/client"
-	"github.com/cloudquery/plugin-sdk/v2/schema"
-	"github.com/cloudquery/plugin-sdk/v2/transformers"
+	"github.com/cloudquery/plugin-sdk/v3/schema"
+	"github.com/cloudquery/plugin-sdk/v3/transformers"
 	heroku "github.com/heroku/heroku-go/v5"
 	"github.com/pkg/errors"
 )

--- a/plugins/source/heroku/resources/services/add_on_attachment.go
+++ b/plugins/source/heroku/resources/services/add_on_attachment.go
@@ -3,6 +3,8 @@ package services
 import (
 	"context"
 
+	"github.com/apache/arrow/go/v13/arrow"
+
 	"github.com/cloudquery/cloudquery/plugins/source/heroku/client"
 	"github.com/cloudquery/plugin-sdk/v3/schema"
 	"github.com/cloudquery/plugin-sdk/v3/transformers"
@@ -18,12 +20,10 @@ func AddOnAttachments() *schema.Table {
 		Transform:   transformers.TransformWithStruct(&heroku.AddOnAttachment{}),
 		Columns: []schema.Column{
 			{
-				Name:     "id",
-				Type:     schema.TypeString,
-				Resolver: schema.PathResolver("ID"),
-				CreationOptions: schema.ColumnCreationOptions{
-					PrimaryKey: true,
-				},
+				Name:       "id",
+				Type:       arrow.BinaryTypes.String,
+				Resolver:   schema.PathResolver("ID"),
+				PrimaryKey: true,
 			},
 		},
 	}

--- a/plugins/source/heroku/resources/services/add_on_attachment_mock_test.go
+++ b/plugins/source/heroku/resources/services/add_on_attachment_mock_test.go
@@ -7,7 +7,7 @@ import (
 	"testing"
 
 	"github.com/cloudquery/cloudquery/plugins/source/heroku/client"
-	"github.com/cloudquery/plugin-sdk/v2/faker"
+	"github.com/cloudquery/plugin-sdk/v3/faker"
 	heroku "github.com/heroku/heroku-go/v5"
 	"github.com/julienschmidt/httprouter"
 )

--- a/plugins/source/heroku/resources/services/add_on_config.go
+++ b/plugins/source/heroku/resources/services/add_on_config.go
@@ -4,8 +4,8 @@ import (
 	"context"
 
 	"github.com/cloudquery/cloudquery/plugins/source/heroku/client"
-	"github.com/cloudquery/plugin-sdk/v2/schema"
-	"github.com/cloudquery/plugin-sdk/v2/transformers"
+	"github.com/cloudquery/plugin-sdk/v3/schema"
+	"github.com/cloudquery/plugin-sdk/v3/transformers"
 	heroku "github.com/heroku/heroku-go/v5"
 	"github.com/pkg/errors"
 )

--- a/plugins/source/heroku/resources/services/add_on_config_mock_test.go
+++ b/plugins/source/heroku/resources/services/add_on_config_mock_test.go
@@ -7,7 +7,7 @@ import (
 	"testing"
 
 	"github.com/cloudquery/cloudquery/plugins/source/heroku/client"
-	"github.com/cloudquery/plugin-sdk/v2/faker"
+	"github.com/cloudquery/plugin-sdk/v3/faker"
 	heroku "github.com/heroku/heroku-go/v5"
 	"github.com/julienschmidt/httprouter"
 )

--- a/plugins/source/heroku/resources/services/add_on_mock_test.go
+++ b/plugins/source/heroku/resources/services/add_on_mock_test.go
@@ -7,7 +7,7 @@ import (
 	"testing"
 
 	"github.com/cloudquery/cloudquery/plugins/source/heroku/client"
-	"github.com/cloudquery/plugin-sdk/v2/faker"
+	"github.com/cloudquery/plugin-sdk/v3/faker"
 	heroku "github.com/heroku/heroku-go/v5"
 	"github.com/julienschmidt/httprouter"
 )

--- a/plugins/source/heroku/resources/services/add_on_region_capability.go
+++ b/plugins/source/heroku/resources/services/add_on_region_capability.go
@@ -3,6 +3,8 @@ package services
 import (
 	"context"
 
+	"github.com/apache/arrow/go/v13/arrow"
+
 	"github.com/cloudquery/cloudquery/plugins/source/heroku/client"
 	"github.com/cloudquery/plugin-sdk/v3/schema"
 	"github.com/cloudquery/plugin-sdk/v3/transformers"
@@ -18,12 +20,10 @@ func AddOnRegionCapabilities() *schema.Table {
 		Transform:   transformers.TransformWithStruct(&heroku.AddOnRegionCapability{}),
 		Columns: []schema.Column{
 			{
-				Name:     "id",
-				Type:     schema.TypeString,
-				Resolver: schema.PathResolver("ID"),
-				CreationOptions: schema.ColumnCreationOptions{
-					PrimaryKey: true,
-				},
+				Name:       "id",
+				Type:       arrow.BinaryTypes.String,
+				Resolver:   schema.PathResolver("ID"),
+				PrimaryKey: true,
 			},
 		},
 	}

--- a/plugins/source/heroku/resources/services/add_on_region_capability.go
+++ b/plugins/source/heroku/resources/services/add_on_region_capability.go
@@ -4,8 +4,8 @@ import (
 	"context"
 
 	"github.com/cloudquery/cloudquery/plugins/source/heroku/client"
-	"github.com/cloudquery/plugin-sdk/v2/schema"
-	"github.com/cloudquery/plugin-sdk/v2/transformers"
+	"github.com/cloudquery/plugin-sdk/v3/schema"
+	"github.com/cloudquery/plugin-sdk/v3/transformers"
 	heroku "github.com/heroku/heroku-go/v5"
 	"github.com/pkg/errors"
 )

--- a/plugins/source/heroku/resources/services/add_on_region_capability_mock_test.go
+++ b/plugins/source/heroku/resources/services/add_on_region_capability_mock_test.go
@@ -7,7 +7,7 @@ import (
 	"testing"
 
 	"github.com/cloudquery/cloudquery/plugins/source/heroku/client"
-	"github.com/cloudquery/plugin-sdk/v2/faker"
+	"github.com/cloudquery/plugin-sdk/v3/faker"
 	heroku "github.com/heroku/heroku-go/v5"
 	"github.com/julienschmidt/httprouter"
 )

--- a/plugins/source/heroku/resources/services/add_on_service.go
+++ b/plugins/source/heroku/resources/services/add_on_service.go
@@ -3,6 +3,8 @@ package services
 import (
 	"context"
 
+	"github.com/apache/arrow/go/v13/arrow"
+
 	"github.com/cloudquery/cloudquery/plugins/source/heroku/client"
 	"github.com/cloudquery/plugin-sdk/v3/schema"
 	"github.com/cloudquery/plugin-sdk/v3/transformers"
@@ -18,12 +20,10 @@ func AddOnServices() *schema.Table {
 		Transform:   transformers.TransformWithStruct(&heroku.AddOnService{}),
 		Columns: []schema.Column{
 			{
-				Name:     "id",
-				Type:     schema.TypeString,
-				Resolver: schema.PathResolver("ID"),
-				CreationOptions: schema.ColumnCreationOptions{
-					PrimaryKey: true,
-				},
+				Name:       "id",
+				Type:       arrow.BinaryTypes.String,
+				Resolver:   schema.PathResolver("ID"),
+				PrimaryKey: true,
 			},
 		},
 	}

--- a/plugins/source/heroku/resources/services/add_on_service.go
+++ b/plugins/source/heroku/resources/services/add_on_service.go
@@ -4,8 +4,8 @@ import (
 	"context"
 
 	"github.com/cloudquery/cloudquery/plugins/source/heroku/client"
-	"github.com/cloudquery/plugin-sdk/v2/schema"
-	"github.com/cloudquery/plugin-sdk/v2/transformers"
+	"github.com/cloudquery/plugin-sdk/v3/schema"
+	"github.com/cloudquery/plugin-sdk/v3/transformers"
 	heroku "github.com/heroku/heroku-go/v5"
 	"github.com/pkg/errors"
 )

--- a/plugins/source/heroku/resources/services/add_on_service_mock_test.go
+++ b/plugins/source/heroku/resources/services/add_on_service_mock_test.go
@@ -7,7 +7,7 @@ import (
 	"testing"
 
 	"github.com/cloudquery/cloudquery/plugins/source/heroku/client"
-	"github.com/cloudquery/plugin-sdk/v2/faker"
+	"github.com/cloudquery/plugin-sdk/v3/faker"
 	heroku "github.com/heroku/heroku-go/v5"
 	"github.com/julienschmidt/httprouter"
 )

--- a/plugins/source/heroku/resources/services/add_on_webhook.go
+++ b/plugins/source/heroku/resources/services/add_on_webhook.go
@@ -3,6 +3,8 @@ package services
 import (
 	"context"
 
+	"github.com/apache/arrow/go/v13/arrow"
+
 	"github.com/cloudquery/cloudquery/plugins/source/heroku/client"
 	"github.com/cloudquery/plugin-sdk/v3/schema"
 	"github.com/cloudquery/plugin-sdk/v3/transformers"
@@ -18,12 +20,10 @@ func AddOnWebhooks() *schema.Table {
 		Transform:   transformers.TransformWithStruct(&heroku.AddOnWebhook{}),
 		Columns: []schema.Column{
 			{
-				Name:     "id",
-				Type:     schema.TypeString,
-				Resolver: schema.PathResolver("ID"),
-				CreationOptions: schema.ColumnCreationOptions{
-					PrimaryKey: true,
-				},
+				Name:       "id",
+				Type:       arrow.BinaryTypes.String,
+				Resolver:   schema.PathResolver("ID"),
+				PrimaryKey: true,
 			},
 		},
 	}

--- a/plugins/source/heroku/resources/services/add_on_webhook.go
+++ b/plugins/source/heroku/resources/services/add_on_webhook.go
@@ -4,8 +4,8 @@ import (
 	"context"
 
 	"github.com/cloudquery/cloudquery/plugins/source/heroku/client"
-	"github.com/cloudquery/plugin-sdk/v2/schema"
-	"github.com/cloudquery/plugin-sdk/v2/transformers"
+	"github.com/cloudquery/plugin-sdk/v3/schema"
+	"github.com/cloudquery/plugin-sdk/v3/transformers"
 	heroku "github.com/heroku/heroku-go/v5"
 	"github.com/pkg/errors"
 )

--- a/plugins/source/heroku/resources/services/add_on_webhook_delivery.go
+++ b/plugins/source/heroku/resources/services/add_on_webhook_delivery.go
@@ -4,8 +4,8 @@ import (
 	"context"
 
 	"github.com/cloudquery/cloudquery/plugins/source/heroku/client"
-	"github.com/cloudquery/plugin-sdk/v2/schema"
-	"github.com/cloudquery/plugin-sdk/v2/transformers"
+	"github.com/cloudquery/plugin-sdk/v3/schema"
+	"github.com/cloudquery/plugin-sdk/v3/transformers"
 	heroku "github.com/heroku/heroku-go/v5"
 	"github.com/pkg/errors"
 )

--- a/plugins/source/heroku/resources/services/add_on_webhook_delivery.go
+++ b/plugins/source/heroku/resources/services/add_on_webhook_delivery.go
@@ -3,6 +3,8 @@ package services
 import (
 	"context"
 
+	"github.com/apache/arrow/go/v13/arrow"
+
 	"github.com/cloudquery/cloudquery/plugins/source/heroku/client"
 	"github.com/cloudquery/plugin-sdk/v3/schema"
 	"github.com/cloudquery/plugin-sdk/v3/transformers"
@@ -18,12 +20,10 @@ func AddOnWebhookDeliveries() *schema.Table {
 		Transform:   transformers.TransformWithStruct(&heroku.AddOnWebhookDeliveryInfoResult{}),
 		Columns: []schema.Column{
 			{
-				Name:     "id",
-				Type:     schema.TypeString,
-				Resolver: schema.PathResolver("ID"),
-				CreationOptions: schema.ColumnCreationOptions{
-					PrimaryKey: true,
-				},
+				Name:       "id",
+				Type:       arrow.BinaryTypes.String,
+				Resolver:   schema.PathResolver("ID"),
+				PrimaryKey: true,
 			},
 		},
 	}

--- a/plugins/source/heroku/resources/services/add_on_webhook_delivery_mock_test.go
+++ b/plugins/source/heroku/resources/services/add_on_webhook_delivery_mock_test.go
@@ -7,7 +7,7 @@ import (
 	"testing"
 
 	"github.com/cloudquery/cloudquery/plugins/source/heroku/client"
-	"github.com/cloudquery/plugin-sdk/v2/faker"
+	"github.com/cloudquery/plugin-sdk/v3/faker"
 	heroku "github.com/heroku/heroku-go/v5"
 	"github.com/julienschmidt/httprouter"
 )

--- a/plugins/source/heroku/resources/services/add_on_webhook_event.go
+++ b/plugins/source/heroku/resources/services/add_on_webhook_event.go
@@ -4,8 +4,8 @@ import (
 	"context"
 
 	"github.com/cloudquery/cloudquery/plugins/source/heroku/client"
-	"github.com/cloudquery/plugin-sdk/v2/schema"
-	"github.com/cloudquery/plugin-sdk/v2/transformers"
+	"github.com/cloudquery/plugin-sdk/v3/schema"
+	"github.com/cloudquery/plugin-sdk/v3/transformers"
 	heroku "github.com/heroku/heroku-go/v5"
 	"github.com/pkg/errors"
 )

--- a/plugins/source/heroku/resources/services/add_on_webhook_event.go
+++ b/plugins/source/heroku/resources/services/add_on_webhook_event.go
@@ -3,6 +3,8 @@ package services
 import (
 	"context"
 
+	"github.com/apache/arrow/go/v13/arrow"
+
 	"github.com/cloudquery/cloudquery/plugins/source/heroku/client"
 	"github.com/cloudquery/plugin-sdk/v3/schema"
 	"github.com/cloudquery/plugin-sdk/v3/transformers"
@@ -18,12 +20,10 @@ func AddOnWebhookEvents() *schema.Table {
 		Transform:   transformers.TransformWithStruct(&heroku.AddOnWebhookEventInfoResult{}),
 		Columns: []schema.Column{
 			{
-				Name:     "id",
-				Type:     schema.TypeString,
-				Resolver: schema.PathResolver("ID"),
-				CreationOptions: schema.ColumnCreationOptions{
-					PrimaryKey: true,
-				},
+				Name:       "id",
+				Type:       arrow.BinaryTypes.String,
+				Resolver:   schema.PathResolver("ID"),
+				PrimaryKey: true,
 			},
 		},
 	}

--- a/plugins/source/heroku/resources/services/add_on_webhook_event_mock_test.go
+++ b/plugins/source/heroku/resources/services/add_on_webhook_event_mock_test.go
@@ -7,7 +7,7 @@ import (
 	"testing"
 
 	"github.com/cloudquery/cloudquery/plugins/source/heroku/client"
-	"github.com/cloudquery/plugin-sdk/v2/faker"
+	"github.com/cloudquery/plugin-sdk/v3/faker"
 	heroku "github.com/heroku/heroku-go/v5"
 	"github.com/julienschmidt/httprouter"
 )

--- a/plugins/source/heroku/resources/services/add_on_webhook_mock_test.go
+++ b/plugins/source/heroku/resources/services/add_on_webhook_mock_test.go
@@ -7,7 +7,7 @@ import (
 	"testing"
 
 	"github.com/cloudquery/cloudquery/plugins/source/heroku/client"
-	"github.com/cloudquery/plugin-sdk/v2/faker"
+	"github.com/cloudquery/plugin-sdk/v3/faker"
 	heroku "github.com/heroku/heroku-go/v5"
 	"github.com/julienschmidt/httprouter"
 )

--- a/plugins/source/heroku/resources/services/app.go
+++ b/plugins/source/heroku/resources/services/app.go
@@ -4,8 +4,8 @@ import (
 	"context"
 
 	"github.com/cloudquery/cloudquery/plugins/source/heroku/client"
-	"github.com/cloudquery/plugin-sdk/v2/schema"
-	"github.com/cloudquery/plugin-sdk/v2/transformers"
+	"github.com/cloudquery/plugin-sdk/v3/schema"
+	"github.com/cloudquery/plugin-sdk/v3/transformers"
 	heroku "github.com/heroku/heroku-go/v5"
 	"github.com/pkg/errors"
 )

--- a/plugins/source/heroku/resources/services/app.go
+++ b/plugins/source/heroku/resources/services/app.go
@@ -3,6 +3,8 @@ package services
 import (
 	"context"
 
+	"github.com/apache/arrow/go/v13/arrow"
+
 	"github.com/cloudquery/cloudquery/plugins/source/heroku/client"
 	"github.com/cloudquery/plugin-sdk/v3/schema"
 	"github.com/cloudquery/plugin-sdk/v3/transformers"
@@ -18,12 +20,10 @@ func Apps() *schema.Table {
 		Transform:   transformers.TransformWithStruct(&heroku.App{}),
 		Columns: []schema.Column{
 			{
-				Name:     "id",
-				Type:     schema.TypeString,
-				Resolver: schema.PathResolver("ID"),
-				CreationOptions: schema.ColumnCreationOptions{
-					PrimaryKey: true,
-				},
+				Name:       "id",
+				Type:       arrow.BinaryTypes.String,
+				Resolver:   schema.PathResolver("ID"),
+				PrimaryKey: true,
 			},
 		},
 	}

--- a/plugins/source/heroku/resources/services/app_feature.go
+++ b/plugins/source/heroku/resources/services/app_feature.go
@@ -3,6 +3,8 @@ package services
 import (
 	"context"
 
+	"github.com/apache/arrow/go/v13/arrow"
+
 	"github.com/cloudquery/cloudquery/plugins/source/heroku/client"
 	"github.com/cloudquery/plugin-sdk/v3/schema"
 	"github.com/cloudquery/plugin-sdk/v3/transformers"
@@ -18,12 +20,10 @@ func AppFeatures() *schema.Table {
 		Transform:   transformers.TransformWithStruct(&heroku.AppFeature{}),
 		Columns: []schema.Column{
 			{
-				Name:     "id",
-				Type:     schema.TypeString,
-				Resolver: schema.PathResolver("ID"),
-				CreationOptions: schema.ColumnCreationOptions{
-					PrimaryKey: true,
-				},
+				Name:       "id",
+				Type:       arrow.BinaryTypes.String,
+				Resolver:   schema.PathResolver("ID"),
+				PrimaryKey: true,
 			},
 		},
 	}

--- a/plugins/source/heroku/resources/services/app_feature.go
+++ b/plugins/source/heroku/resources/services/app_feature.go
@@ -4,8 +4,8 @@ import (
 	"context"
 
 	"github.com/cloudquery/cloudquery/plugins/source/heroku/client"
-	"github.com/cloudquery/plugin-sdk/v2/schema"
-	"github.com/cloudquery/plugin-sdk/v2/transformers"
+	"github.com/cloudquery/plugin-sdk/v3/schema"
+	"github.com/cloudquery/plugin-sdk/v3/transformers"
 	heroku "github.com/heroku/heroku-go/v5"
 	"github.com/pkg/errors"
 )

--- a/plugins/source/heroku/resources/services/app_feature_mock_test.go
+++ b/plugins/source/heroku/resources/services/app_feature_mock_test.go
@@ -7,7 +7,7 @@ import (
 	"testing"
 
 	"github.com/cloudquery/cloudquery/plugins/source/heroku/client"
-	"github.com/cloudquery/plugin-sdk/v2/faker"
+	"github.com/cloudquery/plugin-sdk/v3/faker"
 	heroku "github.com/heroku/heroku-go/v5"
 	"github.com/julienschmidt/httprouter"
 )

--- a/plugins/source/heroku/resources/services/app_mock_test.go
+++ b/plugins/source/heroku/resources/services/app_mock_test.go
@@ -7,7 +7,7 @@ import (
 	"testing"
 
 	"github.com/cloudquery/cloudquery/plugins/source/heroku/client"
-	"github.com/cloudquery/plugin-sdk/v2/faker"
+	"github.com/cloudquery/plugin-sdk/v3/faker"
 	heroku "github.com/heroku/heroku-go/v5"
 	"github.com/julienschmidt/httprouter"
 )

--- a/plugins/source/heroku/resources/services/app_transfer.go
+++ b/plugins/source/heroku/resources/services/app_transfer.go
@@ -3,6 +3,8 @@ package services
 import (
 	"context"
 
+	"github.com/apache/arrow/go/v13/arrow"
+
 	"github.com/cloudquery/cloudquery/plugins/source/heroku/client"
 	"github.com/cloudquery/plugin-sdk/v3/schema"
 	"github.com/cloudquery/plugin-sdk/v3/transformers"
@@ -18,12 +20,10 @@ func AppTransfers() *schema.Table {
 		Transform:   transformers.TransformWithStruct(&heroku.AppTransfer{}),
 		Columns: []schema.Column{
 			{
-				Name:     "id",
-				Type:     schema.TypeString,
-				Resolver: schema.PathResolver("ID"),
-				CreationOptions: schema.ColumnCreationOptions{
-					PrimaryKey: true,
-				},
+				Name:       "id",
+				Type:       arrow.BinaryTypes.String,
+				Resolver:   schema.PathResolver("ID"),
+				PrimaryKey: true,
 			},
 		},
 	}

--- a/plugins/source/heroku/resources/services/app_transfer.go
+++ b/plugins/source/heroku/resources/services/app_transfer.go
@@ -4,8 +4,8 @@ import (
 	"context"
 
 	"github.com/cloudquery/cloudquery/plugins/source/heroku/client"
-	"github.com/cloudquery/plugin-sdk/v2/schema"
-	"github.com/cloudquery/plugin-sdk/v2/transformers"
+	"github.com/cloudquery/plugin-sdk/v3/schema"
+	"github.com/cloudquery/plugin-sdk/v3/transformers"
 	heroku "github.com/heroku/heroku-go/v5"
 	"github.com/pkg/errors"
 )

--- a/plugins/source/heroku/resources/services/app_transfer_mock_test.go
+++ b/plugins/source/heroku/resources/services/app_transfer_mock_test.go
@@ -7,7 +7,7 @@ import (
 	"testing"
 
 	"github.com/cloudquery/cloudquery/plugins/source/heroku/client"
-	"github.com/cloudquery/plugin-sdk/v2/faker"
+	"github.com/cloudquery/plugin-sdk/v3/faker"
 	heroku "github.com/heroku/heroku-go/v5"
 	"github.com/julienschmidt/httprouter"
 )

--- a/plugins/source/heroku/resources/services/app_webhook.go
+++ b/plugins/source/heroku/resources/services/app_webhook.go
@@ -3,6 +3,8 @@ package services
 import (
 	"context"
 
+	"github.com/apache/arrow/go/v13/arrow"
+
 	"github.com/cloudquery/cloudquery/plugins/source/heroku/client"
 	"github.com/cloudquery/plugin-sdk/v3/schema"
 	"github.com/cloudquery/plugin-sdk/v3/transformers"
@@ -18,12 +20,10 @@ func AppWebhooks() *schema.Table {
 		Transform:   transformers.TransformWithStruct(&heroku.AppWebhookInfoResult{}),
 		Columns: []schema.Column{
 			{
-				Name:     "id",
-				Type:     schema.TypeString,
-				Resolver: schema.PathResolver("ID"),
-				CreationOptions: schema.ColumnCreationOptions{
-					PrimaryKey: true,
-				},
+				Name:       "id",
+				Type:       arrow.BinaryTypes.String,
+				Resolver:   schema.PathResolver("ID"),
+				PrimaryKey: true,
 			},
 		},
 	}

--- a/plugins/source/heroku/resources/services/app_webhook.go
+++ b/plugins/source/heroku/resources/services/app_webhook.go
@@ -4,8 +4,8 @@ import (
 	"context"
 
 	"github.com/cloudquery/cloudquery/plugins/source/heroku/client"
-	"github.com/cloudquery/plugin-sdk/v2/schema"
-	"github.com/cloudquery/plugin-sdk/v2/transformers"
+	"github.com/cloudquery/plugin-sdk/v3/schema"
+	"github.com/cloudquery/plugin-sdk/v3/transformers"
 	heroku "github.com/heroku/heroku-go/v5"
 	"github.com/pkg/errors"
 )

--- a/plugins/source/heroku/resources/services/app_webhook_delivery.go
+++ b/plugins/source/heroku/resources/services/app_webhook_delivery.go
@@ -4,8 +4,8 @@ import (
 	"context"
 
 	"github.com/cloudquery/cloudquery/plugins/source/heroku/client"
-	"github.com/cloudquery/plugin-sdk/v2/schema"
-	"github.com/cloudquery/plugin-sdk/v2/transformers"
+	"github.com/cloudquery/plugin-sdk/v3/schema"
+	"github.com/cloudquery/plugin-sdk/v3/transformers"
 	heroku "github.com/heroku/heroku-go/v5"
 	"github.com/pkg/errors"
 )

--- a/plugins/source/heroku/resources/services/app_webhook_delivery.go
+++ b/plugins/source/heroku/resources/services/app_webhook_delivery.go
@@ -3,6 +3,8 @@ package services
 import (
 	"context"
 
+	"github.com/apache/arrow/go/v13/arrow"
+
 	"github.com/cloudquery/cloudquery/plugins/source/heroku/client"
 	"github.com/cloudquery/plugin-sdk/v3/schema"
 	"github.com/cloudquery/plugin-sdk/v3/transformers"
@@ -18,12 +20,10 @@ func AppWebhookDeliveries() *schema.Table {
 		Transform:   transformers.TransformWithStruct(&heroku.AppWebhookDelivery{}),
 		Columns: []schema.Column{
 			{
-				Name:     "id",
-				Type:     schema.TypeString,
-				Resolver: schema.PathResolver("ID"),
-				CreationOptions: schema.ColumnCreationOptions{
-					PrimaryKey: true,
-				},
+				Name:       "id",
+				Type:       arrow.BinaryTypes.String,
+				Resolver:   schema.PathResolver("ID"),
+				PrimaryKey: true,
 			},
 		},
 	}

--- a/plugins/source/heroku/resources/services/app_webhook_delivery_mock_test.go
+++ b/plugins/source/heroku/resources/services/app_webhook_delivery_mock_test.go
@@ -7,7 +7,7 @@ import (
 	"testing"
 
 	"github.com/cloudquery/cloudquery/plugins/source/heroku/client"
-	"github.com/cloudquery/plugin-sdk/v2/faker"
+	"github.com/cloudquery/plugin-sdk/v3/faker"
 	heroku "github.com/heroku/heroku-go/v5"
 	"github.com/julienschmidt/httprouter"
 )

--- a/plugins/source/heroku/resources/services/app_webhook_event.go
+++ b/plugins/source/heroku/resources/services/app_webhook_event.go
@@ -3,6 +3,8 @@ package services
 import (
 	"context"
 
+	"github.com/apache/arrow/go/v13/arrow"
+
 	"github.com/cloudquery/cloudquery/plugins/source/heroku/client"
 	"github.com/cloudquery/plugin-sdk/v3/schema"
 	"github.com/cloudquery/plugin-sdk/v3/transformers"
@@ -18,12 +20,10 @@ func AppWebhookEvents() *schema.Table {
 		Transform:   transformers.TransformWithStruct(&heroku.AppWebhookEvent{}),
 		Columns: []schema.Column{
 			{
-				Name:     "id",
-				Type:     schema.TypeString,
-				Resolver: schema.PathResolver("ID"),
-				CreationOptions: schema.ColumnCreationOptions{
-					PrimaryKey: true,
-				},
+				Name:       "id",
+				Type:       arrow.BinaryTypes.String,
+				Resolver:   schema.PathResolver("ID"),
+				PrimaryKey: true,
 			},
 		},
 	}

--- a/plugins/source/heroku/resources/services/app_webhook_event.go
+++ b/plugins/source/heroku/resources/services/app_webhook_event.go
@@ -4,8 +4,8 @@ import (
 	"context"
 
 	"github.com/cloudquery/cloudquery/plugins/source/heroku/client"
-	"github.com/cloudquery/plugin-sdk/v2/schema"
-	"github.com/cloudquery/plugin-sdk/v2/transformers"
+	"github.com/cloudquery/plugin-sdk/v3/schema"
+	"github.com/cloudquery/plugin-sdk/v3/transformers"
 	heroku "github.com/heroku/heroku-go/v5"
 	"github.com/pkg/errors"
 )

--- a/plugins/source/heroku/resources/services/app_webhook_event_mock_test.go
+++ b/plugins/source/heroku/resources/services/app_webhook_event_mock_test.go
@@ -7,7 +7,7 @@ import (
 	"testing"
 
 	"github.com/cloudquery/cloudquery/plugins/source/heroku/client"
-	"github.com/cloudquery/plugin-sdk/v2/faker"
+	"github.com/cloudquery/plugin-sdk/v3/faker"
 	heroku "github.com/heroku/heroku-go/v5"
 	"github.com/julienschmidt/httprouter"
 )

--- a/plugins/source/heroku/resources/services/app_webhook_mock_test.go
+++ b/plugins/source/heroku/resources/services/app_webhook_mock_test.go
@@ -7,7 +7,7 @@ import (
 	"testing"
 
 	"github.com/cloudquery/cloudquery/plugins/source/heroku/client"
-	"github.com/cloudquery/plugin-sdk/v2/faker"
+	"github.com/cloudquery/plugin-sdk/v3/faker"
 	heroku "github.com/heroku/heroku-go/v5"
 	"github.com/julienschmidt/httprouter"
 )

--- a/plugins/source/heroku/resources/services/build.go
+++ b/plugins/source/heroku/resources/services/build.go
@@ -3,6 +3,8 @@ package services
 import (
 	"context"
 
+	"github.com/apache/arrow/go/v13/arrow"
+
 	"github.com/cloudquery/cloudquery/plugins/source/heroku/client"
 	"github.com/cloudquery/plugin-sdk/v3/schema"
 	"github.com/cloudquery/plugin-sdk/v3/transformers"
@@ -18,12 +20,10 @@ func Builds() *schema.Table {
 		Transform:   transformers.TransformWithStruct(&heroku.Build{}),
 		Columns: []schema.Column{
 			{
-				Name:     "id",
-				Type:     schema.TypeString,
-				Resolver: schema.PathResolver("ID"),
-				CreationOptions: schema.ColumnCreationOptions{
-					PrimaryKey: true,
-				},
+				Name:       "id",
+				Type:       arrow.BinaryTypes.String,
+				Resolver:   schema.PathResolver("ID"),
+				PrimaryKey: true,
 			},
 		},
 	}

--- a/plugins/source/heroku/resources/services/build.go
+++ b/plugins/source/heroku/resources/services/build.go
@@ -4,8 +4,8 @@ import (
 	"context"
 
 	"github.com/cloudquery/cloudquery/plugins/source/heroku/client"
-	"github.com/cloudquery/plugin-sdk/v2/schema"
-	"github.com/cloudquery/plugin-sdk/v2/transformers"
+	"github.com/cloudquery/plugin-sdk/v3/schema"
+	"github.com/cloudquery/plugin-sdk/v3/transformers"
 	heroku "github.com/heroku/heroku-go/v5"
 	"github.com/pkg/errors"
 )

--- a/plugins/source/heroku/resources/services/build_mock_test.go
+++ b/plugins/source/heroku/resources/services/build_mock_test.go
@@ -7,7 +7,7 @@ import (
 	"testing"
 
 	"github.com/cloudquery/cloudquery/plugins/source/heroku/client"
-	"github.com/cloudquery/plugin-sdk/v2/faker"
+	"github.com/cloudquery/plugin-sdk/v3/faker"
 	heroku "github.com/heroku/heroku-go/v5"
 	"github.com/julienschmidt/httprouter"
 )

--- a/plugins/source/heroku/resources/services/buildpack_installation.go
+++ b/plugins/source/heroku/resources/services/buildpack_installation.go
@@ -4,8 +4,8 @@ import (
 	"context"
 
 	"github.com/cloudquery/cloudquery/plugins/source/heroku/client"
-	"github.com/cloudquery/plugin-sdk/v2/schema"
-	"github.com/cloudquery/plugin-sdk/v2/transformers"
+	"github.com/cloudquery/plugin-sdk/v3/schema"
+	"github.com/cloudquery/plugin-sdk/v3/transformers"
 	heroku "github.com/heroku/heroku-go/v5"
 	"github.com/pkg/errors"
 )

--- a/plugins/source/heroku/resources/services/buildpack_installation_mock_test.go
+++ b/plugins/source/heroku/resources/services/buildpack_installation_mock_test.go
@@ -7,7 +7,7 @@ import (
 	"testing"
 
 	"github.com/cloudquery/cloudquery/plugins/source/heroku/client"
-	"github.com/cloudquery/plugin-sdk/v2/faker"
+	"github.com/cloudquery/plugin-sdk/v3/faker"
 	heroku "github.com/heroku/heroku-go/v5"
 	"github.com/julienschmidt/httprouter"
 )

--- a/plugins/source/heroku/resources/services/collaborator.go
+++ b/plugins/source/heroku/resources/services/collaborator.go
@@ -4,8 +4,8 @@ import (
 	"context"
 
 	"github.com/cloudquery/cloudquery/plugins/source/heroku/client"
-	"github.com/cloudquery/plugin-sdk/v2/schema"
-	"github.com/cloudquery/plugin-sdk/v2/transformers"
+	"github.com/cloudquery/plugin-sdk/v3/schema"
+	"github.com/cloudquery/plugin-sdk/v3/transformers"
 	heroku "github.com/heroku/heroku-go/v5"
 	"github.com/pkg/errors"
 )

--- a/plugins/source/heroku/resources/services/collaborator.go
+++ b/plugins/source/heroku/resources/services/collaborator.go
@@ -3,6 +3,8 @@ package services
 import (
 	"context"
 
+	"github.com/apache/arrow/go/v13/arrow"
+
 	"github.com/cloudquery/cloudquery/plugins/source/heroku/client"
 	"github.com/cloudquery/plugin-sdk/v3/schema"
 	"github.com/cloudquery/plugin-sdk/v3/transformers"
@@ -18,12 +20,10 @@ func Collaborators() *schema.Table {
 		Transform:   transformers.TransformWithStruct(&heroku.Collaborator{}),
 		Columns: []schema.Column{
 			{
-				Name:     "id",
-				Type:     schema.TypeString,
-				Resolver: schema.PathResolver("ID"),
-				CreationOptions: schema.ColumnCreationOptions{
-					PrimaryKey: true,
-				},
+				Name:       "id",
+				Type:       arrow.BinaryTypes.String,
+				Resolver:   schema.PathResolver("ID"),
+				PrimaryKey: true,
 			},
 		},
 	}

--- a/plugins/source/heroku/resources/services/collaborator_mock_test.go
+++ b/plugins/source/heroku/resources/services/collaborator_mock_test.go
@@ -7,7 +7,7 @@ import (
 	"testing"
 
 	"github.com/cloudquery/cloudquery/plugins/source/heroku/client"
-	"github.com/cloudquery/plugin-sdk/v2/faker"
+	"github.com/cloudquery/plugin-sdk/v3/faker"
 	heroku "github.com/heroku/heroku-go/v5"
 	"github.com/julienschmidt/httprouter"
 )

--- a/plugins/source/heroku/resources/services/credit.go
+++ b/plugins/source/heroku/resources/services/credit.go
@@ -3,6 +3,8 @@ package services
 import (
 	"context"
 
+	"github.com/apache/arrow/go/v13/arrow"
+
 	"github.com/cloudquery/cloudquery/plugins/source/heroku/client"
 	"github.com/cloudquery/plugin-sdk/v3/schema"
 	"github.com/cloudquery/plugin-sdk/v3/transformers"
@@ -18,12 +20,10 @@ func Credits() *schema.Table {
 		Transform:   transformers.TransformWithStruct(&heroku.Credit{}),
 		Columns: []schema.Column{
 			{
-				Name:     "id",
-				Type:     schema.TypeString,
-				Resolver: schema.PathResolver("ID"),
-				CreationOptions: schema.ColumnCreationOptions{
-					PrimaryKey: true,
-				},
+				Name:       "id",
+				Type:       arrow.BinaryTypes.String,
+				Resolver:   schema.PathResolver("ID"),
+				PrimaryKey: true,
 			},
 		},
 	}

--- a/plugins/source/heroku/resources/services/credit.go
+++ b/plugins/source/heroku/resources/services/credit.go
@@ -4,8 +4,8 @@ import (
 	"context"
 
 	"github.com/cloudquery/cloudquery/plugins/source/heroku/client"
-	"github.com/cloudquery/plugin-sdk/v2/schema"
-	"github.com/cloudquery/plugin-sdk/v2/transformers"
+	"github.com/cloudquery/plugin-sdk/v3/schema"
+	"github.com/cloudquery/plugin-sdk/v3/transformers"
 	heroku "github.com/heroku/heroku-go/v5"
 	"github.com/pkg/errors"
 )

--- a/plugins/source/heroku/resources/services/credit_mock_test.go
+++ b/plugins/source/heroku/resources/services/credit_mock_test.go
@@ -7,7 +7,7 @@ import (
 	"testing"
 
 	"github.com/cloudquery/cloudquery/plugins/source/heroku/client"
-	"github.com/cloudquery/plugin-sdk/v2/faker"
+	"github.com/cloudquery/plugin-sdk/v3/faker"
 	heroku "github.com/heroku/heroku-go/v5"
 	"github.com/julienschmidt/httprouter"
 )

--- a/plugins/source/heroku/resources/services/domain.go
+++ b/plugins/source/heroku/resources/services/domain.go
@@ -3,6 +3,8 @@ package services
 import (
 	"context"
 
+	"github.com/apache/arrow/go/v13/arrow"
+
 	"github.com/cloudquery/cloudquery/plugins/source/heroku/client"
 	"github.com/cloudquery/plugin-sdk/v3/schema"
 	"github.com/cloudquery/plugin-sdk/v3/transformers"
@@ -18,12 +20,10 @@ func Domains() *schema.Table {
 		Transform:   transformers.TransformWithStruct(&heroku.Domain{}),
 		Columns: []schema.Column{
 			{
-				Name:     "id",
-				Type:     schema.TypeString,
-				Resolver: schema.PathResolver("ID"),
-				CreationOptions: schema.ColumnCreationOptions{
-					PrimaryKey: true,
-				},
+				Name:       "id",
+				Type:       arrow.BinaryTypes.String,
+				Resolver:   schema.PathResolver("ID"),
+				PrimaryKey: true,
 			},
 		},
 	}

--- a/plugins/source/heroku/resources/services/domain.go
+++ b/plugins/source/heroku/resources/services/domain.go
@@ -4,8 +4,8 @@ import (
 	"context"
 
 	"github.com/cloudquery/cloudquery/plugins/source/heroku/client"
-	"github.com/cloudquery/plugin-sdk/v2/schema"
-	"github.com/cloudquery/plugin-sdk/v2/transformers"
+	"github.com/cloudquery/plugin-sdk/v3/schema"
+	"github.com/cloudquery/plugin-sdk/v3/transformers"
 	heroku "github.com/heroku/heroku-go/v5"
 	"github.com/pkg/errors"
 )

--- a/plugins/source/heroku/resources/services/domain_mock_test.go
+++ b/plugins/source/heroku/resources/services/domain_mock_test.go
@@ -7,7 +7,7 @@ import (
 	"testing"
 
 	"github.com/cloudquery/cloudquery/plugins/source/heroku/client"
-	"github.com/cloudquery/plugin-sdk/v2/faker"
+	"github.com/cloudquery/plugin-sdk/v3/faker"
 	heroku "github.com/heroku/heroku-go/v5"
 	"github.com/julienschmidt/httprouter"
 )

--- a/plugins/source/heroku/resources/services/dyno.go
+++ b/plugins/source/heroku/resources/services/dyno.go
@@ -4,8 +4,8 @@ import (
 	"context"
 
 	"github.com/cloudquery/cloudquery/plugins/source/heroku/client"
-	"github.com/cloudquery/plugin-sdk/v2/schema"
-	"github.com/cloudquery/plugin-sdk/v2/transformers"
+	"github.com/cloudquery/plugin-sdk/v3/schema"
+	"github.com/cloudquery/plugin-sdk/v3/transformers"
 	heroku "github.com/heroku/heroku-go/v5"
 	"github.com/pkg/errors"
 )

--- a/plugins/source/heroku/resources/services/dyno.go
+++ b/plugins/source/heroku/resources/services/dyno.go
@@ -3,6 +3,8 @@ package services
 import (
 	"context"
 
+	"github.com/apache/arrow/go/v13/arrow"
+
 	"github.com/cloudquery/cloudquery/plugins/source/heroku/client"
 	"github.com/cloudquery/plugin-sdk/v3/schema"
 	"github.com/cloudquery/plugin-sdk/v3/transformers"
@@ -18,12 +20,10 @@ func Dynos() *schema.Table {
 		Transform:   transformers.TransformWithStruct(&heroku.Dyno{}),
 		Columns: []schema.Column{
 			{
-				Name:     "id",
-				Type:     schema.TypeString,
-				Resolver: schema.PathResolver("ID"),
-				CreationOptions: schema.ColumnCreationOptions{
-					PrimaryKey: true,
-				},
+				Name:       "id",
+				Type:       arrow.BinaryTypes.String,
+				Resolver:   schema.PathResolver("ID"),
+				PrimaryKey: true,
 			},
 		},
 	}

--- a/plugins/source/heroku/resources/services/dyno_mock_test.go
+++ b/plugins/source/heroku/resources/services/dyno_mock_test.go
@@ -7,7 +7,7 @@ import (
 	"testing"
 
 	"github.com/cloudquery/cloudquery/plugins/source/heroku/client"
-	"github.com/cloudquery/plugin-sdk/v2/faker"
+	"github.com/cloudquery/plugin-sdk/v3/faker"
 	heroku "github.com/heroku/heroku-go/v5"
 	"github.com/julienschmidt/httprouter"
 )

--- a/plugins/source/heroku/resources/services/dyno_size.go
+++ b/plugins/source/heroku/resources/services/dyno_size.go
@@ -3,6 +3,8 @@ package services
 import (
 	"context"
 
+	"github.com/apache/arrow/go/v13/arrow"
+
 	"github.com/cloudquery/cloudquery/plugins/source/heroku/client"
 	"github.com/cloudquery/plugin-sdk/v3/schema"
 	"github.com/cloudquery/plugin-sdk/v3/transformers"
@@ -18,12 +20,10 @@ func DynoSizes() *schema.Table {
 		Transform:   transformers.TransformWithStruct(&heroku.DynoSize{}),
 		Columns: []schema.Column{
 			{
-				Name:     "id",
-				Type:     schema.TypeString,
-				Resolver: schema.PathResolver("ID"),
-				CreationOptions: schema.ColumnCreationOptions{
-					PrimaryKey: true,
-				},
+				Name:       "id",
+				Type:       arrow.BinaryTypes.String,
+				Resolver:   schema.PathResolver("ID"),
+				PrimaryKey: true,
 			},
 		},
 	}

--- a/plugins/source/heroku/resources/services/dyno_size.go
+++ b/plugins/source/heroku/resources/services/dyno_size.go
@@ -4,8 +4,8 @@ import (
 	"context"
 
 	"github.com/cloudquery/cloudquery/plugins/source/heroku/client"
-	"github.com/cloudquery/plugin-sdk/v2/schema"
-	"github.com/cloudquery/plugin-sdk/v2/transformers"
+	"github.com/cloudquery/plugin-sdk/v3/schema"
+	"github.com/cloudquery/plugin-sdk/v3/transformers"
 	heroku "github.com/heroku/heroku-go/v5"
 	"github.com/pkg/errors"
 )

--- a/plugins/source/heroku/resources/services/dyno_size_mock_test.go
+++ b/plugins/source/heroku/resources/services/dyno_size_mock_test.go
@@ -7,7 +7,7 @@ import (
 	"testing"
 
 	"github.com/cloudquery/cloudquery/plugins/source/heroku/client"
-	"github.com/cloudquery/plugin-sdk/v2/faker"
+	"github.com/cloudquery/plugin-sdk/v3/faker"
 	heroku "github.com/heroku/heroku-go/v5"
 	"github.com/julienschmidt/httprouter"
 )

--- a/plugins/source/heroku/resources/services/enterprise_account.go
+++ b/plugins/source/heroku/resources/services/enterprise_account.go
@@ -3,6 +3,8 @@ package services
 import (
 	"context"
 
+	"github.com/apache/arrow/go/v13/arrow"
+
 	"github.com/cloudquery/cloudquery/plugins/source/heroku/client"
 	"github.com/cloudquery/plugin-sdk/v3/schema"
 	"github.com/cloudquery/plugin-sdk/v3/transformers"
@@ -18,12 +20,10 @@ func EnterpriseAccounts() *schema.Table {
 		Transform:   transformers.TransformWithStruct(&heroku.EnterpriseAccount{}),
 		Columns: []schema.Column{
 			{
-				Name:     "id",
-				Type:     schema.TypeString,
-				Resolver: schema.PathResolver("ID"),
-				CreationOptions: schema.ColumnCreationOptions{
-					PrimaryKey: true,
-				},
+				Name:       "id",
+				Type:       arrow.BinaryTypes.String,
+				Resolver:   schema.PathResolver("ID"),
+				PrimaryKey: true,
 			},
 		},
 	}

--- a/plugins/source/heroku/resources/services/enterprise_account.go
+++ b/plugins/source/heroku/resources/services/enterprise_account.go
@@ -4,8 +4,8 @@ import (
 	"context"
 
 	"github.com/cloudquery/cloudquery/plugins/source/heroku/client"
-	"github.com/cloudquery/plugin-sdk/v2/schema"
-	"github.com/cloudquery/plugin-sdk/v2/transformers"
+	"github.com/cloudquery/plugin-sdk/v3/schema"
+	"github.com/cloudquery/plugin-sdk/v3/transformers"
 	heroku "github.com/heroku/heroku-go/v5"
 	"github.com/pkg/errors"
 )

--- a/plugins/source/heroku/resources/services/enterprise_account_member.go
+++ b/plugins/source/heroku/resources/services/enterprise_account_member.go
@@ -4,8 +4,8 @@ import (
 	"context"
 
 	"github.com/cloudquery/cloudquery/plugins/source/heroku/client"
-	"github.com/cloudquery/plugin-sdk/v2/schema"
-	"github.com/cloudquery/plugin-sdk/v2/transformers"
+	"github.com/cloudquery/plugin-sdk/v3/schema"
+	"github.com/cloudquery/plugin-sdk/v3/transformers"
 	heroku "github.com/heroku/heroku-go/v5"
 	"github.com/pkg/errors"
 )

--- a/plugins/source/heroku/resources/services/enterprise_account_member.go
+++ b/plugins/source/heroku/resources/services/enterprise_account_member.go
@@ -3,6 +3,8 @@ package services
 import (
 	"context"
 
+	"github.com/apache/arrow/go/v13/arrow"
+
 	"github.com/cloudquery/cloudquery/plugins/source/heroku/client"
 	"github.com/cloudquery/plugin-sdk/v3/schema"
 	"github.com/cloudquery/plugin-sdk/v3/transformers"
@@ -18,12 +20,10 @@ func EnterpriseAccountMembers() *schema.Table {
 		Transform:   transformers.TransformWithStruct(&heroku.EnterpriseAccountMember{}),
 		Columns: []schema.Column{
 			{
-				Name:     "id",
-				Type:     schema.TypeString,
-				Resolver: schema.PathResolver("ID"),
-				CreationOptions: schema.ColumnCreationOptions{
-					PrimaryKey: true,
-				},
+				Name:       "id",
+				Type:       arrow.BinaryTypes.String,
+				Resolver:   schema.PathResolver("ID"),
+				PrimaryKey: true,
 			},
 		},
 	}

--- a/plugins/source/heroku/resources/services/enterprise_account_member_mock_test.go
+++ b/plugins/source/heroku/resources/services/enterprise_account_member_mock_test.go
@@ -7,7 +7,7 @@ import (
 	"testing"
 
 	"github.com/cloudquery/cloudquery/plugins/source/heroku/client"
-	"github.com/cloudquery/plugin-sdk/v2/faker"
+	"github.com/cloudquery/plugin-sdk/v3/faker"
 	heroku "github.com/heroku/heroku-go/v5"
 	"github.com/julienschmidt/httprouter"
 )

--- a/plugins/source/heroku/resources/services/enterprise_account_mock_test.go
+++ b/plugins/source/heroku/resources/services/enterprise_account_mock_test.go
@@ -7,7 +7,7 @@ import (
 	"testing"
 
 	"github.com/cloudquery/cloudquery/plugins/source/heroku/client"
-	"github.com/cloudquery/plugin-sdk/v2/faker"
+	"github.com/cloudquery/plugin-sdk/v3/faker"
 	heroku "github.com/heroku/heroku-go/v5"
 	"github.com/julienschmidt/httprouter"
 )

--- a/plugins/source/heroku/resources/services/formation.go
+++ b/plugins/source/heroku/resources/services/formation.go
@@ -3,6 +3,8 @@ package services
 import (
 	"context"
 
+	"github.com/apache/arrow/go/v13/arrow"
+
 	"github.com/cloudquery/cloudquery/plugins/source/heroku/client"
 	"github.com/cloudquery/plugin-sdk/v3/schema"
 	"github.com/cloudquery/plugin-sdk/v3/transformers"
@@ -18,12 +20,10 @@ func Formations() *schema.Table {
 		Transform:   transformers.TransformWithStruct(&heroku.Formation{}),
 		Columns: []schema.Column{
 			{
-				Name:     "id",
-				Type:     schema.TypeString,
-				Resolver: schema.PathResolver("ID"),
-				CreationOptions: schema.ColumnCreationOptions{
-					PrimaryKey: true,
-				},
+				Name:       "id",
+				Type:       arrow.BinaryTypes.String,
+				Resolver:   schema.PathResolver("ID"),
+				PrimaryKey: true,
 			},
 		},
 	}

--- a/plugins/source/heroku/resources/services/formation.go
+++ b/plugins/source/heroku/resources/services/formation.go
@@ -4,8 +4,8 @@ import (
 	"context"
 
 	"github.com/cloudquery/cloudquery/plugins/source/heroku/client"
-	"github.com/cloudquery/plugin-sdk/v2/schema"
-	"github.com/cloudquery/plugin-sdk/v2/transformers"
+	"github.com/cloudquery/plugin-sdk/v3/schema"
+	"github.com/cloudquery/plugin-sdk/v3/transformers"
 	heroku "github.com/heroku/heroku-go/v5"
 	"github.com/pkg/errors"
 )

--- a/plugins/source/heroku/resources/services/formation_mock_test.go
+++ b/plugins/source/heroku/resources/services/formation_mock_test.go
@@ -7,7 +7,7 @@ import (
 	"testing"
 
 	"github.com/cloudquery/cloudquery/plugins/source/heroku/client"
-	"github.com/cloudquery/plugin-sdk/v2/faker"
+	"github.com/cloudquery/plugin-sdk/v3/faker"
 	heroku "github.com/heroku/heroku-go/v5"
 	"github.com/julienschmidt/httprouter"
 )

--- a/plugins/source/heroku/resources/services/inbound_ruleset.go
+++ b/plugins/source/heroku/resources/services/inbound_ruleset.go
@@ -3,6 +3,8 @@ package services
 import (
 	"context"
 
+	"github.com/apache/arrow/go/v13/arrow"
+
 	"github.com/cloudquery/cloudquery/plugins/source/heroku/client"
 	"github.com/cloudquery/plugin-sdk/v3/schema"
 	"github.com/cloudquery/plugin-sdk/v3/transformers"
@@ -18,12 +20,10 @@ func InboundRulesets() *schema.Table {
 		Transform:   transformers.TransformWithStruct(&heroku.InboundRuleset{}),
 		Columns: []schema.Column{
 			{
-				Name:     "id",
-				Type:     schema.TypeString,
-				Resolver: schema.PathResolver("ID"),
-				CreationOptions: schema.ColumnCreationOptions{
-					PrimaryKey: true,
-				},
+				Name:       "id",
+				Type:       arrow.BinaryTypes.String,
+				Resolver:   schema.PathResolver("ID"),
+				PrimaryKey: true,
 			},
 		},
 	}

--- a/plugins/source/heroku/resources/services/inbound_ruleset.go
+++ b/plugins/source/heroku/resources/services/inbound_ruleset.go
@@ -4,8 +4,8 @@ import (
 	"context"
 
 	"github.com/cloudquery/cloudquery/plugins/source/heroku/client"
-	"github.com/cloudquery/plugin-sdk/v2/schema"
-	"github.com/cloudquery/plugin-sdk/v2/transformers"
+	"github.com/cloudquery/plugin-sdk/v3/schema"
+	"github.com/cloudquery/plugin-sdk/v3/transformers"
 	heroku "github.com/heroku/heroku-go/v5"
 	"github.com/pkg/errors"
 )

--- a/plugins/source/heroku/resources/services/inbound_ruleset_mock_test.go
+++ b/plugins/source/heroku/resources/services/inbound_ruleset_mock_test.go
@@ -7,7 +7,7 @@ import (
 	"testing"
 
 	"github.com/cloudquery/cloudquery/plugins/source/heroku/client"
-	"github.com/cloudquery/plugin-sdk/v2/faker"
+	"github.com/cloudquery/plugin-sdk/v3/faker"
 	heroku "github.com/heroku/heroku-go/v5"
 	"github.com/julienschmidt/httprouter"
 )

--- a/plugins/source/heroku/resources/services/invoice.go
+++ b/plugins/source/heroku/resources/services/invoice.go
@@ -4,8 +4,8 @@ import (
 	"context"
 
 	"github.com/cloudquery/cloudquery/plugins/source/heroku/client"
-	"github.com/cloudquery/plugin-sdk/v2/schema"
-	"github.com/cloudquery/plugin-sdk/v2/transformers"
+	"github.com/cloudquery/plugin-sdk/v3/schema"
+	"github.com/cloudquery/plugin-sdk/v3/transformers"
 	heroku "github.com/heroku/heroku-go/v5"
 	"github.com/pkg/errors"
 )

--- a/plugins/source/heroku/resources/services/invoice.go
+++ b/plugins/source/heroku/resources/services/invoice.go
@@ -3,6 +3,8 @@ package services
 import (
 	"context"
 
+	"github.com/apache/arrow/go/v13/arrow"
+
 	"github.com/cloudquery/cloudquery/plugins/source/heroku/client"
 	"github.com/cloudquery/plugin-sdk/v3/schema"
 	"github.com/cloudquery/plugin-sdk/v3/transformers"
@@ -18,12 +20,10 @@ func Invoices() *schema.Table {
 		Transform:   transformers.TransformWithStruct(&heroku.Invoice{}),
 		Columns: []schema.Column{
 			{
-				Name:     "id",
-				Type:     schema.TypeString,
-				Resolver: schema.PathResolver("ID"),
-				CreationOptions: schema.ColumnCreationOptions{
-					PrimaryKey: true,
-				},
+				Name:       "id",
+				Type:       arrow.BinaryTypes.String,
+				Resolver:   schema.PathResolver("ID"),
+				PrimaryKey: true,
 			},
 		},
 	}

--- a/plugins/source/heroku/resources/services/invoice_mock_test.go
+++ b/plugins/source/heroku/resources/services/invoice_mock_test.go
@@ -7,7 +7,7 @@ import (
 	"testing"
 
 	"github.com/cloudquery/cloudquery/plugins/source/heroku/client"
-	"github.com/cloudquery/plugin-sdk/v2/faker"
+	"github.com/cloudquery/plugin-sdk/v3/faker"
 	heroku "github.com/heroku/heroku-go/v5"
 	"github.com/julienschmidt/httprouter"
 )

--- a/plugins/source/heroku/resources/services/key.go
+++ b/plugins/source/heroku/resources/services/key.go
@@ -4,8 +4,8 @@ import (
 	"context"
 
 	"github.com/cloudquery/cloudquery/plugins/source/heroku/client"
-	"github.com/cloudquery/plugin-sdk/v2/schema"
-	"github.com/cloudquery/plugin-sdk/v2/transformers"
+	"github.com/cloudquery/plugin-sdk/v3/schema"
+	"github.com/cloudquery/plugin-sdk/v3/transformers"
 	heroku "github.com/heroku/heroku-go/v5"
 	"github.com/pkg/errors"
 )

--- a/plugins/source/heroku/resources/services/key.go
+++ b/plugins/source/heroku/resources/services/key.go
@@ -3,6 +3,8 @@ package services
 import (
 	"context"
 
+	"github.com/apache/arrow/go/v13/arrow"
+
 	"github.com/cloudquery/cloudquery/plugins/source/heroku/client"
 	"github.com/cloudquery/plugin-sdk/v3/schema"
 	"github.com/cloudquery/plugin-sdk/v3/transformers"
@@ -18,12 +20,10 @@ func Keys() *schema.Table {
 		Transform:   transformers.TransformWithStruct(&heroku.Key{}),
 		Columns: []schema.Column{
 			{
-				Name:     "id",
-				Type:     schema.TypeString,
-				Resolver: schema.PathResolver("ID"),
-				CreationOptions: schema.ColumnCreationOptions{
-					PrimaryKey: true,
-				},
+				Name:       "id",
+				Type:       arrow.BinaryTypes.String,
+				Resolver:   schema.PathResolver("ID"),
+				PrimaryKey: true,
 			},
 		},
 	}

--- a/plugins/source/heroku/resources/services/key_mock_test.go
+++ b/plugins/source/heroku/resources/services/key_mock_test.go
@@ -7,7 +7,7 @@ import (
 	"testing"
 
 	"github.com/cloudquery/cloudquery/plugins/source/heroku/client"
-	"github.com/cloudquery/plugin-sdk/v2/faker"
+	"github.com/cloudquery/plugin-sdk/v3/faker"
 	heroku "github.com/heroku/heroku-go/v5"
 	"github.com/julienschmidt/httprouter"
 )

--- a/plugins/source/heroku/resources/services/log_drain.go
+++ b/plugins/source/heroku/resources/services/log_drain.go
@@ -4,8 +4,8 @@ import (
 	"context"
 
 	"github.com/cloudquery/cloudquery/plugins/source/heroku/client"
-	"github.com/cloudquery/plugin-sdk/v2/schema"
-	"github.com/cloudquery/plugin-sdk/v2/transformers"
+	"github.com/cloudquery/plugin-sdk/v3/schema"
+	"github.com/cloudquery/plugin-sdk/v3/transformers"
 	heroku "github.com/heroku/heroku-go/v5"
 	"github.com/pkg/errors"
 )

--- a/plugins/source/heroku/resources/services/log_drain.go
+++ b/plugins/source/heroku/resources/services/log_drain.go
@@ -3,6 +3,8 @@ package services
 import (
 	"context"
 
+	"github.com/apache/arrow/go/v13/arrow"
+
 	"github.com/cloudquery/cloudquery/plugins/source/heroku/client"
 	"github.com/cloudquery/plugin-sdk/v3/schema"
 	"github.com/cloudquery/plugin-sdk/v3/transformers"
@@ -18,12 +20,10 @@ func LogDrains() *schema.Table {
 		Transform:   transformers.TransformWithStruct(&heroku.LogDrain{}),
 		Columns: []schema.Column{
 			{
-				Name:     "id",
-				Type:     schema.TypeString,
-				Resolver: schema.PathResolver("ID"),
-				CreationOptions: schema.ColumnCreationOptions{
-					PrimaryKey: true,
-				},
+				Name:       "id",
+				Type:       arrow.BinaryTypes.String,
+				Resolver:   schema.PathResolver("ID"),
+				PrimaryKey: true,
 			},
 		},
 	}

--- a/plugins/source/heroku/resources/services/log_drain_mock_test.go
+++ b/plugins/source/heroku/resources/services/log_drain_mock_test.go
@@ -7,7 +7,7 @@ import (
 	"testing"
 
 	"github.com/cloudquery/cloudquery/plugins/source/heroku/client"
-	"github.com/cloudquery/plugin-sdk/v2/faker"
+	"github.com/cloudquery/plugin-sdk/v3/faker"
 	heroku "github.com/heroku/heroku-go/v5"
 	"github.com/julienschmidt/httprouter"
 )

--- a/plugins/source/heroku/resources/services/o_auth_authorization.go
+++ b/plugins/source/heroku/resources/services/o_auth_authorization.go
@@ -3,6 +3,8 @@ package services
 import (
 	"context"
 
+	"github.com/apache/arrow/go/v13/arrow"
+
 	"github.com/cloudquery/cloudquery/plugins/source/heroku/client"
 	"github.com/cloudquery/plugin-sdk/v3/schema"
 	"github.com/cloudquery/plugin-sdk/v3/transformers"
@@ -18,12 +20,10 @@ func OAuthAuthorizations() *schema.Table {
 		Transform:   transformers.TransformWithStruct(&heroku.OAuthAuthorization{}),
 		Columns: []schema.Column{
 			{
-				Name:     "id",
-				Type:     schema.TypeString,
-				Resolver: schema.PathResolver("ID"),
-				CreationOptions: schema.ColumnCreationOptions{
-					PrimaryKey: true,
-				},
+				Name:       "id",
+				Type:       arrow.BinaryTypes.String,
+				Resolver:   schema.PathResolver("ID"),
+				PrimaryKey: true,
 			},
 		},
 	}

--- a/plugins/source/heroku/resources/services/o_auth_authorization.go
+++ b/plugins/source/heroku/resources/services/o_auth_authorization.go
@@ -4,8 +4,8 @@ import (
 	"context"
 
 	"github.com/cloudquery/cloudquery/plugins/source/heroku/client"
-	"github.com/cloudquery/plugin-sdk/v2/schema"
-	"github.com/cloudquery/plugin-sdk/v2/transformers"
+	"github.com/cloudquery/plugin-sdk/v3/schema"
+	"github.com/cloudquery/plugin-sdk/v3/transformers"
 	heroku "github.com/heroku/heroku-go/v5"
 	"github.com/pkg/errors"
 )

--- a/plugins/source/heroku/resources/services/o_auth_authorization_mock_test.go
+++ b/plugins/source/heroku/resources/services/o_auth_authorization_mock_test.go
@@ -7,7 +7,7 @@ import (
 	"testing"
 
 	"github.com/cloudquery/cloudquery/plugins/source/heroku/client"
-	"github.com/cloudquery/plugin-sdk/v2/faker"
+	"github.com/cloudquery/plugin-sdk/v3/faker"
 	heroku "github.com/heroku/heroku-go/v5"
 	"github.com/julienschmidt/httprouter"
 )

--- a/plugins/source/heroku/resources/services/o_auth_client.go
+++ b/plugins/source/heroku/resources/services/o_auth_client.go
@@ -4,8 +4,8 @@ import (
 	"context"
 
 	"github.com/cloudquery/cloudquery/plugins/source/heroku/client"
-	"github.com/cloudquery/plugin-sdk/v2/schema"
-	"github.com/cloudquery/plugin-sdk/v2/transformers"
+	"github.com/cloudquery/plugin-sdk/v3/schema"
+	"github.com/cloudquery/plugin-sdk/v3/transformers"
 	heroku "github.com/heroku/heroku-go/v5"
 	"github.com/pkg/errors"
 )

--- a/plugins/source/heroku/resources/services/o_auth_client.go
+++ b/plugins/source/heroku/resources/services/o_auth_client.go
@@ -3,6 +3,8 @@ package services
 import (
 	"context"
 
+	"github.com/apache/arrow/go/v13/arrow"
+
 	"github.com/cloudquery/cloudquery/plugins/source/heroku/client"
 	"github.com/cloudquery/plugin-sdk/v3/schema"
 	"github.com/cloudquery/plugin-sdk/v3/transformers"
@@ -18,12 +20,10 @@ func OAuthClients() *schema.Table {
 		Transform:   transformers.TransformWithStruct(&heroku.OAuthClient{}),
 		Columns: []schema.Column{
 			{
-				Name:     "id",
-				Type:     schema.TypeString,
-				Resolver: schema.PathResolver("ID"),
-				CreationOptions: schema.ColumnCreationOptions{
-					PrimaryKey: true,
-				},
+				Name:       "id",
+				Type:       arrow.BinaryTypes.String,
+				Resolver:   schema.PathResolver("ID"),
+				PrimaryKey: true,
 			},
 		},
 	}

--- a/plugins/source/heroku/resources/services/o_auth_client_mock_test.go
+++ b/plugins/source/heroku/resources/services/o_auth_client_mock_test.go
@@ -7,7 +7,7 @@ import (
 	"testing"
 
 	"github.com/cloudquery/cloudquery/plugins/source/heroku/client"
-	"github.com/cloudquery/plugin-sdk/v2/faker"
+	"github.com/cloudquery/plugin-sdk/v3/faker"
 	heroku "github.com/heroku/heroku-go/v5"
 	"github.com/julienschmidt/httprouter"
 )

--- a/plugins/source/heroku/resources/services/outbound_ruleset.go
+++ b/plugins/source/heroku/resources/services/outbound_ruleset.go
@@ -4,8 +4,8 @@ import (
 	"context"
 
 	"github.com/cloudquery/cloudquery/plugins/source/heroku/client"
-	"github.com/cloudquery/plugin-sdk/v2/schema"
-	"github.com/cloudquery/plugin-sdk/v2/transformers"
+	"github.com/cloudquery/plugin-sdk/v3/schema"
+	"github.com/cloudquery/plugin-sdk/v3/transformers"
 	heroku "github.com/heroku/heroku-go/v5"
 	"github.com/pkg/errors"
 )

--- a/plugins/source/heroku/resources/services/outbound_ruleset.go
+++ b/plugins/source/heroku/resources/services/outbound_ruleset.go
@@ -3,6 +3,8 @@ package services
 import (
 	"context"
 
+	"github.com/apache/arrow/go/v13/arrow"
+
 	"github.com/cloudquery/cloudquery/plugins/source/heroku/client"
 	"github.com/cloudquery/plugin-sdk/v3/schema"
 	"github.com/cloudquery/plugin-sdk/v3/transformers"
@@ -18,12 +20,10 @@ func OutboundRulesets() *schema.Table {
 		Transform:   transformers.TransformWithStruct(&heroku.OutboundRuleset{}),
 		Columns: []schema.Column{
 			{
-				Name:     "id",
-				Type:     schema.TypeString,
-				Resolver: schema.PathResolver("ID"),
-				CreationOptions: schema.ColumnCreationOptions{
-					PrimaryKey: true,
-				},
+				Name:       "id",
+				Type:       arrow.BinaryTypes.String,
+				Resolver:   schema.PathResolver("ID"),
+				PrimaryKey: true,
 			},
 		},
 	}

--- a/plugins/source/heroku/resources/services/outbound_ruleset_mock_test.go
+++ b/plugins/source/heroku/resources/services/outbound_ruleset_mock_test.go
@@ -7,7 +7,7 @@ import (
 	"testing"
 
 	"github.com/cloudquery/cloudquery/plugins/source/heroku/client"
-	"github.com/cloudquery/plugin-sdk/v2/faker"
+	"github.com/cloudquery/plugin-sdk/v3/faker"
 	heroku "github.com/heroku/heroku-go/v5"
 	"github.com/julienschmidt/httprouter"
 )

--- a/plugins/source/heroku/resources/services/peering.go
+++ b/plugins/source/heroku/resources/services/peering.go
@@ -4,8 +4,8 @@ import (
 	"context"
 
 	"github.com/cloudquery/cloudquery/plugins/source/heroku/client"
-	"github.com/cloudquery/plugin-sdk/v2/schema"
-	"github.com/cloudquery/plugin-sdk/v2/transformers"
+	"github.com/cloudquery/plugin-sdk/v3/schema"
+	"github.com/cloudquery/plugin-sdk/v3/transformers"
 	heroku "github.com/heroku/heroku-go/v5"
 	"github.com/pkg/errors"
 )

--- a/plugins/source/heroku/resources/services/peering_mock_test.go
+++ b/plugins/source/heroku/resources/services/peering_mock_test.go
@@ -7,7 +7,7 @@ import (
 	"testing"
 
 	"github.com/cloudquery/cloudquery/plugins/source/heroku/client"
-	"github.com/cloudquery/plugin-sdk/v2/faker"
+	"github.com/cloudquery/plugin-sdk/v3/faker"
 	heroku "github.com/heroku/heroku-go/v5"
 	"github.com/julienschmidt/httprouter"
 )

--- a/plugins/source/heroku/resources/services/permission_entity.go
+++ b/plugins/source/heroku/resources/services/permission_entity.go
@@ -4,8 +4,8 @@ import (
 	"context"
 
 	"github.com/cloudquery/cloudquery/plugins/source/heroku/client"
-	"github.com/cloudquery/plugin-sdk/v2/schema"
-	"github.com/cloudquery/plugin-sdk/v2/transformers"
+	"github.com/cloudquery/plugin-sdk/v3/schema"
+	"github.com/cloudquery/plugin-sdk/v3/transformers"
 	heroku "github.com/heroku/heroku-go/v5"
 	"github.com/pkg/errors"
 )

--- a/plugins/source/heroku/resources/services/permission_entity.go
+++ b/plugins/source/heroku/resources/services/permission_entity.go
@@ -3,6 +3,8 @@ package services
 import (
 	"context"
 
+	"github.com/apache/arrow/go/v13/arrow"
+
 	"github.com/cloudquery/cloudquery/plugins/source/heroku/client"
 	"github.com/cloudquery/plugin-sdk/v3/schema"
 	"github.com/cloudquery/plugin-sdk/v3/transformers"
@@ -18,12 +20,10 @@ func PermissionEntities() *schema.Table {
 		Transform:   transformers.TransformWithStruct(&heroku.PermissionEntity{}),
 		Columns: []schema.Column{
 			{
-				Name:     "id",
-				Type:     schema.TypeString,
-				Resolver: schema.PathResolver("ID"),
-				CreationOptions: schema.ColumnCreationOptions{
-					PrimaryKey: true,
-				},
+				Name:       "id",
+				Type:       arrow.BinaryTypes.String,
+				Resolver:   schema.PathResolver("ID"),
+				PrimaryKey: true,
 			},
 		},
 	}

--- a/plugins/source/heroku/resources/services/permission_entity_mock_test.go
+++ b/plugins/source/heroku/resources/services/permission_entity_mock_test.go
@@ -7,7 +7,7 @@ import (
 	"testing"
 
 	"github.com/cloudquery/cloudquery/plugins/source/heroku/client"
-	"github.com/cloudquery/plugin-sdk/v2/faker"
+	"github.com/cloudquery/plugin-sdk/v3/faker"
 	heroku "github.com/heroku/heroku-go/v5"
 	"github.com/julienschmidt/httprouter"
 )

--- a/plugins/source/heroku/resources/services/pipeline.go
+++ b/plugins/source/heroku/resources/services/pipeline.go
@@ -4,8 +4,8 @@ import (
 	"context"
 
 	"github.com/cloudquery/cloudquery/plugins/source/heroku/client"
-	"github.com/cloudquery/plugin-sdk/v2/schema"
-	"github.com/cloudquery/plugin-sdk/v2/transformers"
+	"github.com/cloudquery/plugin-sdk/v3/schema"
+	"github.com/cloudquery/plugin-sdk/v3/transformers"
 	heroku "github.com/heroku/heroku-go/v5"
 	"github.com/pkg/errors"
 )

--- a/plugins/source/heroku/resources/services/pipeline.go
+++ b/plugins/source/heroku/resources/services/pipeline.go
@@ -3,6 +3,8 @@ package services
 import (
 	"context"
 
+	"github.com/apache/arrow/go/v13/arrow"
+
 	"github.com/cloudquery/cloudquery/plugins/source/heroku/client"
 	"github.com/cloudquery/plugin-sdk/v3/schema"
 	"github.com/cloudquery/plugin-sdk/v3/transformers"
@@ -18,12 +20,10 @@ func Pipelines() *schema.Table {
 		Transform:   transformers.TransformWithStruct(&heroku.Pipeline{}),
 		Columns: []schema.Column{
 			{
-				Name:     "id",
-				Type:     schema.TypeString,
-				Resolver: schema.PathResolver("ID"),
-				CreationOptions: schema.ColumnCreationOptions{
-					PrimaryKey: true,
-				},
+				Name:       "id",
+				Type:       arrow.BinaryTypes.String,
+				Resolver:   schema.PathResolver("ID"),
+				PrimaryKey: true,
 			},
 		},
 	}

--- a/plugins/source/heroku/resources/services/pipeline_build.go
+++ b/plugins/source/heroku/resources/services/pipeline_build.go
@@ -4,8 +4,8 @@ import (
 	"context"
 
 	"github.com/cloudquery/cloudquery/plugins/source/heroku/client"
-	"github.com/cloudquery/plugin-sdk/v2/schema"
-	"github.com/cloudquery/plugin-sdk/v2/transformers"
+	"github.com/cloudquery/plugin-sdk/v3/schema"
+	"github.com/cloudquery/plugin-sdk/v3/transformers"
 	heroku "github.com/heroku/heroku-go/v5"
 	"github.com/pkg/errors"
 )

--- a/plugins/source/heroku/resources/services/pipeline_build.go
+++ b/plugins/source/heroku/resources/services/pipeline_build.go
@@ -3,6 +3,8 @@ package services
 import (
 	"context"
 
+	"github.com/apache/arrow/go/v13/arrow"
+
 	"github.com/cloudquery/cloudquery/plugins/source/heroku/client"
 	"github.com/cloudquery/plugin-sdk/v3/schema"
 	"github.com/cloudquery/plugin-sdk/v3/transformers"
@@ -18,12 +20,10 @@ func PipelineBuilds() *schema.Table {
 		Transform:   transformers.TransformWithStruct(&heroku.PipelineBuildListResult{}),
 		Columns: []schema.Column{
 			{
-				Name:     "id",
-				Type:     schema.TypeString,
-				Resolver: schema.PathResolver("ID"),
-				CreationOptions: schema.ColumnCreationOptions{
-					PrimaryKey: true,
-				},
+				Name:       "id",
+				Type:       arrow.BinaryTypes.String,
+				Resolver:   schema.PathResolver("ID"),
+				PrimaryKey: true,
 			},
 		},
 	}

--- a/plugins/source/heroku/resources/services/pipeline_build_mock_test.go
+++ b/plugins/source/heroku/resources/services/pipeline_build_mock_test.go
@@ -7,7 +7,7 @@ import (
 	"testing"
 
 	"github.com/cloudquery/cloudquery/plugins/source/heroku/client"
-	"github.com/cloudquery/plugin-sdk/v2/faker"
+	"github.com/cloudquery/plugin-sdk/v3/faker"
 	heroku "github.com/heroku/heroku-go/v5"
 	"github.com/julienschmidt/httprouter"
 )

--- a/plugins/source/heroku/resources/services/pipeline_coupling.go
+++ b/plugins/source/heroku/resources/services/pipeline_coupling.go
@@ -3,6 +3,8 @@ package services
 import (
 	"context"
 
+	"github.com/apache/arrow/go/v13/arrow"
+
 	"github.com/cloudquery/cloudquery/plugins/source/heroku/client"
 	"github.com/cloudquery/plugin-sdk/v3/schema"
 	"github.com/cloudquery/plugin-sdk/v3/transformers"
@@ -18,12 +20,10 @@ func PipelineCouplings() *schema.Table {
 		Transform:   transformers.TransformWithStruct(&heroku.PipelineCoupling{}),
 		Columns: []schema.Column{
 			{
-				Name:     "id",
-				Type:     schema.TypeString,
-				Resolver: schema.PathResolver("ID"),
-				CreationOptions: schema.ColumnCreationOptions{
-					PrimaryKey: true,
-				},
+				Name:       "id",
+				Type:       arrow.BinaryTypes.String,
+				Resolver:   schema.PathResolver("ID"),
+				PrimaryKey: true,
 			},
 		},
 	}

--- a/plugins/source/heroku/resources/services/pipeline_coupling.go
+++ b/plugins/source/heroku/resources/services/pipeline_coupling.go
@@ -4,8 +4,8 @@ import (
 	"context"
 
 	"github.com/cloudquery/cloudquery/plugins/source/heroku/client"
-	"github.com/cloudquery/plugin-sdk/v2/schema"
-	"github.com/cloudquery/plugin-sdk/v2/transformers"
+	"github.com/cloudquery/plugin-sdk/v3/schema"
+	"github.com/cloudquery/plugin-sdk/v3/transformers"
 	heroku "github.com/heroku/heroku-go/v5"
 	"github.com/pkg/errors"
 )

--- a/plugins/source/heroku/resources/services/pipeline_coupling_mock_test.go
+++ b/plugins/source/heroku/resources/services/pipeline_coupling_mock_test.go
@@ -7,7 +7,7 @@ import (
 	"testing"
 
 	"github.com/cloudquery/cloudquery/plugins/source/heroku/client"
-	"github.com/cloudquery/plugin-sdk/v2/faker"
+	"github.com/cloudquery/plugin-sdk/v3/faker"
 	heroku "github.com/heroku/heroku-go/v5"
 	"github.com/julienschmidt/httprouter"
 )

--- a/plugins/source/heroku/resources/services/pipeline_deployment.go
+++ b/plugins/source/heroku/resources/services/pipeline_deployment.go
@@ -3,6 +3,8 @@ package services
 import (
 	"context"
 
+	"github.com/apache/arrow/go/v13/arrow"
+
 	"github.com/cloudquery/cloudquery/plugins/source/heroku/client"
 	"github.com/cloudquery/plugin-sdk/v3/schema"
 	"github.com/cloudquery/plugin-sdk/v3/transformers"
@@ -18,12 +20,10 @@ func PipelineDeployments() *schema.Table {
 		Transform:   transformers.TransformWithStruct(&heroku.PipelineDeploymentListResult{}),
 		Columns: []schema.Column{
 			{
-				Name:     "id",
-				Type:     schema.TypeString,
-				Resolver: schema.PathResolver("ID"),
-				CreationOptions: schema.ColumnCreationOptions{
-					PrimaryKey: true,
-				},
+				Name:       "id",
+				Type:       arrow.BinaryTypes.String,
+				Resolver:   schema.PathResolver("ID"),
+				PrimaryKey: true,
 			},
 		},
 	}

--- a/plugins/source/heroku/resources/services/pipeline_deployment.go
+++ b/plugins/source/heroku/resources/services/pipeline_deployment.go
@@ -4,8 +4,8 @@ import (
 	"context"
 
 	"github.com/cloudquery/cloudquery/plugins/source/heroku/client"
-	"github.com/cloudquery/plugin-sdk/v2/schema"
-	"github.com/cloudquery/plugin-sdk/v2/transformers"
+	"github.com/cloudquery/plugin-sdk/v3/schema"
+	"github.com/cloudquery/plugin-sdk/v3/transformers"
 	heroku "github.com/heroku/heroku-go/v5"
 	"github.com/pkg/errors"
 )

--- a/plugins/source/heroku/resources/services/pipeline_deployment_mock_test.go
+++ b/plugins/source/heroku/resources/services/pipeline_deployment_mock_test.go
@@ -7,7 +7,7 @@ import (
 	"testing"
 
 	"github.com/cloudquery/cloudquery/plugins/source/heroku/client"
-	"github.com/cloudquery/plugin-sdk/v2/faker"
+	"github.com/cloudquery/plugin-sdk/v3/faker"
 	heroku "github.com/heroku/heroku-go/v5"
 	"github.com/julienschmidt/httprouter"
 )

--- a/plugins/source/heroku/resources/services/pipeline_mock_test.go
+++ b/plugins/source/heroku/resources/services/pipeline_mock_test.go
@@ -7,7 +7,7 @@ import (
 	"testing"
 
 	"github.com/cloudquery/cloudquery/plugins/source/heroku/client"
-	"github.com/cloudquery/plugin-sdk/v2/faker"
+	"github.com/cloudquery/plugin-sdk/v3/faker"
 	heroku "github.com/heroku/heroku-go/v5"
 	"github.com/julienschmidt/httprouter"
 )

--- a/plugins/source/heroku/resources/services/pipeline_release.go
+++ b/plugins/source/heroku/resources/services/pipeline_release.go
@@ -4,8 +4,8 @@ import (
 	"context"
 
 	"github.com/cloudquery/cloudquery/plugins/source/heroku/client"
-	"github.com/cloudquery/plugin-sdk/v2/schema"
-	"github.com/cloudquery/plugin-sdk/v2/transformers"
+	"github.com/cloudquery/plugin-sdk/v3/schema"
+	"github.com/cloudquery/plugin-sdk/v3/transformers"
 	heroku "github.com/heroku/heroku-go/v5"
 	"github.com/pkg/errors"
 )

--- a/plugins/source/heroku/resources/services/pipeline_release.go
+++ b/plugins/source/heroku/resources/services/pipeline_release.go
@@ -3,6 +3,8 @@ package services
 import (
 	"context"
 
+	"github.com/apache/arrow/go/v13/arrow"
+
 	"github.com/cloudquery/cloudquery/plugins/source/heroku/client"
 	"github.com/cloudquery/plugin-sdk/v3/schema"
 	"github.com/cloudquery/plugin-sdk/v3/transformers"
@@ -18,12 +20,10 @@ func PipelineReleases() *schema.Table {
 		Transform:   transformers.TransformWithStruct(&heroku.PipelineReleaseListResult{}),
 		Columns: []schema.Column{
 			{
-				Name:     "id",
-				Type:     schema.TypeString,
-				Resolver: schema.PathResolver("ID"),
-				CreationOptions: schema.ColumnCreationOptions{
-					PrimaryKey: true,
-				},
+				Name:       "id",
+				Type:       arrow.BinaryTypes.String,
+				Resolver:   schema.PathResolver("ID"),
+				PrimaryKey: true,
 			},
 		},
 	}

--- a/plugins/source/heroku/resources/services/pipeline_release_mock_test.go
+++ b/plugins/source/heroku/resources/services/pipeline_release_mock_test.go
@@ -7,7 +7,7 @@ import (
 	"testing"
 
 	"github.com/cloudquery/cloudquery/plugins/source/heroku/client"
-	"github.com/cloudquery/plugin-sdk/v2/faker"
+	"github.com/cloudquery/plugin-sdk/v3/faker"
 	heroku "github.com/heroku/heroku-go/v5"
 	"github.com/julienschmidt/httprouter"
 )

--- a/plugins/source/heroku/resources/services/region.go
+++ b/plugins/source/heroku/resources/services/region.go
@@ -3,6 +3,8 @@ package services
 import (
 	"context"
 
+	"github.com/apache/arrow/go/v13/arrow"
+
 	"github.com/cloudquery/cloudquery/plugins/source/heroku/client"
 	"github.com/cloudquery/plugin-sdk/v3/schema"
 	"github.com/cloudquery/plugin-sdk/v3/transformers"
@@ -18,12 +20,10 @@ func Regions() *schema.Table {
 		Transform:   transformers.TransformWithStruct(&heroku.Region{}),
 		Columns: []schema.Column{
 			{
-				Name:     "id",
-				Type:     schema.TypeString,
-				Resolver: schema.PathResolver("ID"),
-				CreationOptions: schema.ColumnCreationOptions{
-					PrimaryKey: true,
-				},
+				Name:       "id",
+				Type:       arrow.BinaryTypes.String,
+				Resolver:   schema.PathResolver("ID"),
+				PrimaryKey: true,
 			},
 		},
 	}

--- a/plugins/source/heroku/resources/services/region.go
+++ b/plugins/source/heroku/resources/services/region.go
@@ -4,8 +4,8 @@ import (
 	"context"
 
 	"github.com/cloudquery/cloudquery/plugins/source/heroku/client"
-	"github.com/cloudquery/plugin-sdk/v2/schema"
-	"github.com/cloudquery/plugin-sdk/v2/transformers"
+	"github.com/cloudquery/plugin-sdk/v3/schema"
+	"github.com/cloudquery/plugin-sdk/v3/transformers"
 	heroku "github.com/heroku/heroku-go/v5"
 	"github.com/pkg/errors"
 )

--- a/plugins/source/heroku/resources/services/region_mock_test.go
+++ b/plugins/source/heroku/resources/services/region_mock_test.go
@@ -7,7 +7,7 @@ import (
 	"testing"
 
 	"github.com/cloudquery/cloudquery/plugins/source/heroku/client"
-	"github.com/cloudquery/plugin-sdk/v2/faker"
+	"github.com/cloudquery/plugin-sdk/v3/faker"
 	heroku "github.com/heroku/heroku-go/v5"
 	"github.com/julienschmidt/httprouter"
 )

--- a/plugins/source/heroku/resources/services/release.go
+++ b/plugins/source/heroku/resources/services/release.go
@@ -3,6 +3,8 @@ package services
 import (
 	"context"
 
+	"github.com/apache/arrow/go/v13/arrow"
+
 	"github.com/cloudquery/cloudquery/plugins/source/heroku/client"
 	"github.com/cloudquery/plugin-sdk/v3/schema"
 	"github.com/cloudquery/plugin-sdk/v3/transformers"
@@ -18,12 +20,10 @@ func Releases() *schema.Table {
 		Transform:   transformers.TransformWithStruct(&heroku.Release{}),
 		Columns: []schema.Column{
 			{
-				Name:     "id",
-				Type:     schema.TypeString,
-				Resolver: schema.PathResolver("ID"),
-				CreationOptions: schema.ColumnCreationOptions{
-					PrimaryKey: true,
-				},
+				Name:       "id",
+				Type:       arrow.BinaryTypes.String,
+				Resolver:   schema.PathResolver("ID"),
+				PrimaryKey: true,
 			},
 		},
 	}

--- a/plugins/source/heroku/resources/services/release.go
+++ b/plugins/source/heroku/resources/services/release.go
@@ -4,8 +4,8 @@ import (
 	"context"
 
 	"github.com/cloudquery/cloudquery/plugins/source/heroku/client"
-	"github.com/cloudquery/plugin-sdk/v2/schema"
-	"github.com/cloudquery/plugin-sdk/v2/transformers"
+	"github.com/cloudquery/plugin-sdk/v3/schema"
+	"github.com/cloudquery/plugin-sdk/v3/transformers"
 	heroku "github.com/heroku/heroku-go/v5"
 	"github.com/pkg/errors"
 )

--- a/plugins/source/heroku/resources/services/release_mock_test.go
+++ b/plugins/source/heroku/resources/services/release_mock_test.go
@@ -7,7 +7,7 @@ import (
 	"testing"
 
 	"github.com/cloudquery/cloudquery/plugins/source/heroku/client"
-	"github.com/cloudquery/plugin-sdk/v2/faker"
+	"github.com/cloudquery/plugin-sdk/v3/faker"
 	heroku "github.com/heroku/heroku-go/v5"
 	"github.com/julienschmidt/httprouter"
 )

--- a/plugins/source/heroku/resources/services/review_app.go
+++ b/plugins/source/heroku/resources/services/review_app.go
@@ -3,6 +3,8 @@ package services
 import (
 	"context"
 
+	"github.com/apache/arrow/go/v13/arrow"
+
 	"github.com/cloudquery/cloudquery/plugins/source/heroku/client"
 	"github.com/cloudquery/plugin-sdk/v3/schema"
 	"github.com/cloudquery/plugin-sdk/v3/transformers"
@@ -18,12 +20,10 @@ func ReviewApps() *schema.Table {
 		Transform:   transformers.TransformWithStruct(&heroku.ReviewApp{}),
 		Columns: []schema.Column{
 			{
-				Name:     "id",
-				Type:     schema.TypeString,
-				Resolver: schema.PathResolver("ID"),
-				CreationOptions: schema.ColumnCreationOptions{
-					PrimaryKey: true,
-				},
+				Name:       "id",
+				Type:       arrow.BinaryTypes.String,
+				Resolver:   schema.PathResolver("ID"),
+				PrimaryKey: true,
 			},
 		},
 	}

--- a/plugins/source/heroku/resources/services/review_app.go
+++ b/plugins/source/heroku/resources/services/review_app.go
@@ -4,8 +4,8 @@ import (
 	"context"
 
 	"github.com/cloudquery/cloudquery/plugins/source/heroku/client"
-	"github.com/cloudquery/plugin-sdk/v2/schema"
-	"github.com/cloudquery/plugin-sdk/v2/transformers"
+	"github.com/cloudquery/plugin-sdk/v3/schema"
+	"github.com/cloudquery/plugin-sdk/v3/transformers"
 	heroku "github.com/heroku/heroku-go/v5"
 	"github.com/pkg/errors"
 )

--- a/plugins/source/heroku/resources/services/review_app_mock_test.go
+++ b/plugins/source/heroku/resources/services/review_app_mock_test.go
@@ -7,7 +7,7 @@ import (
 	"testing"
 
 	"github.com/cloudquery/cloudquery/plugins/source/heroku/client"
-	"github.com/cloudquery/plugin-sdk/v2/faker"
+	"github.com/cloudquery/plugin-sdk/v3/faker"
 	heroku "github.com/heroku/heroku-go/v5"
 	"github.com/julienschmidt/httprouter"
 )

--- a/plugins/source/heroku/resources/services/space.go
+++ b/plugins/source/heroku/resources/services/space.go
@@ -4,8 +4,8 @@ import (
 	"context"
 
 	"github.com/cloudquery/cloudquery/plugins/source/heroku/client"
-	"github.com/cloudquery/plugin-sdk/v2/schema"
-	"github.com/cloudquery/plugin-sdk/v2/transformers"
+	"github.com/cloudquery/plugin-sdk/v3/schema"
+	"github.com/cloudquery/plugin-sdk/v3/transformers"
 	heroku "github.com/heroku/heroku-go/v5"
 	"github.com/pkg/errors"
 )

--- a/plugins/source/heroku/resources/services/space.go
+++ b/plugins/source/heroku/resources/services/space.go
@@ -3,6 +3,8 @@ package services
 import (
 	"context"
 
+	"github.com/apache/arrow/go/v13/arrow"
+
 	"github.com/cloudquery/cloudquery/plugins/source/heroku/client"
 	"github.com/cloudquery/plugin-sdk/v3/schema"
 	"github.com/cloudquery/plugin-sdk/v3/transformers"
@@ -18,12 +20,10 @@ func Spaces() *schema.Table {
 		Transform:   transformers.TransformWithStruct(&heroku.Space{}),
 		Columns: []schema.Column{
 			{
-				Name:     "id",
-				Type:     schema.TypeString,
-				Resolver: schema.PathResolver("ID"),
-				CreationOptions: schema.ColumnCreationOptions{
-					PrimaryKey: true,
-				},
+				Name:       "id",
+				Type:       arrow.BinaryTypes.String,
+				Resolver:   schema.PathResolver("ID"),
+				PrimaryKey: true,
 			},
 		},
 	}

--- a/plugins/source/heroku/resources/services/space_app_access.go
+++ b/plugins/source/heroku/resources/services/space_app_access.go
@@ -3,6 +3,8 @@ package services
 import (
 	"context"
 
+	"github.com/apache/arrow/go/v13/arrow"
+
 	"github.com/cloudquery/cloudquery/plugins/source/heroku/client"
 	"github.com/cloudquery/plugin-sdk/v3/schema"
 	"github.com/cloudquery/plugin-sdk/v3/transformers"
@@ -18,12 +20,10 @@ func SpaceAppAccesses() *schema.Table {
 		Transform:   transformers.TransformWithStruct(&heroku.SpaceAppAccess{}),
 		Columns: []schema.Column{
 			{
-				Name:     "id",
-				Type:     schema.TypeString,
-				Resolver: schema.PathResolver("ID"),
-				CreationOptions: schema.ColumnCreationOptions{
-					PrimaryKey: true,
-				},
+				Name:       "id",
+				Type:       arrow.BinaryTypes.String,
+				Resolver:   schema.PathResolver("ID"),
+				PrimaryKey: true,
 			},
 		},
 	}

--- a/plugins/source/heroku/resources/services/space_app_access.go
+++ b/plugins/source/heroku/resources/services/space_app_access.go
@@ -4,8 +4,8 @@ import (
 	"context"
 
 	"github.com/cloudquery/cloudquery/plugins/source/heroku/client"
-	"github.com/cloudquery/plugin-sdk/v2/schema"
-	"github.com/cloudquery/plugin-sdk/v2/transformers"
+	"github.com/cloudquery/plugin-sdk/v3/schema"
+	"github.com/cloudquery/plugin-sdk/v3/transformers"
 	heroku "github.com/heroku/heroku-go/v5"
 	"github.com/pkg/errors"
 )

--- a/plugins/source/heroku/resources/services/space_app_access_mock_test.go
+++ b/plugins/source/heroku/resources/services/space_app_access_mock_test.go
@@ -7,7 +7,7 @@ import (
 	"testing"
 
 	"github.com/cloudquery/cloudquery/plugins/source/heroku/client"
-	"github.com/cloudquery/plugin-sdk/v2/faker"
+	"github.com/cloudquery/plugin-sdk/v3/faker"
 	heroku "github.com/heroku/heroku-go/v5"
 	"github.com/julienschmidt/httprouter"
 )

--- a/plugins/source/heroku/resources/services/space_mock_test.go
+++ b/plugins/source/heroku/resources/services/space_mock_test.go
@@ -7,7 +7,7 @@ import (
 	"testing"
 
 	"github.com/cloudquery/cloudquery/plugins/source/heroku/client"
-	"github.com/cloudquery/plugin-sdk/v2/faker"
+	"github.com/cloudquery/plugin-sdk/v3/faker"
 	heroku "github.com/heroku/heroku-go/v5"
 	"github.com/julienschmidt/httprouter"
 )

--- a/plugins/source/heroku/resources/services/stack.go
+++ b/plugins/source/heroku/resources/services/stack.go
@@ -4,8 +4,8 @@ import (
 	"context"
 
 	"github.com/cloudquery/cloudquery/plugins/source/heroku/client"
-	"github.com/cloudquery/plugin-sdk/v2/schema"
-	"github.com/cloudquery/plugin-sdk/v2/transformers"
+	"github.com/cloudquery/plugin-sdk/v3/schema"
+	"github.com/cloudquery/plugin-sdk/v3/transformers"
 	heroku "github.com/heroku/heroku-go/v5"
 	"github.com/pkg/errors"
 )

--- a/plugins/source/heroku/resources/services/stack.go
+++ b/plugins/source/heroku/resources/services/stack.go
@@ -3,6 +3,8 @@ package services
 import (
 	"context"
 
+	"github.com/apache/arrow/go/v13/arrow"
+
 	"github.com/cloudquery/cloudquery/plugins/source/heroku/client"
 	"github.com/cloudquery/plugin-sdk/v3/schema"
 	"github.com/cloudquery/plugin-sdk/v3/transformers"
@@ -18,12 +20,10 @@ func Stacks() *schema.Table {
 		Transform:   transformers.TransformWithStruct(&heroku.Stack{}),
 		Columns: []schema.Column{
 			{
-				Name:     "id",
-				Type:     schema.TypeString,
-				Resolver: schema.PathResolver("ID"),
-				CreationOptions: schema.ColumnCreationOptions{
-					PrimaryKey: true,
-				},
+				Name:       "id",
+				Type:       arrow.BinaryTypes.String,
+				Resolver:   schema.PathResolver("ID"),
+				PrimaryKey: true,
 			},
 		},
 	}

--- a/plugins/source/heroku/resources/services/stack_mock_test.go
+++ b/plugins/source/heroku/resources/services/stack_mock_test.go
@@ -7,7 +7,7 @@ import (
 	"testing"
 
 	"github.com/cloudquery/cloudquery/plugins/source/heroku/client"
-	"github.com/cloudquery/plugin-sdk/v2/faker"
+	"github.com/cloudquery/plugin-sdk/v3/faker"
 	heroku "github.com/heroku/heroku-go/v5"
 	"github.com/julienschmidt/httprouter"
 )

--- a/plugins/source/heroku/resources/services/team.go
+++ b/plugins/source/heroku/resources/services/team.go
@@ -3,6 +3,8 @@ package services
 import (
 	"context"
 
+	"github.com/apache/arrow/go/v13/arrow"
+
 	"github.com/cloudquery/cloudquery/plugins/source/heroku/client"
 	"github.com/cloudquery/plugin-sdk/v3/schema"
 	"github.com/cloudquery/plugin-sdk/v3/transformers"
@@ -18,12 +20,10 @@ func Teams() *schema.Table {
 		Transform:   transformers.TransformWithStruct(&heroku.Team{}),
 		Columns: []schema.Column{
 			{
-				Name:     "id",
-				Type:     schema.TypeString,
-				Resolver: schema.PathResolver("ID"),
-				CreationOptions: schema.ColumnCreationOptions{
-					PrimaryKey: true,
-				},
+				Name:       "id",
+				Type:       arrow.BinaryTypes.String,
+				Resolver:   schema.PathResolver("ID"),
+				PrimaryKey: true,
 			},
 		},
 	}

--- a/plugins/source/heroku/resources/services/team.go
+++ b/plugins/source/heroku/resources/services/team.go
@@ -4,8 +4,8 @@ import (
 	"context"
 
 	"github.com/cloudquery/cloudquery/plugins/source/heroku/client"
-	"github.com/cloudquery/plugin-sdk/v2/schema"
-	"github.com/cloudquery/plugin-sdk/v2/transformers"
+	"github.com/cloudquery/plugin-sdk/v3/schema"
+	"github.com/cloudquery/plugin-sdk/v3/transformers"
 	heroku "github.com/heroku/heroku-go/v5"
 	"github.com/pkg/errors"
 )

--- a/plugins/source/heroku/resources/services/team_app_permission.go
+++ b/plugins/source/heroku/resources/services/team_app_permission.go
@@ -4,8 +4,8 @@ import (
 	"context"
 
 	"github.com/cloudquery/cloudquery/plugins/source/heroku/client"
-	"github.com/cloudquery/plugin-sdk/v2/schema"
-	"github.com/cloudquery/plugin-sdk/v2/transformers"
+	"github.com/cloudquery/plugin-sdk/v3/schema"
+	"github.com/cloudquery/plugin-sdk/v3/transformers"
 	heroku "github.com/heroku/heroku-go/v5"
 	"github.com/pkg/errors"
 )

--- a/plugins/source/heroku/resources/services/team_app_permission_mock_test.go
+++ b/plugins/source/heroku/resources/services/team_app_permission_mock_test.go
@@ -7,7 +7,7 @@ import (
 	"testing"
 
 	"github.com/cloudquery/cloudquery/plugins/source/heroku/client"
-	"github.com/cloudquery/plugin-sdk/v2/faker"
+	"github.com/cloudquery/plugin-sdk/v3/faker"
 	heroku "github.com/heroku/heroku-go/v5"
 	"github.com/julienschmidt/httprouter"
 )

--- a/plugins/source/heroku/resources/services/team_feature.go
+++ b/plugins/source/heroku/resources/services/team_feature.go
@@ -4,8 +4,8 @@ import (
 	"context"
 
 	"github.com/cloudquery/cloudquery/plugins/source/heroku/client"
-	"github.com/cloudquery/plugin-sdk/v2/schema"
-	"github.com/cloudquery/plugin-sdk/v2/transformers"
+	"github.com/cloudquery/plugin-sdk/v3/schema"
+	"github.com/cloudquery/plugin-sdk/v3/transformers"
 	heroku "github.com/heroku/heroku-go/v5"
 	"github.com/pkg/errors"
 )

--- a/plugins/source/heroku/resources/services/team_feature.go
+++ b/plugins/source/heroku/resources/services/team_feature.go
@@ -3,6 +3,8 @@ package services
 import (
 	"context"
 
+	"github.com/apache/arrow/go/v13/arrow"
+
 	"github.com/cloudquery/cloudquery/plugins/source/heroku/client"
 	"github.com/cloudquery/plugin-sdk/v3/schema"
 	"github.com/cloudquery/plugin-sdk/v3/transformers"
@@ -18,12 +20,10 @@ func TeamFeatures() *schema.Table {
 		Transform:   transformers.TransformWithStruct(&heroku.TeamFeature{}),
 		Columns: []schema.Column{
 			{
-				Name:     "id",
-				Type:     schema.TypeString,
-				Resolver: schema.PathResolver("ID"),
-				CreationOptions: schema.ColumnCreationOptions{
-					PrimaryKey: true,
-				},
+				Name:       "id",
+				Type:       arrow.BinaryTypes.String,
+				Resolver:   schema.PathResolver("ID"),
+				PrimaryKey: true,
 			},
 		},
 	}

--- a/plugins/source/heroku/resources/services/team_feature_mock_test.go
+++ b/plugins/source/heroku/resources/services/team_feature_mock_test.go
@@ -7,7 +7,7 @@ import (
 	"testing"
 
 	"github.com/cloudquery/cloudquery/plugins/source/heroku/client"
-	"github.com/cloudquery/plugin-sdk/v2/faker"
+	"github.com/cloudquery/plugin-sdk/v3/faker"
 	heroku "github.com/heroku/heroku-go/v5"
 	"github.com/julienschmidt/httprouter"
 )

--- a/plugins/source/heroku/resources/services/team_invitation.go
+++ b/plugins/source/heroku/resources/services/team_invitation.go
@@ -4,8 +4,8 @@ import (
 	"context"
 
 	"github.com/cloudquery/cloudquery/plugins/source/heroku/client"
-	"github.com/cloudquery/plugin-sdk/v2/schema"
-	"github.com/cloudquery/plugin-sdk/v2/transformers"
+	"github.com/cloudquery/plugin-sdk/v3/schema"
+	"github.com/cloudquery/plugin-sdk/v3/transformers"
 	heroku "github.com/heroku/heroku-go/v5"
 	"github.com/pkg/errors"
 )

--- a/plugins/source/heroku/resources/services/team_invitation.go
+++ b/plugins/source/heroku/resources/services/team_invitation.go
@@ -3,6 +3,8 @@ package services
 import (
 	"context"
 
+	"github.com/apache/arrow/go/v13/arrow"
+
 	"github.com/cloudquery/cloudquery/plugins/source/heroku/client"
 	"github.com/cloudquery/plugin-sdk/v3/schema"
 	"github.com/cloudquery/plugin-sdk/v3/transformers"
@@ -18,12 +20,10 @@ func TeamInvitations() *schema.Table {
 		Transform:   transformers.TransformWithStruct(&heroku.TeamInvitation{}),
 		Columns: []schema.Column{
 			{
-				Name:     "id",
-				Type:     schema.TypeString,
-				Resolver: schema.PathResolver("ID"),
-				CreationOptions: schema.ColumnCreationOptions{
-					PrimaryKey: true,
-				},
+				Name:       "id",
+				Type:       arrow.BinaryTypes.String,
+				Resolver:   schema.PathResolver("ID"),
+				PrimaryKey: true,
 			},
 		},
 	}

--- a/plugins/source/heroku/resources/services/team_invitation_mock_test.go
+++ b/plugins/source/heroku/resources/services/team_invitation_mock_test.go
@@ -7,7 +7,7 @@ import (
 	"testing"
 
 	"github.com/cloudquery/cloudquery/plugins/source/heroku/client"
-	"github.com/cloudquery/plugin-sdk/v2/faker"
+	"github.com/cloudquery/plugin-sdk/v3/faker"
 	heroku "github.com/heroku/heroku-go/v5"
 	"github.com/julienschmidt/httprouter"
 )

--- a/plugins/source/heroku/resources/services/team_invoice.go
+++ b/plugins/source/heroku/resources/services/team_invoice.go
@@ -3,6 +3,8 @@ package services
 import (
 	"context"
 
+	"github.com/apache/arrow/go/v13/arrow"
+
 	"github.com/cloudquery/cloudquery/plugins/source/heroku/client"
 	"github.com/cloudquery/plugin-sdk/v3/schema"
 	"github.com/cloudquery/plugin-sdk/v3/transformers"
@@ -18,12 +20,10 @@ func TeamInvoices() *schema.Table {
 		Transform:   transformers.TransformWithStruct(&heroku.TeamInvoice{}),
 		Columns: []schema.Column{
 			{
-				Name:     "id",
-				Type:     schema.TypeString,
-				Resolver: schema.PathResolver("ID"),
-				CreationOptions: schema.ColumnCreationOptions{
-					PrimaryKey: true,
-				},
+				Name:       "id",
+				Type:       arrow.BinaryTypes.String,
+				Resolver:   schema.PathResolver("ID"),
+				PrimaryKey: true,
 			},
 		},
 	}

--- a/plugins/source/heroku/resources/services/team_invoice.go
+++ b/plugins/source/heroku/resources/services/team_invoice.go
@@ -4,8 +4,8 @@ import (
 	"context"
 
 	"github.com/cloudquery/cloudquery/plugins/source/heroku/client"
-	"github.com/cloudquery/plugin-sdk/v2/schema"
-	"github.com/cloudquery/plugin-sdk/v2/transformers"
+	"github.com/cloudquery/plugin-sdk/v3/schema"
+	"github.com/cloudquery/plugin-sdk/v3/transformers"
 	heroku "github.com/heroku/heroku-go/v5"
 	"github.com/pkg/errors"
 )

--- a/plugins/source/heroku/resources/services/team_invoice_mock_test.go
+++ b/plugins/source/heroku/resources/services/team_invoice_mock_test.go
@@ -7,7 +7,7 @@ import (
 	"testing"
 
 	"github.com/cloudquery/cloudquery/plugins/source/heroku/client"
-	"github.com/cloudquery/plugin-sdk/v2/faker"
+	"github.com/cloudquery/plugin-sdk/v3/faker"
 	heroku "github.com/heroku/heroku-go/v5"
 	"github.com/julienschmidt/httprouter"
 )

--- a/plugins/source/heroku/resources/services/team_member.go
+++ b/plugins/source/heroku/resources/services/team_member.go
@@ -3,6 +3,8 @@ package services
 import (
 	"context"
 
+	"github.com/apache/arrow/go/v13/arrow"
+
 	"github.com/cloudquery/cloudquery/plugins/source/heroku/client"
 	"github.com/cloudquery/plugin-sdk/v3/schema"
 	"github.com/cloudquery/plugin-sdk/v3/transformers"
@@ -18,12 +20,10 @@ func TeamMembers() *schema.Table {
 		Transform:   transformers.TransformWithStruct(&heroku.TeamMember{}),
 		Columns: []schema.Column{
 			{
-				Name:     "id",
-				Type:     schema.TypeString,
-				Resolver: schema.PathResolver("ID"),
-				CreationOptions: schema.ColumnCreationOptions{
-					PrimaryKey: true,
-				},
+				Name:       "id",
+				Type:       arrow.BinaryTypes.String,
+				Resolver:   schema.PathResolver("ID"),
+				PrimaryKey: true,
 			},
 		},
 	}

--- a/plugins/source/heroku/resources/services/team_member.go
+++ b/plugins/source/heroku/resources/services/team_member.go
@@ -4,8 +4,8 @@ import (
 	"context"
 
 	"github.com/cloudquery/cloudquery/plugins/source/heroku/client"
-	"github.com/cloudquery/plugin-sdk/v2/schema"
-	"github.com/cloudquery/plugin-sdk/v2/transformers"
+	"github.com/cloudquery/plugin-sdk/v3/schema"
+	"github.com/cloudquery/plugin-sdk/v3/transformers"
 	heroku "github.com/heroku/heroku-go/v5"
 	"github.com/pkg/errors"
 )

--- a/plugins/source/heroku/resources/services/team_member_mock_test.go
+++ b/plugins/source/heroku/resources/services/team_member_mock_test.go
@@ -7,7 +7,7 @@ import (
 	"testing"
 
 	"github.com/cloudquery/cloudquery/plugins/source/heroku/client"
-	"github.com/cloudquery/plugin-sdk/v2/faker"
+	"github.com/cloudquery/plugin-sdk/v3/faker"
 	heroku "github.com/heroku/heroku-go/v5"
 	"github.com/julienschmidt/httprouter"
 )

--- a/plugins/source/heroku/resources/services/team_mock_test.go
+++ b/plugins/source/heroku/resources/services/team_mock_test.go
@@ -7,7 +7,7 @@ import (
 	"testing"
 
 	"github.com/cloudquery/cloudquery/plugins/source/heroku/client"
-	"github.com/cloudquery/plugin-sdk/v2/faker"
+	"github.com/cloudquery/plugin-sdk/v3/faker"
 	heroku "github.com/heroku/heroku-go/v5"
 	"github.com/julienschmidt/httprouter"
 )

--- a/plugins/source/heroku/resources/services/team_space.go
+++ b/plugins/source/heroku/resources/services/team_space.go
@@ -4,8 +4,8 @@ import (
 	"context"
 
 	"github.com/cloudquery/cloudquery/plugins/source/heroku/client"
-	"github.com/cloudquery/plugin-sdk/v2/schema"
-	"github.com/cloudquery/plugin-sdk/v2/transformers"
+	"github.com/cloudquery/plugin-sdk/v3/schema"
+	"github.com/cloudquery/plugin-sdk/v3/transformers"
 	heroku "github.com/heroku/heroku-go/v5"
 	"github.com/pkg/errors"
 )

--- a/plugins/source/heroku/resources/services/team_space.go
+++ b/plugins/source/heroku/resources/services/team_space.go
@@ -3,6 +3,8 @@ package services
 import (
 	"context"
 
+	"github.com/apache/arrow/go/v13/arrow"
+
 	"github.com/cloudquery/cloudquery/plugins/source/heroku/client"
 	"github.com/cloudquery/plugin-sdk/v3/schema"
 	"github.com/cloudquery/plugin-sdk/v3/transformers"
@@ -18,12 +20,10 @@ func TeamSpaces() *schema.Table {
 		Transform:   transformers.TransformWithStruct(&heroku.TeamSpaceListResult{}),
 		Columns: []schema.Column{
 			{
-				Name:     "id",
-				Type:     schema.TypeString,
-				Resolver: schema.PathResolver("ID"),
-				CreationOptions: schema.ColumnCreationOptions{
-					PrimaryKey: true,
-				},
+				Name:       "id",
+				Type:       arrow.BinaryTypes.String,
+				Resolver:   schema.PathResolver("ID"),
+				PrimaryKey: true,
 			},
 		},
 	}

--- a/plugins/source/heroku/resources/services/team_space_mock_test.go
+++ b/plugins/source/heroku/resources/services/team_space_mock_test.go
@@ -7,7 +7,7 @@ import (
 	"testing"
 
 	"github.com/cloudquery/cloudquery/plugins/source/heroku/client"
-	"github.com/cloudquery/plugin-sdk/v2/faker"
+	"github.com/cloudquery/plugin-sdk/v3/faker"
 	heroku "github.com/heroku/heroku-go/v5"
 	"github.com/julienschmidt/httprouter"
 )

--- a/plugins/source/heroku/resources/services/vpn_connection.go
+++ b/plugins/source/heroku/resources/services/vpn_connection.go
@@ -3,6 +3,8 @@ package services
 import (
 	"context"
 
+	"github.com/apache/arrow/go/v13/arrow"
+
 	"github.com/cloudquery/cloudquery/plugins/source/heroku/client"
 	"github.com/cloudquery/plugin-sdk/v3/schema"
 	"github.com/cloudquery/plugin-sdk/v3/transformers"
@@ -18,12 +20,10 @@ func VPNConnections() *schema.Table {
 		Transform:   transformers.TransformWithStruct(&heroku.VPNConnection{}),
 		Columns: []schema.Column{
 			{
-				Name:     "id",
-				Type:     schema.TypeString,
-				Resolver: schema.PathResolver("ID"),
-				CreationOptions: schema.ColumnCreationOptions{
-					PrimaryKey: true,
-				},
+				Name:       "id",
+				Type:       arrow.BinaryTypes.String,
+				Resolver:   schema.PathResolver("ID"),
+				PrimaryKey: true,
 			},
 		},
 	}

--- a/plugins/source/heroku/resources/services/vpn_connection.go
+++ b/plugins/source/heroku/resources/services/vpn_connection.go
@@ -4,8 +4,8 @@ import (
 	"context"
 
 	"github.com/cloudquery/cloudquery/plugins/source/heroku/client"
-	"github.com/cloudquery/plugin-sdk/v2/schema"
-	"github.com/cloudquery/plugin-sdk/v2/transformers"
+	"github.com/cloudquery/plugin-sdk/v3/schema"
+	"github.com/cloudquery/plugin-sdk/v3/transformers"
 	heroku "github.com/heroku/heroku-go/v5"
 	"github.com/pkg/errors"
 )

--- a/plugins/source/heroku/resources/services/vpn_connection_mock_test.go
+++ b/plugins/source/heroku/resources/services/vpn_connection_mock_test.go
@@ -7,7 +7,7 @@ import (
 	"testing"
 
 	"github.com/cloudquery/cloudquery/plugins/source/heroku/client"
-	"github.com/cloudquery/plugin-sdk/v2/faker"
+	"github.com/cloudquery/plugin-sdk/v3/faker"
 	heroku "github.com/heroku/heroku-go/v5"
 	"github.com/julienschmidt/httprouter"
 )

--- a/website/tables/heroku/heroku_account_features.md
+++ b/website/tables/heroku/heroku_account_features.md
@@ -10,17 +10,17 @@ The primary key for this table is **id**.
 
 | Name          | Type          |
 | ------------- | ------------- |
-|_cq_source_name|String|
-|_cq_sync_time|Timestamp|
-|_cq_id|UUID|
-|_cq_parent_id|UUID|
-|id (PK)|String|
-|created_at|Timestamp|
-|description|String|
-|display_name|String|
-|doc_url|String|
-|enabled|Bool|
-|feedback_email|String|
-|name|String|
-|state|String|
-|updated_at|Timestamp|
+|_cq_source_name|utf8|
+|_cq_sync_time|timestamp[us, tz=UTC]|
+|_cq_id|uuid|
+|_cq_parent_id|uuid|
+|id (PK)|utf8|
+|created_at|timestamp[us, tz=UTC]|
+|description|utf8|
+|display_name|utf8|
+|doc_url|utf8|
+|enabled|bool|
+|feedback_email|utf8|
+|name|utf8|
+|state|utf8|
+|updated_at|timestamp[us, tz=UTC]|

--- a/website/tables/heroku/heroku_add_on_attachments.md
+++ b/website/tables/heroku/heroku_add_on_attachments.md
@@ -10,16 +10,16 @@ The primary key for this table is **id**.
 
 | Name          | Type          |
 | ------------- | ------------- |
-|_cq_source_name|String|
-|_cq_sync_time|Timestamp|
-|_cq_id|UUID|
-|_cq_parent_id|UUID|
-|id (PK)|String|
-|addon|JSON|
-|app|JSON|
-|created_at|Timestamp|
-|log_input_url|String|
-|name|String|
-|namespace|String|
-|updated_at|Timestamp|
-|web_url|String|
+|_cq_source_name|utf8|
+|_cq_sync_time|timestamp[us, tz=UTC]|
+|_cq_id|uuid|
+|_cq_parent_id|uuid|
+|id (PK)|utf8|
+|addon|json|
+|app|json|
+|created_at|timestamp[us, tz=UTC]|
+|log_input_url|utf8|
+|name|utf8|
+|namespace|utf8|
+|updated_at|timestamp[us, tz=UTC]|
+|web_url|utf8|

--- a/website/tables/heroku/heroku_add_on_configs.md
+++ b/website/tables/heroku/heroku_add_on_configs.md
@@ -10,9 +10,9 @@ The primary key for this table is **_cq_id**.
 
 | Name          | Type          |
 | ------------- | ------------- |
-|_cq_source_name|String|
-|_cq_sync_time|Timestamp|
-|_cq_id (PK)|UUID|
-|_cq_parent_id|UUID|
-|name|String|
-|value|String|
+|_cq_source_name|utf8|
+|_cq_sync_time|timestamp[us, tz=UTC]|
+|_cq_id (PK)|uuid|
+|_cq_parent_id|uuid|
+|name|utf8|
+|value|utf8|

--- a/website/tables/heroku/heroku_add_on_region_capabilities.md
+++ b/website/tables/heroku/heroku_add_on_region_capabilities.md
@@ -10,11 +10,11 @@ The primary key for this table is **id**.
 
 | Name          | Type          |
 | ------------- | ------------- |
-|_cq_source_name|String|
-|_cq_sync_time|Timestamp|
-|_cq_id|UUID|
-|_cq_parent_id|UUID|
-|id (PK)|String|
-|addon_service|JSON|
-|region|JSON|
-|supports_private_networking|Bool|
+|_cq_source_name|utf8|
+|_cq_sync_time|timestamp[us, tz=UTC]|
+|_cq_id|uuid|
+|_cq_parent_id|uuid|
+|id (PK)|utf8|
+|addon_service|json|
+|region|json|
+|supports_private_networking|bool|

--- a/website/tables/heroku/heroku_add_on_services.md
+++ b/website/tables/heroku/heroku_add_on_services.md
@@ -10,16 +10,16 @@ The primary key for this table is **id**.
 
 | Name          | Type          |
 | ------------- | ------------- |
-|_cq_source_name|String|
-|_cq_sync_time|Timestamp|
-|_cq_id|UUID|
-|_cq_parent_id|UUID|
-|id (PK)|String|
-|cli_plugin_name|String|
-|created_at|Timestamp|
-|human_name|String|
-|name|String|
-|state|String|
-|supports_multiple_installations|Bool|
-|supports_sharing|Bool|
-|updated_at|Timestamp|
+|_cq_source_name|utf8|
+|_cq_sync_time|timestamp[us, tz=UTC]|
+|_cq_id|uuid|
+|_cq_parent_id|uuid|
+|id (PK)|utf8|
+|cli_plugin_name|utf8|
+|created_at|timestamp[us, tz=UTC]|
+|human_name|utf8|
+|name|utf8|
+|state|utf8|
+|supports_multiple_installations|bool|
+|supports_sharing|bool|
+|updated_at|timestamp[us, tz=UTC]|

--- a/website/tables/heroku/heroku_add_on_webhook_deliveries.md
+++ b/website/tables/heroku/heroku_add_on_webhook_deliveries.md
@@ -10,16 +10,16 @@ The primary key for this table is **id**.
 
 | Name          | Type          |
 | ------------- | ------------- |
-|_cq_source_name|String|
-|_cq_sync_time|Timestamp|
-|_cq_id|UUID|
-|_cq_parent_id|UUID|
-|id (PK)|String|
-|created_at|Timestamp|
-|event|JSON|
-|last_attempt|JSON|
-|next_attempt_at|Timestamp|
-|num_attempts|Int|
-|status|String|
-|updated_at|Timestamp|
-|webhook|JSON|
+|_cq_source_name|utf8|
+|_cq_sync_time|timestamp[us, tz=UTC]|
+|_cq_id|uuid|
+|_cq_parent_id|uuid|
+|id (PK)|utf8|
+|created_at|timestamp[us, tz=UTC]|
+|event|json|
+|last_attempt|json|
+|next_attempt_at|timestamp[us, tz=UTC]|
+|num_attempts|int64|
+|status|utf8|
+|updated_at|timestamp[us, tz=UTC]|
+|webhook|json|

--- a/website/tables/heroku/heroku_add_on_webhook_events.md
+++ b/website/tables/heroku/heroku_add_on_webhook_events.md
@@ -10,12 +10,12 @@ The primary key for this table is **id**.
 
 | Name          | Type          |
 | ------------- | ------------- |
-|_cq_source_name|String|
-|_cq_sync_time|Timestamp|
-|_cq_id|UUID|
-|_cq_parent_id|UUID|
-|id (PK)|String|
-|created_at|Timestamp|
-|include|String|
-|payload|JSON|
-|updated_at|Timestamp|
+|_cq_source_name|utf8|
+|_cq_sync_time|timestamp[us, tz=UTC]|
+|_cq_id|uuid|
+|_cq_parent_id|uuid|
+|id (PK)|utf8|
+|created_at|timestamp[us, tz=UTC]|
+|include|utf8|
+|payload|json|
+|updated_at|timestamp[us, tz=UTC]|

--- a/website/tables/heroku/heroku_add_on_webhooks.md
+++ b/website/tables/heroku/heroku_add_on_webhooks.md
@@ -10,13 +10,13 @@ The primary key for this table is **id**.
 
 | Name          | Type          |
 | ------------- | ------------- |
-|_cq_source_name|String|
-|_cq_sync_time|Timestamp|
-|_cq_id|UUID|
-|_cq_parent_id|UUID|
-|id (PK)|String|
-|created_at|Timestamp|
-|include|StringArray|
-|level|String|
-|updated_at|Timestamp|
-|url|String|
+|_cq_source_name|utf8|
+|_cq_sync_time|timestamp[us, tz=UTC]|
+|_cq_id|uuid|
+|_cq_parent_id|uuid|
+|id (PK)|utf8|
+|created_at|timestamp[us, tz=UTC]|
+|include|list<item: utf8, nullable>|
+|level|utf8|
+|updated_at|timestamp[us, tz=UTC]|
+|url|utf8|

--- a/website/tables/heroku/heroku_add_ons.md
+++ b/website/tables/heroku/heroku_add_ons.md
@@ -10,21 +10,21 @@ The primary key for this table is **id**.
 
 | Name          | Type          |
 | ------------- | ------------- |
-|_cq_source_name|String|
-|_cq_sync_time|Timestamp|
-|_cq_id|UUID|
-|_cq_parent_id|UUID|
-|id (PK)|String|
-|actions|JSON|
-|addon_service|JSON|
-|app|JSON|
-|billed_price|JSON|
-|billing_entity|JSON|
-|config_vars|StringArray|
-|created_at|Timestamp|
-|name|String|
-|plan|JSON|
-|provider_id|String|
-|state|String|
-|updated_at|Timestamp|
-|web_url|String|
+|_cq_source_name|utf8|
+|_cq_sync_time|timestamp[us, tz=UTC]|
+|_cq_id|uuid|
+|_cq_parent_id|uuid|
+|id (PK)|utf8|
+|actions|json|
+|addon_service|json|
+|app|json|
+|billed_price|json|
+|billing_entity|json|
+|config_vars|list<item: utf8, nullable>|
+|created_at|timestamp[us, tz=UTC]|
+|name|utf8|
+|plan|json|
+|provider_id|utf8|
+|state|utf8|
+|updated_at|timestamp[us, tz=UTC]|
+|web_url|utf8|

--- a/website/tables/heroku/heroku_app_features.md
+++ b/website/tables/heroku/heroku_app_features.md
@@ -10,17 +10,17 @@ The primary key for this table is **id**.
 
 | Name          | Type          |
 | ------------- | ------------- |
-|_cq_source_name|String|
-|_cq_sync_time|Timestamp|
-|_cq_id|UUID|
-|_cq_parent_id|UUID|
-|id (PK)|String|
-|created_at|Timestamp|
-|description|String|
-|display_name|String|
-|doc_url|String|
-|enabled|Bool|
-|feedback_email|String|
-|name|String|
-|state|String|
-|updated_at|Timestamp|
+|_cq_source_name|utf8|
+|_cq_sync_time|timestamp[us, tz=UTC]|
+|_cq_id|uuid|
+|_cq_parent_id|uuid|
+|id (PK)|utf8|
+|created_at|timestamp[us, tz=UTC]|
+|description|utf8|
+|display_name|utf8|
+|doc_url|utf8|
+|enabled|bool|
+|feedback_email|utf8|
+|name|utf8|
+|state|utf8|
+|updated_at|timestamp[us, tz=UTC]|

--- a/website/tables/heroku/heroku_app_transfers.md
+++ b/website/tables/heroku/heroku_app_transfers.md
@@ -10,14 +10,14 @@ The primary key for this table is **id**.
 
 | Name          | Type          |
 | ------------- | ------------- |
-|_cq_source_name|String|
-|_cq_sync_time|Timestamp|
-|_cq_id|UUID|
-|_cq_parent_id|UUID|
-|id (PK)|String|
-|app|JSON|
-|created_at|Timestamp|
-|owner|JSON|
-|recipient|JSON|
-|state|String|
-|updated_at|Timestamp|
+|_cq_source_name|utf8|
+|_cq_sync_time|timestamp[us, tz=UTC]|
+|_cq_id|uuid|
+|_cq_parent_id|uuid|
+|id (PK)|utf8|
+|app|json|
+|created_at|timestamp[us, tz=UTC]|
+|owner|json|
+|recipient|json|
+|state|utf8|
+|updated_at|timestamp[us, tz=UTC]|

--- a/website/tables/heroku/heroku_app_webhook_deliveries.md
+++ b/website/tables/heroku/heroku_app_webhook_deliveries.md
@@ -10,16 +10,16 @@ The primary key for this table is **id**.
 
 | Name          | Type          |
 | ------------- | ------------- |
-|_cq_source_name|String|
-|_cq_sync_time|Timestamp|
-|_cq_id|UUID|
-|_cq_parent_id|UUID|
-|id (PK)|String|
-|created_at|Timestamp|
-|event|JSON|
-|last_attempt|JSON|
-|next_attempt_at|Timestamp|
-|num_attempts|Int|
-|status|String|
-|updated_at|Timestamp|
-|webhook|JSON|
+|_cq_source_name|utf8|
+|_cq_sync_time|timestamp[us, tz=UTC]|
+|_cq_id|uuid|
+|_cq_parent_id|uuid|
+|id (PK)|utf8|
+|created_at|timestamp[us, tz=UTC]|
+|event|json|
+|last_attempt|json|
+|next_attempt_at|timestamp[us, tz=UTC]|
+|num_attempts|int64|
+|status|utf8|
+|updated_at|timestamp[us, tz=UTC]|
+|webhook|json|

--- a/website/tables/heroku/heroku_app_webhook_events.md
+++ b/website/tables/heroku/heroku_app_webhook_events.md
@@ -10,12 +10,12 @@ The primary key for this table is **id**.
 
 | Name          | Type          |
 | ------------- | ------------- |
-|_cq_source_name|String|
-|_cq_sync_time|Timestamp|
-|_cq_id|UUID|
-|_cq_parent_id|UUID|
-|id (PK)|String|
-|created_at|Timestamp|
-|include|String|
-|payload|JSON|
-|updated_at|Timestamp|
+|_cq_source_name|utf8|
+|_cq_sync_time|timestamp[us, tz=UTC]|
+|_cq_id|uuid|
+|_cq_parent_id|uuid|
+|id (PK)|utf8|
+|created_at|timestamp[us, tz=UTC]|
+|include|utf8|
+|payload|json|
+|updated_at|timestamp[us, tz=UTC]|

--- a/website/tables/heroku/heroku_app_webhooks.md
+++ b/website/tables/heroku/heroku_app_webhooks.md
@@ -10,14 +10,14 @@ The primary key for this table is **id**.
 
 | Name          | Type          |
 | ------------- | ------------- |
-|_cq_source_name|String|
-|_cq_sync_time|Timestamp|
-|_cq_id|UUID|
-|_cq_parent_id|UUID|
-|id (PK)|String|
-|app|JSON|
-|created_at|Timestamp|
-|include|StringArray|
-|level|String|
-|updated_at|Timestamp|
-|url|String|
+|_cq_source_name|utf8|
+|_cq_sync_time|timestamp[us, tz=UTC]|
+|_cq_id|uuid|
+|_cq_parent_id|uuid|
+|id (PK)|utf8|
+|app|json|
+|created_at|timestamp[us, tz=UTC]|
+|include|list<item: utf8, nullable>|
+|level|utf8|
+|updated_at|timestamp[us, tz=UTC]|
+|url|utf8|

--- a/website/tables/heroku/heroku_apps.md
+++ b/website/tables/heroku/heroku_apps.md
@@ -10,28 +10,28 @@ The primary key for this table is **id**.
 
 | Name          | Type          |
 | ------------- | ------------- |
-|_cq_source_name|String|
-|_cq_sync_time|Timestamp|
-|_cq_id|UUID|
-|_cq_parent_id|UUID|
-|id (PK)|String|
-|acm|Bool|
-|archived_at|Timestamp|
-|build_stack|JSON|
-|buildpack_provided_description|String|
-|created_at|Timestamp|
-|git_url|String|
-|internal_routing|Bool|
-|maintenance|Bool|
-|name|String|
-|organization|JSON|
-|owner|JSON|
-|region|JSON|
-|released_at|Timestamp|
-|repo_size|Int|
-|slug_size|Int|
-|space|JSON|
-|stack|JSON|
-|team|JSON|
-|updated_at|Timestamp|
-|web_url|String|
+|_cq_source_name|utf8|
+|_cq_sync_time|timestamp[us, tz=UTC]|
+|_cq_id|uuid|
+|_cq_parent_id|uuid|
+|id (PK)|utf8|
+|acm|bool|
+|archived_at|timestamp[us, tz=UTC]|
+|build_stack|json|
+|buildpack_provided_description|utf8|
+|created_at|timestamp[us, tz=UTC]|
+|git_url|utf8|
+|internal_routing|bool|
+|maintenance|bool|
+|name|utf8|
+|organization|json|
+|owner|json|
+|region|json|
+|released_at|timestamp[us, tz=UTC]|
+|repo_size|int64|
+|slug_size|int64|
+|space|json|
+|stack|json|
+|team|json|
+|updated_at|timestamp[us, tz=UTC]|
+|web_url|utf8|

--- a/website/tables/heroku/heroku_buildpack_installations.md
+++ b/website/tables/heroku/heroku_buildpack_installations.md
@@ -10,9 +10,9 @@ The primary key for this table is **_cq_id**.
 
 | Name          | Type          |
 | ------------- | ------------- |
-|_cq_source_name|String|
-|_cq_sync_time|Timestamp|
-|_cq_id (PK)|UUID|
-|_cq_parent_id|UUID|
-|buildpack|JSON|
-|ordinal|Int|
+|_cq_source_name|utf8|
+|_cq_sync_time|timestamp[us, tz=UTC]|
+|_cq_id (PK)|uuid|
+|_cq_parent_id|uuid|
+|buildpack|json|
+|ordinal|int64|

--- a/website/tables/heroku/heroku_builds.md
+++ b/website/tables/heroku/heroku_builds.md
@@ -10,19 +10,19 @@ The primary key for this table is **id**.
 
 | Name          | Type          |
 | ------------- | ------------- |
-|_cq_source_name|String|
-|_cq_sync_time|Timestamp|
-|_cq_id|UUID|
-|_cq_parent_id|UUID|
-|id (PK)|String|
-|app|JSON|
-|buildpacks|JSON|
-|created_at|Timestamp|
-|output_stream_url|String|
-|release|JSON|
-|slug|JSON|
-|source_blob|JSON|
-|stack|String|
-|status|String|
-|updated_at|Timestamp|
-|user|JSON|
+|_cq_source_name|utf8|
+|_cq_sync_time|timestamp[us, tz=UTC]|
+|_cq_id|uuid|
+|_cq_parent_id|uuid|
+|id (PK)|utf8|
+|app|json|
+|buildpacks|json|
+|created_at|timestamp[us, tz=UTC]|
+|output_stream_url|utf8|
+|release|json|
+|slug|json|
+|source_blob|json|
+|stack|utf8|
+|status|utf8|
+|updated_at|timestamp[us, tz=UTC]|
+|user|json|

--- a/website/tables/heroku/heroku_collaborators.md
+++ b/website/tables/heroku/heroku_collaborators.md
@@ -10,14 +10,14 @@ The primary key for this table is **id**.
 
 | Name          | Type          |
 | ------------- | ------------- |
-|_cq_source_name|String|
-|_cq_sync_time|Timestamp|
-|_cq_id|UUID|
-|_cq_parent_id|UUID|
-|id (PK)|String|
-|app|JSON|
-|created_at|Timestamp|
-|permissions|JSON|
-|role|String|
-|updated_at|Timestamp|
-|user|JSON|
+|_cq_source_name|utf8|
+|_cq_sync_time|timestamp[us, tz=UTC]|
+|_cq_id|uuid|
+|_cq_parent_id|uuid|
+|id (PK)|utf8|
+|app|json|
+|created_at|timestamp[us, tz=UTC]|
+|permissions|json|
+|role|utf8|
+|updated_at|timestamp[us, tz=UTC]|
+|user|json|

--- a/website/tables/heroku/heroku_credits.md
+++ b/website/tables/heroku/heroku_credits.md
@@ -10,14 +10,14 @@ The primary key for this table is **id**.
 
 | Name          | Type          |
 | ------------- | ------------- |
-|_cq_source_name|String|
-|_cq_sync_time|Timestamp|
-|_cq_id|UUID|
-|_cq_parent_id|UUID|
-|id (PK)|String|
-|amount|Float|
-|balance|Float|
-|created_at|Timestamp|
-|expires_at|Timestamp|
-|title|String|
-|updated_at|Timestamp|
+|_cq_source_name|utf8|
+|_cq_sync_time|timestamp[us, tz=UTC]|
+|_cq_id|uuid|
+|_cq_parent_id|uuid|
+|id (PK)|utf8|
+|amount|float64|
+|balance|float64|
+|created_at|timestamp[us, tz=UTC]|
+|expires_at|timestamp[us, tz=UTC]|
+|title|utf8|
+|updated_at|timestamp[us, tz=UTC]|

--- a/website/tables/heroku/heroku_domains.md
+++ b/website/tables/heroku/heroku_domains.md
@@ -10,18 +10,18 @@ The primary key for this table is **id**.
 
 | Name          | Type          |
 | ------------- | ------------- |
-|_cq_source_name|String|
-|_cq_sync_time|Timestamp|
-|_cq_id|UUID|
-|_cq_parent_id|UUID|
-|id (PK)|String|
-|acm_status|String|
-|acm_status_reason|String|
-|app|JSON|
-|cname|String|
-|created_at|Timestamp|
-|hostname|String|
-|kind|String|
-|sni_endpoint|JSON|
-|status|String|
-|updated_at|Timestamp|
+|_cq_source_name|utf8|
+|_cq_sync_time|timestamp[us, tz=UTC]|
+|_cq_id|uuid|
+|_cq_parent_id|uuid|
+|id (PK)|utf8|
+|acm_status|utf8|
+|acm_status_reason|utf8|
+|app|json|
+|cname|utf8|
+|created_at|timestamp[us, tz=UTC]|
+|hostname|utf8|
+|kind|utf8|
+|sni_endpoint|json|
+|status|utf8|
+|updated_at|timestamp[us, tz=UTC]|

--- a/website/tables/heroku/heroku_dyno_sizes.md
+++ b/website/tables/heroku/heroku_dyno_sizes.md
@@ -10,15 +10,15 @@ The primary key for this table is **id**.
 
 | Name          | Type          |
 | ------------- | ------------- |
-|_cq_source_name|String|
-|_cq_sync_time|Timestamp|
-|_cq_id|UUID|
-|_cq_parent_id|UUID|
-|id (PK)|String|
-|compute|Int|
-|cost|JSON|
-|dedicated|Bool|
-|dyno_units|Int|
-|memory|Float|
-|name|String|
-|private_space_only|Bool|
+|_cq_source_name|utf8|
+|_cq_sync_time|timestamp[us, tz=UTC]|
+|_cq_id|uuid|
+|_cq_parent_id|uuid|
+|id (PK)|utf8|
+|compute|int64|
+|cost|json|
+|dedicated|bool|
+|dyno_units|int64|
+|memory|float64|
+|name|utf8|
+|private_space_only|bool|

--- a/website/tables/heroku/heroku_dynos.md
+++ b/website/tables/heroku/heroku_dynos.md
@@ -10,18 +10,18 @@ The primary key for this table is **id**.
 
 | Name          | Type          |
 | ------------- | ------------- |
-|_cq_source_name|String|
-|_cq_sync_time|Timestamp|
-|_cq_id|UUID|
-|_cq_parent_id|UUID|
-|id (PK)|String|
-|app|JSON|
-|attach_url|String|
-|command|String|
-|created_at|Timestamp|
-|name|String|
-|release|JSON|
-|size|String|
-|state|String|
-|type|String|
-|updated_at|Timestamp|
+|_cq_source_name|utf8|
+|_cq_sync_time|timestamp[us, tz=UTC]|
+|_cq_id|uuid|
+|_cq_parent_id|uuid|
+|id (PK)|utf8|
+|app|json|
+|attach_url|utf8|
+|command|utf8|
+|created_at|timestamp[us, tz=UTC]|
+|name|utf8|
+|release|json|
+|size|utf8|
+|state|utf8|
+|type|utf8|
+|updated_at|timestamp[us, tz=UTC]|

--- a/website/tables/heroku/heroku_enterprise_account_members.md
+++ b/website/tables/heroku/heroku_enterprise_account_members.md
@@ -10,13 +10,13 @@ The primary key for this table is **id**.
 
 | Name          | Type          |
 | ------------- | ------------- |
-|_cq_source_name|String|
-|_cq_sync_time|Timestamp|
-|_cq_id|UUID|
-|_cq_parent_id|UUID|
-|id (PK)|String|
-|enterprise_account|JSON|
-|identity_provider|JSON|
-|permissions|JSON|
-|two_factor_authentication|Bool|
-|user|JSON|
+|_cq_source_name|utf8|
+|_cq_sync_time|timestamp[us, tz=UTC]|
+|_cq_id|uuid|
+|_cq_parent_id|uuid|
+|id (PK)|utf8|
+|enterprise_account|json|
+|identity_provider|json|
+|permissions|json|
+|two_factor_authentication|bool|
+|user|json|

--- a/website/tables/heroku/heroku_enterprise_accounts.md
+++ b/website/tables/heroku/heroku_enterprise_accounts.md
@@ -10,14 +10,14 @@ The primary key for this table is **id**.
 
 | Name          | Type          |
 | ------------- | ------------- |
-|_cq_source_name|String|
-|_cq_sync_time|Timestamp|
-|_cq_id|UUID|
-|_cq_parent_id|UUID|
-|id (PK)|String|
-|created_at|Timestamp|
-|identity_provider|JSON|
-|name|String|
-|permissions|StringArray|
-|trial|Bool|
-|updated_at|Timestamp|
+|_cq_source_name|utf8|
+|_cq_sync_time|timestamp[us, tz=UTC]|
+|_cq_id|uuid|
+|_cq_parent_id|uuid|
+|id (PK)|utf8|
+|created_at|timestamp[us, tz=UTC]|
+|identity_provider|json|
+|name|utf8|
+|permissions|list<item: utf8, nullable>|
+|trial|bool|
+|updated_at|timestamp[us, tz=UTC]|

--- a/website/tables/heroku/heroku_formations.md
+++ b/website/tables/heroku/heroku_formations.md
@@ -10,15 +10,15 @@ The primary key for this table is **id**.
 
 | Name          | Type          |
 | ------------- | ------------- |
-|_cq_source_name|String|
-|_cq_sync_time|Timestamp|
-|_cq_id|UUID|
-|_cq_parent_id|UUID|
-|id (PK)|String|
-|app|JSON|
-|command|String|
-|created_at|Timestamp|
-|quantity|Int|
-|size|String|
-|type|String|
-|updated_at|Timestamp|
+|_cq_source_name|utf8|
+|_cq_sync_time|timestamp[us, tz=UTC]|
+|_cq_id|uuid|
+|_cq_parent_id|uuid|
+|id (PK)|utf8|
+|app|json|
+|command|utf8|
+|created_at|timestamp[us, tz=UTC]|
+|quantity|int64|
+|size|utf8|
+|type|utf8|
+|updated_at|timestamp[us, tz=UTC]|

--- a/website/tables/heroku/heroku_inbound_rulesets.md
+++ b/website/tables/heroku/heroku_inbound_rulesets.md
@@ -10,12 +10,12 @@ The primary key for this table is **id**.
 
 | Name          | Type          |
 | ------------- | ------------- |
-|_cq_source_name|String|
-|_cq_sync_time|Timestamp|
-|_cq_id|UUID|
-|_cq_parent_id|UUID|
-|id (PK)|String|
-|created_at|Timestamp|
-|created_by|String|
-|rules|JSON|
-|space|JSON|
+|_cq_source_name|utf8|
+|_cq_sync_time|timestamp[us, tz=UTC]|
+|_cq_id|uuid|
+|_cq_parent_id|uuid|
+|id (PK)|utf8|
+|created_at|timestamp[us, tz=UTC]|
+|created_by|utf8|
+|rules|json|
+|space|json|

--- a/website/tables/heroku/heroku_invoices.md
+++ b/website/tables/heroku/heroku_invoices.md
@@ -10,17 +10,17 @@ The primary key for this table is **id**.
 
 | Name          | Type          |
 | ------------- | ------------- |
-|_cq_source_name|String|
-|_cq_sync_time|Timestamp|
-|_cq_id|UUID|
-|_cq_parent_id|UUID|
-|id (PK)|String|
-|charges_total|Float|
-|created_at|Timestamp|
-|credits_total|Float|
-|number|Int|
-|period_end|String|
-|period_start|String|
-|state|Int|
-|total|Float|
-|updated_at|Timestamp|
+|_cq_source_name|utf8|
+|_cq_sync_time|timestamp[us, tz=UTC]|
+|_cq_id|uuid|
+|_cq_parent_id|uuid|
+|id (PK)|utf8|
+|charges_total|float64|
+|created_at|timestamp[us, tz=UTC]|
+|credits_total|float64|
+|number|int64|
+|period_end|utf8|
+|period_start|utf8|
+|state|int64|
+|total|float64|
+|updated_at|timestamp[us, tz=UTC]|

--- a/website/tables/heroku/heroku_keys.md
+++ b/website/tables/heroku/heroku_keys.md
@@ -10,14 +10,14 @@ The primary key for this table is **id**.
 
 | Name          | Type          |
 | ------------- | ------------- |
-|_cq_source_name|String|
-|_cq_sync_time|Timestamp|
-|_cq_id|UUID|
-|_cq_parent_id|UUID|
-|id (PK)|String|
-|comment|String|
-|created_at|Timestamp|
-|email|String|
-|fingerprint|String|
-|public_key|String|
-|updated_at|Timestamp|
+|_cq_source_name|utf8|
+|_cq_sync_time|timestamp[us, tz=UTC]|
+|_cq_id|uuid|
+|_cq_parent_id|uuid|
+|id (PK)|utf8|
+|comment|utf8|
+|created_at|timestamp[us, tz=UTC]|
+|email|utf8|
+|fingerprint|utf8|
+|public_key|utf8|
+|updated_at|timestamp[us, tz=UTC]|

--- a/website/tables/heroku/heroku_log_drains.md
+++ b/website/tables/heroku/heroku_log_drains.md
@@ -10,13 +10,13 @@ The primary key for this table is **id**.
 
 | Name          | Type          |
 | ------------- | ------------- |
-|_cq_source_name|String|
-|_cq_sync_time|Timestamp|
-|_cq_id|UUID|
-|_cq_parent_id|UUID|
-|id (PK)|String|
-|addon|JSON|
-|created_at|Timestamp|
-|token|String|
-|updated_at|Timestamp|
-|url|String|
+|_cq_source_name|utf8|
+|_cq_sync_time|timestamp[us, tz=UTC]|
+|_cq_id|uuid|
+|_cq_parent_id|uuid|
+|id (PK)|utf8|
+|addon|json|
+|created_at|timestamp[us, tz=UTC]|
+|token|utf8|
+|updated_at|timestamp[us, tz=UTC]|
+|url|utf8|

--- a/website/tables/heroku/heroku_oauth_authorizations.md
+++ b/website/tables/heroku/heroku_oauth_authorizations.md
@@ -10,16 +10,16 @@ The primary key for this table is **id**.
 
 | Name          | Type          |
 | ------------- | ------------- |
-|_cq_source_name|String|
-|_cq_sync_time|Timestamp|
-|_cq_id|UUID|
-|_cq_parent_id|UUID|
-|id (PK)|String|
-|access_token|JSON|
-|client|JSON|
-|created_at|Timestamp|
-|grant|JSON|
-|refresh_token|JSON|
-|scope|StringArray|
-|updated_at|Timestamp|
-|user|JSON|
+|_cq_source_name|utf8|
+|_cq_sync_time|timestamp[us, tz=UTC]|
+|_cq_id|uuid|
+|_cq_parent_id|uuid|
+|id (PK)|utf8|
+|access_token|json|
+|client|json|
+|created_at|timestamp[us, tz=UTC]|
+|grant|json|
+|refresh_token|json|
+|scope|list<item: utf8, nullable>|
+|updated_at|timestamp[us, tz=UTC]|
+|user|json|

--- a/website/tables/heroku/heroku_oauth_clients.md
+++ b/website/tables/heroku/heroku_oauth_clients.md
@@ -10,14 +10,14 @@ The primary key for this table is **id**.
 
 | Name          | Type          |
 | ------------- | ------------- |
-|_cq_source_name|String|
-|_cq_sync_time|Timestamp|
-|_cq_id|UUID|
-|_cq_parent_id|UUID|
-|id (PK)|String|
-|created_at|Timestamp|
-|ignores_delinquent|Bool|
-|name|String|
-|redirect_uri|String|
-|secret|String|
-|updated_at|Timestamp|
+|_cq_source_name|utf8|
+|_cq_sync_time|timestamp[us, tz=UTC]|
+|_cq_id|uuid|
+|_cq_parent_id|uuid|
+|id (PK)|utf8|
+|created_at|timestamp[us, tz=UTC]|
+|ignores_delinquent|bool|
+|name|utf8|
+|redirect_uri|utf8|
+|secret|utf8|
+|updated_at|timestamp[us, tz=UTC]|

--- a/website/tables/heroku/heroku_outbound_rulesets.md
+++ b/website/tables/heroku/heroku_outbound_rulesets.md
@@ -10,12 +10,12 @@ The primary key for this table is **id**.
 
 | Name          | Type          |
 | ------------- | ------------- |
-|_cq_source_name|String|
-|_cq_sync_time|Timestamp|
-|_cq_id|UUID|
-|_cq_parent_id|UUID|
-|id (PK)|String|
-|created_at|Timestamp|
-|created_by|String|
-|rules|JSON|
-|space|JSON|
+|_cq_source_name|utf8|
+|_cq_sync_time|timestamp[us, tz=UTC]|
+|_cq_id|uuid|
+|_cq_parent_id|uuid|
+|id (PK)|utf8|
+|created_at|timestamp[us, tz=UTC]|
+|created_by|utf8|
+|rules|json|
+|space|json|

--- a/website/tables/heroku/heroku_peerings.md
+++ b/website/tables/heroku/heroku_peerings.md
@@ -10,15 +10,15 @@ The primary key for this table is **_cq_id**.
 
 | Name          | Type          |
 | ------------- | ------------- |
-|_cq_source_name|String|
-|_cq_sync_time|Timestamp|
-|_cq_id (PK)|UUID|
-|_cq_parent_id|UUID|
-|aws_account_id|String|
-|aws_region|String|
-|aws_vpc_id|String|
-|cidr_blocks|StringArray|
-|expires|Timestamp|
-|pcx_id|String|
-|status|String|
-|type|String|
+|_cq_source_name|utf8|
+|_cq_sync_time|timestamp[us, tz=UTC]|
+|_cq_id (PK)|uuid|
+|_cq_parent_id|uuid|
+|aws_account_id|utf8|
+|aws_region|utf8|
+|aws_vpc_id|utf8|
+|cidr_blocks|list<item: utf8, nullable>|
+|expires|timestamp[us, tz=UTC]|
+|pcx_id|utf8|
+|status|utf8|
+|type|utf8|

--- a/website/tables/heroku/heroku_permission_entities.md
+++ b/website/tables/heroku/heroku_permission_entities.md
@@ -10,12 +10,12 @@ The primary key for this table is **id**.
 
 | Name          | Type          |
 | ------------- | ------------- |
-|_cq_source_name|String|
-|_cq_sync_time|Timestamp|
-|_cq_id|UUID|
-|_cq_parent_id|UUID|
-|id (PK)|String|
-|name|String|
-|team_id|String|
-|type|String|
-|users|JSON|
+|_cq_source_name|utf8|
+|_cq_sync_time|timestamp[us, tz=UTC]|
+|_cq_id|uuid|
+|_cq_parent_id|uuid|
+|id (PK)|utf8|
+|name|utf8|
+|team_id|utf8|
+|type|utf8|
+|users|json|

--- a/website/tables/heroku/heroku_pipeline_builds.md
+++ b/website/tables/heroku/heroku_pipeline_builds.md
@@ -10,19 +10,19 @@ The primary key for this table is **id**.
 
 | Name          | Type          |
 | ------------- | ------------- |
-|_cq_source_name|String|
-|_cq_sync_time|Timestamp|
-|_cq_id|UUID|
-|_cq_parent_id|UUID|
-|id (PK)|String|
-|app|JSON|
-|buildpacks|JSON|
-|created_at|Timestamp|
-|output_stream_url|String|
-|release|JSON|
-|slug|JSON|
-|source_blob|JSON|
-|stack|String|
-|status|String|
-|updated_at|Timestamp|
-|user|JSON|
+|_cq_source_name|utf8|
+|_cq_sync_time|timestamp[us, tz=UTC]|
+|_cq_id|uuid|
+|_cq_parent_id|uuid|
+|id (PK)|utf8|
+|app|json|
+|buildpacks|json|
+|created_at|timestamp[us, tz=UTC]|
+|output_stream_url|utf8|
+|release|json|
+|slug|json|
+|source_blob|json|
+|stack|utf8|
+|status|utf8|
+|updated_at|timestamp[us, tz=UTC]|
+|user|json|

--- a/website/tables/heroku/heroku_pipeline_couplings.md
+++ b/website/tables/heroku/heroku_pipeline_couplings.md
@@ -10,13 +10,13 @@ The primary key for this table is **id**.
 
 | Name          | Type          |
 | ------------- | ------------- |
-|_cq_source_name|String|
-|_cq_sync_time|Timestamp|
-|_cq_id|UUID|
-|_cq_parent_id|UUID|
-|id (PK)|String|
-|app|JSON|
-|created_at|Timestamp|
-|pipeline|JSON|
-|stage|String|
-|updated_at|Timestamp|
+|_cq_source_name|utf8|
+|_cq_sync_time|timestamp[us, tz=UTC]|
+|_cq_id|uuid|
+|_cq_parent_id|uuid|
+|id (PK)|utf8|
+|app|json|
+|created_at|timestamp[us, tz=UTC]|
+|pipeline|json|
+|stage|utf8|
+|updated_at|timestamp[us, tz=UTC]|

--- a/website/tables/heroku/heroku_pipeline_deployments.md
+++ b/website/tables/heroku/heroku_pipeline_deployments.md
@@ -10,19 +10,19 @@ The primary key for this table is **id**.
 
 | Name          | Type          |
 | ------------- | ------------- |
-|_cq_source_name|String|
-|_cq_sync_time|Timestamp|
-|_cq_id|UUID|
-|_cq_parent_id|UUID|
-|id (PK)|String|
-|addon_plan_names|StringArray|
-|app|JSON|
-|created_at|Timestamp|
-|current|Bool|
-|description|String|
-|output_stream_url|String|
-|slug|JSON|
-|status|String|
-|updated_at|Timestamp|
-|user|JSON|
-|version|Int|
+|_cq_source_name|utf8|
+|_cq_sync_time|timestamp[us, tz=UTC]|
+|_cq_id|uuid|
+|_cq_parent_id|uuid|
+|id (PK)|utf8|
+|addon_plan_names|list<item: utf8, nullable>|
+|app|json|
+|created_at|timestamp[us, tz=UTC]|
+|current|bool|
+|description|utf8|
+|output_stream_url|utf8|
+|slug|json|
+|status|utf8|
+|updated_at|timestamp[us, tz=UTC]|
+|user|json|
+|version|int64|

--- a/website/tables/heroku/heroku_pipeline_releases.md
+++ b/website/tables/heroku/heroku_pipeline_releases.md
@@ -10,19 +10,19 @@ The primary key for this table is **id**.
 
 | Name          | Type          |
 | ------------- | ------------- |
-|_cq_source_name|String|
-|_cq_sync_time|Timestamp|
-|_cq_id|UUID|
-|_cq_parent_id|UUID|
-|id (PK)|String|
-|addon_plan_names|StringArray|
-|app|JSON|
-|created_at|Timestamp|
-|current|Bool|
-|description|String|
-|output_stream_url|String|
-|slug|JSON|
-|status|String|
-|updated_at|Timestamp|
-|user|JSON|
-|version|Int|
+|_cq_source_name|utf8|
+|_cq_sync_time|timestamp[us, tz=UTC]|
+|_cq_id|uuid|
+|_cq_parent_id|uuid|
+|id (PK)|utf8|
+|addon_plan_names|list<item: utf8, nullable>|
+|app|json|
+|created_at|timestamp[us, tz=UTC]|
+|current|bool|
+|description|utf8|
+|output_stream_url|utf8|
+|slug|json|
+|status|utf8|
+|updated_at|timestamp[us, tz=UTC]|
+|user|json|
+|version|int64|

--- a/website/tables/heroku/heroku_pipelines.md
+++ b/website/tables/heroku/heroku_pipelines.md
@@ -10,12 +10,12 @@ The primary key for this table is **id**.
 
 | Name          | Type          |
 | ------------- | ------------- |
-|_cq_source_name|String|
-|_cq_sync_time|Timestamp|
-|_cq_id|UUID|
-|_cq_parent_id|UUID|
-|id (PK)|String|
-|created_at|Timestamp|
-|name|String|
-|owner|JSON|
-|updated_at|Timestamp|
+|_cq_source_name|utf8|
+|_cq_sync_time|timestamp[us, tz=UTC]|
+|_cq_id|uuid|
+|_cq_parent_id|uuid|
+|id (PK)|utf8|
+|created_at|timestamp[us, tz=UTC]|
+|name|utf8|
+|owner|json|
+|updated_at|timestamp[us, tz=UTC]|

--- a/website/tables/heroku/heroku_regions.md
+++ b/website/tables/heroku/heroku_regions.md
@@ -10,16 +10,16 @@ The primary key for this table is **id**.
 
 | Name          | Type          |
 | ------------- | ------------- |
-|_cq_source_name|String|
-|_cq_sync_time|Timestamp|
-|_cq_id|UUID|
-|_cq_parent_id|UUID|
-|id (PK)|String|
-|country|String|
-|created_at|Timestamp|
-|description|String|
-|locale|String|
-|name|String|
-|private_capable|Bool|
-|provider|JSON|
-|updated_at|Timestamp|
+|_cq_source_name|utf8|
+|_cq_sync_time|timestamp[us, tz=UTC]|
+|_cq_id|uuid|
+|_cq_parent_id|uuid|
+|id (PK)|utf8|
+|country|utf8|
+|created_at|timestamp[us, tz=UTC]|
+|description|utf8|
+|locale|utf8|
+|name|utf8|
+|private_capable|bool|
+|provider|json|
+|updated_at|timestamp[us, tz=UTC]|

--- a/website/tables/heroku/heroku_releases.md
+++ b/website/tables/heroku/heroku_releases.md
@@ -10,19 +10,19 @@ The primary key for this table is **id**.
 
 | Name          | Type          |
 | ------------- | ------------- |
-|_cq_source_name|String|
-|_cq_sync_time|Timestamp|
-|_cq_id|UUID|
-|_cq_parent_id|UUID|
-|id (PK)|String|
-|addon_plan_names|StringArray|
-|app|JSON|
-|created_at|Timestamp|
-|current|Bool|
-|description|String|
-|output_stream_url|String|
-|slug|JSON|
-|status|String|
-|updated_at|Timestamp|
-|user|JSON|
-|version|Int|
+|_cq_source_name|utf8|
+|_cq_sync_time|timestamp[us, tz=UTC]|
+|_cq_id|uuid|
+|_cq_parent_id|uuid|
+|id (PK)|utf8|
+|addon_plan_names|list<item: utf8, nullable>|
+|app|json|
+|created_at|timestamp[us, tz=UTC]|
+|current|bool|
+|description|utf8|
+|output_stream_url|utf8|
+|slug|json|
+|status|utf8|
+|updated_at|timestamp[us, tz=UTC]|
+|user|json|
+|version|int64|

--- a/website/tables/heroku/heroku_review_apps.md
+++ b/website/tables/heroku/heroku_review_apps.md
@@ -10,21 +10,21 @@ The primary key for this table is **id**.
 
 | Name          | Type          |
 | ------------- | ------------- |
-|_cq_source_name|String|
-|_cq_sync_time|Timestamp|
-|_cq_id|UUID|
-|_cq_parent_id|UUID|
-|id (PK)|String|
-|app|JSON|
-|app_setup|JSON|
-|branch|String|
-|created_at|Timestamp|
-|creator|JSON|
-|error_status|String|
-|fork_repo|JSON|
-|message|String|
-|pipeline|JSON|
-|pr_number|Int|
-|status|String|
-|updated_at|Timestamp|
-|wait_for_ci|Bool|
+|_cq_source_name|utf8|
+|_cq_sync_time|timestamp[us, tz=UTC]|
+|_cq_id|uuid|
+|_cq_parent_id|uuid|
+|id (PK)|utf8|
+|app|json|
+|app_setup|json|
+|branch|utf8|
+|created_at|timestamp[us, tz=UTC]|
+|creator|json|
+|error_status|utf8|
+|fork_repo|json|
+|message|utf8|
+|pipeline|json|
+|pr_number|int64|
+|status|utf8|
+|updated_at|timestamp[us, tz=UTC]|
+|wait_for_ci|bool|

--- a/website/tables/heroku/heroku_space_app_accesses.md
+++ b/website/tables/heroku/heroku_space_app_accesses.md
@@ -10,13 +10,13 @@ The primary key for this table is **id**.
 
 | Name          | Type          |
 | ------------- | ------------- |
-|_cq_source_name|String|
-|_cq_sync_time|Timestamp|
-|_cq_id|UUID|
-|_cq_parent_id|UUID|
-|id (PK)|String|
-|created_at|Timestamp|
-|permissions|JSON|
-|space|JSON|
-|updated_at|Timestamp|
-|user|JSON|
+|_cq_source_name|utf8|
+|_cq_sync_time|timestamp[us, tz=UTC]|
+|_cq_id|uuid|
+|_cq_parent_id|uuid|
+|id (PK)|utf8|
+|created_at|timestamp[us, tz=UTC]|
+|permissions|json|
+|space|json|
+|updated_at|timestamp[us, tz=UTC]|
+|user|json|

--- a/website/tables/heroku/heroku_spaces.md
+++ b/website/tables/heroku/heroku_spaces.md
@@ -10,18 +10,18 @@ The primary key for this table is **id**.
 
 | Name          | Type          |
 | ------------- | ------------- |
-|_cq_source_name|String|
-|_cq_sync_time|Timestamp|
-|_cq_id|UUID|
-|_cq_parent_id|UUID|
-|id (PK)|String|
-|cidr|String|
-|created_at|Timestamp|
-|data_cidr|String|
-|name|String|
-|organization|JSON|
-|region|JSON|
-|shield|Bool|
-|state|String|
-|team|JSON|
-|updated_at|Timestamp|
+|_cq_source_name|utf8|
+|_cq_sync_time|timestamp[us, tz=UTC]|
+|_cq_id|uuid|
+|_cq_parent_id|uuid|
+|id (PK)|utf8|
+|cidr|utf8|
+|created_at|timestamp[us, tz=UTC]|
+|data_cidr|utf8|
+|name|utf8|
+|organization|json|
+|region|json|
+|shield|bool|
+|state|utf8|
+|team|json|
+|updated_at|timestamp[us, tz=UTC]|

--- a/website/tables/heroku/heroku_stacks.md
+++ b/website/tables/heroku/heroku_stacks.md
@@ -10,13 +10,13 @@ The primary key for this table is **id**.
 
 | Name          | Type          |
 | ------------- | ------------- |
-|_cq_source_name|String|
-|_cq_sync_time|Timestamp|
-|_cq_id|UUID|
-|_cq_parent_id|UUID|
-|id (PK)|String|
-|created_at|Timestamp|
-|default|Bool|
-|name|String|
-|state|String|
-|updated_at|Timestamp|
+|_cq_source_name|utf8|
+|_cq_sync_time|timestamp[us, tz=UTC]|
+|_cq_id|uuid|
+|_cq_parent_id|uuid|
+|id (PK)|utf8|
+|created_at|timestamp[us, tz=UTC]|
+|default|bool|
+|name|utf8|
+|state|utf8|
+|updated_at|timestamp[us, tz=UTC]|

--- a/website/tables/heroku/heroku_team_app_permissions.md
+++ b/website/tables/heroku/heroku_team_app_permissions.md
@@ -10,9 +10,9 @@ The primary key for this table is **_cq_id**.
 
 | Name          | Type          |
 | ------------- | ------------- |
-|_cq_source_name|String|
-|_cq_sync_time|Timestamp|
-|_cq_id (PK)|UUID|
-|_cq_parent_id|UUID|
-|description|String|
-|name|String|
+|_cq_source_name|utf8|
+|_cq_sync_time|timestamp[us, tz=UTC]|
+|_cq_id (PK)|uuid|
+|_cq_parent_id|uuid|
+|description|utf8|
+|name|utf8|

--- a/website/tables/heroku/heroku_team_features.md
+++ b/website/tables/heroku/heroku_team_features.md
@@ -10,17 +10,17 @@ The primary key for this table is **id**.
 
 | Name          | Type          |
 | ------------- | ------------- |
-|_cq_source_name|String|
-|_cq_sync_time|Timestamp|
-|_cq_id|UUID|
-|_cq_parent_id|UUID|
-|id (PK)|String|
-|created_at|Timestamp|
-|description|String|
-|display_name|String|
-|doc_url|String|
-|enabled|Bool|
-|feedback_email|String|
-|name|String|
-|state|String|
-|updated_at|Timestamp|
+|_cq_source_name|utf8|
+|_cq_sync_time|timestamp[us, tz=UTC]|
+|_cq_id|uuid|
+|_cq_parent_id|uuid|
+|id (PK)|utf8|
+|created_at|timestamp[us, tz=UTC]|
+|description|utf8|
+|display_name|utf8|
+|doc_url|utf8|
+|enabled|bool|
+|feedback_email|utf8|
+|name|utf8|
+|state|utf8|
+|updated_at|timestamp[us, tz=UTC]|

--- a/website/tables/heroku/heroku_team_invitations.md
+++ b/website/tables/heroku/heroku_team_invitations.md
@@ -10,14 +10,14 @@ The primary key for this table is **id**.
 
 | Name          | Type          |
 | ------------- | ------------- |
-|_cq_source_name|String|
-|_cq_sync_time|Timestamp|
-|_cq_id|UUID|
-|_cq_parent_id|UUID|
-|id (PK)|String|
-|created_at|Timestamp|
-|invited_by|JSON|
-|role|String|
-|team|JSON|
-|updated_at|Timestamp|
-|user|JSON|
+|_cq_source_name|utf8|
+|_cq_sync_time|timestamp[us, tz=UTC]|
+|_cq_id|uuid|
+|_cq_parent_id|uuid|
+|id (PK)|utf8|
+|created_at|timestamp[us, tz=UTC]|
+|invited_by|json|
+|role|utf8|
+|team|json|
+|updated_at|timestamp[us, tz=UTC]|
+|user|json|

--- a/website/tables/heroku/heroku_team_invoices.md
+++ b/website/tables/heroku/heroku_team_invoices.md
@@ -10,23 +10,23 @@ The primary key for this table is **id**.
 
 | Name          | Type          |
 | ------------- | ------------- |
-|_cq_source_name|String|
-|_cq_sync_time|Timestamp|
-|_cq_id|UUID|
-|_cq_parent_id|UUID|
-|id (PK)|String|
-|addons_total|Int|
-|charges_total|Int|
-|created_at|Timestamp|
-|credits_total|Int|
-|database_total|Int|
-|dyno_units|Float|
-|number|Int|
-|payment_status|String|
-|period_end|String|
-|period_start|String|
-|platform_total|Int|
-|state|Int|
-|total|Int|
-|updated_at|Timestamp|
-|weighted_dyno_hours|Float|
+|_cq_source_name|utf8|
+|_cq_sync_time|timestamp[us, tz=UTC]|
+|_cq_id|uuid|
+|_cq_parent_id|uuid|
+|id (PK)|utf8|
+|addons_total|int64|
+|charges_total|int64|
+|created_at|timestamp[us, tz=UTC]|
+|credits_total|int64|
+|database_total|int64|
+|dyno_units|float64|
+|number|int64|
+|payment_status|utf8|
+|period_end|utf8|
+|period_start|utf8|
+|platform_total|int64|
+|state|int64|
+|total|int64|
+|updated_at|timestamp[us, tz=UTC]|
+|weighted_dyno_hours|float64|

--- a/website/tables/heroku/heroku_team_members.md
+++ b/website/tables/heroku/heroku_team_members.md
@@ -10,16 +10,16 @@ The primary key for this table is **id**.
 
 | Name          | Type          |
 | ------------- | ------------- |
-|_cq_source_name|String|
-|_cq_sync_time|Timestamp|
-|_cq_id|UUID|
-|_cq_parent_id|UUID|
-|id (PK)|String|
-|created_at|Timestamp|
-|email|String|
-|federated|Bool|
-|identity_provider|JSON|
-|role|String|
-|two_factor_authentication|Bool|
-|updated_at|Timestamp|
-|user|JSON|
+|_cq_source_name|utf8|
+|_cq_sync_time|timestamp[us, tz=UTC]|
+|_cq_id|uuid|
+|_cq_parent_id|uuid|
+|id (PK)|utf8|
+|created_at|timestamp[us, tz=UTC]|
+|email|utf8|
+|federated|bool|
+|identity_provider|json|
+|role|utf8|
+|two_factor_authentication|bool|
+|updated_at|timestamp[us, tz=UTC]|
+|user|json|

--- a/website/tables/heroku/heroku_team_spaces.md
+++ b/website/tables/heroku/heroku_team_spaces.md
@@ -10,18 +10,18 @@ The primary key for this table is **id**.
 
 | Name          | Type          |
 | ------------- | ------------- |
-|_cq_source_name|String|
-|_cq_sync_time|Timestamp|
-|_cq_id|UUID|
-|_cq_parent_id|UUID|
-|id (PK)|String|
-|cidr|String|
-|created_at|Timestamp|
-|data_cidr|String|
-|name|String|
-|organization|JSON|
-|region|JSON|
-|shield|Bool|
-|state|String|
-|team|JSON|
-|updated_at|Timestamp|
+|_cq_source_name|utf8|
+|_cq_sync_time|timestamp[us, tz=UTC]|
+|_cq_id|uuid|
+|_cq_parent_id|uuid|
+|id (PK)|utf8|
+|cidr|utf8|
+|created_at|timestamp[us, tz=UTC]|
+|data_cidr|utf8|
+|name|utf8|
+|organization|json|
+|region|json|
+|shield|bool|
+|state|utf8|
+|team|json|
+|updated_at|timestamp[us, tz=UTC]|

--- a/website/tables/heroku/heroku_teams.md
+++ b/website/tables/heroku/heroku_teams.md
@@ -10,19 +10,19 @@ The primary key for this table is **id**.
 
 | Name          | Type          |
 | ------------- | ------------- |
-|_cq_source_name|String|
-|_cq_sync_time|Timestamp|
-|_cq_id|UUID|
-|_cq_parent_id|UUID|
-|id (PK)|String|
-|created_at|Timestamp|
-|credit_card_collections|Bool|
-|default|Bool|
-|enterprise_account|JSON|
-|identity_provider|JSON|
-|membership_limit|Float|
-|name|String|
-|provisioned_licenses|Bool|
-|role|String|
-|type|String|
-|updated_at|Timestamp|
+|_cq_source_name|utf8|
+|_cq_sync_time|timestamp[us, tz=UTC]|
+|_cq_id|uuid|
+|_cq_parent_id|uuid|
+|id (PK)|utf8|
+|created_at|timestamp[us, tz=UTC]|
+|credit_card_collections|bool|
+|default|bool|
+|enterprise_account|json|
+|identity_provider|json|
+|membership_limit|float64|
+|name|utf8|
+|provisioned_licenses|bool|
+|role|utf8|
+|type|utf8|
+|updated_at|timestamp[us, tz=UTC]|

--- a/website/tables/heroku/heroku_vpn_connections.md
+++ b/website/tables/heroku/heroku_vpn_connections.md
@@ -10,16 +10,16 @@ The primary key for this table is **id**.
 
 | Name          | Type          |
 | ------------- | ------------- |
-|_cq_source_name|String|
-|_cq_sync_time|Timestamp|
-|_cq_id|UUID|
-|_cq_parent_id|UUID|
-|id (PK)|String|
-|ike_version|Int|
-|name|String|
-|public_ip|String|
-|routable_cidrs|StringArray|
-|space_cidr_block|String|
-|status|String|
-|status_message|String|
-|tunnels|JSON|
+|_cq_source_name|utf8|
+|_cq_sync_time|timestamp[us, tz=UTC]|
+|_cq_id|uuid|
+|_cq_parent_id|uuid|
+|id (PK)|utf8|
+|ike_version|int64|
+|name|utf8|
+|public_ip|utf8|
+|routable_cidrs|list<item: utf8, nullable>|
+|space_cidr_block|utf8|
+|status|utf8|
+|status_message|utf8|
+|tunnels|json|


### PR DESCRIPTION
feat!: Update to use [Apache Arrow](https://arrow.apache.org/) type system

  This release introduces an internal change to our type system to use [Apache Arrow](https://arrow.apache.org/). This should not have any visible breaking changes, however due to the size of the change we are introducing it under a major version bump to communicate that it might have some bugs that we weren't able to catch during our internal tests. If you encounter an issue during the upgrade, please submit a [bug report](https://github.com/cloudquery/cloudquery/issues/new/choose). You will also need to update destinations depending on which one you use:
  - Azure Blob Storage >= v3.2.0
  - BigQuery >= v3.0.0
  - ClickHouse >= v3.1.1
  - DuckDB >= v1.1.6
  - Elasticsearch >= v2.0.0
  - File >= v3.2.0
  - Firehose >= v2.0.2
  - GCS >= v3.2.0
  - Gremlin >= v2.1.10
  - Kafka >= v3.0.1
  - Meilisearch >= v2.0.1
  - Microsoft SQL Server >= v4.2.0
  - MongoDB >= v2.0.1
  - MySQL >= v2.0.2
  - Neo4j >= v3.0.0
  - PostgreSQL >= v4.2.0
  - S3 >= v4.4.0
  - Snowflake >= v2.1.1
  - SQLite >= v2.2.0

Closes https://github.com/cloudquery/cloudquery/issues/10750
