### PR TITLE
refactor: Remove refs to deprecated io/ioutil

### DIFF
--- a/plugins/source/gcp/codegen/client/discover.go
+++ b/plugins/source/gcp/codegen/client/discover.go
@@ -2,7 +2,7 @@ package client
 
 import (
 	"encoding/json"
-	"io/ioutil"
+	"io"
 	"log"
 	"net/http"
 	"sort"
@@ -20,7 +20,7 @@ func Discover() ([]string, error) {
 		return nil, err
 	}
 	defer resp.Body.Close()
-	body, err := ioutil.ReadAll(resp.Body)
+	body, err := io.ReadAll(resp.Body)
 	if err != nil {
 		log.Fatalln(err)
 	}


### PR DESCRIPTION
<!-- 🎉 Thank you for making CloudQuery awesome by submitting a PR 🎉 -->

#### Summary
"io/ioutil" has been deprecated since Go 1.19: As of Go 1.16
<!--
Explain what problem this PR addresses
-->
"io/ioutil" has been deprecated since Go 1.19: As of Go 1.16
<!--
Use the following steps to ensure your PR is ready to be reviewed

- [ ] Read the [contribution guidelines](../blob/main/CONTRIBUTING.md) 🧑‍🎓
- [ ] Run `make lint` to ensure the proposed changes follow the coding style 🚨 (install golangci-lint [here](https://golangci-lint.run/usage/install/#local-installation))
- [ ] Run `make test` to ensure the proposed changes pass the tests 🧪
- [ ] If changing a source plugin run `make gen` to ensure docs are up to date 📝
- [ ] Ensure the status checks below are successful ✅
--->
