### PR TITLE
fix(aws): Codebuild builds

### DIFF
--- a/plugins/source/aws/docs/tables/README.md
+++ b/plugins/source/aws/docs/tables/README.md
@@ -127,7 +127,6 @@
 - [aws_codebuild_projects](../../../../../website/tables/aws/aws_codebuild_projects.md)
   - [aws_codebuild_builds](../../../../../website/tables/aws/aws_codebuild_builds.md)
 - [aws_codebuild_source_credentials](../../../../../website/tables/aws/aws_codebuild_source_credentials.md)
-  - [aws_codebuild_builds](../../../../../website/tables/aws/aws_codebuild_builds.md)
 - [aws_codepipeline_pipelines](../../../../../website/tables/aws/aws_codepipeline_pipelines.md)
 - [aws_codepipeline_webhooks](../../../../../website/tables/aws/aws_codepipeline_webhooks.md)
 - [aws_cognito_identity_pools](../../../../../website/tables/aws/aws_cognito_identity_pools.md)

--- a/plugins/source/aws/resources/services/codebuild/source_credentials.go
+++ b/plugins/source/aws/resources/services/codebuild/source_credentials.go
@@ -22,9 +22,6 @@ func SourceCredentials() *schema.Table {
 			client.DefaultAccountIDColumn(false),
 			client.DefaultRegionColumn(false),
 		},
-		Relations: schema.Tables{
-			builds(),
-		},
 	}
 }
 

--- a/website/pages/docs/plugins/sources/aws/tables.md
+++ b/website/pages/docs/plugins/sources/aws/tables.md
@@ -127,7 +127,6 @@
 - [aws_codebuild_projects](tables/aws_codebuild_projects)
   - [aws_codebuild_builds](tables/aws_codebuild_builds)
 - [aws_codebuild_source_credentials](tables/aws_codebuild_source_credentials)
-  - [aws_codebuild_builds](tables/aws_codebuild_builds)
 - [aws_codepipeline_pipelines](tables/aws_codepipeline_pipelines)
 - [aws_codepipeline_webhooks](tables/aws_codepipeline_webhooks)
 - [aws_cognito_identity_pools](tables/aws_cognito_identity_pools)

--- a/website/tables/aws/aws_codebuild_builds.md
+++ b/website/tables/aws/aws_codebuild_builds.md
@@ -8,7 +8,7 @@ The primary key for this table is **arn**.
 
 ## Relations
 
-This table depends on [aws_codebuild_source_credentials](aws_codebuild_source_credentials).
+This table depends on [aws_codebuild_projects](aws_codebuild_projects).
 
 ## Columns
 

--- a/website/tables/aws/aws_codebuild_source_credentials.md
+++ b/website/tables/aws/aws_codebuild_source_credentials.md
@@ -6,11 +6,6 @@ https://docs.aws.amazon.com/codebuild/latest/APIReference/API_SourceCredentialsI
 
 The primary key for this table is **arn**.
 
-## Relations
-
-The following tables depend on aws_codebuild_source_credentials:
-  - [aws_codebuild_builds](aws_codebuild_builds)
-
 ## Columns
 
 | Name          | Type          |


### PR DESCRIPTION
`builds()` in two different, (looks like unrelated) resources.

Fixes https://github.com/cloudquery/cloudquery-issues/issues/580