### PR TITLE
feat(aws): Add PolicyStatus to WrappedBucket

### DIFF
--- a/plugins/source/aws/resources/services/s3/buckets.go
+++ b/plugins/source/aws/resources/services/s3/buckets.go
@@ -180,10 +180,9 @@ func resolveBucketPolicyStatus(ctx context.Context, meta schema.ClientMeta, reso
 		}
 		return err
 	}
-	if policyStatusOutput == nil {
-		return nil
+	if policyStatusOutput != nil {
+		resource.PolicyStatus = policyStatusOutput.PolicyStatus
 	}
-	resource.PolicyStatus = policyStatusOutput.PolicyStatus
 	return nil
 }
 

--- a/plugins/source/aws/resources/services/s3/buckets.go
+++ b/plugins/source/aws/resources/services/s3/buckets.go
@@ -180,10 +180,10 @@ func resolveBucketPolicyStatus(ctx context.Context, meta schema.ClientMeta, reso
 		}
 		return err
 	}
-	if policyStatusOutput == nil || policyStatusOutput.PolicyStatus == nil {
+	if policyStatusOutput == nil {
 		return nil
 	}
-	resource.IsPublicByPolicy = policyStatusOutput.PolicyStatus.IsPublic
+	resource.PolicyStatus = policyStatusOutput.PolicyStatus
 	return nil
 }
 

--- a/plugins/source/aws/resources/services/s3/buckets_mock_test.go
+++ b/plugins/source/aws/resources/services/s3/buckets_mock_test.go
@@ -33,6 +33,11 @@ func buildS3Buckets(t *testing.T, ctrl *gomock.Controller) client.Services {
 	if err != nil {
 		t.Fatal(err)
 	}
+	bpols := s3.GetBucketPolicyStatusOutput{}
+	err = faker.FakeObject(&bpols)
+	if err != nil {
+		t.Fatal(err)
+	}
 	jsonDoc := `{"stuff": 3}`
 	bpol.Policy = &jsonDoc
 	bver := s3.GetBucketVersioningOutput{}
@@ -85,6 +90,8 @@ func buildS3Buckets(t *testing.T, ctrl *gomock.Controller) client.Services {
 		&blog, nil)
 	m.EXPECT().GetBucketPolicy(gomock.Any(), gomock.Any(), gomock.Any()).Return(
 		&bpol, nil)
+	m.EXPECT().GetBucketPolicyStatus(gomock.Any(), gomock.Any(), gomock.Any()).Return(
+		&bpols, nil)
 	m.EXPECT().GetBucketVersioning(gomock.Any(), gomock.Any(), gomock.Any()).Return(
 		&bver, nil)
 	m.EXPECT().GetBucketAcl(gomock.Any(), gomock.Any(), gomock.Any()).Return(

--- a/plugins/source/aws/resources/services/s3/models/s3.go
+++ b/plugins/source/aws/resources/services/s3/models/s3.go
@@ -29,6 +29,7 @@ type WrappedBucket struct {
 	LoggingTargetBucket   *string
 	LoggingTargetPrefix   *string
 	Policy                map[string]any
+	IsPublicByPolicy      bool
 	VersioningStatus      types.BucketVersioningStatus
 	VersioningMfaDelete   types.MFADeleteStatus
 	BlockPublicAcls       bool

--- a/plugins/source/aws/resources/services/s3/models/s3.go
+++ b/plugins/source/aws/resources/services/s3/models/s3.go
@@ -29,7 +29,7 @@ type WrappedBucket struct {
 	LoggingTargetBucket   *string
 	LoggingTargetPrefix   *string
 	Policy                map[string]any
-	IsPublicByPolicy      bool
+	PolicyStatus          *types.PolicyStatus
 	VersioningStatus      types.BucketVersioningStatus
 	VersioningMfaDelete   types.MFADeleteStatus
 	BlockPublicAcls       bool

--- a/website/tables/aws/aws_s3_buckets.md
+++ b/website/tables/aws/aws_s3_buckets.md
@@ -31,7 +31,7 @@ The following tables depend on aws_s3_buckets:
 |logging_target_bucket|`utf8`|
 |logging_target_prefix|`utf8`|
 |policy|`json`|
-|is_public_by_policy|`bool`|
+|policy_status|`json`|
 |versioning_status|`utf8`|
 |versioning_mfa_delete|`utf8`|
 |block_public_acls|`bool`|

--- a/website/tables/aws/aws_s3_buckets.md
+++ b/website/tables/aws/aws_s3_buckets.md
@@ -31,6 +31,7 @@ The following tables depend on aws_s3_buckets:
 |logging_target_bucket|`utf8`|
 |logging_target_prefix|`utf8`|
 |policy|`json`|
+|is_public_by_policy|`bool`|
 |versioning_status|`utf8`|
 |versioning_mfa_delete|`utf8`|
 |block_public_acls|`bool`|


### PR DESCRIPTION
<!-- 🎉 Thank you for making CloudQuery awesome by submitting a PR 🎉 -->

#### Summary
Thank you for implementing this amazing project.

I added ~`is_public_by_policy`~ `policy_status` to `WrappedBucket`.
Though AWS shows the criteria ([criteria](https://docs.aws.amazon.com/AmazonS3/latest/userguide/access-control-block-public-access.html#access-control-block-public-access-policy-status)), It is difficult for me to conclude whether a s3 bucket which uses bucket policy is public or not.
so I suggest the way using `GetBucketPolicyStatus` API in this PR.


- [x] Read the [contribution guidelines](../blob/main/CONTRIBUTING.md) 🧑‍🎓
- [x] Run `make lint` to ensure the proposed changes follow the coding style 🚨 (install golangci-lint [here](https://golangci-lint.run/usage/install/#local-installation))
- [x] Run `make test` to ensure the proposed changes pass the tests 🧪
- [x] If changing a source plugin run `make gen` to ensure docs are up to date 📝
- [x] Ensure the status checks below are successful ✅
