### PR TITLE
chore(website): Use MotherDuck docs link redirect target

### DIFF
--- a/website/pages/how-to-guides/moving-data-from-postgres-to-motherduck.mdx
+++ b/website/pages/how-to-guides/moving-data-from-postgres-to-motherduck.mdx
@@ -113,7 +113,7 @@ In production, you should use environment variable expansion to reference the co
 
 ## Step 3. Set Up Authentication
 
-To authenticate with MotherDuck, we need to export our service token as an environment variable. As documented in the [MotherDuck documentation](https://motherduck.com/docs), you can find the token by navigating to `https://app.motherduck.com/` and clicking the cog in the top right-hand corner:
+To authenticate with MotherDuck, we need to export our service token as an environment variable. As documented in the [MotherDuck documentation](https://motherduck.com/docs/intro/), you can find the token by navigating to `https://app.motherduck.com/` and clicking the cog in the top right-hand corner:
 
 ![Where to find your token on the MotherDuck app page](/images/how-to-guides/moving-data-from-postgres-to-motherduck/motherduck-token.png)
 


### PR DESCRIPTION
<!-- 🎉 Thank you for making CloudQuery awesome by submitting a PR 🎉 -->

#### Summary

`https://motherduck.com/docs` seems to have multiple redirects to `https://motherduck.com/docs/intro/` which fails our broken links checker.

We can either use the redirect target, or exclude this link from the broken links check. This PR does the former

<!--
Use the following steps to ensure your PR is ready to be reviewed

- [ ] Read the [contribution guidelines](../blob/main/CONTRIBUTING.md) 🧑‍🎓
- [ ] Run `make lint` to ensure the proposed changes follow the coding style 🚨 (install golangci-lint [here](https://golangci-lint.run/usage/install/#local-installation))
- [ ] Run `make test` to ensure the proposed changes pass the tests 🧪
- [ ] If changing a source plugin run `make gen` to ensure docs are up to date 📝
- [ ] Ensure the status checks below are successful ✅
--->
