### PR TITLE
fix: Write buffered parquet files

### DIFF
--- a/plugins/destination/duckdb/client/write.go
+++ b/plugins/destination/duckdb/client/write.go
@@ -170,7 +170,7 @@ func writeTMPFile(table *schema.Table, records []arrow.Record) (fileName string,
 
 	// write records
 	for _, r := range records {
-		if err = fw.Write(transformRecord(sc, r)); err != nil {
+		if err = fw.WriteBuffered(transformRecord(sc, r)); err != nil {
 			return "", err
 		}
 	}


### PR DESCRIPTION
Follow-up for https://github.com/cloudquery/filetypes/issues/137