### PR TITLE
fix: Fix syncing multiple sources to multiple non-overlapping destinations

### DIFF
--- a/cli/cmd/sync.go
+++ b/cli/cmd/sync.go
@@ -98,12 +98,18 @@ func sync(cmd *cobra.Command, args []string) error {
 
 	for _, cl := range sourcesClients {
 		maxVersion, err := cl.MaxVersion(ctx)
+		destinationClientsForSource := make([]*manageddestination.Client, 0)
+		for _, destination := range destinationsClients {
+			if slices.Contains(cl.Spec.Destinations, destination.Spec.Name) {
+				destinationClientsForSource = append(destinationClientsForSource, destination)
+			}
+		}
 		if err != nil {
 			return err
 		}
 		switch maxVersion {
 		case 2:
-			for _, destination := range destinationsClients {
+			for _, destination := range destinationClientsForSource {
 				versions, err := destination.Versions(ctx)
 				if err != nil {
 					return fmt.Errorf("failed to get destination versions: %w", err)
@@ -112,15 +118,15 @@ func sync(cmd *cobra.Command, args []string) error {
 					return fmt.Errorf("destination %[1]s does not support CloudQuery SDK version 1. Please upgrade to newer version of %[1]s", destination.Spec.Name)
 				}
 			}
-			if err := syncConnectionV2(ctx, cl, destinationsClients, invocationUUID.String(), noMigrate); err != nil {
+			if err := syncConnectionV2(ctx, cl, destinationClientsForSource, invocationUUID.String(), noMigrate); err != nil {
 				return fmt.Errorf("failed to sync v2 source %s: %w", cl.Spec.Name, err)
 			}
 		case 1:
-			if err := syncConnectionV1(ctx, cl, destinationsClients, invocationUUID.String(), noMigrate); err != nil {
+			if err := syncConnectionV1(ctx, cl, destinationClientsForSource, invocationUUID.String(), noMigrate); err != nil {
 				return fmt.Errorf("failed to sync v1 source %s: %w", cl.Spec.Name, err)
 			}
 		case 0:
-			if err := syncConnectionV0_2(ctx, cl, destinationsClients, invocationUUID.String(), noMigrate); err != nil {
+			if err := syncConnectionV0_2(ctx, cl, destinationClientsForSource, invocationUUID.String(), noMigrate); err != nil {
 				return fmt.Errorf("failed to sync v1 source %s: %w", cl.Spec.Name, err)
 			}
 		case -1:

--- a/cli/cmd/sync.go
+++ b/cli/cmd/sync.go
@@ -98,7 +98,7 @@ func sync(cmd *cobra.Command, args []string) error {
 
 	for _, cl := range sourcesClients {
 		maxVersion, err := cl.MaxVersion(ctx)
-		destinationClientsForSource := make([]*manageddestination.Client, 0)
+		var destinationClientsForSource []*manageddestination.Client
 		for _, destination := range destinationsClients {
 			if slices.Contains(cl.Spec.Destinations, destination.Spec.Name) {
 				destinationClientsForSource = append(destinationClientsForSource, destination)

--- a/cli/cmd/testdata/multiple-sources-destinations.yml
+++ b/cli/cmd/testdata/multiple-sources-destinations.yml
@@ -2,7 +2,7 @@ kind: "source"
 spec:
   name: "test-1"
   path: "cloudquery/test"
-  destinations: [test-1, test-2]
+  destinations: [test-1]
   version: "v2.0.3" # latest version of source test plugin
   tables: ["*"]
 ---
@@ -10,7 +10,7 @@ kind: "source"
 spec:
   name: "test-2"
   path: "cloudquery/test"
-  destinations: [test-2, test-1]
+  destinations: [test-2]
   version: "v2.0.3" # latest version of source test plugin
   tables: ["*"]
 ---


### PR DESCRIPTION
This fixes the case where different sources are specified in one config, syncing to their own destinations. Previously the code incorrectly assumed that all sources should sync to all destinations.

Tested with the following config:

```yaml
kind: source
spec:
  name: xkcd1
  path: hermanschaaf/xkcd
  version: v2.0.0
  destinations: ["postgresql_schema1"]
  tables: ["*"]
  spec:
---
kind: source
spec:
  name: xkcd2
  path: hermanschaaf/xkcd
  version: v2.0.0
  destinations: ["postgresql_schema2"]
  tables: ["*"]
  spec:
---
kind: destination
spec:
  name: postgresql_schema1
  registry: "github"
  path: cloudquery/postgresql
  version: "v4.2.1"
  spec:
    connection_string: "postgresql://postgres:pass@localhost:5432/cloudquery?sslmode=disable&search_path=test1"
---
kind: destination
spec:
  name: postgresql_schema2
  registry: "github"
  path: cloudquery/postgresql
  version: "v4.2.1"
  spec:
    connection_string: "postgresql://postgres:pass@localhost:5432/cloudquery?sslmode=disable&search_path=test2"
```

Before this synced the XKCD comics to both schemas both times, but now it syncs the comics first to `test1`, then to `test2`. Currently it's difficult to have an automated test with assertions for this kind of setup, but we should work towards that being possible.