### PR TITLE
feat(alicloud)!: Migrate to Arrow native SDK

### DIFF
--- a/plugins/source/alicloud/client/client.go
+++ b/plugins/source/alicloud/client/client.go
@@ -6,8 +6,8 @@ import (
 	"strings"
 
 	"github.com/cloudquery/plugin-pb-go/specs"
-	"github.com/cloudquery/plugin-sdk/v2/plugins/source"
-	"github.com/cloudquery/plugin-sdk/v2/schema"
+	"github.com/cloudquery/plugin-sdk/v3/plugins/source"
+	"github.com/cloudquery/plugin-sdk/v3/schema"
 	"github.com/rs/zerolog"
 )
 

--- a/plugins/source/alicloud/client/multiplexers.go
+++ b/plugins/source/alicloud/client/multiplexers.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"sort"
 
-	"github.com/cloudquery/plugin-sdk/v2/schema"
+	"github.com/cloudquery/plugin-sdk/v3/schema"
 )
 
 // Extract region from service list

--- a/plugins/source/alicloud/client/resolvers.go
+++ b/plugins/source/alicloud/client/resolvers.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"time"
 
-	"github.com/cloudquery/plugin-sdk/v2/schema"
+	"github.com/cloudquery/plugin-sdk/v3/schema"
 	"github.com/thoas/go-funk"
 )
 

--- a/plugins/source/alicloud/client/testing.go
+++ b/plugins/source/alicloud/client/testing.go
@@ -8,8 +8,8 @@ import (
 	"time"
 
 	"github.com/cloudquery/plugin-pb-go/specs"
-	"github.com/cloudquery/plugin-sdk/v2/plugins/source"
-	"github.com/cloudquery/plugin-sdk/v2/schema"
+	"github.com/cloudquery/plugin-sdk/v3/plugins/source"
+	"github.com/cloudquery/plugin-sdk/v3/schema"
 	"github.com/golang/mock/gomock"
 	"github.com/rs/zerolog"
 )

--- a/plugins/source/alicloud/go.mod
+++ b/plugins/source/alicloud/go.mod
@@ -7,21 +7,21 @@ require (
 	github.com/aliyun/aliyun-oss-go-sdk v2.2.7+incompatible
 	github.com/cloudquery/codegen v0.2.1
 	github.com/cloudquery/plugin-pb-go v1.0.8
-	github.com/cloudquery/plugin-sdk/v2 v2.7.0
+	github.com/cloudquery/plugin-sdk/v3 v3.6.4
 	github.com/golang/mock v1.5.0
 	github.com/pkg/errors v0.9.1
 	github.com/rs/zerolog v1.29.0
 	github.com/thoas/go-funk v0.9.3
 )
 
