### PR TITLE
feat(googleads)!: Migrate to Apache Arrow type system

### DIFF
--- a/plugins/source/googleads/client/client.go
+++ b/plugins/source/googleads/client/client.go
@@ -4,8 +4,8 @@ import (
 	"context"
 
 	"github.com/cloudquery/plugin-pb-go/specs"
-	"github.com/cloudquery/plugin-sdk/v2/plugins/source"
-	"github.com/cloudquery/plugin-sdk/v2/schema"
+	"github.com/cloudquery/plugin-sdk/v3/plugins/source"
+	"github.com/cloudquery/plugin-sdk/v3/schema"
 	"github.com/rs/zerolog"
 	"github.com/shenzhencenter/google-ads-pb/clients"
 	"golang.org/x/oauth2/google"

--- a/plugins/source/googleads/client/columns.go
+++ b/plugins/source/googleads/client/columns.go
@@ -1,22 +1,25 @@
 package client
 
 import (
-	"github.com/cloudquery/plugin-sdk/v2/schema"
+	"github.com/apache/arrow/go/v13/arrow"
+	"github.com/cloudquery/plugin-sdk/v3/schema"
 )
 
 var CustomerID = schema.Column{
-	Name:            "customer_id",
-	Type:            schema.TypeInt,
-	Description:     "Customer ID",
-	Resolver:        ResolveCustomerID,
-	CreationOptions: schema.ColumnCreationOptions{PrimaryKey: true, NotNull: true},
+	Name:        "customer_id",
+	Type:        arrow.PrimitiveTypes.Int64,
+	Description: "Customer ID",
+	PrimaryKey:  true,
+	NotNull:     true,
+	Resolver:    ResolveCustomerID,
 }
 
 func IDColumn(path string) schema.Column {
 	return schema.Column{
-		Name:            "id",
-		Type:            schema.TypeInt,
-		Resolver:        schema.PathResolver(path),
-		CreationOptions: schema.ColumnCreationOptions{PrimaryKey: true, NotNull: true},
+		Name:       "id",
+		Type:       arrow.PrimitiveTypes.Int64,
+		PrimaryKey: true,
+		NotNull:    true,
+		Resolver:   schema.PathResolver(path),
 	}
 }

--- a/plugins/source/googleads/client/fetch.go
+++ b/plugins/source/googleads/client/fetch.go
@@ -4,7 +4,7 @@ import (
 	"context"
 
 	"github.com/cloudquery/cloudquery/plugins/source/googleads/gaql"
-	"github.com/cloudquery/plugin-sdk/v2/schema"
+	"github.com/cloudquery/plugin-sdk/v3/schema"
 	"github.com/shenzhencenter/google-ads-pb/enums"
 	"github.com/shenzhencenter/google-ads-pb/services"
 )

--- a/plugins/source/googleads/client/multiplex.go
+++ b/plugins/source/googleads/client/multiplex.go
@@ -1,7 +1,7 @@
 package client
 
 import (
-	"github.com/cloudquery/plugin-sdk/v2/schema"
+	"github.com/cloudquery/plugin-sdk/v3/schema"
 )
 
 func MultiplexByCustomer(meta schema.ClientMeta) []schema.ClientMeta {

--- a/plugins/source/googleads/client/resolvers.go
+++ b/plugins/source/googleads/client/resolvers.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/cloudquery/plugin-sdk/v2/schema"
+	"github.com/cloudquery/plugin-sdk/v3/schema"
 	"github.com/thoas/go-funk"
 	"google.golang.org/protobuf/reflect/protoreflect"
 	"google.golang.org/protobuf/runtime/protoimpl"

--- a/plugins/source/googleads/client/testing.go
+++ b/plugins/source/googleads/client/testing.go
@@ -11,8 +11,8 @@ import (
 	"time"
 
 	"github.com/cloudquery/plugin-pb-go/specs"
-	"github.com/cloudquery/plugin-sdk/v2/plugins/source"
-	"github.com/cloudquery/plugin-sdk/v2/schema"
+	"github.com/cloudquery/plugin-sdk/v3/plugins/source"
+	"github.com/cloudquery/plugin-sdk/v3/schema"
 	"github.com/rs/zerolog"
 	"github.com/shenzhencenter/google-ads-pb/clients"
 	"github.com/shenzhencenter/google-ads-pb/services"

--- a/plugins/source/googleads/client/transformers.go
+++ b/plugins/source/googleads/client/transformers.go
@@ -3,25 +3,26 @@ package client
 import (
 	"reflect"
 
-	"github.com/cloudquery/plugin-sdk/v2/schema"
-	"github.com/cloudquery/plugin-sdk/v2/transformers"
+	"github.com/apache/arrow/go/v13/arrow"
+	"github.com/cloudquery/plugin-sdk/v3/schema"
+	"github.com/cloudquery/plugin-sdk/v3/transformers"
 	"google.golang.org/protobuf/reflect/protoreflect"
 	"google.golang.org/protobuf/types/known/durationpb"
 	"google.golang.org/protobuf/types/known/timestamppb"
 )
 
-func typeTransformer(field reflect.StructField) (schema.ValueType, error) {
+func typeTransformer(field reflect.StructField) (arrow.DataType, error) {
 	switch reflect.New(field.Type).Elem().Interface().(type) {
 	case *timestamppb.Timestamp,
 		timestamppb.Timestamp:
-		return schema.TypeTimestamp, nil
+		return arrow.FixedWidthTypes.Timestamp_us, nil
 	case *durationpb.Duration,
 		durationpb.Duration:
-		return schema.TypeInt, nil
+		return arrow.PrimitiveTypes.Int64, nil
 	case protoreflect.Enum:
-		return schema.TypeString, nil
+		return arrow.BinaryTypes.String, nil
 	default:
-		return schema.TypeInvalid, nil
+		return nil, nil
 	}
 }
 

--- a/plugins/source/googleads/gaql/query.go
+++ b/plugins/source/googleads/gaql/query.go
@@ -4,7 +4,7 @@ import (
 	"reflect"
 	"strings"
 
-	"github.com/cloudquery/plugin-sdk/v2/schema"
+	"github.com/cloudquery/plugin-sdk/v3/schema"
 )
 
 func Query(a any, parent *schema.Resource, o ...*Options) string {

--- a/plugins/source/googleads/gaql/query_test.go
+++ b/plugins/source/googleads/gaql/query_test.go
@@ -3,7 +3,7 @@ package gaql
 import (
 	"testing"
 
-	"github.com/cloudquery/plugin-sdk/v2/schema"
+	"github.com/cloudquery/plugin-sdk/v3/schema"
 	"github.com/shenzhencenter/google-ads-pb/resources"
 	"github.com/stretchr/testify/require"
 )

--- a/plugins/source/googleads/go.mod
+++ b/plugins/source/googleads/go.mod
@@ -3,8 +3,9 @@ module github.com/cloudquery/cloudquery/plugins/source/googleads
 go 1.19
 
 require (
+	github.com/apache/arrow/go/v13 v13.0.0-20230509040948-de6c3cd2b604
 	github.com/cloudquery/plugin-pb-go v1.0.8
-	github.com/cloudquery/plugin-sdk/v2 v2.7.0
+	github.com/cloudquery/plugin-sdk/v3 v3.6.4
 	github.com/rs/zerolog v1.29.0
 	github.com/shenzhencenter/google-ads-pb v1.4.0
 	github.com/stretchr/testify v1.8.2
@@ -18,7 +19,7 @@ require (
 )
 
 // TODO: remove once all updates are merged
-replace github.com/apache/arrow/go/v13 => github.com/cloudquery/arrow/go/v13 v13.0.0-20230509053643-898a79b1d3c8
+replace github.com/apache/arrow/go/v13 => github.com/cloudquery/arrow/go/v13 v13.0.0-20230526062000-b3fdc24ed8d6
 
 require (
 	cloud.google.com/go v0.110.0 // indirect
@@ -26,8 +27,8 @@ require (
 	cloud.google.com/go/compute/metadata v0.2.3 // indirect
 	cloud.google.com/go/longrunning v0.4.1 // indirect
 	github.com/andybalholm/brotli v1.0.5 // indirect
-	github.com/apache/arrow/go/v13 v13.0.0-20230509040948-de6c3cd2b604 // indirect
 	github.com/apache/thrift v0.16.0 // indirect
+	github.com/cloudquery/plugin-sdk/v2 v2.7.0 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/getsentry/sentry-go v0.20.0 // indirect
 	github.com/ghodss/yaml v1.0.0 // indirect
@@ -50,6 +51,7 @@ require (
 	github.com/mattn/go-isatty v0.0.18 // indirect
 	github.com/minio/asm2plan9s v0.0.0-20200509001527-cdd76441f9d8 // indirect
 	github.com/minio/c2goasm v0.0.0-20190812172519-36a3d3bbc4f3 // indirect
+	github.com/pierrec/lz4/v4 v4.1.15 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/spf13/cast v1.5.0 // indirect
 	github.com/spf13/cobra v1.6.1 // indirect

--- a/plugins/source/googleads/go.sum
+++ b/plugins/source/googleads/go.sum
@@ -68,12 +68,14 @@ github.com/chzyer/logex v1.1.10/go.mod h1:+Ywpsq7O8HXn0nuIou7OrIPyXbp3wmkHB+jjWR
 github.com/chzyer/readline v0.0.0-20180603132655-2972be24d48e/go.mod h1:nSuG5e5PlCu98SY8svDHJxuZscDgtXS6KTTbou5AhLI=
 github.com/chzyer/test v0.0.0-20180213035817-a1ea475d72b1/go.mod h1:Q3SI9o4m/ZMnBNeIyt5eFwwo7qiLfzFZmjNmxjkiQlU=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
-github.com/cloudquery/arrow/go/v13 v13.0.0-20230509053643-898a79b1d3c8 h1:CmgLSEGQNLHpUQ5cU4L4aF7cuJZRnc1toIIWqC1gmPg=
-github.com/cloudquery/arrow/go/v13 v13.0.0-20230509053643-898a79b1d3c8/go.mod h1:/XatdE3kDIBqZKhZ7OBUHwP2jaASDFZHqF4puOWM8po=
+github.com/cloudquery/arrow/go/v13 v13.0.0-20230526062000-b3fdc24ed8d6 h1:pXLimp7SeA1AiRYANtNto/uJu5aMjeXC8zeMS4BV3dg=
+github.com/cloudquery/arrow/go/v13 v13.0.0-20230526062000-b3fdc24ed8d6/go.mod h1:/XatdE3kDIBqZKhZ7OBUHwP2jaASDFZHqF4puOWM8po=
 github.com/cloudquery/plugin-pb-go v1.0.8 h1:wn3GXhcNItcP+6wUUZuzUFbvdL59liKBO37/izMi+FQ=
 github.com/cloudquery/plugin-pb-go v1.0.8/go.mod h1:vAGA27psem7ZZNAY4a3S9TKuA/JDQWstjKcHPJX91Mc=
 github.com/cloudquery/plugin-sdk/v2 v2.7.0 h1:hRXsdEiaOxJtsn/wZMFQC9/jPfU1MeMK3KF+gPGqm7U=
 github.com/cloudquery/plugin-sdk/v2 v2.7.0/go.mod h1:pAX6ojIW99b/Vg4CkhnsGkRIzNaVEceYMR+Bdit73ug=
+github.com/cloudquery/plugin-sdk/v3 v3.6.4 h1:P4OkS5tJYkv3OqeL60DAVqXXbFQUyPKJ5YDtAgjl9b4=
+github.com/cloudquery/plugin-sdk/v3 v3.6.4/go.mod h1:3JrZXEULmGXpkOukVaRIzaA63d7TJr9Ukp6hemTjbtc=
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
 github.com/cncf/udpa/go v0.0.0-20200629203442-efcf912fb354/go.mod h1:WmhPx2Nbnhtbo57+VJT5O0JRkEi1Wbu0z5j0R8u5Hbk=
 github.com/cncf/udpa/go v0.0.0-20201120205902-5459f2c99403/go.mod h1:WmhPx2Nbnhtbo57+VJT5O0JRkEi1Wbu0z5j0R8u5Hbk=
@@ -236,6 +238,7 @@ github.com/minio/c2goasm v0.0.0-20190812172519-36a3d3bbc4f3 h1:+n/aFZefKZp7spd8D
 github.com/minio/c2goasm v0.0.0-20190812172519-36a3d3bbc4f3/go.mod h1:RagcQ7I8IeTMnF8JTXieKnO4Z6JCsikNEzj0DwauVzE=
 github.com/opentracing/opentracing-go v1.1.0/go.mod h1:UkNAQd3GIcIGf0SeVgPpRdFStlNbqXla1AfSYxPUl2o=
 github.com/pierrec/lz4/v4 v4.1.15 h1:MO0/ucJhngq7299dKLwIMtgTfbkoSPF6AoMYDd8Q4q0=
+github.com/pierrec/lz4/v4 v4.1.15/go.mod h1:gZWDp/Ze/IJXGXf23ltt2EXimqmTUXEy0GFuRQyBid4=
 github.com/pingcap/errors v0.11.4 h1:lFuQV/oaUMGcD2tqt+01ROSmJs75VG1ToEOkZIZ4nE4=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=

--- a/plugins/source/googleads/main.go
+++ b/plugins/source/googleads/main.go
@@ -2,7 +2,7 @@ package main
 
 import (
 	"github.com/cloudquery/cloudquery/plugins/source/googleads/resources/plugin"
-	"github.com/cloudquery/plugin-sdk/v2/serve"
+	"github.com/cloudquery/plugin-sdk/v3/serve"
 )
 
 const sentryDSN = "https://5f6d36d7025942e28c48dac425a0d09f@o1396617.ingest.sentry.io/4504881508646912"

--- a/plugins/source/googleads/resources/ads/group_ad_labels.go
+++ b/plugins/source/googleads/resources/ads/group_ad_labels.go
@@ -2,8 +2,8 @@ package ads
 
 import (
 	"github.com/cloudquery/cloudquery/plugins/source/googleads/client"
-	"github.com/cloudquery/plugin-sdk/v2/schema"
-	"github.com/cloudquery/plugin-sdk/v2/transformers"
+	"github.com/cloudquery/plugin-sdk/v3/schema"
+	"github.com/cloudquery/plugin-sdk/v3/transformers"
 	"github.com/shenzhencenter/google-ads-pb/resources"
 	"github.com/shenzhencenter/google-ads-pb/services"
 )

--- a/plugins/source/googleads/resources/ads/group_ad_labels_test.go
+++ b/plugins/source/googleads/resources/ads/group_ad_labels_test.go
@@ -5,8 +5,8 @@ import (
 
 	"github.com/cloudquery/cloudquery/plugins/source/googleads/client"
 	"github.com/cloudquery/cloudquery/plugins/source/googleads/gaql"
-	"github.com/cloudquery/plugin-sdk/v2/faker"
-	"github.com/cloudquery/plugin-sdk/v2/schema"
+	"github.com/cloudquery/plugin-sdk/v3/faker"
+	"github.com/cloudquery/plugin-sdk/v3/schema"
 	"github.com/shenzhencenter/google-ads-pb/resources"
 	"github.com/shenzhencenter/google-ads-pb/services"
 	"github.com/stretchr/testify/require"

--- a/plugins/source/googleads/resources/ads/group_ads.go
+++ b/plugins/source/googleads/resources/ads/group_ads.go
@@ -3,8 +3,8 @@ package ads
 import (
 	"github.com/cloudquery/cloudquery/plugins/source/googleads/client"
 	"github.com/cloudquery/cloudquery/plugins/source/googleads/gaql"
-	"github.com/cloudquery/plugin-sdk/v2/schema"
-	"github.com/cloudquery/plugin-sdk/v2/transformers"
+	"github.com/cloudquery/plugin-sdk/v3/schema"
+	"github.com/cloudquery/plugin-sdk/v3/transformers"
 	"github.com/shenzhencenter/google-ads-pb/resources"
 	"github.com/shenzhencenter/google-ads-pb/services"
 )

--- a/plugins/source/googleads/resources/ads/group_ads_test.go
+++ b/plugins/source/googleads/resources/ads/group_ads_test.go
@@ -5,8 +5,8 @@ import (
 
 	"github.com/cloudquery/cloudquery/plugins/source/googleads/client"
 	"github.com/cloudquery/cloudquery/plugins/source/googleads/gaql"
-	"github.com/cloudquery/plugin-sdk/v2/faker"
-	"github.com/cloudquery/plugin-sdk/v2/schema"
+	"github.com/cloudquery/plugin-sdk/v3/faker"
+	"github.com/cloudquery/plugin-sdk/v3/schema"
 	"github.com/shenzhencenter/google-ads-pb/resources"
 	"github.com/shenzhencenter/google-ads-pb/services"
 	"github.com/stretchr/testify/require"

--- a/plugins/source/googleads/resources/ads/group_criteria.go
+++ b/plugins/source/googleads/resources/ads/group_criteria.go
@@ -3,8 +3,8 @@ package ads
 import (
 	"github.com/cloudquery/cloudquery/plugins/source/googleads/client"
 	"github.com/cloudquery/cloudquery/plugins/source/googleads/gaql"
-	"github.com/cloudquery/plugin-sdk/v2/schema"
-	"github.com/cloudquery/plugin-sdk/v2/transformers"
+	"github.com/cloudquery/plugin-sdk/v3/schema"
+	"github.com/cloudquery/plugin-sdk/v3/transformers"
 	"github.com/shenzhencenter/google-ads-pb/resources"
 	"github.com/shenzhencenter/google-ads-pb/services"
 )

--- a/plugins/source/googleads/resources/ads/group_criteria_test.go
+++ b/plugins/source/googleads/resources/ads/group_criteria_test.go
@@ -5,8 +5,8 @@ import (
 
 	"github.com/cloudquery/cloudquery/plugins/source/googleads/client"
 	"github.com/cloudquery/cloudquery/plugins/source/googleads/gaql"
-	"github.com/cloudquery/plugin-sdk/v2/faker"
-	"github.com/cloudquery/plugin-sdk/v2/schema"
+	"github.com/cloudquery/plugin-sdk/v3/faker"
+	"github.com/cloudquery/plugin-sdk/v3/schema"
 	"github.com/shenzhencenter/google-ads-pb/resources"
 	"github.com/shenzhencenter/google-ads-pb/services"
 	"github.com/stretchr/testify/require"

--- a/plugins/source/googleads/resources/ads/group_criterion_labels.go
+++ b/plugins/source/googleads/resources/ads/group_criterion_labels.go
@@ -2,8 +2,8 @@ package ads
 
 import (
 	"github.com/cloudquery/cloudquery/plugins/source/googleads/client"
-	"github.com/cloudquery/plugin-sdk/v2/schema"
-	"github.com/cloudquery/plugin-sdk/v2/transformers"
+	"github.com/cloudquery/plugin-sdk/v3/schema"
+	"github.com/cloudquery/plugin-sdk/v3/transformers"
 	"github.com/shenzhencenter/google-ads-pb/resources"
 	"github.com/shenzhencenter/google-ads-pb/services"
 )

--- a/plugins/source/googleads/resources/ads/group_criterion_labels_test.go
+++ b/plugins/source/googleads/resources/ads/group_criterion_labels_test.go
@@ -5,8 +5,8 @@ import (
 
 	"github.com/cloudquery/cloudquery/plugins/source/googleads/client"
 	"github.com/cloudquery/cloudquery/plugins/source/googleads/gaql"
-	"github.com/cloudquery/plugin-sdk/v2/faker"
-	"github.com/cloudquery/plugin-sdk/v2/schema"
+	"github.com/cloudquery/plugin-sdk/v3/faker"
+	"github.com/cloudquery/plugin-sdk/v3/schema"
 	"github.com/shenzhencenter/google-ads-pb/resources"
 	"github.com/shenzhencenter/google-ads-pb/services"
 	"github.com/stretchr/testify/require"

--- a/plugins/source/googleads/resources/ads/group_labels.go
+++ b/plugins/source/googleads/resources/ads/group_labels.go
@@ -2,8 +2,8 @@ package ads
 
 import (
 	"github.com/cloudquery/cloudquery/plugins/source/googleads/client"
-	"github.com/cloudquery/plugin-sdk/v2/schema"
-	"github.com/cloudquery/plugin-sdk/v2/transformers"
+	"github.com/cloudquery/plugin-sdk/v3/schema"
+	"github.com/cloudquery/plugin-sdk/v3/transformers"
 	"github.com/shenzhencenter/google-ads-pb/resources"
 	"github.com/shenzhencenter/google-ads-pb/services"
 )

--- a/plugins/source/googleads/resources/ads/group_labels_test.go
+++ b/plugins/source/googleads/resources/ads/group_labels_test.go
@@ -5,8 +5,8 @@ import (
 
 	"github.com/cloudquery/cloudquery/plugins/source/googleads/client"
 	"github.com/cloudquery/cloudquery/plugins/source/googleads/gaql"
-	"github.com/cloudquery/plugin-sdk/v2/faker"
-	"github.com/cloudquery/plugin-sdk/v2/schema"
+	"github.com/cloudquery/plugin-sdk/v3/faker"
+	"github.com/cloudquery/plugin-sdk/v3/schema"
 	"github.com/shenzhencenter/google-ads-pb/resources"
 	"github.com/shenzhencenter/google-ads-pb/services"
 	"github.com/stretchr/testify/require"

--- a/plugins/source/googleads/resources/ads/groups.go
+++ b/plugins/source/googleads/resources/ads/groups.go
@@ -3,8 +3,8 @@ package ads
 import (
 	"github.com/cloudquery/cloudquery/plugins/source/googleads/client"
 	"github.com/cloudquery/cloudquery/plugins/source/googleads/gaql"
-	"github.com/cloudquery/plugin-sdk/v2/schema"
-	"github.com/cloudquery/plugin-sdk/v2/transformers"
+	"github.com/cloudquery/plugin-sdk/v3/schema"
+	"github.com/cloudquery/plugin-sdk/v3/transformers"
 	"github.com/shenzhencenter/google-ads-pb/resources"
 	"github.com/shenzhencenter/google-ads-pb/services"
 )

--- a/plugins/source/googleads/resources/ads/groups_test.go
+++ b/plugins/source/googleads/resources/ads/groups_test.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/cloudquery/cloudquery/plugins/source/googleads/client"
 	"github.com/cloudquery/cloudquery/plugins/source/googleads/gaql"
-	"github.com/cloudquery/plugin-sdk/v2/faker"
+	"github.com/cloudquery/plugin-sdk/v3/faker"
 	"github.com/shenzhencenter/google-ads-pb/resources"
 	"github.com/shenzhencenter/google-ads-pb/services"
 	"github.com/stretchr/testify/require"

--- a/plugins/source/googleads/resources/campaigns/campaign_criteria.go
+++ b/plugins/source/googleads/resources/campaigns/campaign_criteria.go
@@ -2,8 +2,8 @@ package campaigns
 
 import (
 	"github.com/cloudquery/cloudquery/plugins/source/googleads/client"
-	"github.com/cloudquery/plugin-sdk/v2/schema"
-	"github.com/cloudquery/plugin-sdk/v2/transformers"
+	"github.com/cloudquery/plugin-sdk/v3/schema"
+	"github.com/cloudquery/plugin-sdk/v3/transformers"
 	"github.com/shenzhencenter/google-ads-pb/resources"
 	"github.com/shenzhencenter/google-ads-pb/services"
 )

--- a/plugins/source/googleads/resources/campaigns/campaign_criteria_test.go
+++ b/plugins/source/googleads/resources/campaigns/campaign_criteria_test.go
@@ -5,8 +5,8 @@ import (
 
 	"github.com/cloudquery/cloudquery/plugins/source/googleads/client"
 	"github.com/cloudquery/cloudquery/plugins/source/googleads/gaql"
-	"github.com/cloudquery/plugin-sdk/v2/faker"
-	"github.com/cloudquery/plugin-sdk/v2/schema"
+	"github.com/cloudquery/plugin-sdk/v3/faker"
+	"github.com/cloudquery/plugin-sdk/v3/schema"
 	"github.com/shenzhencenter/google-ads-pb/resources"
 	"github.com/shenzhencenter/google-ads-pb/services"
 	"github.com/stretchr/testify/require"

--- a/plugins/source/googleads/resources/campaigns/campaign_labels.go
+++ b/plugins/source/googleads/resources/campaigns/campaign_labels.go
@@ -2,8 +2,8 @@ package campaigns
 
 import (
 	"github.com/cloudquery/cloudquery/plugins/source/googleads/client"
-	"github.com/cloudquery/plugin-sdk/v2/schema"
-	"github.com/cloudquery/plugin-sdk/v2/transformers"
+	"github.com/cloudquery/plugin-sdk/v3/schema"
+	"github.com/cloudquery/plugin-sdk/v3/transformers"
 	"github.com/shenzhencenter/google-ads-pb/resources"
 	"github.com/shenzhencenter/google-ads-pb/services"
 )

--- a/plugins/source/googleads/resources/campaigns/campaign_labels_test.go
+++ b/plugins/source/googleads/resources/campaigns/campaign_labels_test.go
@@ -5,8 +5,8 @@ import (
 
 	"github.com/cloudquery/cloudquery/plugins/source/googleads/client"
 	"github.com/cloudquery/cloudquery/plugins/source/googleads/gaql"
-	"github.com/cloudquery/plugin-sdk/v2/faker"
-	"github.com/cloudquery/plugin-sdk/v2/schema"
+	"github.com/cloudquery/plugin-sdk/v3/faker"
+	"github.com/cloudquery/plugin-sdk/v3/schema"
 	"github.com/shenzhencenter/google-ads-pb/resources"
 	"github.com/shenzhencenter/google-ads-pb/services"
 	"github.com/stretchr/testify/require"

--- a/plugins/source/googleads/resources/campaigns/campaigns.go
+++ b/plugins/source/googleads/resources/campaigns/campaigns.go
@@ -3,8 +3,8 @@ package campaigns
 import (
 	"github.com/cloudquery/cloudquery/plugins/source/googleads/client"
 	"github.com/cloudquery/cloudquery/plugins/source/googleads/gaql"
-	"github.com/cloudquery/plugin-sdk/v2/schema"
-	"github.com/cloudquery/plugin-sdk/v2/transformers"
+	"github.com/cloudquery/plugin-sdk/v3/schema"
+	"github.com/cloudquery/plugin-sdk/v3/transformers"
 	"github.com/shenzhencenter/google-ads-pb/resources"
 	"github.com/shenzhencenter/google-ads-pb/services"
 )

--- a/plugins/source/googleads/resources/campaigns/campaigns_test.go
+++ b/plugins/source/googleads/resources/campaigns/campaigns_test.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/cloudquery/cloudquery/plugins/source/googleads/client"
 	"github.com/cloudquery/cloudquery/plugins/source/googleads/gaql"
-	"github.com/cloudquery/plugin-sdk/v2/faker"
+	"github.com/cloudquery/plugin-sdk/v3/faker"
 	"github.com/shenzhencenter/google-ads-pb/resources"
 	"github.com/shenzhencenter/google-ads-pb/services"
 	"github.com/stretchr/testify/require"

--- a/plugins/source/googleads/resources/customers/customer_labels.go
+++ b/plugins/source/googleads/resources/customers/customer_labels.go
@@ -2,8 +2,8 @@ package customers
 
 import (
 	"github.com/cloudquery/cloudquery/plugins/source/googleads/client"
-	"github.com/cloudquery/plugin-sdk/v2/schema"
-	"github.com/cloudquery/plugin-sdk/v2/transformers"
+	"github.com/cloudquery/plugin-sdk/v3/schema"
+	"github.com/cloudquery/plugin-sdk/v3/transformers"
 	"github.com/shenzhencenter/google-ads-pb/resources"
 	"github.com/shenzhencenter/google-ads-pb/services"
 )

--- a/plugins/source/googleads/resources/customers/customer_labels_test.go
+++ b/plugins/source/googleads/resources/customers/customer_labels_test.go
@@ -5,8 +5,8 @@ import (
 
 	"github.com/cloudquery/cloudquery/plugins/source/googleads/client"
 	"github.com/cloudquery/cloudquery/plugins/source/googleads/gaql"
-	"github.com/cloudquery/plugin-sdk/v2/faker"
-	"github.com/cloudquery/plugin-sdk/v2/schema"
+	"github.com/cloudquery/plugin-sdk/v3/faker"
+	"github.com/cloudquery/plugin-sdk/v3/schema"
 	"github.com/shenzhencenter/google-ads-pb/resources"
 	"github.com/shenzhencenter/google-ads-pb/services"
 	"github.com/stretchr/testify/require"

--- a/plugins/source/googleads/resources/customers/customers.go
+++ b/plugins/source/googleads/resources/customers/customers.go
@@ -5,8 +5,8 @@ import (
 
 	"github.com/cloudquery/cloudquery/plugins/source/googleads/client"
 	"github.com/cloudquery/cloudquery/plugins/source/googleads/gaql"
-	"github.com/cloudquery/plugin-sdk/v2/schema"
-	"github.com/cloudquery/plugin-sdk/v2/transformers"
+	"github.com/cloudquery/plugin-sdk/v3/schema"
+	"github.com/cloudquery/plugin-sdk/v3/transformers"
 	"github.com/shenzhencenter/google-ads-pb/enums"
 	"github.com/shenzhencenter/google-ads-pb/resources"
 	"github.com/shenzhencenter/google-ads-pb/services"

--- a/plugins/source/googleads/resources/customers/customers_test.go
+++ b/plugins/source/googleads/resources/customers/customers_test.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/cloudquery/cloudquery/plugins/source/googleads/client"
 	"github.com/cloudquery/cloudquery/plugins/source/googleads/gaql"
-	"github.com/cloudquery/plugin-sdk/v2/faker"
+	"github.com/cloudquery/plugin-sdk/v3/faker"
 	"github.com/shenzhencenter/google-ads-pb/resources"
 	"github.com/shenzhencenter/google-ads-pb/services"
 	"github.com/stretchr/testify/require"

--- a/plugins/source/googleads/resources/plugin/plugin.go
+++ b/plugins/source/googleads/resources/plugin/plugin.go
@@ -7,9 +7,9 @@ import (
 	"github.com/cloudquery/cloudquery/plugins/source/googleads/resources/ads"
 	"github.com/cloudquery/cloudquery/plugins/source/googleads/resources/campaigns"
 	"github.com/cloudquery/cloudquery/plugins/source/googleads/resources/customers"
-	"github.com/cloudquery/plugin-sdk/v2/caser"
-	"github.com/cloudquery/plugin-sdk/v2/plugins/source"
-	"github.com/cloudquery/plugin-sdk/v2/schema"
+	"github.com/cloudquery/plugin-sdk/v3/caser"
+	"github.com/cloudquery/plugin-sdk/v3/plugins/source"
+	"github.com/cloudquery/plugin-sdk/v3/schema"
 	"golang.org/x/exp/maps"
 )
 

--- a/website/tables/googleads/googleads_ad_group_ad_labels.md
+++ b/website/tables/googleads/googleads_ad_group_ad_labels.md
@@ -14,11 +14,11 @@ This table depends on [googleads_ad_group_ads](googleads_ad_group_ads).
 
 | Name          | Type          |
 | ------------- | ------------- |
-|_cq_source_name|String|
-|_cq_sync_time|Timestamp|
-|_cq_id|UUID|
-|_cq_parent_id|UUID|
-|customer_id (PK)|Int|
-|resource_name (PK)|String|
-|ad_group_ad (PK)|String|
-|label|String|
+|_cq_source_name|utf8|
+|_cq_sync_time|timestamp[us, tz=UTC]|
+|_cq_id|uuid|
+|_cq_parent_id|uuid|
+|customer_id (PK)|int64|
+|resource_name (PK)|utf8|
+|ad_group_ad (PK)|utf8|
+|label|utf8|

--- a/website/tables/googleads/googleads_ad_group_ads.md
+++ b/website/tables/googleads/googleads_ad_group_ads.md
@@ -17,17 +17,17 @@ The following tables depend on googleads_ad_group_ads:
 
 | Name          | Type          |
 | ------------- | ------------- |
-|_cq_source_name|String|
-|_cq_sync_time|Timestamp|
-|_cq_id|UUID|
-|_cq_parent_id|UUID|
-|customer_id (PK)|Int|
-|id (PK)|Int|
-|resource_name (PK)|String|
-|status|String|
-|ad_group (PK)|String|
-|ad|JSON|
-|policy_summary|JSON|
-|ad_strength|String|
-|action_items|StringArray|
-|labels|StringArray|
+|_cq_source_name|utf8|
+|_cq_sync_time|timestamp[us, tz=UTC]|
+|_cq_id|uuid|
+|_cq_parent_id|uuid|
+|customer_id (PK)|int64|
+|id (PK)|int64|
+|resource_name (PK)|utf8|
+|status|utf8|
+|ad_group (PK)|utf8|
+|ad|json|
+|policy_summary|json|
+|ad_strength|utf8|
+|action_items|list<item: utf8, nullable>|
+|labels|list<item: utf8, nullable>|

--- a/website/tables/googleads/googleads_ad_group_criteria.md
+++ b/website/tables/googleads/googleads_ad_group_criteria.md
@@ -17,40 +17,40 @@ The following tables depend on googleads_ad_group_criteria:
 
 | Name          | Type          |
 | ------------- | ------------- |
-|_cq_source_name|String|
-|_cq_sync_time|Timestamp|
-|_cq_id|UUID|
-|_cq_parent_id|UUID|
-|customer_id (PK)|Int|
-|id (PK)|Int|
-|resource_name (PK)|String|
-|criterion_id|Int|
-|display_name|String|
-|status|String|
-|quality_info|JSON|
-|ad_group (PK)|String|
-|type|String|
-|negative|Bool|
-|system_serving_status|String|
-|approval_status|String|
-|disapproval_reasons|StringArray|
-|labels|StringArray|
-|bid_modifier|Float|
-|cpc_bid_micros|Int|
-|cpm_bid_micros|Int|
-|cpv_bid_micros|Int|
-|percent_cpc_bid_micros|Int|
-|effective_cpc_bid_micros|Int|
-|effective_cpm_bid_micros|Int|
-|effective_cpv_bid_micros|Int|
-|effective_percent_cpc_bid_micros|Int|
-|effective_cpc_bid_source|String|
-|effective_cpm_bid_source|String|
-|effective_cpv_bid_source|String|
-|effective_percent_cpc_bid_source|String|
-|position_estimates|JSON|
-|final_urls|StringArray|
-|final_mobile_urls|StringArray|
-|final_url_suffix|String|
-|tracking_url_template|String|
-|url_custom_parameters|JSON|
+|_cq_source_name|utf8|
+|_cq_sync_time|timestamp[us, tz=UTC]|
+|_cq_id|uuid|
+|_cq_parent_id|uuid|
+|customer_id (PK)|int64|
+|id (PK)|int64|
+|resource_name (PK)|utf8|
+|criterion_id|int64|
+|display_name|utf8|
+|status|utf8|
+|quality_info|json|
+|ad_group (PK)|utf8|
+|type|utf8|
+|negative|bool|
+|system_serving_status|utf8|
+|approval_status|utf8|
+|disapproval_reasons|list<item: utf8, nullable>|
+|labels|list<item: utf8, nullable>|
+|bid_modifier|float64|
+|cpc_bid_micros|int64|
+|cpm_bid_micros|int64|
+|cpv_bid_micros|int64|
+|percent_cpc_bid_micros|int64|
+|effective_cpc_bid_micros|int64|
+|effective_cpm_bid_micros|int64|
+|effective_cpv_bid_micros|int64|
+|effective_percent_cpc_bid_micros|int64|
+|effective_cpc_bid_source|utf8|
+|effective_cpm_bid_source|utf8|
+|effective_cpv_bid_source|utf8|
+|effective_percent_cpc_bid_source|utf8|
+|position_estimates|json|
+|final_urls|list<item: utf8, nullable>|
+|final_mobile_urls|list<item: utf8, nullable>|
+|final_url_suffix|utf8|
+|tracking_url_template|utf8|
+|url_custom_parameters|json|

--- a/website/tables/googleads/googleads_ad_group_criterion_labels.md
+++ b/website/tables/googleads/googleads_ad_group_criterion_labels.md
@@ -14,11 +14,11 @@ This table depends on [googleads_ad_group_criteria](googleads_ad_group_criteria)
 
 | Name          | Type          |
 | ------------- | ------------- |
-|_cq_source_name|String|
-|_cq_sync_time|Timestamp|
-|_cq_id|UUID|
-|_cq_parent_id|UUID|
-|customer_id (PK)|Int|
-|resource_name (PK)|String|
-|ad_group_criterion (PK)|String|
-|label|String|
+|_cq_source_name|utf8|
+|_cq_sync_time|timestamp[us, tz=UTC]|
+|_cq_id|uuid|
+|_cq_parent_id|uuid|
+|customer_id (PK)|int64|
+|resource_name (PK)|utf8|
+|ad_group_criterion (PK)|utf8|
+|label|utf8|

--- a/website/tables/googleads/googleads_ad_group_labels.md
+++ b/website/tables/googleads/googleads_ad_group_labels.md
@@ -14,11 +14,11 @@ This table depends on [googleads_ad_groups](googleads_ad_groups).
 
 | Name          | Type          |
 | ------------- | ------------- |
-|_cq_source_name|String|
-|_cq_sync_time|Timestamp|
-|_cq_id|UUID|
-|_cq_parent_id|UUID|
-|customer_id (PK)|Int|
-|resource_name (PK)|String|
-|ad_group (PK)|String|
-|label|String|
+|_cq_source_name|utf8|
+|_cq_sync_time|timestamp[us, tz=UTC]|
+|_cq_id|uuid|
+|_cq_parent_id|uuid|
+|customer_id (PK)|int64|
+|resource_name (PK)|utf8|
+|ad_group (PK)|utf8|
+|label|utf8|

--- a/website/tables/googleads/googleads_ad_groups.md
+++ b/website/tables/googleads/googleads_ad_groups.md
@@ -17,37 +17,37 @@ The following tables depend on googleads_ad_groups:
 
 | Name          | Type          |
 | ------------- | ------------- |
-|_cq_source_name|String|
-|_cq_sync_time|Timestamp|
-|_cq_id|UUID|
-|_cq_parent_id|UUID|
-|customer_id (PK)|Int|
-|resource_name (PK)|String|
-|id (PK)|Int|
-|name|String|
-|status|String|
-|type|String|
-|ad_rotation_mode|String|
-|base_ad_group|String|
-|tracking_url_template|String|
-|url_custom_parameters|JSON|
-|campaign|String|
-|cpc_bid_micros|Int|
-|effective_cpc_bid_micros|Int|
-|cpm_bid_micros|Int|
-|target_cpa_micros|Int|
-|cpv_bid_micros|Int|
-|target_cpm_micros|Int|
-|target_roas|Float|
-|percent_cpc_bid_micros|Int|
-|optimized_targeting_enabled|Bool|
-|display_custom_bid_dimension|String|
-|final_url_suffix|String|
-|audience_setting|JSON|
-|effective_target_cpa_micros|Int|
-|effective_target_cpa_source|String|
-|effective_target_roas|Float|
-|effective_target_roas_source|String|
-|labels|StringArray|
-|excluded_parent_asset_field_types|IntArray|
-|excluded_parent_asset_set_types|IntArray|
+|_cq_source_name|utf8|
+|_cq_sync_time|timestamp[us, tz=UTC]|
+|_cq_id|uuid|
+|_cq_parent_id|uuid|
+|customer_id (PK)|int64|
+|resource_name (PK)|utf8|
+|id (PK)|int64|
+|name|utf8|
+|status|utf8|
+|type|utf8|
+|ad_rotation_mode|utf8|
+|base_ad_group|utf8|
+|tracking_url_template|utf8|
+|url_custom_parameters|json|
+|campaign|utf8|
+|cpc_bid_micros|int64|
+|effective_cpc_bid_micros|int64|
+|cpm_bid_micros|int64|
+|target_cpa_micros|int64|
+|cpv_bid_micros|int64|
+|target_cpm_micros|int64|
+|target_roas|float64|
+|percent_cpc_bid_micros|int64|
+|optimized_targeting_enabled|bool|
+|display_custom_bid_dimension|utf8|
+|final_url_suffix|utf8|
+|audience_setting|json|
+|effective_target_cpa_micros|int64|
+|effective_target_cpa_source|utf8|
+|effective_target_roas|float64|
+|effective_target_roas_source|utf8|
+|labels|list<item: utf8, nullable>|
+|excluded_parent_asset_field_types|list<item: int64, nullable>|
+|excluded_parent_asset_set_types|list<item: int64, nullable>|

--- a/website/tables/googleads/googleads_campaign_criteria.md
+++ b/website/tables/googleads/googleads_campaign_criteria.md
@@ -14,17 +14,17 @@ This table depends on [googleads_campaigns](googleads_campaigns).
 
 | Name          | Type          |
 | ------------- | ------------- |
-|_cq_source_name|String|
-|_cq_sync_time|Timestamp|
-|_cq_id|UUID|
-|_cq_parent_id|UUID|
-|customer_id (PK)|Int|
-|id (PK)|Int|
-|resource_name (PK)|String|
-|campaign (PK)|String|
-|criterion_id|Int|
-|display_name|String|
-|bid_modifier|Float|
-|negative|Bool|
-|type|String|
-|status|String|
+|_cq_source_name|utf8|
+|_cq_sync_time|timestamp[us, tz=UTC]|
+|_cq_id|uuid|
+|_cq_parent_id|uuid|
+|customer_id (PK)|int64|
+|id (PK)|int64|
+|resource_name (PK)|utf8|
+|campaign (PK)|utf8|
+|criterion_id|int64|
+|display_name|utf8|
+|bid_modifier|float64|
+|negative|bool|
+|type|utf8|
+|status|utf8|

--- a/website/tables/googleads/googleads_campaign_labels.md
+++ b/website/tables/googleads/googleads_campaign_labels.md
@@ -14,11 +14,11 @@ This table depends on [googleads_campaigns](googleads_campaigns).
 
 | Name          | Type          |
 | ------------- | ------------- |
-|_cq_source_name|String|
-|_cq_sync_time|Timestamp|
-|_cq_id|UUID|
-|_cq_parent_id|UUID|
-|customer_id (PK)|Int|
-|resource_name (PK)|String|
-|campaign (PK)|String|
-|label|String|
+|_cq_source_name|utf8|
+|_cq_sync_time|timestamp[us, tz=UTC]|
+|_cq_id|uuid|
+|_cq_parent_id|uuid|
+|customer_id (PK)|int64|
+|resource_name (PK)|utf8|
+|campaign (PK)|utf8|
+|label|utf8|

--- a/website/tables/googleads/googleads_campaigns.md
+++ b/website/tables/googleads/googleads_campaigns.md
@@ -16,55 +16,55 @@ The following tables depend on googleads_campaigns:
 
 | Name          | Type          |
 | ------------- | ------------- |
-|_cq_source_name|String|
-|_cq_sync_time|Timestamp|
-|_cq_id|UUID|
-|_cq_parent_id|UUID|
-|customer_id (PK)|Int|
-|resource_name (PK)|String|
-|id (PK)|Int|
-|name|String|
-|primary_status|String|
-|primary_status_reasons|IntArray|
-|status|String|
-|serving_status|String|
-|bidding_strategy_system_status|String|
-|ad_serving_optimization_status|String|
-|advertising_channel_type|String|
-|advertising_channel_sub_type|String|
-|tracking_url_template|String|
-|url_custom_parameters|JSON|
-|local_services_campaign_settings|JSON|
-|travel_campaign_settings|JSON|
-|real_time_bidding_setting|JSON|
-|network_settings|JSON|
-|hotel_setting|JSON|
-|dynamic_search_ads_setting|JSON|
-|shopping_setting|JSON|
-|audience_setting|JSON|
-|geo_target_type_setting|JSON|
-|local_campaign_setting|JSON|
-|app_campaign_setting|JSON|
-|labels|StringArray|
-|experiment_type|String|
-|base_campaign|String|
-|campaign_budget|String|
-|bidding_strategy_type|String|
-|accessible_bidding_strategy|String|
-|start_date|String|
-|campaign_group|String|
-|end_date|String|
-|final_url_suffix|String|
-|frequency_caps|JSON|
-|video_brand_safety_suitability|String|
-|vanity_pharma|JSON|
-|selective_optimization|JSON|
-|optimization_goal_setting|JSON|
-|tracking_setting|JSON|
-|payment_mode|String|
-|optimization_score|Float|
-|excluded_parent_asset_field_types|IntArray|
-|excluded_parent_asset_set_types|IntArray|
-|url_expansion_opt_out|Bool|
-|performance_max_upgrade|JSON|
-|hotel_property_asset_set|String|
+|_cq_source_name|utf8|
+|_cq_sync_time|timestamp[us, tz=UTC]|
+|_cq_id|uuid|
+|_cq_parent_id|uuid|
+|customer_id (PK)|int64|
+|resource_name (PK)|utf8|
+|id (PK)|int64|
+|name|utf8|
+|primary_status|utf8|
+|primary_status_reasons|list<item: int64, nullable>|
+|status|utf8|
+|serving_status|utf8|
+|bidding_strategy_system_status|utf8|
+|ad_serving_optimization_status|utf8|
+|advertising_channel_type|utf8|
+|advertising_channel_sub_type|utf8|
+|tracking_url_template|utf8|
+|url_custom_parameters|json|
+|local_services_campaign_settings|json|
+|travel_campaign_settings|json|
+|real_time_bidding_setting|json|
+|network_settings|json|
+|hotel_setting|json|
+|dynamic_search_ads_setting|json|
+|shopping_setting|json|
+|audience_setting|json|
+|geo_target_type_setting|json|
+|local_campaign_setting|json|
+|app_campaign_setting|json|
+|labels|list<item: utf8, nullable>|
+|experiment_type|utf8|
+|base_campaign|utf8|
+|campaign_budget|utf8|
+|bidding_strategy_type|utf8|
+|accessible_bidding_strategy|utf8|
+|start_date|utf8|
+|campaign_group|utf8|
+|end_date|utf8|
+|final_url_suffix|utf8|
+|frequency_caps|json|
+|video_brand_safety_suitability|utf8|
+|vanity_pharma|json|
+|selective_optimization|json|
+|optimization_goal_setting|json|
+|tracking_setting|json|
+|payment_mode|utf8|
+|optimization_score|float64|
+|excluded_parent_asset_field_types|list<item: int64, nullable>|
+|excluded_parent_asset_set_types|list<item: int64, nullable>|
+|url_expansion_opt_out|bool|
+|performance_max_upgrade|json|
+|hotel_property_asset_set|utf8|

--- a/website/tables/googleads/googleads_customer_labels.md
+++ b/website/tables/googleads/googleads_customer_labels.md
@@ -14,11 +14,11 @@ This table depends on [googleads_customers](googleads_customers).
 
 | Name          | Type          |
 | ------------- | ------------- |
-|_cq_source_name|String|
-|_cq_sync_time|Timestamp|
-|_cq_id|UUID|
-|_cq_parent_id|UUID|
-|customer_id (PK)|Int|
-|resource_name (PK)|String|
-|customer (PK)|String|
-|label|String|
+|_cq_source_name|utf8|
+|_cq_sync_time|timestamp[us, tz=UTC]|
+|_cq_id|uuid|
+|_cq_parent_id|uuid|
+|customer_id (PK)|int64|
+|resource_name (PK)|utf8|
+|customer (PK)|utf8|
+|label|utf8|

--- a/website/tables/googleads/googleads_customers.md
+++ b/website/tables/googleads/googleads_customers.md
@@ -15,29 +15,29 @@ The following tables depend on googleads_customers:
 
 | Name          | Type          |
 | ------------- | ------------- |
-|_cq_source_name|String|
-|_cq_sync_time|Timestamp|
-|_cq_id|UUID|
-|_cq_parent_id|UUID|
-|resource_name (PK)|String|
-|id (PK)|Int|
-|descriptive_name|String|
-|currency_code|String|
-|time_zone|String|
-|tracking_url_template|String|
-|final_url_suffix|String|
-|auto_tagging_enabled|Bool|
-|has_partners_badge|Bool|
-|manager|Bool|
-|test_account|Bool|
-|call_reporting_setting|JSON|
-|conversion_tracking_setting|JSON|
-|remarketing_setting|JSON|
-|pay_per_conversion_eligibility_failure_reasons|IntArray|
-|optimization_score|Float|
-|optimization_score_weight|Float|
-|status|String|
-|location_asset_auto_migration_done|Bool|
-|image_asset_auto_migration_done|Bool|
-|location_asset_auto_migration_done_date_time|String|
-|image_asset_auto_migration_done_date_time|String|
+|_cq_source_name|utf8|
+|_cq_sync_time|timestamp[us, tz=UTC]|
+|_cq_id|uuid|
+|_cq_parent_id|uuid|
+|resource_name (PK)|utf8|
+|id (PK)|int64|
+|descriptive_name|utf8|
+|currency_code|utf8|
+|time_zone|utf8|
+|tracking_url_template|utf8|
+|final_url_suffix|utf8|
+|auto_tagging_enabled|bool|
+|has_partners_badge|bool|
+|manager|bool|
+|test_account|bool|
+|call_reporting_setting|json|
+|conversion_tracking_setting|json|
+|remarketing_setting|json|
+|pay_per_conversion_eligibility_failure_reasons|list<item: int64, nullable>|
+|optimization_score|float64|
+|optimization_score_weight|float64|
+|status|utf8|
+|location_asset_auto_migration_done|bool|
+|image_asset_auto_migration_done|bool|
+|location_asset_auto_migration_done_date_time|utf8|
+|image_asset_auto_migration_done_date_time|utf8|


### PR DESCRIPTION
Closes #10747 

BEGIN_COMMIT_OVERRIDE
feat: Update to use [Apache Arrow](https://arrow.apache.org/) type system (#11021)

BREAKING-CHANGE: This release introduces an internal change to our type system to use [Apache Arrow](https://arrow.apache.org/). This should not have any visible breaking changes, however due to the size of the change we are introducing it under a major version bump to communicate that it might have some bugs that we weren't able to catch during our internal tests. If you encounter an issue during the upgrade, please submit a [bug report](https://github.com/cloudquery/cloudquery/issues/new/choose). You will also need to update destinations depending on which one you use:
- Azure Blob Storage >= v3.2.0
- BigQuery >= v3.0.0
- ClickHouse >= v3.1.1
- DuckDB >= v1.1.6
- Elasticsearch >= v2.0.0
- File >= v3.2.0
- Firehose >= v2.0.2
- GCS >= v3.2.0
- Gremlin >= v2.1.10
- Kafka >= v3.0.1
- Meilisearch >= v2.0.1
- Microsoft SQL Server >= v4.2.0
- MongoDB >= v2.0.1
- MySQL >= v2.0.2
- Neo4j >= v3.0.0
- PostgreSQL >= v4.2.0
- S3 >= v4.4.0
- Snowflake >= v2.1.1
- SQLite >= v2.2.0

END_COMMIT_OVERRIDE