### PR TITLE
chore(website): Add premium plugins

### DIFF
--- a/website/pages/docs/plugins/sources/gandi/_configuration.mdx
+++ b/website/pages/docs/plugins/sources/gandi/_configuration.mdx
@@ -3,7 +3,7 @@ kind: source
 # Common source-plugin configuration
 spec:
   name: gandi
-  path: cloudquery/gandi
+  path: /path/to/downloaded/plugin # https://cloudquery.io/buy/gandi
   version: "VERSION_SOURCE_GANDI"
   concurrency: 10000
   tables: ["*"]

--- a/website/pages/docs/plugins/sources/gandi/overview.mdx
+++ b/website/pages/docs/plugins/sources/gandi/overview.mdx
@@ -1,6 +1,6 @@
 ---
 name: Gandi
-stage: GA
+stage: GA (Premium)
 title: Gandi Source Plugin
 description: CloudQuery Gandi source plugin documentation
 ---
@@ -10,7 +10,9 @@ import { getLatestVersion } from "../../../../../utils/versions";
 import { Badge } from "../../../../../components/Badge";
 import Authentication from "./_authentication.mdx";
 
-<Badge text={"Latest: " + getLatestVersion("source", `gandi`)}/>
+<Badge text={"Latest Premium: " + getLatestVersion("source", `gandi`)}/>
+
+This is a premium plugin that you can buy [here](https://cloudquery.io/buy/gandi) (`$50` with 6 months of free updates and support).
 
 The CloudQuery Gandi plugin pulls configuration out of Gandi resources and loads it into any supported CloudQuery destination (e.g. PostgreSQL, BigQuery, Snowflake, and [more](/docs/plugins/destinations/overview)).
 

--- a/website/pages/docs/plugins/sources/googleads/_configuration.mdx
+++ b/website/pages/docs/plugins/sources/googleads/_configuration.mdx
@@ -3,7 +3,7 @@ kind: source
 # Common source-plugin configuration
 spec:
   name: googleads
-  path: cloudquery/googleads
+  path: /path/to/downloaded/plugin # https://cloudquery.io/buy/googleads
   version: "VERSION_SOURCE_GOOGLEADS"
   concurrency: 10000
   tables: ["*"]

--- a/website/pages/docs/plugins/sources/googleads/overview.mdx
+++ b/website/pages/docs/plugins/sources/googleads/overview.mdx
@@ -12,6 +12,8 @@ import Configuration from "./_configuration.mdx";
 
 <Badge text={"Latest: " + getLatestVersion("source", `googleads`)}/>
 
+This is a premium plugin that you can buy [here](https://cloudquery.io/buy/googleads) (`$50` with 6 months of free updates and support).
+
 The CloudQuery Google Ads plugin for CloudQuery pulls configuration from
 [Google Ads API](https://developers.google.com/google-ads/api/)
 and loads it into any supported CloudQuery destination (e.g. PostgreSQL, BigQuery, Snowflake, and [more](/docs/plugins/destinations/overview)).

--- a/website/pages/docs/plugins/sources/googleads/overview.mdx
+++ b/website/pages/docs/plugins/sources/googleads/overview.mdx
@@ -1,6 +1,6 @@
 ---
 name: Google Ads
-stage: GA
+stage: GA (Premium)
 title: Google Ads Source Plugin
 description: CloudQuery Google Ads source plugin documentation
 ---

--- a/website/pages/docs/plugins/sources/heroku/_configuration.mdx
+++ b/website/pages/docs/plugins/sources/heroku/_configuration.mdx
@@ -2,7 +2,7 @@
 kind: source
 spec: # Common source spec section
   name: heroku
-  path: cloudquery/heroku
+  path: /path/to/downloaded/plugin # https://cloudquery.io/buy/heroku
   version: "VERSION_SOURCE_HEROKU"
   concurrency: 10000
   tables: ["*"]

--- a/website/pages/docs/plugins/sources/heroku/overview.mdx
+++ b/website/pages/docs/plugins/sources/heroku/overview.mdx
@@ -1,6 +1,6 @@
 ---
 name: Heroku
-stage: GA
+stage: GA (Premium)
 title: Heroku Source Plugin
 description: CloudQuery Heroku source plugin documentation
 ---
@@ -11,7 +11,9 @@ import { Badge } from "../../../../../components/Badge";
 import Configuration from "./_configuration.mdx";
 import Authentication from "./_authentication.mdx";
 
-<Badge text={"Latest: " + getLatestVersion("source", "heroku")}/>
+<Badge text={"Premium Latest: " + getLatestVersion("source", "heroku")}/>
+
+This is a premium plugin that you can buy [here](https://cloudquery.io/buy/heroku) (`$50` with 6 months of free updates and support).
 
 The CloudQuery Heroku plugin extracts your Heroku data and loads it into any supported CloudQuery destination (e.g. PostgreSQL, BigQuery, Snowflake, and [more](/docs/plugins/destinations/overview)).
 

--- a/website/pages/docs/plugins/sources/launchdarkly/_configuration.mdx
+++ b/website/pages/docs/plugins/sources/launchdarkly/_configuration.mdx
@@ -3,7 +3,7 @@ kind: source
 # Common source-plugin configuration
 spec:
   name: launchdarkly
-  path: cloudquery/launchdarkly
+  path: /path/to/downloaded/plugin # https://cloudquery.io/buy/launchdakrly
   version: "VERSION_SOURCE_LAUNCHDARKLY"
   concurrency: 10000
   tables: ["*"]

--- a/website/pages/docs/plugins/sources/launchdarkly/overview.mdx
+++ b/website/pages/docs/plugins/sources/launchdarkly/overview.mdx
@@ -1,6 +1,6 @@
 ---
 name: LaunchDarkly
-stage: GA
+stage: GA (Premium)
 title: LaunchDarkly Source Plugin
 description: CloudQuery LaunchDarkly source plugin documentation
 ---
@@ -11,7 +11,9 @@ import { Badge } from "../../../../../components/Badge";
 import Configuration from "./_configuration.mdx";
 import Authentication from "./_authentication.mdx";
 
-<Badge text={"Latest: " + getLatestVersion("source", `launchdarkly`)}/>
+<Badge text={"Premium Latest: " + getLatestVersion("source", `launchdarkly`)}/>
+
+This is a premium plugin that you can buy [here](https://cloudquery.io/buy/launchdarkly) (`$50` with 6 months of free updates and support).
 
 The CloudQuery LaunchDarkly plugin pulls data from LaunchDarkly and loads it into any supported CloudQuery destination (e.g. PostgreSQL, BigQuery, Snowflake, and [more](/docs/plugins/destinations/overview)).
 

--- a/website/pages/docs/plugins/sources/mixpanel/_configuration.mdx
+++ b/website/pages/docs/plugins/sources/mixpanel/_configuration.mdx
@@ -3,7 +3,7 @@ kind: source
 # Common source-plugin configuration
 spec:
   name: mixpanel
-  path: cloudquery/mixpanel
+  path: /path/to/downloaded/plugin # https://cloudquery.io/buy/mixpanel
   version: "VERSION_SOURCE_MIXPANEL"
   concurrency: 10000
   tables: ["*"]

--- a/website/pages/docs/plugins/sources/mixpanel/overview.mdx
+++ b/website/pages/docs/plugins/sources/mixpanel/overview.mdx
@@ -1,6 +1,6 @@
 ---
 name: Mixpanel
-stage: GA
+stage: GA (Premium)
 title: Mixpanel Source Plugin
 description: CloudQuery Mixpanel source plugin documentation
 ---
@@ -11,7 +11,9 @@ import { Badge } from "../../../../../components/Badge";
 import Configuration from "./_configuration.mdx";
 import Authentication from "./_authentication.mdx";
 
-<Badge text={"Latest: " + getLatestVersion("source", `mixpanel`)}/>
+<Badge text={"Premium Latest: " + getLatestVersion("source", `mixpanel`)}/>
+
+This is a premium plugin that you can buy [here](https://cloudquery.io/buy/mixpanel) (`$50` with 6 months of free updates and support).
 
 The CloudQuery Mixpanel plugin pulls data from Mixpanel and loads it into any supported CloudQuery destination (e.g. PostgreSQL, BigQuery, Snowflake, and [more](/docs/plugins/destinations/overview)).
 

--- a/website/pages/docs/plugins/sources/plausible/_configuration.mdx
+++ b/website/pages/docs/plugins/sources/plausible/_configuration.mdx
@@ -3,7 +3,7 @@ kind: source
 # Common source-plugin configuration
 spec:
   name: plausible
-  path: cloudquery/plausible
+  path: /path/to/downloaded/plugin # https://cloudquery.io/buy/plausible
   version: "VERSION_SOURCE_PLAUSIBLE"
   concurrency: 10000
   tables: ["*"]

--- a/website/pages/docs/plugins/sources/plausible/overview.mdx
+++ b/website/pages/docs/plugins/sources/plausible/overview.mdx
@@ -1,6 +1,6 @@
 ---
 name: Plausible
-stage: GA
+stage: GA (Premium)
 title: Plausible Source Plugin
 description: CloudQuery Plausible source plugin documentation
 ---
@@ -13,6 +13,8 @@ import Configuration from "./_configuration.mdx";
 import Authentication from "./_authentication.mdx";
 
 <Badge text={"Latest: " + getLatestVersion("source", "plausible")}/>
+
+This is a premium plugin that you can buy [here](https://cloudquery.io/buy/plausible) (`$50` with 6 months of free updates and support).
 
 The CloudQuery Plausible plugin extracts information from your [Plausible Analytics Stats API](https://plausible.io/docs/stats-api#get-apiv1statstimeseries) and loads it into any supported CloudQuery destination (e.g. PostgreSQL, BigQuery, Snowflake, and [more](/docs/plugins/destinations/overview)).
 

--- a/website/pages/docs/plugins/sources/slack/_configuration.mdx
+++ b/website/pages/docs/plugins/sources/slack/_configuration.mdx
@@ -3,7 +3,7 @@ kind: source
 # Common source-plugin configuration
 spec:
   name: slack
-  path: cloudquery/slack
+  path: /path/to/downloaded/plugin # https://cloudquery.io/buy/slack
   version: "VERSION_SOURCE_SLACK"
   concurrency: 10000
   tables: ["*"]

--- a/website/pages/docs/plugins/sources/slack/overview.mdx
+++ b/website/pages/docs/plugins/sources/slack/overview.mdx
@@ -1,6 +1,6 @@
 ---
 name: Slack
-stage: GA
+stage: GA (Premium)
 title: Slack Source Plugin
 description: CloudQuery Slack source plugin documentation
 ---
@@ -11,6 +11,8 @@ import { Badge } from "../../../../../components/Badge";
 import Authentication from "./_authentication.mdx";
 
 <Badge text={"Latest: " + getLatestVersion("source", "slack")}/>
+
+This is a premium plugin that you can buy [here](https://cloudquery.io/buy/slack) (`$50` with 6 months of free updates and support).
 
 The CloudQuery Slack plugin extracts information from your Slack organization(s) and loads it into any supported CloudQuery destination (e.g. PostgreSQL, BigQuery, Snowflake, and [more](/docs/plugins/destinations/overview)).
 

--- a/website/pages/docs/plugins/sources/tailscale/_configuration.mdx
+++ b/website/pages/docs/plugins/sources/tailscale/_configuration.mdx
@@ -3,7 +3,7 @@ kind: source
 # Common source-plugin configuration
 spec:
   name: tailscale
-  path: cloudquery/tailscale
+  path: /path/to/downloaded/plugin # https://cloudquery.io/buy/tailscale
   version: "VERSION_SOURCE_TAILSCALE"
   concurrency: 10000
   tables: ["*"]

--- a/website/pages/docs/plugins/sources/tailscale/overview.mdx
+++ b/website/pages/docs/plugins/sources/tailscale/overview.mdx
@@ -1,6 +1,6 @@
 ---
 name: Tailscale
-stage: GA
+stage: GA (Premium)
 title: Tailscale Source Plugin
 description: CloudQuery Tailscale source plugin documentation
 ---
@@ -11,7 +11,9 @@ import { Badge } from "../../../../../components/Badge";
 import Configuration from "./_configuration.mdx";
 import Authentication from "./_authentication.mdx";
 
-<Badge text={"Latest: " + getLatestVersion("source", `tailscale`)}/>
+<Badge text={"Premium Latest: " + getLatestVersion("source", `tailscale`)}/>
+
+This is a premium plugin that you can buy [here](https://cloudquery.io/buy/tailscale) (`$50` with 6 months of free updates and support).
 
 The CloudQuery Tailscale plugin pulls configuration out of Tailscale resources and loads it into any supported CloudQuery destination (e.g. PostgreSQL, BigQuery, Snowflake, and [more](/docs/plugins/destinations/overview)).
 

--- a/website/pages/docs/plugins/sources/vercel/_configuration.mdx
+++ b/website/pages/docs/plugins/sources/vercel/_configuration.mdx
@@ -3,7 +3,7 @@ kind: source
 # Common source-plugin configuration
 spec:
   name: vercel
-  path: cloudquery/vercel
+  path: /path/to/downloaded/plugin # https://cloudquery.io/buy/vercle
   version: "VERSION_SOURCE_VERCEL"
   tables: ["*"]
   destinations: ["DESTINATION_NAME"]

--- a/website/pages/docs/plugins/sources/vercel/overview.mdx
+++ b/website/pages/docs/plugins/sources/vercel/overview.mdx
@@ -10,7 +10,9 @@ import { getLatestVersion } from "../../../../../utils/versions";
 import { Badge } from "../../../../../components/Badge";
 import Authentication from "./_authentication.mdx";
 
-<Badge text={"Latest: " + getLatestVersion("source", `vercel`)}/>
+<Badge text={"Premium Latest: " + getLatestVersion("source", `vercel`)}/>
+
+This is a premium plugin that you can buy [here](https://cloudquery.io/buy/vercel) (`$50` with 6 months of free updates and support).
 
 The CloudQuery Vercel plugin pulls configuration out of Vercel resources and loads it into any supported CloudQuery destination (e.g. PostgreSQL, BigQuery, Snowflake, and [more](/docs/plugins/destinations/overview)).
 

--- a/website/pages/docs/plugins/sources/vercel/overview.mdx
+++ b/website/pages/docs/plugins/sources/vercel/overview.mdx
@@ -1,6 +1,6 @@
 ---
 name: Vercel
-stage: GA
+stage: GA (Premium)
 title: Vercel Source Plugin
 description: CloudQuery Vercel source plugin documentation
 ---

--- a/website/vercel.json
+++ b/website/vercel.json
@@ -249,6 +249,42 @@
     {
       "source": "/buy/jira",
       "destination": "https://buy.stripe.com/eVa4gk8U99tB9ywbIR"
+    },
+    {
+      "source": "/buy/googleads",
+      "destination": "https://buy.stripe.com/dR6aEIgmBcFN5ig000"
+    },
+    {
+      "source": "/buy/firehose",
+      "destination": "https://buy.stripe.com/6oEbIMfix35d7qo28i"
+    },
+    {
+      "source": "/buy/gandi",
+      "destination": "https://buy.stripe.com/00geUY6M17lt9yw3cd"
+    },
+    {
+      "source": "/buy/heroku",
+      "destination": "https://buy.stripe.com/28o28c0nD7ltfWU9AC"
+    },
+    {
+      "source": "/buy/launchdarkly",
+      "destination": "https://buy.stripe.com/9AQbIM0nDgW35ig4gj"
+    },
+    {
+      "source": "/buy/mixpanel",
+      "destination": "https://buy.stripe.com/fZe4gk1rH6hpcKI7sw"
+    },
+    {
+      "source": "/buy/slack",
+      "destination": "https://buy.stripe.com/6oE5koc6l49h1209AF"
+    },
+    {
+      "source": "/buy/tailscale",
+      "destination": "https://buy.stripe.com/14kdQU6M17lt8us14c"
+    },
+    {
+      "source": "/buy/vercel",
+      "destination": "https://buy.stripe.com/fZeeUYeet7lteSQcMS"
     }
   ]
 }


### PR DESCRIPTION
Instead of https://github.com/cloudquery/cloudquery/pull/12026.

Some more fine tuning is needed and still missing redirect for vercel but should be good for first version.