### PR TITLE
fix: Don't try to Close backend connection when it's `nil`

### DIFF
--- a/plugins/source/github/resources/services/repositories/branches.go
+++ b/plugins/source/github/resources/services/repositories/branches.go
@@ -4,9 +4,9 @@ import (
 	"context"
 
 	"github.com/cloudquery/cloudquery/plugins/source/github/client"
-	"github.com/cloudquery/plugin-sdk/v3/schema"
-	"github.com/cloudquery/plugin-sdk/v3/transformers"
-	"github.com/cloudquery/plugin-sdk/v3/types"
+	"github.com/cloudquery/plugin-sdk/v4/schema"
+	"github.com/cloudquery/plugin-sdk/v4/transformers"
+	"github.com/cloudquery/plugin-sdk/v4/types"
 	"github.com/google/go-github/v49/github"
 )
 

--- a/plugins/source/hackernews/resources/plugin/client.go
+++ b/plugins/source/hackernews/resources/plugin/client.go
@@ -79,7 +79,7 @@ func (c *Client) Sync(ctx context.Context, options plugin.SyncOptions, res chan<
 	return c.scheduler.Sync(ctx, schedulerClient, tt, res, scheduler.WithSyncDeterministicCQID(options.DeterministicCQID))
 }
 
-func (c *Client) Tables(ctx context.Context, options plugin.TableOptions) (schema.Tables, error) {
+func (c *Client) Tables(_ context.Context, options plugin.TableOptions) (schema.Tables, error) {
 	tt, err := c.tables.FilterDfs(options.Tables, options.SkipTables, options.SkipDependentTables)
 	if err != nil {
 		return nil, err
@@ -87,8 +87,11 @@ func (c *Client) Tables(ctx context.Context, options plugin.TableOptions) (schem
 	return tt, nil
 }
 
-func (c *Client) Close(ctx context.Context) error {
-	return c.backendConn.Close()
+func (c *Client) Close(_ context.Context) error {
+	if c.backendConn != nil {
+		return c.backendConn.Close()
+	}
+	return nil
 }
 
 func getTables() []*schema.Table {

--- a/plugins/source/hackernews/resources/plugin/client.go
+++ b/plugins/source/hackernews/resources/plugin/client.go
@@ -53,8 +53,9 @@ func (c *Client) Sync(ctx context.Context, options plugin.SyncOptions, res chan<
 	if options.BackendOptions == nil {
 		c.logger.Info().Msg("No backend options provided, using no state backend")
 		stateClient = &state.NoOpClient{}
+		c.backendConn = nil
 	} else {
-		conn, err := grpc.DialContext(ctx, options.BackendOptions.Connection,
+		c.backendConn, err = grpc.DialContext(ctx, options.BackendOptions.Connection,
 			grpc.WithTransportCredentials(insecure.NewCredentials()),
 			grpc.WithDefaultCallOptions(
 				grpc.MaxCallRecvMsgSize(maxMsgSize),
@@ -109,7 +110,7 @@ func getTables() []*schema.Table {
 	return tables
 }
 
-func Configure(ctx context.Context, logger zerolog.Logger, specBytes []byte, opts plugin.NewClientOptions) (plugin.Client, error) {
+func Configure(_ context.Context, logger zerolog.Logger, specBytes []byte, opts plugin.NewClientOptions) (plugin.Client, error) {
 	if opts.NoConnection {
 		return &Client{
 			logger: logger,

--- a/plugins/source/shopify/resources/plugin/client.go
+++ b/plugins/source/shopify/resources/plugin/client.go
@@ -55,8 +55,9 @@ func (c *Client) Sync(ctx context.Context, options plugin.SyncOptions, res chan<
 	if options.BackendOptions == nil {
 		c.logger.Info().Msg("No backend options provided, using no state backend")
 		stateClient = &state.NoOpClient{}
+		c.backendConn = nil
 	} else {
-		conn, err := grpc.DialContext(ctx, options.BackendOptions.Connection,
+		c.backendConn, err = grpc.DialContext(ctx, options.BackendOptions.Connection,
 			grpc.WithTransportCredentials(insecure.NewCredentials()),
 			grpc.WithDefaultCallOptions(
 				grpc.MaxCallRecvMsgSize(maxMsgSize),
@@ -66,7 +67,7 @@ func (c *Client) Sync(ctx context.Context, options plugin.SyncOptions, res chan<
 		if err != nil {
 			return fmt.Errorf("failed to dial grpc source plugin at %s: %w", options.BackendOptions.Connection, err)
 		}
-		stateClient, err = state.NewClient(ctx, conn, options.BackendOptions.TableName)
+		stateClient, err = state.NewClient(ctx, c.backendConn, options.BackendOptions.TableName)
 		if err != nil {
 			return fmt.Errorf("failed to create state client: %w", err)
 		}

--- a/plugins/source/shopify/resources/plugin/client.go
+++ b/plugins/source/shopify/resources/plugin/client.go
@@ -86,7 +86,10 @@ func (c *Client) Tables(_ context.Context, options plugin.TableOptions) (schema.
 }
 
 func (c *Client) Close(_ context.Context) error {
-	return c.backendConn.Close()
+	if c.backendConn != nil {
+		return c.backendConn.Close()
+	}
+	return nil
 }
 
 func Configure(_ context.Context, logger zerolog.Logger, specBytes []byte, opts plugin.NewClientOptions) (plugin.Client, error) {

--- a/plugins/source/stripe/resources/plugin/client.go
+++ b/plugins/source/stripe/resources/plugin/client.go
@@ -83,7 +83,10 @@ func (c *Client) Tables(_ context.Context, options plugin.TableOptions) (schema.
 }
 
 func (c *Client) Close(_ context.Context) error {
-	return c.backendConn.Close()
+	if c.backendConn != nil {
+		return c.backendConn.Close()
+	}
+	return nil
 }
 
 func Configure(_ context.Context, logger zerolog.Logger, specBytes []byte, opts plugin.NewClientOptions) (plugin.Client, error) {

--- a/plugins/source/stripe/resources/plugin/client.go
+++ b/plugins/source/stripe/resources/plugin/client.go
@@ -52,8 +52,9 @@ func (c *Client) Sync(ctx context.Context, options plugin.SyncOptions, res chan<
 	if options.BackendOptions == nil {
 		c.logger.Info().Msg("No backend options provided, using no state backend")
 		stateClient = &state.NoOpClient{}
+		c.backendConn = nil
 	} else {
-		conn, err := grpc.DialContext(ctx, options.BackendOptions.Connection,
+		c.backendConn, err = grpc.DialContext(ctx, options.BackendOptions.Connection,
 			grpc.WithTransportCredentials(insecure.NewCredentials()),
 			grpc.WithDefaultCallOptions(
 				grpc.MaxCallRecvMsgSize(maxMsgSize),
@@ -63,7 +64,7 @@ func (c *Client) Sync(ctx context.Context, options plugin.SyncOptions, res chan<
 		if err != nil {
 			return fmt.Errorf("failed to dial grpc source plugin at %s: %w", options.BackendOptions.Connection, err)
 		}
-		stateClient, err = state.NewClient(ctx, conn, options.BackendOptions.TableName)
+		stateClient, err = state.NewClient(ctx, c.backendConn, options.BackendOptions.TableName)
 		if err != nil {
 			return fmt.Errorf("failed to create state client: %w", err)
 		}


### PR DESCRIPTION
Unrelated to `state.NoOpClient`, `c.backendConn` is not set at all.