### PR TITLE
fix!: List `azure_costmanagement_views` without scope

### DIFF
--- a/plugins/source/azure/resources/services/costmanagement/views.go
+++ b/plugins/source/azure/resources/services/costmanagement/views.go
@@ -20,20 +20,18 @@ func Views() *schema.Table {
 			transformers.WithNameTransformer(client.ETagNameTransformer),
 			transformers.WithPrimaryKeys("ID"),
 		),
-		Columns: schema.ColumnList{client.SubscriptionID},
-		Relations: []*schema.Table{
-			view_queries(),
-		},
+		Columns:   schema.ColumnList{client.SubscriptionIDPK},
+		Relations: schema.Tables{view_queries()},
 	}
 }
 
-func fetchViews(ctx context.Context, meta schema.ClientMeta, parent *schema.Resource, res chan<- any) error {
+func fetchViews(ctx context.Context, meta schema.ClientMeta, _ *schema.Resource, res chan<- any) error {
 	cl := meta.(*client.Client)
 	svc, err := armcostmanagement.NewViewsClient(cl.Creds, cl.Options)
 	if err != nil {
 		return err
 	}
-	pager := svc.NewListByScopePager("subscriptions/"+cl.SubscriptionId, nil)
+	pager := svc.NewListPager(nil)
 	for pager.More() {
 		p, err := pager.NextPage(ctx)
 		if err != nil {

--- a/plugins/source/azure/resources/services/costmanagement/views_mock_test.go
+++ b/plugins/source/azure/resources/services/costmanagement/views_mock_test.go
@@ -21,7 +21,7 @@ func createViews(router *mux.Router) error {
 	emptyStr := ""
 	item.NextLink = &emptyStr
 
-	router.HandleFunc("/subscriptions/{subscriptionId}/providers/Microsoft.CostManagement/views", func(w http.ResponseWriter, r *http.Request) {
+	router.HandleFunc("/providers/Microsoft.CostManagement/views", func(w http.ResponseWriter, r *http.Request) {
 		b, err := json.Marshal(&item)
 		if err != nil {
 			http.Error(w, "unable to marshal request: "+err.Error(), http.StatusBadRequest)

--- a/website/tables/azure/azure_costmanagement_views.md
+++ b/website/tables/azure/azure_costmanagement_views.md
@@ -4,7 +4,7 @@ This table shows data for Azure Cost Management Views.
 
 https://learn.microsoft.com/en-us/rest/api/cost-management/views/list?tabs=HTTP#view
 
-The primary key for this table is **id**.
+The composite primary key for this table is (**subscription_id**, **id**).
 
 ## Relations
 
@@ -19,7 +19,7 @@ The following tables depend on azure_costmanagement_views:
 |_cq_sync_time|`timestamp[us, tz=UTC]`|
 |_cq_id|`uuid`|
 |_cq_parent_id|`uuid`|
-|subscription_id|`utf8`|
+|subscription_id (PK)|`utf8`|
 |etag|`utf8`|
 |properties|`json`|
 |id (PK)|`utf8`|


### PR DESCRIPTION
Closes #9859

BEGIN_COMMIT_OVERRIDE
fix: List `azure_costmanagement_views` without scope (#11621)
BREAKING-CHANGE: Add `subscription_id` to `azure_costmanagement_views` primary key (#11621)
END_COMMIT_OVERRIDE