### PR TITLE
doc(website): Remove broken Configuration link from Heroku docs

### DIFF
--- a/website/pages/docs/plugins/sources/heroku/_meta.json
+++ b/website/pages/docs/plugins/sources/heroku/_meta.json
@@ -1,6 +1,5 @@
 {
   "overview": "Overview",
-  "configuration": "Configuration",
   "tables": "Tables",
   "_authentication": {
     "display": "hidden"


### PR DESCRIPTION
Closes https://github.com/cloudquery/cloudquery/issues/11681