### PR TITLE
fix(website): Update how-to-guides.mdx

### DIFF
--- a/website/pages/how-to-guides.mdx
+++ b/website/pages/how-to-guides.mdx
@@ -9,7 +9,7 @@ import { HowToGuideIndex } from "../components/HowToGuideIndex";
 
 <div className="max-w-screen-lg mx-auto pt-4 pb-8 mb-16 border-b border-gray-400 border-opacity-20">
   <h1 className="text-center"><span className="font-bold leading-tight lg:text-5xl">How-to Guides</span></h1>
-  <p className="text-center text-gray-500 dark:text-gray-400">Task-oriented guides to integrating CloudQuery with a variety of tools, quickly</p>
+  <p className="text-center text-gray-500 dark:text-gray-400">Task-oriented guides to integrating CloudQuery with a variety of tools</p>
 </div>
 
 <HowToGuideIndex/>


### PR DESCRIPTION
Quick grammar fix for main how-to-guide page.  Removed 'quickly`