### PR TITLE
fix(aws): Validate table relations not just top level table

### DIFF
--- a/plugins/source/aws/client/testing.go
+++ b/plugins/source/aws/client/testing.go
@@ -52,6 +52,5 @@ func AwsMockTestHelper(t *testing.T, parentTable *schema.Table, builder func(*te
 		if len(emptyColumns) > 0 {
 			t.Fatalf("empty columns: %v", emptyColumns)
 		}
-
 	}
 }

--- a/plugins/source/aws/client/testing.go
+++ b/plugins/source/aws/client/testing.go
@@ -52,5 +52,6 @@ func AwsMockTestHelper(t *testing.T, parentTable *schema.Table, builder func(*te
 		if len(emptyColumns) > 0 {
 			t.Fatalf("empty columns: %v", emptyColumns)
 		}
+
 	}
 }

--- a/plugins/source/aws/client/testing.go
+++ b/plugins/source/aws/client/testing.go
@@ -50,7 +50,7 @@ func AwsMockTestHelper(t *testing.T, parentTable *schema.Table, builder func(*te
 		records := messages.GetInserts().GetRecordsForTable(table)
 		emptyColumns := schema.FindEmptyColumns(table, records)
 		if len(emptyColumns) > 0 {
-			t.Fatalf("empty columns: %v", emptyColumns)
+			t.Fatalf("found empty column(s): %v in %s", emptyColumns, table.Name)
 		}
 	}
 }


### PR DESCRIPTION
<!-- 🎉 Thank you for making CloudQuery awesome by submitting a PR 🎉 -->

#### Summary

Currently we are only validating that the top level table has no empty columns... This change ensures we validate all relations as well