### PR TITLE
chore: Revert "fix: Add internal columns"

### DIFF
--- a/plugins/source/firestore/resources/plugin/plugin.go
+++ b/plugins/source/firestore/resources/plugin/plugin.go
@@ -14,6 +14,7 @@ func Plugin() *source.Plugin {
 		nil,
 		client.Configure,
 		source.WithDynamicTableOption(getDynamicTables),
+		source.WithNoInternalColumns(),
 		source.WithUnmanaged(),
 	)
 }


### PR DESCRIPTION
Reverts cloudquery/cloudquery#11429

This doesn't work, as while it adds the internal columns those are not populated with values so the destination writes fail