### PR TITLE
feat!: Support number type with precision and scale

### DIFF
--- a/plugins/source/oracledb/client/list_tables.go
+++ b/plugins/source/oracledb/client/list_tables.go
@@ -2,6 +2,7 @@ package client
 
 import (
 	"context"
+	"database/sql"
 	"fmt"
 	"sort"
 	"strings"
@@ -60,7 +61,7 @@ func (c *Client) listTables(ctx context.Context) (schema.Tables, error) {
 	// See more about the default namespaces we exclude in https://www.oracletutorial.com/oracle-administration/oracle-tablespace/
 	// Also invisible columns have COLUMN_ID = NULL so we exclude them as well. See https://forums.oracle.com/ords/apexds/post/oracle-12c-invisible-columns-0462
 	query := `
-	SELECT ALL_TAB_COLS.TABLE_NAME, COLUMN_ID, COLUMN_NAME, DATA_TYPE, DATA_LENGTH, NULLABLE FROM ALL_TABLES
+	SELECT ALL_TAB_COLS.TABLE_NAME, COLUMN_ID, COLUMN_NAME, DATA_TYPE, DATA_LENGTH, NULLABLE, DATA_PRECISION, DATA_SCALE FROM ALL_TABLES
 	LEFT JOIN ALL_TAB_COLS ON ALL_TABLES.TABLE_NAME = ALL_TAB_COLS.TABLE_NAME
 	WHERE ALL_TABLES.TABLESPACE_NAME NOT IN ('SYSAUX', 'SYSTEM', 'TEMP', 'UNDOTBS1')
 	AND ALL_TAB_COLS.COLUMN_ID IS NOT NULL
@@ -78,13 +79,22 @@ func (c *Client) listTables(ctx context.Context) (schema.Tables, error) {
 		var dataType string
 		var dataLength int
 		var nullable string
+		var precision sql.NullInt64
+		var scale sql.NullInt64
 
-		if err := rows.Scan(&tableName, &columnId, &columnName, &dataType, &dataLength, &nullable); err != nil {
+		if err := rows.Scan(&tableName, &columnId, &columnName, &dataType, &dataLength, &nullable, &precision, &scale); err != nil {
 			return nil, err
 		}
 		dataType = strings.ToLower(dataType)
 		if dataType == "char" || dataType == "raw" {
 			dataType = fmt.Sprintf("%s(%d)", dataType, dataLength)
+		}
+		if dataType == "number" {
+			if precision.Valid && scale.Valid {
+				dataType = fmt.Sprintf("number(%d,%d)", precision.Int64, scale.Int64)
+			} else if precision.Valid {
+				dataType = fmt.Sprintf("number(%d)", precision.Int64)
+			}
 		}
 		schemaTables[tableName] = append(schemaTables[tableName], column{
 			id:       columnId,

--- a/plugins/source/oracledb/client/types.go
+++ b/plugins/source/oracledb/client/types.go
@@ -1,10 +1,45 @@
 package client
 
 import (
+	"strconv"
 	"strings"
 
 	"github.com/cloudquery/plugin-sdk/v2/schema"
 )
+
+const defaultPrecision = 38
+const defaultScale = 0
+
+func getValue(str string, defaultValue int32) int32 {
+	val, err := strconv.ParseInt(str, 10, 32)
+	if err != nil {
+		return defaultValue
+	}
+	return int32(val)
+}
+
+func getPrecisionAndScale(dataType string) (precision, scale int32) {
+	str := strings.TrimPrefix(dataType, "number")
+	if str == "" {
+		return defaultPrecision, defaultScale
+	}
+	str = strings.TrimPrefix(str, "(")
+	str = strings.TrimSuffix(str, ")")
+	parts := strings.Split(str, ",")
+
+	switch len(parts) {
+	case 1:
+		precision = getValue(parts[0], defaultPrecision)
+		scale = defaultScale
+	case 2:
+		precision = getValue(parts[0], defaultPrecision)
+		scale = getValue(parts[1], defaultScale)
+	default:
+		precision = defaultPrecision
+		scale = defaultScale
+	}
+	return precision, scale
+}
 
 func SQLType(t schema.ValueType) string {
 	switch t {
@@ -42,6 +77,14 @@ func SchemaType(tableName string, columnName string, dataType string) schema.Val
 		return schema.TypeTimestamp
 	}
 
+	if strings.HasPrefix(dataType, "number") {
+		_, scale := getPrecisionAndScale(dataType)
+		if scale == 0 {
+			return schema.TypeInt
+		}
+		return schema.TypeFloat
+	}
+
 	switch dataType {
 	case "raw(16)":
 		return schema.TypeUUID
@@ -51,8 +94,6 @@ func SchemaType(tableName string, columnName string, dataType string) schema.Val
 		return schema.TypeFloat
 	case "binary":
 		return schema.TypeByteArray
-	case "number":
-		return schema.TypeInt
 	case "blob", "raw", "long raw":
 		return schema.TypeByteArray
 	}

--- a/plugins/source/oracledb/client/types_test.go
+++ b/plugins/source/oracledb/client/types_test.go
@@ -1,0 +1,50 @@
+package client
+
+import (
+	"testing"
+)
+
+func Test_getPrecisionAndScale(t *testing.T) {
+	tests := []struct {
+		name          string
+		dataType      string
+		wantPrecision int32
+		wantScale     int32
+	}{
+		{
+			name:          "should return default precision and scale when not provided",
+			dataType:      "number",
+			wantPrecision: 38,
+			wantScale:     0,
+		},
+		{
+			name:          "should return default scale when only precision is provided",
+			dataType:      "number(10)",
+			wantPrecision: 10,
+			wantScale:     0,
+		},
+		{
+			name:          "should return precision and scale when precision and scale are provided",
+			dataType:      "number(10,2)",
+			wantPrecision: 10,
+			wantScale:     2,
+		},
+		{
+			name:          "should return default precision when * is provided",
+			dataType:      "number(*,3)",
+			wantPrecision: 38,
+			wantScale:     3,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotPrecision, gotScale := getPrecisionAndScale(tt.dataType)
+			if gotPrecision != tt.wantPrecision {
+				t.Errorf("getPrecisionAndScale() gotPrecision = %v, want %v", gotPrecision, tt.wantPrecision)
+			}
+			if gotScale != tt.wantScale {
+				t.Errorf("getPrecisionAndScale() gotScale = %v, want %v", gotScale, tt.wantScale)
+			}
+		})
+	}
+}


### PR DESCRIPTION
<!-- 🎉 Thank you for making CloudQuery awesome by submitting a PR 🎉 -->

#### Summary

Fixes https://github.com/cloudquery/cloudquery/issues/11538. This is a breaking change since now if a `number` has precision it will create a float type column at the destination.

Parsing the precision and scale is take from https://github.com/cloudquery/cloudquery/pull/11115/files#diff-619acf691639d4d0288b58b3814d54d67a93f4774f22d61dc5812348ef099b4c and I'll port the query update from this PR to https://github.com/cloudquery/cloudquery/pull/11115


BEGIN_COMMIT_OVERRIDE
feat: Support number type with precision and scale
BREAKING-CHANGE: Support for parsing `number` type precision and scale was added. As a result number columns with scale that is different than `0`, e.g. `number(6,2)` will be converted to `float` type at the destination instead of `int`. You might need to either run with [forced migration mode](https://www.cloudquery.io/docs/reference/destination-spec#migrate_mode) or migrate the destination manually.

END_COMMIT_OVERRIDE

<!--
Use the following steps to ensure your PR is ready to be reviewed

- [ ] Read the [contribution guidelines](../blob/main/CONTRIBUTING.md) 🧑‍🎓
- [ ] Run `make lint` to ensure the proposed changes follow the coding style 🚨 (install golangci-lint [here](https://golangci-lint.run/usage/install/#local-installation))
- [ ] Run `make test` to ensure the proposed changes pass the tests 🧪
- [ ] If changing a source plugin run `make gen` to ensure docs are up to date 📝
- [ ] Ensure the status checks below are successful ✅
--->
