### PR TITLE
fix(dest-mysql): Set key prefix for `blob/text` PK columns

### DIFF
--- a/plugins/destination/mysql/client/schema.go
+++ b/plugins/destination/mysql/client/schema.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/apache/arrow/go/v13/arrow"
 	"github.com/cloudquery/plugin-sdk/v3/schema"
 )
 
@@ -140,18 +139,21 @@ func (c *Client) createTable(ctx context.Context, table *schema.Table) error {
 		builder.WriteString(identifier(column.Name))
 		builder.WriteString(" ")
 		builder.WriteString(arrowTypeToMySqlStr(column.Type))
-		if column.Unique {
-			builder.WriteString(" UNIQUE")
-		}
-		if column.NotNull {
-			builder.WriteString(" NOT NULL")
-		}
-		if i < totalColumns-1 {
-			builder.WriteString(",\n  ")
-		}
 
 		if c.pkEnabled() && column.PrimaryKey {
 			primaryKeysIndices = append(primaryKeysIndices, i)
+		} else {
+			// Primary keys are implicitly not null and unique, so we only need to add these constraints if the column is not a primary key
+			if column.Unique {
+				builder.WriteString(" UNIQUE")
+			}
+			if column.NotNull {
+				builder.WriteString(" NOT NULL")
+			}
+		}
+
+		if i < totalColumns-1 {
+			builder.WriteString(",\n  ")
 		}
 	}
 	if len(primaryKeysIndices) > 0 {
@@ -160,9 +162,11 @@ func (c *Client) createTable(ctx context.Context, table *schema.Table) error {
 		for i, pk := range primaryKeysIndices {
 			column := table.Columns[pk]
 			builder.WriteString(identifier(column.Name))
-			if column.Type == arrow.BinaryTypes.LargeString {
-				// Since we use `text` for strings we need to specify the prefix length to use for the primary key
+			sqlType := arrowTypeToMySqlStr(column.Type)
+			if sqlType == "blob" || sqlType == "text" {
+				// `blob/text` SQL types require specifying prefix length to use for the primary key
 				builder.WriteString("(64)")
+
 			}
 			if i < len(primaryKeysIndices)-1 {
 				builder.WriteString(", ")

--- a/plugins/destination/mysql/client/schema.go
+++ b/plugins/destination/mysql/client/schema.go
@@ -166,7 +166,6 @@ func (c *Client) createTable(ctx context.Context, table *schema.Table) error {
 			if sqlType == "blob" || sqlType == "text" {
 				// `blob/text` SQL types require specifying prefix length to use for the primary key
 				builder.WriteString("(64)")
-
 			}
 			if i < len(primaryKeysIndices)-1 {
 				builder.WriteString(", ")


### PR DESCRIPTION
<!-- 🎉 Thank you for making CloudQuery awesome by submitting a PR 🎉 -->

#### Summary

This is a follow up to https://github.com/cloudquery/cloudquery/pull/11360 to ensure `blob/text` SQL types have their PK configured correctly.
It also has another PK fix related to the arrow migration to avoid creating a duplicate index for columns that have all `Unique,NotNull,PrimaryKey` flags set

<!--
Use the following steps to ensure your PR is ready to be reviewed

- [ ] Read the [contribution guidelines](../blob/main/CONTRIBUTING.md) 🧑‍🎓
- [ ] Run `make lint` to ensure the proposed changes follow the coding style 🚨 (install golangci-lint [here](https://golangci-lint.run/usage/install/#local-installation))
- [ ] Run `make test` to ensure the proposed changes pass the tests 🧪
- [ ] If changing a source plugin run `make gen` to ensure docs are up to date 📝
- [ ] Ensure the status checks below are successful ✅
--->
