### PR TITLE
chore(aws): Fix AWS release workflow

### DIFF
--- a/.github/workflows/source_aws.yml
+++ b/.github/workflows/source_aws.yml
@@ -77,7 +77,7 @@ jobs:
         if: startsWith(github.head_ref, 'release-please--branches--main--components')
         uses: cloudquery/setup-cloudquery@v3
         with:
-          version: 'v3.5.0'
+          version: 'v3.9.0'
       - name: Configure AWS credentials
         if: startsWith(github.head_ref, 'release-please--branches--main--components')
         uses: aws-actions/configure-aws-credentials@v2


### PR DESCRIPTION
<!-- 🎉 Thank you for making CloudQuery awesome by submitting a PR 🎉 -->

#### Summary

Current workflow uses cq cli `v3.5` to run a sync, which fails because new protocol requires at least v3.6