### PR TITLE
fix(mysql): Handle Multiple Schemas

### DIFF
--- a/plugins/destination/mysql/client/schema.go
+++ b/plugins/destination/mysql/client/schema.go
@@ -76,7 +76,7 @@ func (c *Client) getTableColumns(ctx context.Context, tableName string) ([]schem
 
 // TODO: in the future this could theoretically be done in a single query and then the tables could be filtered in memory
 func (c *Client) schemaTables(ctx context.Context, tables schema.Tables) (schema.Tables, error) {
-	query := `SELECT TABLE_NAME FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_TYPE = 'BASE TABLE' and (DATABASE() is NULL or table_SCHEMA = DATABASE());`
+	query := `SELECT TABLE_NAME FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_TYPE = 'BASE TABLE' AND (DATABASE() IS NULL OR table_SCHEMA = DATABASE());`
 	rows, err := c.db.QueryContext(ctx, query)
 	if err != nil {
 		return nil, err

--- a/plugins/destination/mysql/client/schema.go
+++ b/plugins/destination/mysql/client/schema.go
@@ -76,7 +76,7 @@ func (c *Client) getTableColumns(ctx context.Context, tableName string) ([]schem
 
 // TODO: in the future this could theoretically be done in a single query and then the tables could be filtered in memory
 func (c *Client) schemaTables(ctx context.Context, tables schema.Tables) (schema.Tables, error) {
-	query := `SELECT TABLE_NAME FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_TYPE = 'BASE TABLE';`
+	query := `SELECT TABLE_NAME FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_TYPE = 'BASE TABLE' and (DATABASE() is NULL or table_SCHEMA = DATABASE());`
 	rows, err := c.db.QueryContext(ctx, query)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
<!-- 🎉 Thank you for making CloudQuery awesome by submitting a PR 🎉 -->

#### Summary

Currently when CQ is syncing to MySQL the query to get all tables returns tables in ALL schemas, not just the schema that the user specified in the connection string. This means that if a user is syncing data from the same plugin multiple times to different schemas the finding tables function will never be able to tell the difference between the same table name in different schemas...


The fix is to only return tables from the current database if it is selected... Users that do not specify a default database in their DSN/connection string will continue to have issues though... In a following PR we should add in validation that will require a default DB `select database()` should return a value that is not null...