### PR TITLE
fix(azure): Consumption legacy usage details

### DIFF
--- a/plugins/source/azure/resources/services/consumption/subscription_legacy_usage_details.go
+++ b/plugins/source/azure/resources/services/consumption/subscription_legacy_usage_details.go
@@ -7,7 +7,14 @@ import (
 	"github.com/cloudquery/cloudquery/plugins/source/azure/client"
 	"github.com/cloudquery/plugin-sdk/v3/schema"
 	"github.com/cloudquery/plugin-sdk/v3/transformers"
+	"github.com/cloudquery/plugin-sdk/v3/types"
 )
+
+type usageDetail struct {
+	*armconsumption.UsageDetail
+
+	Properties any `json:"properties"`
+}
 
 func SubscriptionLegacyUsageDetails() *schema.Table {
 	return &schema.Table{
@@ -15,7 +22,18 @@ func SubscriptionLegacyUsageDetails() *schema.Table {
 		Resolver:    fetchSubscriptionLegacyUsageDetails,
 		Description: "https://learn.microsoft.com/en-us/rest/api/consumption/usage-details/list?tabs=HTTP#legacyusagedetail",
 		Multiplex:   client.SubscriptionBillingPeriodMultiplex,
-		Transform:   transformers.TransformWithStruct(&armconsumption.LegacyUsageDetail{}, transformers.WithPrimaryKeys("ID")),
+		Transform: transformers.TransformWithStruct(
+			&usageDetail{},
+			transformers.WithPrimaryKeys("ID"),
+			transformers.WithUnwrapAllEmbeddedStructs(),
+		),
+		Columns: schema.ColumnList{
+			{
+				Name:     "properties",
+				Type:     types.ExtensionTypes.JSON,
+				Resolver: schema.PathResolver("Properties"),
+			},
+		},
 	}
 }
 
@@ -32,7 +50,14 @@ func fetchSubscriptionLegacyUsageDetails(ctx context.Context, meta schema.Client
 			return err
 		}
 		for _, v := range p.Value {
-			res <- v.(*armconsumption.LegacyUsageDetail)
+			ud := &usageDetail{UsageDetail: v.GetUsageDetail()}
+			switch d := v.(type) {
+			case *armconsumption.LegacyUsageDetail:
+				ud.Properties = d.Properties
+			case *armconsumption.ModernUsageDetail:
+				ud.Properties = d.Properties
+			}
+			res <- ud
 		}
 	}
 	return nil

--- a/plugins/source/azure/resources/services/consumption/subscription_legacy_usage_details_test.go
+++ b/plugins/source/azure/resources/services/consumption/subscription_legacy_usage_details_test.go
@@ -3,7 +3,6 @@ package consumption
 import (
 	"encoding/json"
 	"net/http"
-
 	"testing"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
@@ -14,16 +13,24 @@ import (
 )
 
 func createSubscriptionLegacyUsageDetails(router *mux.Router) error {
-	var item armconsumption.LegacyUsageDetail
-	if err := faker.FakeObject(&item); err != nil {
+	var (
+		item1 armconsumption.LegacyUsageDetail
+		item2 armconsumption.ModernUsageDetail
+	)
+	if err := faker.FakeObject(&item1); err != nil {
 		return err
 	}
-	item.Kind = to.Ptr(armconsumption.UsageDetailsKindLegacy)
+	item1.Kind = to.Ptr(armconsumption.UsageDetailsKindLegacy)
+
+	if err := faker.FakeObject(&item2); err != nil {
+		return err
+	}
+	item2.Kind = to.Ptr(armconsumption.UsageDetailsKindModern)
 
 	resp := armconsumption.UsageDetailsClientListResponse{
 		UsageDetailsListResult: armconsumption.UsageDetailsListResult{
 			// Value is an interface{} so we can't mock it directly
-			Value: []armconsumption.UsageDetailClassification{&item},
+			Value: []armconsumption.UsageDetailClassification{&item1, &item2},
 		},
 	}
 	resp.NextLink = to.Ptr("")

--- a/website/tables/azure/azure_consumption_subscription_legacy_usage_details.md
+++ b/website/tables/azure/azure_consumption_subscription_legacy_usage_details.md
@@ -14,8 +14,8 @@ The primary key for this table is **id**.
 |_cq_sync_time|`timestamp[us, tz=UTC]`|
 |_cq_id|`uuid`|
 |_cq_parent_id|`uuid`|
-|kind|`utf8`|
 |properties|`json`|
+|kind|`utf8`|
 |etag|`utf8`|
 |id (PK)|`utf8`|
 |name|`utf8`|


### PR DESCRIPTION
Fixes https://github.com/cloudquery/cloudquery-issues/issues/565

```go
// UsageDetailClassification provides polymorphic access to related types.
// Call the interface's GetUsageDetail() method to access the common type.
// Use a type switch to determine the concrete type.  The possible types are:
// - *LegacyUsageDetail, *ModernUsageDetail, *UsageDetail
type UsageDetailClassification interface {
	// GetUsageDetail returns the UsageDetail content of the underlying type.
	GetUsageDetail() *UsageDetail
}
```