### PR TITLE
fix(cli): Propagate destinations errors

### DIFF
--- a/cli/cmd/sync_v2.go
+++ b/cli/cmd/sync_v2.go
@@ -98,17 +98,6 @@ func syncConnectionV2(ctx context.Context, sourceClient *managedsource.Client, d
 		return err
 	}
 	writeClients := make([]destination.Destination_WriteClient, len(destinationsPbClients))
-	defer func() {
-		for i, wc := range writeClients {
-			if wc == nil {
-				continue
-			}
-			if _, closeErr := wc.CloseAndRecv(); closeErr != nil {
-				log.Err(closeErr).Str("destination", destinationsClients[i].Spec.Name).Msg("Failed to close write stream")
-			}
-		}
-	}()
-
 	for i := range destinationsPbClients {
 		writeClients[i], err = destinationsPbClients[i].Write(ctx)
 		if err != nil {
@@ -163,6 +152,12 @@ func syncConnectionV2(ctx context.Context, sourceClient *managedsource.Client, d
 			}
 		}
 	}
+	for i := range destinationsClients {
+		if _, err := writeClients[i].CloseAndRecv(); err != nil {
+			return err
+		}
+	}
+
 	getMetricsRes, err := sourcePbClient.GetMetrics(ctx, &source.GetMetrics_Request{})
 	if err != nil {
 		return err


### PR DESCRIPTION
<!-- 🎉 Thank you for making CloudQuery awesome by submitting a PR 🎉 -->

#### Summary

Scoped only the error handling part from https://github.com/cloudquery/cloudquery/pull/11444 to this PR.

`CloseAndRecv` returns the error reported by the destination (it also returns application level errors, not just protocol errors), so we need to report it. See https://grpc.io/docs/languages/go/basics/#client-side-streaming-rpc-1

<!--
Use the following steps to ensure your PR is ready to be reviewed

- [ ] Read the [contribution guidelines](../blob/main/CONTRIBUTING.md) 🧑‍🎓
- [ ] Run `make lint` to ensure the proposed changes follow the coding style 🚨 (install golangci-lint [here](https://golangci-lint.run/usage/install/#local-installation))
- [ ] Run `make test` to ensure the proposed changes pass the tests 🧪
- [ ] If changing a source plugin run `make gen` to ensure docs are up to date 📝
- [ ] Ensure the status checks below are successful ✅
--->
