### PR TITLE
fix(aws)!: Remove ARN from `aws_cloudfront_cache_policies`

### DIFF
--- a/website/tables/aws/aws_cloudfront_cache_policies.md
+++ b/website/tables/aws/aws_cloudfront_cache_policies.md
@@ -4,7 +4,7 @@ This table shows data for Cloudfront Cache Policies.
 
 https://docs.aws.amazon.com/cloudfront/latest/APIReference/API_CachePolicySummary.html
 
-The primary key for this table is **arn**.
+The composite primary key for this table is (**account_id**, **id**).
 
 ## Columns
 
@@ -14,8 +14,7 @@ The primary key for this table is **arn**.
 |_cq_sync_time|`timestamp[us, tz=UTC]`|
 |_cq_id|`uuid`|
 |_cq_parent_id|`uuid`|
-|account_id|`utf8`|
-|id|`utf8`|
-|arn (PK)|`utf8`|
+|account_id (PK)|`utf8`|
+|id (PK)|`utf8`|
 |cache_policy|`json`|
 |type|`utf8`|


### PR DESCRIPTION
<!-- 🎉 Thank you for making CloudQuery awesome by submitting a PR 🎉 -->

#### Summary

Cannot find any reference or documentation to an ARN for cache policies... Changed the PK from arn to resource id  + account id