### PR TITLE
feat: Provide better error message on mismatch between plugin and CLI protocol support

### DIFF
--- a/cli/cmd/migrate.go
+++ b/cli/cmd/migrate.go
@@ -95,8 +95,8 @@ func migrate(cmd *cobra.Command, args []string) error {
 		if err != nil {
 			return fmt.Errorf("failed to get source versions: %w", err)
 		}
-		maxVersion := findMaxVersion(versions)
-		if maxVersion >= 3 {
+		maxVersion := findMaxSupportedVersion(versions, maxSupportedProtocolVersion)
+		if maxVersion > maxSupportedProtocolVersion {
 			return fmt.Errorf("please upgrade CLI to latest version to sync source %s", cl.Name())
 		}
 

--- a/cli/cmd/sync.go
+++ b/cli/cmd/sync.go
@@ -20,7 +20,7 @@ cloudquery sync ./directory
 # Sync resources from directories and files
 cloudquery sync ./directory ./aws.yml ./pg.yml
 `
-	unknownFieldErrorPrefix = "code = InvalidArgument desc = failed to decode spec: json: unknown field "
+	maxSupportedProtocolVersion = 2
 )
 
 func NewCmdSync() *cobra.Command {
@@ -36,13 +36,13 @@ func NewCmdSync() *cobra.Command {
 	return cmd
 }
 
-func findMaxVersion(versions []int) int {
+func findMaxSupportedVersion(versions []int, supported int) int {
 	max := -1
 	if len(versions) == 0 {
 		return max
 	}
 	for _, v := range versions {
-		if v > max {
+		if v > max && v <= supported {
 			max = v
 		}
 	}
@@ -129,8 +129,8 @@ func sync(cmd *cobra.Command, args []string) error {
 		if err != nil {
 			return fmt.Errorf("failed to get source versions: %w", err)
 		}
-		maxVersion := findMaxVersion(versions)
-		if maxVersion >= 3 {
+		maxVersion := findMaxSupportedVersion(versions, maxSupportedProtocolVersion)
+		if maxVersion > maxSupportedProtocolVersion {
 			return fmt.Errorf("please upgrade CLI to latest version to sync source %s", cl.Name())
 		}
 

--- a/cli/cmd/sync.go
+++ b/cli/cmd/sync.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"fmt"
+	"math"
 	"strings"
 
 	"github.com/google/uuid"
@@ -20,7 +21,6 @@ cloudquery sync ./directory
 # Sync resources from directories and files
 cloudquery sync ./directory ./aws.yml ./pg.yml
 `
-	maxSupportedProtocolVersion = 2
 )
 
 func NewCmdSync() *cobra.Command {
@@ -36,17 +36,41 @@ func NewCmdSync() *cobra.Command {
 	return cmd
 }
 
-func findMaxSupportedVersion(versions []int, supported int) int {
-	max := -1
-	if len(versions) == 0 {
-		return max
+// findMaxCommonVersion finds the max common version between protocol versions supported by a plugin and those supported by the CLI.
+// If all plugin versions are lower than min CLI supported version, it returns -1.
+// If all plugin versions are higher than max CLI supported version, it returns -2.
+// In this way it is possible tell whether the source or the CLI needs to be updated:
+// if -1, the source needs to be updated or the CLI downgraded;
+// if -2, the CLI needs to be updated or the source downgraded.
+func findMaxCommonVersion(pluginSupported []int, cliSupported []int) int {
+	if len(pluginSupported) == 0 {
+		return -1
 	}
-	for _, v := range versions {
-		if v > max && v <= supported {
-			max = v
+
+	minCLISupported, maxCLISupported := math.MaxInt32, -1
+	for _, v := range cliSupported {
+		if v < minCLISupported {
+			minCLISupported = v
+		}
+		if v > maxCLISupported {
+			maxCLISupported = v
 		}
 	}
-	return max
+
+	minVersion := math.MaxInt32
+	maxCommon := -1
+	for _, v := range pluginSupported {
+		if v < minVersion {
+			minVersion = v
+		}
+		if v > maxCommon && slices.Contains(cliSupported, v) {
+			maxCommon = v
+		}
+	}
+	if maxCommon == -1 && minVersion > maxCLISupported {
+		return -2
+	}
+	return maxCommon
 }
 
 func sync(cmd *cobra.Command, args []string) error {
@@ -129,10 +153,7 @@ func sync(cmd *cobra.Command, args []string) error {
 		if err != nil {
 			return fmt.Errorf("failed to get source versions: %w", err)
 		}
-		maxVersion := findMaxSupportedVersion(versions, maxSupportedProtocolVersion)
-		if maxVersion > maxSupportedProtocolVersion {
-			return fmt.Errorf("please upgrade CLI to latest version to sync source %s", cl.Name())
-		}
+		maxVersion := findMaxCommonVersion(versions, []int{0, 1, 2})
 
 		var destinationClientsForSource []*managedplugin.Client
 		var destinationForSourceSpec []specs.Destination
@@ -161,9 +182,11 @@ func sync(cmd *cobra.Command, args []string) error {
 				return fmt.Errorf("failed to sync v1 source %s: %w", cl.Name(), err)
 			}
 		case 0:
-			return fmt.Errorf("please upgrade your source or use an older v3.0.1 < CLI version < v3.5.3")
+			return fmt.Errorf("please upgrade source %v or use an older CLI version, between v3.0.1 and v3.5.3", source.Name)
 		case -1:
-			return fmt.Errorf("please upgrade your source or use an older CLI version < v3.0.1")
+			return fmt.Errorf("please upgrade source %v or use an older CLI version, < v3.0.1", source.Name)
+		case -2:
+			return fmt.Errorf("please downgrade CLI or upgrade source to sync %v", source.Name)
 		default:
 			return fmt.Errorf("unknown source version %d", maxVersion)
 		}

--- a/cli/cmd/sync_test.go
+++ b/cli/cmd/sync_test.go
@@ -104,21 +104,22 @@ func TestSyncCqDir(t *testing.T) {
 	require.NotEmpty(t, files, "destination plugin not downloaded to cache")
 }
 
-func TestFindMaxSupportedVersion(t *testing.T) {
+func TestFindMaxCommonVersion(t *testing.T) {
 	cases := []struct {
-		name          string
-		giveVersions  []int
-		giveSupported int
-		want          int
+		name       string
+		givePlugin []int
+		giveCLI    []int
+		want       int
 	}{
-		{name: "support_less", giveVersions: []int{1, 2, 3}, giveSupported: 2, want: 2},
-		{name: "support_same", giveVersions: []int{1, 2, 3}, giveSupported: 3, want: 3},
-		{name: "support_more", giveVersions: []int{1, 2, 3}, giveSupported: 4, want: 3},
-		{name: "support_none", giveVersions: []int{3, 4, 5}, giveSupported: 2, want: -1},
+		{name: "support_less", givePlugin: []int{1, 2, 3}, giveCLI: []int{1, 2}, want: 2},
+		{name: "support_same", givePlugin: []int{1, 2, 3}, giveCLI: []int{1, 2, 3}, want: 3},
+		{name: "support_more", givePlugin: []int{1, 2, 3}, giveCLI: []int{2, 3, 4}, want: 3},
+		{name: "support_only_lower", givePlugin: []int{3, 4, 5}, giveCLI: []int{6, 7}, want: -1},
+		{name: "support_only_higher", givePlugin: []int{3, 4, 5}, giveCLI: []int{1, 2}, want: -2},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			got := findMaxSupportedVersion(tc.giveVersions, tc.giveSupported)
+			got := findMaxCommonVersion(tc.givePlugin, tc.giveCLI)
 			assert.Equal(t, tc.want, got)
 		})
 	}

--- a/cli/cmd/sync_test.go
+++ b/cli/cmd/sync_test.go
@@ -103,3 +103,23 @@ func TestSyncCqDir(t *testing.T) {
 	}
 	require.NotEmpty(t, files, "destination plugin not downloaded to cache")
 }
+
+func TestFindMaxSupportedVersion(t *testing.T) {
+	cases := []struct {
+		name          string
+		giveVersions  []int
+		giveSupported int
+		want          int
+	}{
+		{name: "support_less", giveVersions: []int{1, 2, 3}, giveSupported: 2, want: 2},
+		{name: "support_same", giveVersions: []int{1, 2, 3}, giveSupported: 3, want: 3},
+		{name: "support_more", giveVersions: []int{1, 2, 3}, giveSupported: 4, want: 3},
+		{name: "support_none", giveVersions: []int{3, 4, 5}, giveSupported: 2, want: -1},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := findMaxSupportedVersion(tc.giveVersions, tc.giveSupported)
+			assert.Equal(t, tc.want, got)
+		})
+	}
+}

--- a/cli/cmd/tables.go
+++ b/cli/cmd/tables.go
@@ -87,7 +87,7 @@ func tables(cmd *cobra.Command, args []string) error {
 		if err != nil {
 			return fmt.Errorf("failed to get versions for %s. Error: %w", source.Name, err)
 		}
-		maxVersion := findMaxSupportedVersion(versions, maxSupportedProtocolVersion)
+		maxVersion := findMaxCommonVersion(versions, []int{2})
 		switch maxVersion {
 		case 2:
 			if err := tablesV2(ctx, cl, outputPath, format); err != nil {

--- a/cli/cmd/tables.go
+++ b/cli/cmd/tables.go
@@ -87,7 +87,7 @@ func tables(cmd *cobra.Command, args []string) error {
 		if err != nil {
 			return fmt.Errorf("failed to get versions for %s. Error: %w", source.Name, err)
 		}
-		maxVersion := findMaxVersion(versions)
+		maxVersion := findMaxSupportedVersion(versions, maxSupportedProtocolVersion)
 		switch maxVersion {
 		case 2:
 			if err := tablesV2(ctx, cl, outputPath, format); err != nil {


### PR DESCRIPTION
This is a small change to the protocol version handling logic to make it more robust in the face of differing support between the CLI and source plugins.