-// TODO: remove once all updates are merged
-replace github.com/apache/arrow/go/v13 => github.com/cloudquery/arrow/go/v13 v13.0.0-20230509053643-898a79b1d3c8
+replace github.com/apache/arrow/go/v13 => github.com/cloudquery/arrow/go/v13 v13.0.0-20230525142029-2d32efeedad8
 
 require (
 	github.com/andybalholm/brotli v1.0.5 // indirect
 	github.com/apache/arrow/go/v13 v13.0.0-20230509040948-de6c3cd2b604 // indirect
 	github.com/apache/thrift v0.16.0 // indirect
 	github.com/cloudquery/plugin-sdk v1.45.0 // indirect
+	github.com/cloudquery/plugin-sdk/v2 v2.7.0 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/getsentry/sentry-go v0.20.0 // indirect
 	github.com/ghodss/yaml v1.0.0 // indirect
@@ -45,6 +45,7 @@ require (
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.2 // indirect
 	github.com/opentracing/opentracing-go v1.2.1-0.20220228012449-10b1cf09e00b // indirect
+	github.com/pierrec/lz4/v4 v4.1.15 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/spf13/cast v1.5.0 // indirect
 	github.com/spf13/cobra v1.6.1 // indirect

--- a/plugins/source/alicloud/go.sum
+++ b/plugins/source/alicloud/go.sum
@@ -48,8 +48,8 @@ github.com/chzyer/logex v1.1.10/go.mod h1:+Ywpsq7O8HXn0nuIou7OrIPyXbp3wmkHB+jjWR
 github.com/chzyer/readline v0.0.0-20180603132655-2972be24d48e/go.mod h1:nSuG5e5PlCu98SY8svDHJxuZscDgtXS6KTTbou5AhLI=
 github.com/chzyer/test v0.0.0-20180213035817-a1ea475d72b1/go.mod h1:Q3SI9o4m/ZMnBNeIyt5eFwwo7qiLfzFZmjNmxjkiQlU=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
-github.com/cloudquery/arrow/go/v13 v13.0.0-20230509053643-898a79b1d3c8 h1:CmgLSEGQNLHpUQ5cU4L4aF7cuJZRnc1toIIWqC1gmPg=
-github.com/cloudquery/arrow/go/v13 v13.0.0-20230509053643-898a79b1d3c8/go.mod h1:/XatdE3kDIBqZKhZ7OBUHwP2jaASDFZHqF4puOWM8po=
+github.com/cloudquery/arrow/go/v13 v13.0.0-20230525142029-2d32efeedad8 h1:/mgK+To5HNUzuZDWdVygbfn8oaPG5c7I/8qCxwwpWO8=
+github.com/cloudquery/arrow/go/v13 v13.0.0-20230525142029-2d32efeedad8/go.mod h1:/XatdE3kDIBqZKhZ7OBUHwP2jaASDFZHqF4puOWM8po=
 github.com/cloudquery/codegen v0.2.1 h1:AWpGNKIFUyzI7vulYADXi/3SoksUaNXgTgIMuSrTHZk=
 github.com/cloudquery/codegen v0.2.1/go.mod h1:oJxzUuOC79fP36vBPU1BJ7n+jgQemS33y/mbgNq6vfM=
 github.com/cloudquery/plugin-pb-go v1.0.8 h1:wn3GXhcNItcP+6wUUZuzUFbvdL59liKBO37/izMi+FQ=
@@ -58,6 +58,8 @@ github.com/cloudquery/plugin-sdk v1.45.0 h1:5vrfQZtaO1dp6ebKt8ouXDmPC7eeLuOB3JMd
 github.com/cloudquery/plugin-sdk v1.45.0/go.mod h1:9KGuuTGjTCKgh9amKwS+7Zrrqq7/M6lormteOyqoKwg=
 github.com/cloudquery/plugin-sdk/v2 v2.7.0 h1:hRXsdEiaOxJtsn/wZMFQC9/jPfU1MeMK3KF+gPGqm7U=
 github.com/cloudquery/plugin-sdk/v2 v2.7.0/go.mod h1:pAX6ojIW99b/Vg4CkhnsGkRIzNaVEceYMR+Bdit73ug=
+github.com/cloudquery/plugin-sdk/v3 v3.6.4 h1:P4OkS5tJYkv3OqeL60DAVqXXbFQUyPKJ5YDtAgjl9b4=
+github.com/cloudquery/plugin-sdk/v3 v3.6.4/go.mod h1:3JrZXEULmGXpkOukVaRIzaA63d7TJr9Ukp6hemTjbtc=
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
 github.com/cncf/udpa/go v0.0.0-20201120205902-5459f2c99403/go.mod h1:WmhPx2Nbnhtbo57+VJT5O0JRkEi1Wbu0z5j0R8u5Hbk=
 github.com/coreos/go-systemd v0.0.0-20190321100706-95778dfbb74e/go.mod h1:F5haX7vjVVG0kc13fIWeqUViNPyEJxv/OmvnBo0Yme4=
@@ -201,6 +203,7 @@ github.com/opentracing/opentracing-go v1.1.0/go.mod h1:UkNAQd3GIcIGf0SeVgPpRdFSt
 github.com/opentracing/opentracing-go v1.2.1-0.20220228012449-10b1cf09e00b h1:FfH+VrHHk6Lxt9HdVS0PXzSXFyS2NbZKXv33FYPol0A=
 github.com/opentracing/opentracing-go v1.2.1-0.20220228012449-10b1cf09e00b/go.mod h1:AC62GU6hc0BrNm+9RK9VSiwa/EUe1bkIeFORAMcHvJU=
 github.com/pierrec/lz4/v4 v4.1.15 h1:MO0/ucJhngq7299dKLwIMtgTfbkoSPF6AoMYDd8Q4q0=
+github.com/pierrec/lz4/v4 v4.1.15/go.mod h1:gZWDp/Ze/IJXGXf23ltt2EXimqmTUXEy0GFuRQyBid4=
 github.com/pingcap/errors v0.11.4 h1:lFuQV/oaUMGcD2tqt+01ROSmJs75VG1ToEOkZIZ4nE4=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=

--- a/plugins/source/alicloud/main.go
+++ b/plugins/source/alicloud/main.go
@@ -2,7 +2,7 @@ package main
 
 import (
 	"github.com/cloudquery/cloudquery/plugins/source/alicloud/resources/plugin"
-	"github.com/cloudquery/plugin-sdk/v2/serve"
+	"github.com/cloudquery/plugin-sdk/v3/serve"
 )
 
 const sentryDSN = "https://c1a3fc67153e4f7781125a8dbc1a737f@o1396617.ingest.sentry.io/4504530915557376"

--- a/plugins/source/alicloud/resources/plugin/plugin.go
+++ b/plugins/source/alicloud/resources/plugin/plugin.go
@@ -5,8 +5,8 @@ import (
 	"github.com/cloudquery/cloudquery/plugins/source/alicloud/resources/services/bss"
 	"github.com/cloudquery/cloudquery/plugins/source/alicloud/resources/services/ecs"
 	"github.com/cloudquery/cloudquery/plugins/source/alicloud/resources/services/oss"
-	"github.com/cloudquery/plugin-sdk/v2/plugins/source"
-	"github.com/cloudquery/plugin-sdk/v2/schema"
+	"github.com/cloudquery/plugin-sdk/v3/plugins/source"
+	"github.com/cloudquery/plugin-sdk/v3/schema"
 )
 
 var (

--- a/plugins/source/alicloud/resources/services/bss/bill.go
+++ b/plugins/source/alicloud/resources/services/bss/bill.go
@@ -2,8 +2,8 @@ package bss
 
 import (
 	"github.com/cloudquery/cloudquery/plugins/source/alicloud/client"
-	"github.com/cloudquery/plugin-sdk/v2/schema"
-	"github.com/cloudquery/plugin-sdk/v2/transformers"
+	"github.com/cloudquery/plugin-sdk/v3/schema"
+	"github.com/cloudquery/plugin-sdk/v3/transformers"
 )
 
 func Bill() *schema.Table {

--- a/plugins/source/alicloud/resources/services/bss/bill_details.go
+++ b/plugins/source/alicloud/resources/services/bss/bill_details.go
@@ -2,8 +2,8 @@ package bss
 
 import (
 	"github.com/cloudquery/cloudquery/plugins/source/alicloud/client"
-	"github.com/cloudquery/plugin-sdk/v2/schema"
-	"github.com/cloudquery/plugin-sdk/v2/transformers"
+	"github.com/cloudquery/plugin-sdk/v3/schema"
+	"github.com/cloudquery/plugin-sdk/v3/transformers"
 )
 
 func BillDetails() *schema.Table {

--- a/plugins/source/alicloud/resources/services/bss/bill_details_fetch.go
+++ b/plugins/source/alicloud/resources/services/bss/bill_details_fetch.go
@@ -9,7 +9,7 @@ import (
 	"github.com/aliyun/alibaba-cloud-sdk-go/sdk/requests"
 	"github.com/aliyun/alibaba-cloud-sdk-go/services/bssopenapi"
 	"github.com/cloudquery/cloudquery/plugins/source/alicloud/client"
-	"github.com/cloudquery/plugin-sdk/v2/schema"
+	"github.com/cloudquery/plugin-sdk/v3/schema"
 )
 
 /*

--- a/plugins/source/alicloud/resources/services/bss/bill_details_fetch_mock_test.go
+++ b/plugins/source/alicloud/resources/services/bss/bill_details_fetch_mock_test.go
@@ -6,7 +6,7 @@ import (
 	"github.com/aliyun/alibaba-cloud-sdk-go/services/bssopenapi"
 	"github.com/cloudquery/cloudquery/plugins/source/alicloud/client"
 	"github.com/cloudquery/cloudquery/plugins/source/alicloud/client/mocks"
-	"github.com/cloudquery/plugin-sdk/v2/faker"
+	"github.com/cloudquery/plugin-sdk/v3/faker"
 	"github.com/golang/mock/gomock"
 )
 

--- a/plugins/source/alicloud/resources/services/bss/bill_fetch.go
+++ b/plugins/source/alicloud/resources/services/bss/bill_fetch.go
@@ -9,7 +9,7 @@ import (
 	"github.com/aliyun/alibaba-cloud-sdk-go/sdk/requests"
 	"github.com/aliyun/alibaba-cloud-sdk-go/services/bssopenapi"
 	"github.com/cloudquery/cloudquery/plugins/source/alicloud/client"
-	"github.com/cloudquery/plugin-sdk/v2/schema"
+	"github.com/cloudquery/plugin-sdk/v3/schema"
 )
 
 var (

--- a/plugins/source/alicloud/resources/services/bss/bill_fetch_mock_test.go
+++ b/plugins/source/alicloud/resources/services/bss/bill_fetch_mock_test.go
@@ -6,7 +6,7 @@ import (
 	"github.com/aliyun/alibaba-cloud-sdk-go/services/bssopenapi"
 	"github.com/cloudquery/cloudquery/plugins/source/alicloud/client"
 	"github.com/cloudquery/cloudquery/plugins/source/alicloud/client/mocks"
-	"github.com/cloudquery/plugin-sdk/v2/faker"
+	"github.com/cloudquery/plugin-sdk/v3/faker"
 	"github.com/golang/mock/gomock"
 )
 

--- a/plugins/source/alicloud/resources/services/bss/bill_overview.go
+++ b/plugins/source/alicloud/resources/services/bss/bill_overview.go
@@ -2,8 +2,8 @@ package bss
 
 import (
 	"github.com/cloudquery/cloudquery/plugins/source/alicloud/client"
-	"github.com/cloudquery/plugin-sdk/v2/schema"
-	"github.com/cloudquery/plugin-sdk/v2/transformers"
+	"github.com/cloudquery/plugin-sdk/v3/schema"
+	"github.com/cloudquery/plugin-sdk/v3/transformers"
 )
 
 func BillOverview() *schema.Table {

--- a/plugins/source/alicloud/resources/services/bss/bill_overview_fetch.go
+++ b/plugins/source/alicloud/resources/services/bss/bill_overview_fetch.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/aliyun/alibaba-cloud-sdk-go/services/bssopenapi"
 	"github.com/cloudquery/cloudquery/plugins/source/alicloud/client"
-	"github.com/cloudquery/plugin-sdk/v2/schema"
+	"github.com/cloudquery/plugin-sdk/v3/schema"
 )
 
 func fetchBssBillOverview(_ context.Context, meta schema.ClientMeta, _ *schema.Resource, res chan<- any) error {

--- a/plugins/source/alicloud/resources/services/bss/bill_overview_fetch_mock_test.go
+++ b/plugins/source/alicloud/resources/services/bss/bill_overview_fetch_mock_test.go
@@ -6,7 +6,7 @@ import (
 	"github.com/aliyun/alibaba-cloud-sdk-go/services/bssopenapi"
 	"github.com/cloudquery/cloudquery/plugins/source/alicloud/client"
 	"github.com/cloudquery/cloudquery/plugins/source/alicloud/client/mocks"
-	"github.com/cloudquery/plugin-sdk/v2/faker"
+	"github.com/cloudquery/plugin-sdk/v3/faker"
 	"github.com/golang/mock/gomock"
 )
 

--- a/plugins/source/alicloud/resources/services/ecs/instances.go
+++ b/plugins/source/alicloud/resources/services/ecs/instances.go
@@ -2,9 +2,10 @@ package ecs
 
 import (
 	"github.com/aliyun/alibaba-cloud-sdk-go/services/ecs"
+	"github.com/apache/arrow/go/v13/arrow"
 	"github.com/cloudquery/cloudquery/plugins/source/alicloud/client"
-	"github.com/cloudquery/plugin-sdk/v2/schema"
-	"github.com/cloudquery/plugin-sdk/v2/transformers"
+	"github.com/cloudquery/plugin-sdk/v3/schema"
+	"github.com/cloudquery/plugin-sdk/v3/transformers"
 
 	"reflect"
 	"strings"
@@ -22,11 +23,11 @@ func Instances() *schema.Table {
 			transformers.WithPrimaryKeys(
 				"RegionId", "InstanceId",
 			),
-			transformers.WithTypeTransformer(func(f reflect.StructField) (schema.ValueType, error) {
+			transformers.WithTypeTransformer(func(f reflect.StructField) (arrow.DataType, error) {
 				if strings.HasSuffix(f.Name, "Time") {
-					return schema.TypeTimestamp, nil
+					return arrow.FixedWidthTypes.Timestamp_us, nil
 				}
-				return transformers.DefaultTypeTransformer(f)
+				return nil, nil
 			}),
 			transformers.WithResolverTransformer(func(f reflect.StructField, path string) schema.ColumnResolver {
 				if strings.HasSuffix(f.Name, "Time") {
@@ -37,12 +38,10 @@ func Instances() *schema.Table {
 		),
 		Columns: []schema.Column{
 			{
-				Name:     "account_id",
-				Type:     schema.TypeString,
-				Resolver: client.ResolveAccount,
-				CreationOptions: schema.ColumnCreationOptions{
-					PrimaryKey: true,
-				},
+				Name:       "account_id",
+				Type:       arrow.BinaryTypes.String,
+				Resolver:   client.ResolveAccount,
+				PrimaryKey: true,
 			},
 		},
 	}

--- a/plugins/source/alicloud/resources/services/ecs/instances_fetch.go
+++ b/plugins/source/alicloud/resources/services/ecs/instances_fetch.go
@@ -8,7 +8,7 @@ import (
 	"github.com/aliyun/alibaba-cloud-sdk-go/sdk/requests"
 	"github.com/aliyun/alibaba-cloud-sdk-go/services/ecs"
 	"github.com/cloudquery/cloudquery/plugins/source/alicloud/client"
-	"github.com/cloudquery/plugin-sdk/v2/schema"
+	"github.com/cloudquery/plugin-sdk/v3/schema"
 )
 
 var (

--- a/plugins/source/alicloud/resources/services/ecs/instances_fetch_mock_test.go
+++ b/plugins/source/alicloud/resources/services/ecs/instances_fetch_mock_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/aliyun/alibaba-cloud-sdk-go/services/ecs"
 	"github.com/cloudquery/cloudquery/plugins/source/alicloud/client"
 	"github.com/cloudquery/cloudquery/plugins/source/alicloud/client/mocks"
-	"github.com/cloudquery/plugin-sdk/v2/faker"
+	"github.com/cloudquery/plugin-sdk/v3/faker"
 	"github.com/golang/mock/gomock"
 )
 

--- a/plugins/source/alicloud/resources/services/oss/bucket_stats.go
+++ b/plugins/source/alicloud/resources/services/oss/bucket_stats.go
@@ -4,9 +4,10 @@ import (
 	"reflect"
 
 	"github.com/aliyun/aliyun-oss-go-sdk/oss"
+	"github.com/apache/arrow/go/v13/arrow"
 	"github.com/cloudquery/cloudquery/plugins/source/alicloud/client"
-	"github.com/cloudquery/plugin-sdk/v2/schema"
-	"github.com/cloudquery/plugin-sdk/v2/transformers"
+	"github.com/cloudquery/plugin-sdk/v3/schema"
+	"github.com/cloudquery/plugin-sdk/v3/transformers"
 )
 
 func BucketStats() *schema.Table {
@@ -16,29 +17,25 @@ func BucketStats() *schema.Table {
 		Resolver: fetchOssBucketStats,
 		Transform: transformers.TransformWithStruct(
 			&oss.BucketStat{},
-			transformers.WithTypeTransformer(func(f reflect.StructField) (schema.ValueType, error) {
+			transformers.WithTypeTransformer(func(f reflect.StructField) (arrow.DataType, error) {
 				if f.Name == "LastModifiedTime" {
-					return schema.TypeTimestamp, nil
+					return arrow.FixedWidthTypes.Timestamp_us, nil
 				}
-				return transformers.DefaultTypeTransformer(f)
+				return nil, nil
 			}),
 		),
 		Columns: []schema.Column{
 			{
-				Name:     "bucket_name",
-				Type:     schema.TypeString,
-				Resolver: schema.ParentColumnResolver("name"),
-				CreationOptions: schema.ColumnCreationOptions{
-					PrimaryKey: true,
-				},
+				Name:       "bucket_name",
+				Type:       arrow.BinaryTypes.String,
+				Resolver:   schema.ParentColumnResolver("name"),
+				PrimaryKey: true,
 			},
 			{
-				Name:     "account_id",
-				Type:     schema.TypeString,
-				Resolver: client.ResolveAccount,
-				CreationOptions: schema.ColumnCreationOptions{
-					PrimaryKey: true,
-				},
+				Name:       "account_id",
+				Type:       arrow.BinaryTypes.String,
+				Resolver:   client.ResolveAccount,
+				PrimaryKey: true,
 			},
 		},
 	}

--- a/plugins/source/alicloud/resources/services/oss/buckets.go
+++ b/plugins/source/alicloud/resources/services/oss/buckets.go
@@ -2,9 +2,10 @@ package oss
 
 import (
 	"github.com/aliyun/aliyun-oss-go-sdk/oss"
+	"github.com/apache/arrow/go/v13/arrow"
 	"github.com/cloudquery/cloudquery/plugins/source/alicloud/client"
-	"github.com/cloudquery/plugin-sdk/v2/schema"
-	"github.com/cloudquery/plugin-sdk/v2/transformers"
+	"github.com/cloudquery/plugin-sdk/v3/schema"
+	"github.com/cloudquery/plugin-sdk/v3/transformers"
 )
 
 func Buckets() *schema.Table {
@@ -21,12 +22,10 @@ func Buckets() *schema.Table {
 		),
 		Columns: []schema.Column{
 			{
-				Name:     "account_id",
-				Type:     schema.TypeString,
-				Resolver: client.ResolveAccount,
-				CreationOptions: schema.ColumnCreationOptions{
-					PrimaryKey: true,
-				},
+				Name:       "account_id",
+				Type:       arrow.BinaryTypes.String,
+				Resolver:   client.ResolveAccount,
+				PrimaryKey: true,
 			},
 		},
 		Relations: []*schema.Table{

--- a/plugins/source/alicloud/resources/services/oss/buckets_fetch.go
+++ b/plugins/source/alicloud/resources/services/oss/buckets_fetch.go
@@ -4,7 +4,7 @@ import (
 	"context"
 
 	"github.com/cloudquery/cloudquery/plugins/source/alicloud/client"
-	"github.com/cloudquery/plugin-sdk/v2/schema"
+	"github.com/cloudquery/plugin-sdk/v3/schema"
 	"github.com/pkg/errors"
 )
 

--- a/plugins/source/alicloud/resources/services/oss/buckets_fetch_mock_test.go
+++ b/plugins/source/alicloud/resources/services/oss/buckets_fetch_mock_test.go
@@ -6,7 +6,7 @@ import (
 	"github.com/aliyun/aliyun-oss-go-sdk/oss"
 	"github.com/cloudquery/cloudquery/plugins/source/alicloud/client"
 	"github.com/cloudquery/cloudquery/plugins/source/alicloud/client/mocks"
-	"github.com/cloudquery/plugin-sdk/v2/faker"
+	"github.com/cloudquery/plugin-sdk/v3/faker"
 	"github.com/golang/mock/gomock"
 )
 

--- a/plugins/source/alicloud/resources/services/oss/buckets_stats_fetch.go
+++ b/plugins/source/alicloud/resources/services/oss/buckets_stats_fetch.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/aliyun/aliyun-oss-go-sdk/oss"
 	"github.com/cloudquery/cloudquery/plugins/source/alicloud/client"
-	"github.com/cloudquery/plugin-sdk/v2/schema"
+	"github.com/cloudquery/plugin-sdk/v3/schema"
 )
 
 func fetchOssBucketStats(_ context.Context, meta schema.ClientMeta, parent *schema.Resource, res chan<- any) error {

--- a/plugins/source/alicloud/resources/services/oss/buckets_stats_mock_test.go
+++ b/plugins/source/alicloud/resources/services/oss/buckets_stats_mock_test.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/aliyun/aliyun-oss-go-sdk/oss"
 	"github.com/cloudquery/cloudquery/plugins/source/alicloud/client/mocks"
-	"github.com/cloudquery/plugin-sdk/v2/faker"
+	"github.com/cloudquery/plugin-sdk/v3/faker"
 )
 
 func buildOssBucketStats(t *testing.T, mock *mocks.MockOssClient, bucketName string) {

--- a/website/tables/alicloud/alicloud_bss_bill.md
+++ b/website/tables/alicloud/alicloud_bss_bill.md
@@ -10,37 +10,37 @@ The composite primary key for this table is (**billing_cycle**, **account_id**, 
 
 | Name          | Type          |
 | ------------- | ------------- |
-|_cq_source_name|String|
-|_cq_sync_time|Timestamp|
-|_cq_id|UUID|
-|_cq_parent_id|UUID|
-|billing_cycle (PK)|String|
-|account_id (PK)|String|
-|account_name|String|
-|product_name|String|
-|sub_order_id|String|
-|deducted_by_cash_coupons|Float|
-|payment_time|String|
-|payment_amount|Float|
-|deducted_by_prepaid_card|Float|
-|invoice_discount|Float|
-|usage_end_time|String|
-|item|String|
-|subscription_type (PK)|String|
-|pretax_gross_amount|Float|
-|currency|String|
-|commodity_code (PK)|String|
-|usage_start_time|String|
-|adjust_amount|Float|
-|status|String|
-|deducted_by_coupons|Float|
-|round_down_discount|String|
-|product_detail|String|
-|product_code (PK)|String|
-|product_type (PK)|String|
-|outstanding_amount|Float|
-|pip_code (PK)|String|
-|pretax_amount|Float|
-|owner_id|String|
-|record_id (PK)|String|
-|cash_amount|Float|
+|_cq_source_name|utf8|
+|_cq_sync_time|timestamp[us, tz=UTC]|
+|_cq_id|uuid|
+|_cq_parent_id|uuid|
+|billing_cycle (PK)|utf8|
+|account_id (PK)|utf8|
+|account_name|utf8|
+|product_name|utf8|
+|sub_order_id|utf8|
+|deducted_by_cash_coupons|float64|
+|payment_time|utf8|
+|payment_amount|float64|
+|deducted_by_prepaid_card|float64|
+|invoice_discount|float64|
+|usage_end_time|utf8|
+|item|utf8|
+|subscription_type (PK)|utf8|
+|pretax_gross_amount|float64|
+|currency|utf8|
+|commodity_code (PK)|utf8|
+|usage_start_time|utf8|
+|adjust_amount|float64|
+|status|utf8|
+|deducted_by_coupons|float64|
+|round_down_discount|utf8|
+|product_detail|utf8|
+|product_code (PK)|utf8|
+|product_type (PK)|utf8|
+|outstanding_amount|float64|
+|pip_code (PK)|utf8|
+|pretax_amount|float64|
+|owner_id|utf8|
+|record_id (PK)|utf8|
+|cash_amount|float64|

--- a/website/tables/alicloud/alicloud_bss_bill_details.md
+++ b/website/tables/alicloud/alicloud_bss_bill_details.md
@@ -10,40 +10,40 @@ The composite primary key for this table is (**billing_cycle**, **billing_date**
 
 | Name          | Type          |
 | ------------- | ------------- |
-|_cq_source_name|String|
-|_cq_sync_time|Timestamp|
-|_cq_id|UUID|
-|_cq_parent_id|UUID|
-|billing_cycle (PK)|String|
-|billing_date (PK)|String|
-|account_id (PK)|String|
-|account_name|String|
-|product_name|String|
-|sub_order_id|String|
-|deducted_by_cash_coupons|Float|
-|payment_time|String|
-|payment_amount|Float|
-|deducted_by_prepaid_card|Float|
-|invoice_discount|Float|
-|usage_end_time|String|
-|item|String|
-|subscription_type (PK)|String|
-|pretax_gross_amount|Float|
-|currency|String|
-|commodity_code (PK)|String|
-|usage_start_time|String|
-|adjust_amount|Float|
-|status|String|
-|deducted_by_coupons|Float|
-|round_down_discount|String|
-|product_detail|String|
-|product_code (PK)|String|
-|product_type (PK)|String|
-|outstanding_amount|Float|
-|pip_code (PK)|String|
-|pretax_amount|Float|
-|owner_id|String|
-|record_id (PK)|String|
-|resource_group|String|
-|instance_id (PK)|String|
-|cash_amount|Float|
+|_cq_source_name|utf8|
+|_cq_sync_time|timestamp[us, tz=UTC]|
+|_cq_id|uuid|
+|_cq_parent_id|uuid|
+|billing_cycle (PK)|utf8|
+|billing_date (PK)|utf8|
+|account_id (PK)|utf8|
+|account_name|utf8|
+|product_name|utf8|
+|sub_order_id|utf8|
+|deducted_by_cash_coupons|float64|
+|payment_time|utf8|
+|payment_amount|float64|
+|deducted_by_prepaid_card|float64|
+|invoice_discount|float64|
+|usage_end_time|utf8|
+|item|utf8|
+|subscription_type (PK)|utf8|
+|pretax_gross_amount|float64|
+|currency|utf8|
+|commodity_code (PK)|utf8|
+|usage_start_time|utf8|
+|adjust_amount|float64|
+|status|utf8|
+|deducted_by_coupons|float64|
+|round_down_discount|utf8|
+|product_detail|utf8|
+|product_code (PK)|utf8|
+|product_type (PK)|utf8|
+|outstanding_amount|float64|
+|pip_code (PK)|utf8|
+|pretax_amount|float64|
+|owner_id|utf8|
+|record_id (PK)|utf8|
+|resource_group|utf8|
+|instance_id (PK)|utf8|
+|cash_amount|float64|

--- a/website/tables/alicloud/alicloud_bss_bill_overview.md
+++ b/website/tables/alicloud/alicloud_bss_bill_overview.md
@@ -10,34 +10,34 @@ The composite primary key for this table is (**billing_cycle**, **account_id**, 
 
 | Name          | Type          |
 | ------------- | ------------- |
-|_cq_source_name|String|
-|_cq_sync_time|Timestamp|
-|_cq_id|UUID|
-|_cq_parent_id|UUID|
-|billing_cycle (PK)|String|
-|account_id (PK)|String|
-|account_name|String|
-|deducted_by_coupons|Float|
-|round_down_discount|String|
-|product_name|String|
-|product_detail|String|
-|product_code (PK)|String|
-|bill_account_id (PK)|String|
-|product_type (PK)|String|
-|deducted_by_cash_coupons|Float|
-|outstanding_amount|Float|
-|biz_type|String|
-|payment_amount|Float|
-|pip_code (PK)|String|
-|deducted_by_prepaid_card|Float|
-|invoice_discount|Float|
-|item|String|
-|subscription_type (PK)|String|
-|pretax_gross_amount|Float|
-|pretax_amount|Float|
-|owner_id|String|
-|currency|String|
-|commodity_code (PK)|String|
-|bill_account_name|String|
-|adjust_amount|Float|
-|cash_amount|Float|
+|_cq_source_name|utf8|
+|_cq_sync_time|timestamp[us, tz=UTC]|
+|_cq_id|uuid|
+|_cq_parent_id|uuid|
+|billing_cycle (PK)|utf8|
+|account_id (PK)|utf8|
+|account_name|utf8|
+|deducted_by_coupons|float64|
+|round_down_discount|utf8|
+|product_name|utf8|
+|product_detail|utf8|
+|product_code (PK)|utf8|
+|bill_account_id (PK)|utf8|
+|product_type (PK)|utf8|
+|deducted_by_cash_coupons|float64|
+|outstanding_amount|float64|
+|biz_type|utf8|
+|payment_amount|float64|
+|pip_code (PK)|utf8|
+|deducted_by_prepaid_card|float64|
+|invoice_discount|float64|
+|item|utf8|
+|subscription_type (PK)|utf8|
+|pretax_gross_amount|float64|
+|pretax_amount|float64|
+|owner_id|utf8|
+|currency|utf8|
+|commodity_code (PK)|utf8|
+|bill_account_name|utf8|
+|adjust_amount|float64|
+|cash_amount|float64|

--- a/website/tables/alicloud/alicloud_ecs_instances.md
+++ b/website/tables/alicloud/alicloud_ecs_instances.md
@@ -10,88 +10,88 @@ The composite primary key for this table is (**account_id**, **region_id**, **in
 
 | Name          | Type          |
 | ------------- | ------------- |
-|_cq_source_name|String|
-|_cq_sync_time|Timestamp|
-|_cq_id|UUID|
-|_cq_parent_id|UUID|
-|account_id (PK)|String|
-|hostname|String|
-|image_id|String|
-|instance_type|String|
-|auto_release_time|Timestamp|
-|last_invoked_time|Timestamp|
-|os_type|String|
-|device_available|Bool|
-|instance_network_type|String|
-|registration_time|Timestamp|
-|local_storage_amount|Int|
-|network_type|String|
-|intranet_ip|String|
-|is_spot|Bool|
-|instance_charge_type|String|
-|machine_id|String|
-|private_pool_options_id|String|
-|cluster_id|String|
-|socket_id|String|
-|instance_name|String|
-|private_pool_options_match_criteria|String|
-|deployment_set_group_no|Int|
-|credit_specification|String|
-|gpu_amount|Int|
-|connected|Bool|
-|invocation_count|Int|
-|start_time|Timestamp|
-|zone_id|String|
-|internet_max_bandwidth_in|Int|
-|internet_charge_type|String|
-|host_name|String|
-|status|String|
-|cpu|Int|
-|isp|String|
-|os_version|String|
-|spot_price_limit|Float|
-|os_name|String|
-|instance_owner_id|Int|
-|os_name_en|String|
-|serial_number|String|
-|region_id (PK)|String|
-|io_optimized|Bool|
-|internet_max_bandwidth_out|Int|
-|resource_group_id|String|
-|activation_id|String|
-|instance_type_family|String|
-|instance_id (PK)|String|
-|deployment_set_id|String|
-|gpu_spec|String|
-|description|String|
-|recyclable|Bool|
-|sale_cycle|String|
-|expired_time|Timestamp|
-|internet_ip|String|
-|memory|Int|
-|creation_time|Timestamp|
-|agent_version|String|
-|key_pair_name|String|
-|hpc_cluster_id|String|
-|local_storage_capacity|Int|
-|vlan_id|String|
-|stopped_mode|String|
-|spot_strategy|String|
-|spot_duration|Int|
-|deletion_protection|Bool|
-|security_group_ids|JSON|
-|inner_ip_address|JSON|
-|public_ip_address|JSON|
-|rdma_ip_address|JSON|
-|image_options|JSON|
-|dedicated_host_attribute|JSON|
-|ecs_capacity_reservation_attr|JSON|
-|hibernation_options|JSON|
-|dedicated_instance_attribute|JSON|
-|eip_address|JSON|
-|metadata_options|JSON|
-|cpu_options|JSON|
-|vpc_attributes|JSON|
-|network_interfaces|JSON|
-|tags|JSON|
-|operation_locks|JSON|
+|_cq_source_name|utf8|
+|_cq_sync_time|timestamp[us, tz=UTC]|
+|_cq_id|uuid|
+|_cq_parent_id|uuid|
+|account_id (PK)|utf8|
+|hostname|utf8|
+|image_id|utf8|
+|instance_type|utf8|
+|auto_release_time|timestamp[us, tz=UTC]|
+|last_invoked_time|timestamp[us, tz=UTC]|
+|os_type|utf8|
+|device_available|bool|
+|instance_network_type|utf8|
+|registration_time|timestamp[us, tz=UTC]|
+|local_storage_amount|int64|
+|network_type|utf8|
+|intranet_ip|utf8|
+|is_spot|bool|
+|instance_charge_type|utf8|
+|machine_id|utf8|
+|private_pool_options_id|utf8|
+|cluster_id|utf8|
+|socket_id|utf8|
+|instance_name|utf8|
+|private_pool_options_match_criteria|utf8|
+|deployment_set_group_no|int64|
+|credit_specification|utf8|
+|gpu_amount|int64|
+|connected|bool|
+|invocation_count|int64|
+|start_time|timestamp[us, tz=UTC]|
+|zone_id|utf8|
+|internet_max_bandwidth_in|int64|
+|internet_charge_type|utf8|
+|host_name|utf8|
+|status|utf8|
+|cpu|int64|
+|isp|utf8|
+|os_version|utf8|
+|spot_price_limit|float64|
+|os_name|utf8|
+|instance_owner_id|int64|
+|os_name_en|utf8|
+|serial_number|utf8|
+|region_id (PK)|utf8|
+|io_optimized|bool|
+|internet_max_bandwidth_out|int64|
+|resource_group_id|utf8|
+|activation_id|utf8|
+|instance_type_family|utf8|
+|instance_id (PK)|utf8|
+|deployment_set_id|utf8|
+|gpu_spec|utf8|
+|description|utf8|
+|recyclable|bool|
+|sale_cycle|utf8|
+|expired_time|timestamp[us, tz=UTC]|
+|internet_ip|utf8|
+|memory|int64|
+|creation_time|timestamp[us, tz=UTC]|
+|agent_version|utf8|
+|key_pair_name|utf8|
+|hpc_cluster_id|utf8|
+|local_storage_capacity|int64|
+|vlan_id|utf8|
+|stopped_mode|utf8|
+|spot_strategy|utf8|
+|spot_duration|int64|
+|deletion_protection|bool|
+|security_group_ids|json|
+|inner_ip_address|json|
+|public_ip_address|json|
+|rdma_ip_address|json|
+|image_options|json|
+|dedicated_host_attribute|json|
+|ecs_capacity_reservation_attr|json|
+|hibernation_options|json|
+|dedicated_instance_attribute|json|
+|eip_address|json|
+|metadata_options|json|
+|cpu_options|json|
+|vpc_attributes|json|
+|network_interfaces|json|
+|tags|json|
+|operation_locks|json|

--- a/website/tables/alicloud/alicloud_oss_bucket_stats.md
+++ b/website/tables/alicloud/alicloud_oss_bucket_stats.md
@@ -12,26 +12,26 @@ This table depends on [alicloud_oss_buckets](alicloud_oss_buckets).
 
 | Name          | Type          |
 | ------------- | ------------- |
-|_cq_source_name|String|
-|_cq_sync_time|Timestamp|
-|_cq_id|UUID|
-|_cq_parent_id|UUID|
-|bucket_name (PK)|String|
-|account_id (PK)|String|
-|xml_name|JSON|
-|storage|Int|
-|object_count|Int|
-|multipart_upload_count|Int|
-|live_channel_count|Int|
-|last_modified_time|Timestamp|
-|standard_storage|Int|
-|standard_object_count|Int|
-|infrequent_access_storage|Int|
-|infrequent_access_real_storage|Int|
-|infrequent_access_object_count|Int|
-|archive_storage|Int|
-|archive_real_storage|Int|
-|archive_object_count|Int|
-|cold_archive_storage|Int|
-|cold_archive_real_storage|Int|
-|cold_archive_object_count|Int|
+|_cq_source_name|utf8|
+|_cq_sync_time|timestamp[us, tz=UTC]|
+|_cq_id|uuid|
+|_cq_parent_id|uuid|
+|bucket_name (PK)|utf8|
+|account_id (PK)|utf8|
+|xml_name|json|
+|storage|int64|
+|object_count|int64|
+|multipart_upload_count|int64|
+|live_channel_count|int64|
+|last_modified_time|timestamp[us, tz=UTC]|
+|standard_storage|int64|
+|standard_object_count|int64|
+|infrequent_access_storage|int64|
+|infrequent_access_real_storage|int64|
+|infrequent_access_object_count|int64|
+|archive_storage|int64|
+|archive_real_storage|int64|
+|archive_object_count|int64|
+|cold_archive_storage|int64|
+|cold_archive_real_storage|int64|
+|cold_archive_object_count|int64|

--- a/website/tables/alicloud/alicloud_oss_buckets.md
+++ b/website/tables/alicloud/alicloud_oss_buckets.md
@@ -13,13 +13,13 @@ The following tables depend on alicloud_oss_buckets:
 
 | Name          | Type          |
 | ------------- | ------------- |
-|_cq_source_name|String|
-|_cq_sync_time|Timestamp|
-|_cq_id|UUID|
-|_cq_parent_id|UUID|
-|account_id (PK)|String|
-|xml_name|JSON|
-|name (PK)|String|
-|location|String|
-|creation_date|Timestamp|
-|storage_class|String|
+|_cq_source_name|utf8|
+|_cq_sync_time|timestamp[us, tz=UTC]|
+|_cq_id|uuid|
+|_cq_parent_id|uuid|
+|account_id (PK)|utf8|
+|xml_name|json|
+|name (PK)|utf8|
+|location|utf8|
+|creation_date|timestamp[us, tz=UTC]|
+|storage_class|utf8|


### PR DESCRIPTION
Closes #10732

BEGIN_COMMIT_OVERRIDE
feat: Update to use [Apache Arrow](https://arrow.apache.org/) type system (#)

BREAKING-CHANGE: This release introduces an internal change to our type system to use [Apache Arrow](https://arrow.apache.org/). This should not have any visible breaking changes, however due to the size of the change we are introducing it under a major version bump to communicate that it might have some bugs that we weren't able to catch during our internal tests. If you encounter an issue during the upgrade, please submit a [bug report](https://github.com/cloudquery/cloudquery/issues/new/choose). You will also need to update destinations depending on which one you use:
- Azure Blob Storage >= v3.2.0
- BigQuery >= v3.0.0
- ClickHouse >= v3.1.1
- DuckDB >= v1.1.6
- Elasticsearch >= v2.0.0
- File >= v3.2.0
- Firehose >= v2.0.2
- GCS >= v3.2.0
- Gremlin >= v2.1.10
- Kafka >= v3.0.1
- Meilisearch >= v2.0.1
- Microsoft SQL Server >= v4.2.0
- MongoDB >= v2.0.1
- MySQL >= v2.0.2
- Neo4j >= v3.0.0
- PostgreSQL >= v4.2.0
- S3 >= v4.4.0
- Snowflake >= v2.1.1
- SQLite >= v2.2.0

END_COMMIT_OVERRIDE