### PR TITLE
chore(website): Fix broken link in `proto-v3` blog

### DIFF
--- a/.github/workflows/broken_links.yml
+++ b/.github/workflows/broken_links.yml
@@ -88,5 +88,6 @@ jobs:
             --exclude plausible.io \
             --exclude localhost \
             --exclude twitter.com \
+            --exclude mongodb.com \
             ${{ steps.vercel.outputs.url }} \
             | grep -v '───OK───' | grep -v '──SKIP──' | grep -v '0 broken'

--- a/website/pages/blog/proto-v3.mdx
+++ b/website/pages/blog/proto-v3.mdx
@@ -26,7 +26,7 @@ Let's begin with a high-level summary before diving deeper into each of the upda
 
 ## Apache Arrow
 
-We extensively discussed this update in our previous [blog post](./adopting-apache-arrow-at-cloudquery). Now, with all our [destinations](../docs/plugins/destinations/overview) migrated to SDK V4, they support over 30 different [Apache Arrow data types](https://arrow.apache.org/docs/python/api/datatypes.html)!
+We extensively discussed this update in our previous [blog post](/blog/adopting-apache-arrow-at-cloudquery). Now, with all our [destinations](/docs/plugins/destinations/overview) migrated to SDK V4, they support over 30 different [Apache Arrow data types](https://arrow.apache.org/docs/python/api/datatypes.html)!
 
 All fields that are sending CloudQuery tables are encoded as Apache Arrow Schemas, and all fields sending data are Apache Arrow records (Fields are commented in the code).
 
@@ -36,7 +36,7 @@ Updates to [plugin-pb](https://github.com/cloudquery/plugin-pb/blob/main/plugin/
 
 Having a single protocol version ensures better manageability of upgrades and maintains backward compatibility, providing users and developers with ample time for transitioning. It also enables plugin authors to create plugins that function as both sources and destinations.
 
-Moreover, any of the CloudQuery destinations can now be utilized as backends for [incremental syncs](docs/core-concepts/syncs#incremental-table-syncs). For example, you can now specify the following for sources with incremental syncs:
+Moreover, any of the CloudQuery destinations can now be utilized as backends for [incremental syncs](/docs/core-concepts/syncs#incremental-table-syncs). For example, you can now specify the following for sources with incremental syncs:
 
 ```
 kind: source


### PR DESCRIPTION
<!-- 🎉 Thank you for making CloudQuery awesome by submitting a PR 🎉 -->

#### Summary

The link to `incremental syncs` was broken so I fixed it. Also excluded the links to `mongodb.com` as it seems they have some kind of bot protection.
Finally, changed all the links in the blog to absolute ones so it's easier to understand to what they resolve

<!--
Use the following steps to ensure your PR is ready to be reviewed

- [ ] Read the [contribution guidelines](../blob/main/CONTRIBUTING.md) 🧑‍🎓
- [ ] Run `make lint` to ensure the proposed changes follow the coding style 🚨 (install golangci-lint [here](https://golangci-lint.run/usage/install/#local-installation))
- [ ] Run `make test` to ensure the proposed changes pass the tests 🧪
- [ ] If changing a source plugin run `make gen` to ensure docs are up to date 📝
- [ ] Ensure the status checks below are successful ✅
--->
