### PR TITLE
fix(aws): Resolve All types of attached Resources in `aws_wafv2_web_acls`

### DIFF
--- a/plugins/source/aws/resources/services/ec2/instances.go
+++ b/plugins/source/aws/resources/services/ec2/instances.go
@@ -51,7 +51,6 @@ func Instances() *schema.Table {
 var stateTransitionReasonTimeRegex = regexp.MustCompile(`\((.*)\)`)
 
 func fetchEc2Instances(ctx context.Context, meta schema.ClientMeta, _ *schema.Resource, res chan<- any) error {
-
 	cl := meta.(*client.Client)
 	svc := cl.Services().Ec2
 	p := ec2.NewDescribeInstancesPaginator(svc,

--- a/plugins/source/aws/resources/services/wafv2/web_acls.go
+++ b/plugins/source/aws/resources/services/wafv2/web_acls.go
@@ -143,13 +143,20 @@ func resolveWafv2webACLResourcesForWebACL(ctx context.Context, meta schema.Clien
 			params.Marker = output.DistributionList.NextMarker
 		}
 	} else {
-		output, err := service.ListResourcesForWebACL(ctx, &wafv2.ListResourcesForWebACLInput{WebACLArn: webACL.ARN}, func(o *wafv2.Options) {
-			o.Region = cl.Region
-		})
-		if err != nil {
-			return err
+		var resourceType types.ResourceType
+		for _, resType := range resourceType.Values() {
+			output, err := service.ListResourcesForWebACL(ctx,
+				&wafv2.ListResourcesForWebACLInput{
+					WebACLArn:    webACL.ARN,
+					ResourceType: resType,
+				}, func(o *wafv2.Options) {
+					o.Region = cl.Region
+				})
+			if err != nil {
+				return err
+			}
+			resourceArns = append(resourceArns, output.ResourceArns...)
 		}
-		resourceArns = output.ResourceArns
 	}
 	return resource.Set(c.Name, resourceArns)
 }

--- a/plugins/source/aws/resources/services/wafv2/web_acls_mock_test.go
+++ b/plugins/source/aws/resources/services/wafv2/web_acls_mock_test.go
@@ -66,7 +66,7 @@ func buildWAFV2WebACLMock(t *testing.T, ctrl *gomock.Controller) client.Services
 	}
 	m.EXPECT().ListResourcesForWebACL(gomock.Any(), gomock.Any(), gomock.Any()).Return(&wafv2.ListResourcesForWebACLOutput{
 		ResourceArns: tempResourceArns,
-	}, nil)
+	}, nil).MinTimes(1)
 
 	distributionList := cftypes.DistributionList{}
 	if err := faker.FakeObject(&distributionList); err != nil {


### PR DESCRIPTION
<!-- 🎉 Thank you for making CloudQuery awesome by submitting a PR 🎉 -->

#### Summary

Prior to fix resolver only grabs ALB resources which is the default value. WebACL can also be attached to Cognito, AppSync and API Gateway resources.