### PR TITLE
Fix example query in analysing-gcp-cost-with-bigquery-and-cq.mdx

### DIFF
--- a/website/pages/blog/analysing-gcp-cost-with-bigquery-and-cq.mdx
+++ b/website/pages/blog/analysing-gcp-cost-with-bigquery-and-cq.mdx
@@ -80,7 +80,7 @@ Now let's join with the GCP billing data.
 SELECT sum(cost) FROM `cq-playground.costdata.gcp_billing_export_resource_v1_0183D4_4E0A4D_60E401` gcp_billing_export_resource 
   join `cq-playground.costdata.gcp_compute_disks` gcp_compute_disks on 
   gcp_billing_export_resource.resource.name = gcp_compute_disks.name 
-WHERE DATE(_PARTITIONTIME) = "2022-12-14" and gcp_compute_disks.users is null
+WHERE DATE(_PARTITIONTIME) = "2022-12-14" and ARRAY_LENGTH(gcp_compute_disks.users) = 0
 ```
 
 This query should give us total of all costs of unattached disks for a specific date, so we don't scan the whole historical table. We can also run this on a date range. 


### PR DESCRIPTION
<!-- 🎉 Thank you for making CloudQuery awesome by submitting a PR 🎉 -->

#### Summary

The SCHEMA for gcp_compute_disks.users is a REPEATED so you have to check for an empty array.

I found this solution via https://stackoverflow.com/a/67506844


When running the command in the doc, we get no results
![image](https://github.com/cloudquery/cloudquery/assets/8085744/9986e11b-5365-49f3-87d5-ce252d5a193f)


Updating it to use the proposal in the MR gets data back

![image](https://github.com/cloudquery/cloudquery/assets/8085744/2518ef2b-4724-441c-a57d-0c2e9bb5c94c)

Investigating the data type of the `users` column
![image](https://github.com/cloudquery/cloudquery/assets/8085744/71a17d8b-8987-43bb-9f83-c27ddcaf4a15)

<!--
Use the following steps to ensure your PR is ready to be reviewed

- [ ] Read the [contribution guidelines](../blob/main/CONTRIBUTING.md) 🧑‍🎓
- [ ] Run `make lint` to ensure the proposed changes follow the coding style 🚨 (install golangci-lint [here](https://golangci-lint.run/usage/install/#local-installation))
- [ ] Run `make test` to ensure the proposed changes pass the tests 🧪
- [ ] If changing a source plugin run `make gen` to ensure docs are up to date 📝
- [ ] Ensure the status checks below are successful ✅
--->
