### PR TITLE
feat(aws): Support for `id` column in `aws_resources` view

### DIFF
--- a/plugins/source/aws/views/resources.sql
+++ b/plugins/source/aws/views/resources.sql
@@ -4,43 +4,56 @@ DO $$
 DECLARE
     tbl TEXT;
     strSQL TEXT = '';
+    arnField TEXT = '';
 BEGIN
--- iterate over every table in our information_schema that has an `arn` column available
+-- iterate over every table in our information_schema that has an `arn` or 'id' columns available
 FOR tbl IN
     SELECT DISTINCT table_name
     FROM information_schema.columns
     WHERE table_name LIKE 'aws_%s' and COLUMN_NAME IN ('account_id', 'request_account_id')
     INTERSECT
-    SELECT table_name
+    SELECT DISTINCT table_name
     FROM information_schema.columns
-    WHERE table_name LIKE 'aws_%s' and COLUMN_NAME = 'arn'
+    WHERE table_name LIKE 'aws_%s' and COLUMN_NAME IN ('arn', 'id')
 LOOP
     -- UNION each table query to create one view
  	IF NOT (strSQL = ''::TEXT) THEN
 		strSQL = strSQL || ' UNION ALL ';
 	END IF;
+
+    SELECT CASE WHEN EXISTS (SELECT 1 FROM information_schema.columns WHERE column_name='arn' AND table_name=tbl) THEN 'arn' ELSE 'NULL' END INTO arnField;
+
 	-- create an SQL query to select from table and transform it into our resources view schema
 	strSQL = strSQL || FORMAT(E'
         SELECT _cq_id,
             _cq_source_name,
             _cq_sync_time,
             %L AS _cq_table,
-            COALESCE(%s, SPLIT_PART(arn, \':\', 5)) AS account_id,
-            COALESCE(%s, %s, SPLIT_PART(arn, \':\', 5)) AS request_account_id,
+            COALESCE(%s, SPLIT_PART(%s, \':\', 5)) AS account_id,
+            COALESCE(%s, %s, SPLIT_PART(%s, \':\', 5)) AS request_account_id,
             %s AS region,
-            SPLIT_PART(arn, \':\', 2) AS PARTITION,
-            SPLIT_PART(arn, \':\', 3) AS service,
+            SPLIT_PART(%s, \':\', 2) AS PARTITION,
+            SPLIT_PART(%s, \':\', 3) AS service,
             CASE
-            WHEN SPLIT_PART(SPLIT_PART(ARN, \':\', 6), \'/\', 2) = \'\' AND SPLIT_PART(arn, \':\', 7) = \'\' THEN NULL
-                ELSE SPLIT_PART(SPLIT_PART(arn, \':\', 6), \'/\', 1)
+            WHEN SPLIT_PART(SPLIT_PART(%s, \':\', 6), \'/\', 2) = \'\' AND SPLIT_PART(%s, \':\', 7) = \'\' THEN NULL
+                ELSE SPLIT_PART(SPLIT_PART(%s, \':\', 6), \'/\', 1)
             END AS TYPE,
-            arn, %s AS tags
+            %s AS arn, %s AS id, %s AS tags
         FROM %s',
         tbl,
         CASE WHEN EXISTS (SELECT 1 FROM information_schema.columns WHERE column_name='account_id' AND table_name=tbl) THEN 'account_id' ELSE 'NULL' END,
+        arnField,
         CASE WHEN EXISTS (SELECT 1 FROM information_schema.columns WHERE column_name='request_account_id' AND table_name=tbl) THEN 'request_account_id' ELSE 'NULL' END,
+        arnField,
         CASE WHEN EXISTS (SELECT 1 FROM information_schema.columns WHERE column_name='account_id' AND table_name=tbl) THEN 'account_id' ELSE 'NULL' END,
         CASE WHEN EXISTS (SELECT 1 FROM information_schema.columns WHERE column_name='region' AND table_name=tbl) THEN 'region' ELSE E'\'unavailable\'' END,
+        arnField,
+        arnField,
+        arnField,
+        arnField,
+        arnField,
+        arnField,
+        CASE WHEN EXISTS (SELECT 1 FROM information_schema.columns WHERE column_name='id' AND table_name=tbl) THEN 'id' ELSE 'NULL' END,
         CASE WHEN EXISTS (SELECT 1 FROM information_schema.columns WHERE column_name='tags' AND table_name=tbl) THEN 'tags' ELSE '''{}''::jsonb' END,
         tbl);
 END LOOP;

--- a/plugins/source/aws/views/resources.sql
+++ b/plugins/source/aws/views/resources.sql
@@ -17,14 +17,14 @@ FOR tbl IN
     WHERE table_name LIKE 'aws_%s' and COLUMN_NAME IN ('arn', 'id')
 LOOP
     -- UNION each table query to create one view
- 	IF NOT (strSQL = ''::TEXT) THEN
-		strSQL = strSQL || ' UNION ALL ';
-	END IF;
+    IF NOT (strSQL = ''::TEXT) THEN
+        strSQL = strSQL || ' UNION ALL ';
+    END IF;
 
     SELECT CASE WHEN EXISTS (SELECT 1 FROM information_schema.columns WHERE column_name='arn' AND table_name=tbl) THEN 'arn' ELSE 'NULL' END INTO arnField;
 
-	-- create an SQL query to select from table and transform it into our resources view schema
-	strSQL = strSQL || FORMAT(E'
+    -- create an SQL query to select from table and transform it into our resources view schema
+    strSQL = strSQL || FORMAT(E'
         SELECT _cq_id,
             _cq_source_name,
             _cq_sync_time,
@@ -61,7 +61,7 @@ END LOOP;
 IF strSQL = ''::TEXT THEN
     RAISE EXCEPTION 'No tables found with ARN and ACCOUNT_ID columns. Run a sync first and try again.';
 ELSE
-	EXECUTE FORMAT('CREATE VIEW aws_resources AS (%s)', strSQL);
+    EXECUTE FORMAT('CREATE VIEW aws_resources AS (%s)', strSQL);
 END IF;
 
 END $$;

--- a/website/pages/blog/aws-resources-view.mdx
+++ b/website/pages/blog/aws-resources-view.mdx
@@ -48,14 +48,14 @@ FOR tbl IN
     WHERE table_name LIKE 'aws_%s' and COLUMN_NAME IN ('arn', 'id')
 LOOP
     -- UNION each table query to create one view
- 	IF NOT (strSQL = ''::TEXT) THEN
-		strSQL = strSQL || ' UNION ALL ';
-	END IF;
+    IF NOT (strSQL = ''::TEXT) THEN
+        strSQL = strSQL || ' UNION ALL ';
+    END IF;
 
     SELECT CASE WHEN EXISTS (SELECT 1 FROM information_schema.columns WHERE column_name='arn' AND table_name=tbl) THEN 'arn' ELSE 'NULL' END INTO arnField;
 
-	-- create an SQL query to select from table and transform it into our resources view schema
-	strSQL = strSQL || FORMAT(E'
+    -- create an SQL query to select from table and transform it into our resources view schema
+    strSQL = strSQL || FORMAT(E'
         SELECT _cq_id,
             _cq_source_name,
             _cq_sync_time,
@@ -92,7 +92,7 @@ END LOOP;
 IF strSQL = ''::TEXT THEN
     RAISE EXCEPTION 'No tables found with ARN and ACCOUNT_ID columns. Run a sync first and try again.';
 ELSE
-	EXECUTE FORMAT('CREATE VIEW aws_resources AS (%s)', strSQL);
+    EXECUTE FORMAT('CREATE VIEW aws_resources AS (%s)', strSQL);
 END IF;
 
 END $$;

--- a/website/pages/blog/aws-resources-view.mdx
+++ b/website/pages/blog/aws-resources-view.mdx
@@ -35,43 +35,56 @@ DO $$
 DECLARE
     tbl TEXT;
     strSQL TEXT = '';
+    arnField TEXT = '';
 BEGIN
--- iterate over every table in our information_schema that has an `arn` column available
+-- iterate over every table in our information_schema that has an `arn` or 'id' columns available
 FOR tbl IN
     SELECT DISTINCT table_name
     FROM information_schema.columns
     WHERE table_name LIKE 'aws_%s' and COLUMN_NAME IN ('account_id', 'request_account_id')
     INTERSECT
-    SELECT table_name
+    SELECT DISTINCT table_name
     FROM information_schema.columns
-    WHERE table_name LIKE 'aws_%s' and COLUMN_NAME = 'arn'
+    WHERE table_name LIKE 'aws_%s' and COLUMN_NAME IN ('arn', 'id')
 LOOP
     -- UNION each table query to create one view
  	IF NOT (strSQL = ''::TEXT) THEN
 		strSQL = strSQL || ' UNION ALL ';
 	END IF;
+
+    SELECT CASE WHEN EXISTS (SELECT 1 FROM information_schema.columns WHERE column_name='arn' AND table_name=tbl) THEN 'arn' ELSE 'NULL' END INTO arnField;
+
 	-- create an SQL query to select from table and transform it into our resources view schema
 	strSQL = strSQL || FORMAT(E'
         SELECT _cq_id,
             _cq_source_name,
             _cq_sync_time,
             %L AS _cq_table,
-            COALESCE(%s, SPLIT_PART(arn, \':\', 5)) AS account_id,
-            COALESCE(%s, %s, SPLIT_PART(arn, \':\', 5)) AS request_account_id,
+            COALESCE(%s, SPLIT_PART(%s, \':\', 5)) AS account_id,
+            COALESCE(%s, %s, SPLIT_PART(%s, \':\', 5)) AS request_account_id,
             %s AS region,
-            SPLIT_PART(arn, \':\', 2) AS PARTITION,
-            SPLIT_PART(arn, \':\', 3) AS service,
+            SPLIT_PART(%s, \':\', 2) AS PARTITION,
+            SPLIT_PART(%s, \':\', 3) AS service,
             CASE
-            WHEN SPLIT_PART(SPLIT_PART(ARN, \':\', 6), \'/\', 2) = \'\' AND SPLIT_PART(arn, \':\', 7) = \'\' THEN NULL
-                ELSE SPLIT_PART(SPLIT_PART(arn, \':\', 6), \'/\', 1)
+            WHEN SPLIT_PART(SPLIT_PART(%s, \':\', 6), \'/\', 2) = \'\' AND SPLIT_PART(%s, \':\', 7) = \'\' THEN NULL
+                ELSE SPLIT_PART(SPLIT_PART(%s, \':\', 6), \'/\', 1)
             END AS TYPE,
-            arn, %s AS tags
+            %s AS arn, %s AS id, %s AS tags
         FROM %s',
         tbl,
         CASE WHEN EXISTS (SELECT 1 FROM information_schema.columns WHERE column_name='account_id' AND table_name=tbl) THEN 'account_id' ELSE 'NULL' END,
+        arnField,
         CASE WHEN EXISTS (SELECT 1 FROM information_schema.columns WHERE column_name='request_account_id' AND table_name=tbl) THEN 'request_account_id' ELSE 'NULL' END,
+        arnField,
         CASE WHEN EXISTS (SELECT 1 FROM information_schema.columns WHERE column_name='account_id' AND table_name=tbl) THEN 'account_id' ELSE 'NULL' END,
         CASE WHEN EXISTS (SELECT 1 FROM information_schema.columns WHERE column_name='region' AND table_name=tbl) THEN 'region' ELSE E'\'unavailable\'' END,
+        arnField,
+        arnField,
+        arnField,
+        arnField,
+        arnField,
+        arnField,
+        CASE WHEN EXISTS (SELECT 1 FROM information_schema.columns WHERE column_name='id' AND table_name=tbl) THEN 'id' ELSE 'NULL' END,
         CASE WHEN EXISTS (SELECT 1 FROM information_schema.columns WHERE column_name='tags' AND table_name=tbl) THEN 'tags' ELSE '''{}''::jsonb' END,
         tbl);
 END LOOP;


### PR DESCRIPTION
Fixes #11676

Now `arn` can be `NULL` in the view, in that case `id` should be there. Both `id` and `arn` can be non-null if both are in the table. `arn`-derived fields (`partition`, `service` and `type`) will be `NULL` if `arn` field is missing from the table.