### PR TITLE
fix(timestamp): Use `time.Time` in `__created_at` & `__updated_at` resolvers

### DIFF
--- a/plugins/source/firestore/client/list_tables.go
+++ b/plugins/source/firestore/client/list_tables.go
@@ -29,30 +29,21 @@ func (*Client) listTables(ctx context.Context, client *firestore.Client) (schema
 			}
 			return nil, err
 		}
-		columns := make(schema.ColumnList, 0, 4)
-		columns = append(columns, schema.Column{
-			Name:       "__id",
-			Type:       arrow.BinaryTypes.String,
-			PrimaryKey: true,
-			Unique:     true,
-			NotNull:    true,
-		})
-		columns = append(columns, schema.Column{
-			Name: "__created_at",
-			Type: arrow.FixedWidthTypes.Timestamp_us,
-		})
-		columns = append(columns, schema.Column{
-			Name: "__updated_at",
-			Type: arrow.FixedWidthTypes.Timestamp_us,
-		})
-		columns = append(columns, schema.Column{
-			Name: "data",
-			Type: types.ExtensionTypes.JSON,
-		})
 
 		schemaTables = append(schemaTables, &schema.Table{
-			Name:    collection.ID,
-			Columns: columns,
+			Name: collection.ID,
+			Columns: schema.ColumnList{
+				{
+					Name:       "__id",
+					Type:       arrow.BinaryTypes.String,
+					PrimaryKey: true,
+					Unique:     true,
+					NotNull:    true,
+				},
+				{Name: "__created_at", Type: arrow.FixedWidthTypes.Timestamp_us},
+				{Name: "__updated_at", Type: arrow.FixedWidthTypes.Timestamp_us},
+				{Name: "data", Type: types.ExtensionTypes.JSON},
+			},
 		})
 	}
 	return schemaTables, nil

--- a/plugins/source/firestore/client/sync.go
+++ b/plugins/source/firestore/client/sync.go
@@ -2,7 +2,6 @@ package client
 
 import (
 	"context"
-	"time"
 
 	"cloud.google.com/go/firestore"
 	"github.com/cloudquery/plugin-sdk/v3/plugins/source"
@@ -68,11 +67,11 @@ func (c *Client) syncTable(ctx context.Context, table *schema.Table, res chan<- 
 			if err != nil {
 				return err
 			}
-			err = resource.Set("__created_at", docSnap.CreateTime.Format(time.RFC3339))
+			err = resource.Set("__created_at", docSnap.CreateTime)
 			if err != nil {
 				return err
 			}
-			err = resource.Set("__updated_at", docSnap.UpdateTime.Format(time.RFC3339))
+			err = resource.Set("__updated_at", docSnap.UpdateTime)
 			if err != nil {
 				return err
 			}


### PR DESCRIPTION
Closes #10391