### PR TITLE
chore(ci): Increase lint timeout for plugins

### DIFF
--- a/plugins/.golangci.yml
+++ b/plugins/.golangci.yml
@@ -6,7 +6,7 @@ run:
     - client/mocks
     - resources/forks
     - codegen
-  timeout: 10m
+  timeout: 15m
   build-tags:
     - all
 


### PR DESCRIPTION
<!-- 🎉 Thank you for making CloudQuery awesome by submitting a PR 🎉 -->

#### Summary

Big plugins (like AWS) sometimes fail on the linting timeout 

<!--
Use the following steps to ensure your PR is ready to be reviewed

- [ ] Read the [contribution guidelines](../blob/main/CONTRIBUTING.md) 🧑‍🎓
- [ ] Run `make lint` to ensure the proposed changes follow the coding style 🚨 (install golangci-lint [here](https://golangci-lint.run/usage/install/#local-installation))
- [ ] Run `make test` to ensure the proposed changes pass the tests 🧪
- [ ] If changing a source plugin run `make gen` to ensure docs are up to date 📝
- [ ] Ensure the status checks below are successful ✅
--->
