### PR TITLE
chore(website): Add Jira premium plugin

### DIFF
--- a/.github/styles/Vocab/Base/accept.txt
+++ b/.github/styles/Vocab/Base/accept.txt
@@ -110,6 +110,7 @@ IPs
 json
 JSON
 jsonb
+Jira
 Kestra
 keyless
 Kibana

--- a/website/pages/docs/plugins/sources/jira/_authentication.mdx
+++ b/website/pages/docs/plugins/sources/jira/_authentication.mdx
@@ -1,0 +1,2 @@
+In Order for CloudQuery to sync resources from your Jira setup,
+you will need to generate [Jira API Key](https://support.atlassian.com/atlassian-account/docs/manage-api-tokens-for-your-atlassian-account/).

--- a/website/pages/docs/plugins/sources/jira/_configuration.mdx
+++ b/website/pages/docs/plugins/sources/jira/_configuration.mdx
@@ -1,0 +1,15 @@
+```yaml copy
+kind: source
+spec:
+  name: "jira"
+  path: "/path/to/downloaded/plugin # Jira is a premium plugin: https://cloudquery.io/buy/jira
+  registry: "local"
+  version: "v0.0.1"
+  destinations: ["DESTINATION_NAME"]
+  concurrency: 10000
+  tables: ["*"]
+  spec:
+    base_url: "https://your_uri.atlassian.net"
+  	username: "your_username"
+    token: ${ENV_WITH_API_KEY}
+```

--- a/website/pages/docs/plugins/sources/jira/_meta.json
+++ b/website/pages/docs/plugins/sources/jira/_meta.json
@@ -1,0 +1,10 @@
+{
+  "overview": "Overview",
+  "tables": "Tables",
+  "_authentication": {
+    "display": "hidden"
+  },
+  "_configuration": {
+    "display": "hidden"
+  }
+}

--- a/website/pages/docs/plugins/sources/jira/overview.mdx
+++ b/website/pages/docs/plugins/sources/jira/overview.mdx
@@ -1,0 +1,45 @@
+---
+name: Jira
+stage: Preview (Paid)
+title: Jira Source Plugin
+description: CloudQuery Jira source plugin documentation
+---
+# Jira Source Plugin
+
+import { getLatestVersion } from "../../../../../utils/versions";
+import { Badge } from "../../../../../components/Badge";
+import { Callout } from 'nextra-theme-docs';
+import Configuration from "./_configuration.mdx";
+import Authentication from "./_authentication.mdx";
+
+<Badge text={"Latest: 0.0.1"}/>
+
+This is a premium plugin that you can buy [here](https://cloudquery.io/buy/jira).
+
+The CloudQuery Jira plugin extracts Jira information and loads it into any supported CloudQuery destination (e.g. PostgreSQL, BigQuery, Snowflake, and [more](/docs/plugins/destinations/overview)). It is based on the [Jira API](https://developer.atlassian.com/cloud/jira/platform/rest/v3/) and the [github.com/andygrunwald/go-jira](https://github.com/andygrunwald/go-jira) library.
+
+## Authentication
+
+<Authentication/>
+
+## Configuration
+
+The following example sets up the Jira plugin, and connects it to a postgresql destination:
+
+<Configuration/>
+
+### Jira Spec
+
+This is the specs that can be used by the Jira source Plugin.
+
+- `base_url` (`string`, required.)
+
+  Your Jira base URL. For hosted versions URI is `https://your_account_name.atlassian.net/`
+
+- `username` (`string`, required.)
+
+  The username to authenticate with.
+
+- `token` (`string`, required.)
+
+  Personal access to authenticate with (recommendation: Use environment variable instead of hardcoding the token in the config).

--- a/website/pages/docs/plugins/sources/jira/overview.mdx
+++ b/website/pages/docs/plugins/sources/jira/overview.mdx
@@ -42,4 +42,4 @@ This is the specs that can be used by the Jira source Plugin.
 
 - `token` (`string`, required.)
 
-  Personal access to authenticate with (recommendation: Use environment variable instead of hardcoding the token in the config).
+  Personal access to authenticate with (recommendation: Use environment variable instead of hardcoded the token in the config).

--- a/website/pages/docs/plugins/sources/jira/tables.md
+++ b/website/pages/docs/plugins/sources/jira/tables.md
@@ -1,0 +1,9 @@
+# Source Plugin: jira
+
+## Tables
+
+- [jira_boards](tables/jira_boards.md)
+- [jira_fields](tables/jira_fields.md)
+- [jira_issues](tables/jira_issues.md)
+- [jira_priorities](tables/jira_priorities.md)
+- [jira_projects](tables/jira_projects.md)

--- a/website/pages/docs/plugins/sources/jira/tables/jira_boards.md
+++ b/website/pages/docs/plugins/sources/jira/tables/jira_boards.md
@@ -1,0 +1,15 @@
+# Table: jira_boards
+
+This table shows data for Jira Boards.
+
+The primary key for this table is **self**.
+
+## Columns
+
+| Name          | Type          |
+| ------------- | ------------- |
+|id|`int64`|
+|self (PK)|`utf8`|
+|name|`utf8`|
+|type|`utf8`|
+|filter_id|`int64`|

--- a/website/pages/docs/plugins/sources/jira/tables/jira_fields.md
+++ b/website/pages/docs/plugins/sources/jira/tables/jira_fields.md
@@ -1,0 +1,18 @@
+# Table: jira_fields
+
+This table shows data for Jira Fields.
+
+The primary key for this table is **id**.
+
+## Columns
+
+| Name          | Type          |
+| ------------- | ------------- |
+|id (PK)|`utf8`|
+|key|`utf8`|
+|name|`utf8`|
+|custom|`bool`|
+|navigable|`bool`|
+|searchable|`bool`|
+|clause_names|`list<item: utf8, nullable>`|
+|schema|`json`|

--- a/website/pages/docs/plugins/sources/jira/tables/jira_issues.md
+++ b/website/pages/docs/plugins/sources/jira/tables/jira_issues.md
@@ -1,0 +1,19 @@
+# Table: jira_issues
+
+This table shows data for Jira Issues.
+
+The primary key for this table is **self**.
+
+## Columns
+
+| Name          | Type          |
+| ------------- | ------------- |
+|expand|`utf8`|
+|id|`utf8`|
+|self (PK)|`utf8`|
+|key|`utf8`|
+|fields|`json`|
+|rendered_fields|`json`|
+|changelog|`json`|
+|transitions|`json`|
+|names|`json`|

--- a/website/pages/docs/plugins/sources/jira/tables/jira_priorities.md
+++ b/website/pages/docs/plugins/sources/jira/tables/jira_priorities.md
@@ -1,0 +1,16 @@
+# Table: jira_priorities
+
+This table shows data for Jira Priorities.
+
+The primary key for this table is **self**.
+
+## Columns
+
+| Name          | Type          |
+| ------------- | ------------- |
+|self (PK)|`utf8`|
+|icon_url|`utf8`|
+|name|`utf8`|
+|id|`utf8`|
+|status_color|`utf8`|
+|description|`utf8`|

--- a/website/pages/docs/plugins/sources/jira/tables/jira_projects.md
+++ b/website/pages/docs/plugins/sources/jira/tables/jira_projects.md
@@ -1,0 +1,19 @@
+# Table: jira_projects
+
+This table shows data for Jira Projects.
+
+The primary key for this table is **self**.
+
+## Columns
+
+| Name          | Type          |
+| ------------- | ------------- |
+|expand|`utf8`|
+|self (PK)|`utf8`|
+|id|`utf8`|
+|key|`utf8`|
+|name|`utf8`|
+|avatar_urls|`json`|
+|project_type_key|`utf8`|
+|project_category|`json`|
+|issue_types|`json`|

--- a/website/vercel.json
+++ b/website/vercel.json
@@ -245,6 +245,10 @@
     {
       "source": "/docs/advanced-topics/docker",
       "destination": "/docs/deployment/docker"
+    },
+    {
+      "source": "/buy/jira",
+      "destination": "https://buy.stripe.com/eVa4gk8U99tB9ywbIR"
     }
   ]
 }


### PR DESCRIPTION
This is a very draft version for documentation for our first premium plugin - Jira.

Some more fine tuning might be needed but this should be a good start and a buy link is available at `https://cloudquery.io/buy/jira` (after this PR is merged)