### PR TITLE
chore(aws): Add more validation tests

### DIFF
--- a/plugins/source/aws/client/testing.go
+++ b/plugins/source/aws/client/testing.go
@@ -6,6 +6,8 @@ import (
 	"testing"
 	"time"
 
+	sdkTypes "github.com/cloudquery/plugin-sdk/v4/types"
+
 	"github.com/cloudquery/cloudquery/plugins/source/aws/client/tableoptions"
 	"github.com/cloudquery/plugin-sdk/v4/scheduler"
 	"github.com/cloudquery/plugin-sdk/v4/schema"
@@ -57,5 +59,37 @@ func AwsMockTestHelper(t *testing.T, parentTable *schema.Table, builder func(*te
 		if len(emptyColumns) > 0 {
 			t.Fatalf("found empty column(s): %v in %s", emptyColumns, table.Name)
 		}
+		validateTagStructure(t, tables)
+	}
+	validateMultiplexers(t, parentTable)
+}
+
+func validateTagStructure(t *testing.T, tables schema.Tables) {
+	for _, table := range tables.FlattenTables() {
+		t.Run(table.Name, func(t *testing.T) {
+			for _, column := range table.Columns {
+				if column.Name != "tags" {
+					continue
+				}
+				if column.Type != sdkTypes.ExtensionTypes.JSON {
+					t.Fatalf("tags column in %s should be of type JSON", table.Name)
+				}
+				// TODO: Get actual field value and ensure it is of type map[string]string
+			}
+		})
+	}
+}
+
+func validateMultiplexers(t *testing.T, parentTable *schema.Table) {
+	tables := schema.Tables{parentTable}
+	for _, table := range tables.FlattenTables() {
+		if table.Name == parentTable.Name {
+			continue
+		}
+		if table.Multiplex == nil {
+			continue
+		}
+		t.Fatalf("table %s should not have multiplexer", table.Name)
+
 	}
 }

--- a/plugins/source/aws/client/testing.go
+++ b/plugins/source/aws/client/testing.go
@@ -88,6 +88,6 @@ func validateMultiplexers(t *testing.T, parentTable *schema.Table) {
 		if table.Multiplex == nil {
 			continue
 		}
-		t.Fatalf("table %s should not have multiplexer", table.Name)
+		t.Fatalf("table %s is a relation and should not have multiplexer", table.Name)
 	}
 }

--- a/plugins/source/aws/client/testing.go
+++ b/plugins/source/aws/client/testing.go
@@ -47,7 +47,8 @@ func AwsMockTestHelper(t *testing.T, parentTable *schema.Table, builder func(*te
 	if err := transformers.TransformTables(tables); err != nil {
 		t.Fatal(err)
 	}
-
+	validateTagStructure(t, tables)
+	validateMultiplexers(t, parentTable)
 	sc := scheduler.NewScheduler(scheduler.WithLogger(l))
 	messages, err := sc.SyncAll(context.Background(), &c, tables)
 	if err != nil {
@@ -59,9 +60,7 @@ func AwsMockTestHelper(t *testing.T, parentTable *schema.Table, builder func(*te
 		if len(emptyColumns) > 0 {
 			t.Fatalf("found empty column(s): %v in %s", emptyColumns, table.Name)
 		}
-		validateTagStructure(t, tables)
 	}
-	validateMultiplexers(t, parentTable)
 }
 
 func validateTagStructure(t *testing.T, tables schema.Tables) {
@@ -90,6 +89,5 @@ func validateMultiplexers(t *testing.T, parentTable *schema.Table) {
 			continue
 		}
 		t.Fatalf("table %s should not have multiplexer", table.Name)
-
 	}
 }

--- a/plugins/source/aws/resources/services/apigateway/domain_name_base_path_mappings.go
+++ b/plugins/source/aws/resources/services/apigateway/domain_name_base_path_mappings.go
@@ -20,7 +20,6 @@ func domainNameBasePathMappings() *schema.Table {
 		Name:        tableName,
 		Description: `https://docs.aws.amazon.com/apigateway/latest/api/API_BasePathMapping.html`,
 		Resolver:    fetchApigatewayDomainNameBasePathMappings,
-		Multiplex:   client.ServiceAccountRegionMultiplexer(tableName, "apigateway"),
 		Transform:   transformers.TransformWithStruct(&types.BasePathMapping{}),
 		Columns: []schema.Column{
 			client.DefaultAccountIDColumn(true),

--- a/plugins/source/aws/resources/services/apigateway/rest_api_authorizers.go
+++ b/plugins/source/aws/resources/services/apigateway/rest_api_authorizers.go
@@ -20,7 +20,6 @@ func restApiAuthorizers() *schema.Table {
 		Name:        tableName,
 		Description: `https://docs.aws.amazon.com/apigateway/latest/api/API_Authorizer.html`,
 		Resolver:    fetchApigatewayRestApiAuthorizers,
-		Multiplex:   client.ServiceAccountRegionMultiplexer(tableName, "apigateway"),
 		Transform: transformers.TransformWithStruct(
 			&types.Authorizer{},
 			transformers.WithNameTransformer(client.CreateReplaceTransformer(map[string]string{"ar_ns": "arns"})),

--- a/plugins/source/aws/resources/services/apigateway/rest_api_deployments.go
+++ b/plugins/source/aws/resources/services/apigateway/rest_api_deployments.go
@@ -20,7 +20,6 @@ func restApiDeployments() *schema.Table {
 		Name:        tableName,
 		Description: `https://docs.aws.amazon.com/apigateway/latest/api/API_Deployment.html`,
 		Resolver:    fetchApigatewayRestApiDeployments,
-		Multiplex:   client.ServiceAccountRegionMultiplexer(tableName, "apigateway"),
 		Transform:   transformers.TransformWithStruct(&types.Deployment{}),
 		Columns: []schema.Column{
 			client.DefaultAccountIDColumn(true),

--- a/plugins/source/aws/resources/services/apigateway/rest_api_documentation_parts.go
+++ b/plugins/source/aws/resources/services/apigateway/rest_api_documentation_parts.go
@@ -20,7 +20,6 @@ func restApiDocumentationParts() *schema.Table {
 		Name:        tableName,
 		Description: `https://docs.aws.amazon.com/apigateway/latest/api/API_DocumentationPart.html`,
 		Resolver:    fetchApigatewayRestApiDocumentationParts,
-		Multiplex:   client.ServiceAccountRegionMultiplexer(tableName, "apigateway"),
 		Transform:   transformers.TransformWithStruct(&types.DocumentationPart{}),
 		Columns: []schema.Column{
 			client.DefaultAccountIDColumn(true),

--- a/plugins/source/aws/resources/services/apigateway/rest_api_documentation_versions.go
+++ b/plugins/source/aws/resources/services/apigateway/rest_api_documentation_versions.go
@@ -20,7 +20,6 @@ func restApiDocumentationVersions() *schema.Table {
 		Name:        tableName,
 		Description: `https://docs.aws.amazon.com/apigateway/latest/api/API_DocumentationVersion.html`,
 		Resolver:    fetchApigatewayRestApiDocumentationVersions,
-		Multiplex:   client.ServiceAccountRegionMultiplexer(tableName, "apigateway"),
 		Transform:   transformers.TransformWithStruct(&types.DocumentationVersion{}),
 		Columns: []schema.Column{
 			client.DefaultAccountIDColumn(true),

--- a/plugins/source/aws/resources/services/apigateway/rest_api_gateway_responses.go
+++ b/plugins/source/aws/resources/services/apigateway/rest_api_gateway_responses.go
@@ -20,7 +20,6 @@ func restApiGatewayResponses() *schema.Table {
 		Name:        tableName,
 		Description: `https://docs.aws.amazon.com/apigateway/latest/api/API_GatewayResponse.html`,
 		Resolver:    fetchApigatewayRestApiGatewayResponses,
-		Multiplex:   client.ServiceAccountRegionMultiplexer(tableName, "apigateway"),
 		Transform:   transformers.TransformWithStruct(&types.GatewayResponse{}),
 		Columns: []schema.Column{
 			client.DefaultAccountIDColumn(true),

--- a/plugins/source/aws/resources/services/apigateway/rest_api_models.go
+++ b/plugins/source/aws/resources/services/apigateway/rest_api_models.go
@@ -20,7 +20,6 @@ func restApiModels() *schema.Table {
 		Name:        tableName,
 		Description: `https://docs.aws.amazon.com/apigateway/latest/api/API_Model.html`,
 		Resolver:    fetchApigatewayRestApiModels,
-		Multiplex:   client.ServiceAccountRegionMultiplexer(tableName, "apigateway"),
 		Transform:   transformers.TransformWithStruct(&types.Model{}),
 		Columns: []schema.Column{
 			client.DefaultAccountIDColumn(true),

--- a/plugins/source/aws/resources/services/apigateway/rest_api_request_validators.go
+++ b/plugins/source/aws/resources/services/apigateway/rest_api_request_validators.go
@@ -20,7 +20,6 @@ func restApiRequestValidators() *schema.Table {
 		Name:        tableName,
 		Description: `https://docs.aws.amazon.com/apigateway/latest/api/API_RequestValidator.html`,
 		Resolver:    fetchApigatewayRestApiRequestValidators,
-		Multiplex:   client.ServiceAccountRegionMultiplexer(tableName, "apigateway"),
 		Transform:   transformers.TransformWithStruct(&types.RequestValidator{}),
 		Columns: []schema.Column{
 			client.DefaultAccountIDColumn(true),

--- a/plugins/source/aws/resources/services/apigateway/rest_api_resource_method_integration.go
+++ b/plugins/source/aws/resources/services/apigateway/rest_api_resource_method_integration.go
@@ -20,7 +20,6 @@ func restApiResourceMethodIntegrations() *schema.Table {
 		Name:        tableName,
 		Description: `https://docs.aws.amazon.com/apigateway/latest/api/API_Integration.html`,
 		Resolver:    fetchApigatewayRestApiResourceMethodIntegration,
-		Multiplex:   client.ServiceAccountRegionMultiplexer(tableName, "apigateway"),
 		Transform:   transformers.TransformWithStruct(&apigateway.GetIntegrationOutput{}, transformers.WithSkipFields("ResultMetadata")),
 		Columns: []schema.Column{
 			client.DefaultAccountIDColumn(true),

--- a/plugins/source/aws/resources/services/apigateway/rest_api_resource_methods.go
+++ b/plugins/source/aws/resources/services/apigateway/rest_api_resource_methods.go
@@ -20,7 +20,6 @@ func restApiResourceMethods() *schema.Table {
 		Name:        tableName,
 		Description: `https://docs.aws.amazon.com/apigateway/latest/api/API_Method.html`,
 		Resolver:    fetchApigatewayRestApiResourceMethods,
-		Multiplex:   client.ServiceAccountRegionMultiplexer(tableName, "apigateway"),
 		Transform:   transformers.TransformWithStruct(&apigateway.GetMethodOutput{}, transformers.WithSkipFields("ResultMetadata")),
 		Columns: []schema.Column{
 			client.DefaultAccountIDColumn(true),

--- a/plugins/source/aws/resources/services/apigateway/rest_api_resources.go
+++ b/plugins/source/aws/resources/services/apigateway/rest_api_resources.go
@@ -20,7 +20,6 @@ func restApiResources() *schema.Table {
 		Name:        tableName,
 		Description: `https://docs.aws.amazon.com/apigateway/latest/api/API_Resource.html`,
 		Resolver:    fetchApigatewayRestApiResources,
-		Multiplex:   client.ServiceAccountRegionMultiplexer(tableName, "apigateway"),
 		Transform:   transformers.TransformWithStruct(&types.Resource{}),
 		Columns: []schema.Column{
 			client.DefaultAccountIDColumn(true),

--- a/plugins/source/aws/resources/services/apigateway/rest_api_stages.go
+++ b/plugins/source/aws/resources/services/apigateway/rest_api_stages.go
@@ -20,7 +20,6 @@ func restApiStages() *schema.Table {
 		Name:        tableName,
 		Description: `https://docs.aws.amazon.com/apigateway/latest/api/API_Stage.html`,
 		Resolver:    fetchApigatewayRestApiStages,
-		Multiplex:   client.ServiceAccountRegionMultiplexer(tableName, "apigateway"),
 		Transform:   transformers.TransformWithStruct(&types.Stage{}),
 		Columns: []schema.Column{
 			client.DefaultAccountIDColumn(true),

--- a/plugins/source/aws/resources/services/apigateway/usage_plan_keys.go
+++ b/plugins/source/aws/resources/services/apigateway/usage_plan_keys.go
@@ -14,7 +14,6 @@ func usagePlanKeys() *schema.Table {
 		Name:        tableName,
 		Description: `https://docs.aws.amazon.com/apigateway/latest/api/API_UsagePlanKey.html`,
 		Resolver:    fetchApigatewayUsagePlanKeys,
-		Multiplex:   client.ServiceAccountRegionMultiplexer(tableName, "apigateway"),
 		Transform:   transformers.TransformWithStruct(&types.UsagePlanKey{}),
 		Columns: []schema.Column{
 			client.DefaultAccountIDColumn(true),

--- a/plugins/source/aws/resources/services/apigatewayv2/api_authorizers.go
+++ b/plugins/source/aws/resources/services/apigatewayv2/api_authorizers.go
@@ -20,7 +20,6 @@ func apiAuthorizers() *schema.Table {
 		Name:        tableName,
 		Description: `https://docs.aws.amazon.com/apigatewayv2/latest/api-reference/apis-apiid-authorizers.html`,
 		Resolver:    fetchApigatewayv2ApiAuthorizers,
-		Multiplex:   client.ServiceAccountRegionMultiplexer(tableName, "apigateway"),
 		Transform:   transformers.TransformWithStruct(&types.Authorizer{}),
 		Columns: []schema.Column{
 			client.DefaultAccountIDColumn(true),

--- a/plugins/source/aws/resources/services/apigatewayv2/api_deployments.go
+++ b/plugins/source/aws/resources/services/apigatewayv2/api_deployments.go
@@ -20,7 +20,6 @@ func apiDeployments() *schema.Table {
 		Name:        tableName,
 		Description: `https://docs.aws.amazon.com/apigatewayv2/latest/api-reference/apis-apiid-deployments.html`,
 		Resolver:    fetchApigatewayv2ApiDeployments,
-		Multiplex:   client.ServiceAccountRegionMultiplexer(tableName, "apigateway"),
 		Transform:   transformers.TransformWithStruct(&types.Deployment{}),
 		Columns: []schema.Column{
 			client.DefaultAccountIDColumn(true),

--- a/plugins/source/aws/resources/services/apigatewayv2/api_integration_responses.go
+++ b/plugins/source/aws/resources/services/apigatewayv2/api_integration_responses.go
@@ -20,7 +20,6 @@ func apiIntegrationResponses() *schema.Table {
 		Name:        tableName,
 		Description: `https://docs.aws.amazon.com/apigatewayv2/latest/api-reference/apis-apiid-integrations-integrationid-integrationresponses-integrationresponseid.html`,
 		Resolver:    fetchApigatewayv2ApiIntegrationResponses,
-		Multiplex:   client.ServiceAccountRegionMultiplexer(tableName, "apigateway"),
 		Transform:   transformers.TransformWithStruct(&types.IntegrationResponse{}),
 		Columns: []schema.Column{
 			client.DefaultAccountIDColumn(true),

--- a/plugins/source/aws/resources/services/apigatewayv2/api_integrations.go
+++ b/plugins/source/aws/resources/services/apigatewayv2/api_integrations.go
@@ -20,7 +20,6 @@ func apiIntegrations() *schema.Table {
 		Name:        tableName,
 		Description: `https://docs.aws.amazon.com/apigatewayv2/latest/api-reference/apis-apiid-integrations-integrationid.html`,
 		Resolver:    fetchApigatewayv2ApiIntegrations,
-		Multiplex:   client.ServiceAccountRegionMultiplexer(tableName, "apigateway"),
 		Transform:   transformers.TransformWithStruct(&types.Integration{}),
 		Columns: []schema.Column{
 			client.DefaultAccountIDColumn(true),

--- a/plugins/source/aws/resources/services/apigatewayv2/api_models.go
+++ b/plugins/source/aws/resources/services/apigatewayv2/api_models.go
@@ -20,7 +20,6 @@ func apiModels() *schema.Table {
 		Name:        tableName,
 		Description: `https://docs.aws.amazon.com/apigatewayv2/latest/api-reference/apis-apiid-models.html`,
 		Resolver:    fetchApigatewayv2ApiModels,
-		Multiplex:   client.ServiceAccountRegionMultiplexer(tableName, "apigateway"),
 		Transform:   transformers.TransformWithStruct(&types.Model{}),
 		Columns: []schema.Column{
 			client.DefaultAccountIDColumn(true),

--- a/plugins/source/aws/resources/services/apigatewayv2/api_route_responses.go
+++ b/plugins/source/aws/resources/services/apigatewayv2/api_route_responses.go
@@ -20,7 +20,6 @@ func apiRouteResponses() *schema.Table {
 		Name:        tableName,
 		Description: `https://docs.aws.amazon.com/apigatewayv2/latest/api-reference/apis-apiid-routes-routeid-routeresponses.html`,
 		Resolver:    fetchApigatewayv2ApiRouteResponses,
-		Multiplex:   client.ServiceAccountRegionMultiplexer(tableName, "apigateway"),
 		Transform:   transformers.TransformWithStruct(&types.RouteResponse{}),
 		Columns: []schema.Column{
 			client.DefaultAccountIDColumn(true),

--- a/plugins/source/aws/resources/services/apigatewayv2/api_routes.go
+++ b/plugins/source/aws/resources/services/apigatewayv2/api_routes.go
@@ -20,7 +20,6 @@ func apiRoutes() *schema.Table {
 		Name:        tableName,
 		Description: `https://docs.aws.amazon.com/apigatewayv2/latest/api-reference/apis-apiid-routes.html`,
 		Resolver:    fetchApigatewayv2ApiRoutes,
-		Multiplex:   client.ServiceAccountRegionMultiplexer(tableName, "apigateway"),
 		Transform:   transformers.TransformWithStruct(&types.Route{}),
 		Columns: []schema.Column{
 			client.DefaultAccountIDColumn(true),

--- a/plugins/source/aws/resources/services/apigatewayv2/api_stages.go
+++ b/plugins/source/aws/resources/services/apigatewayv2/api_stages.go
@@ -20,7 +20,6 @@ func apiStages() *schema.Table {
 		Name:        tableName,
 		Description: `https://docs.aws.amazon.com/apigatewayv2/latest/api-reference/apis-apiid-stages.html`,
 		Resolver:    fetchApigatewayv2ApiStages,
-		Multiplex:   client.ServiceAccountRegionMultiplexer(tableName, "apigateway"),
 		Transform:   transformers.TransformWithStruct(&types.Stage{}),
 		Columns: []schema.Column{
 			client.DefaultAccountIDColumn(true),

--- a/plugins/source/aws/resources/services/apigatewayv2/domain_name_rest_api_mappings.go
+++ b/plugins/source/aws/resources/services/apigatewayv2/domain_name_rest_api_mappings.go
@@ -20,7 +20,6 @@ func domainNameRestApiMappings() *schema.Table {
 		Name:        tableName,
 		Description: `https://docs.aws.amazon.com/apigatewayv2/latest/api-reference/domainnames-domainname-apimappings.html`,
 		Resolver:    fetchApigatewayv2DomainNameRestApiMappings,
-		Multiplex:   client.ServiceAccountRegionMultiplexer(tableName, "apigateway"),
 		Transform:   transformers.TransformWithStruct(&types.ApiMapping{}),
 		Columns: []schema.Column{
 			client.DefaultAccountIDColumn(true),

--- a/plugins/source/aws/resources/services/appstream/application_fleet_associations.go
+++ b/plugins/source/aws/resources/services/appstream/application_fleet_associations.go
@@ -18,7 +18,6 @@ func applicationFleetAssociations() *schema.Table {
 		Name:        tableName,
 		Description: `https://docs.aws.amazon.com/appstream2/latest/APIReference/API_ApplicationFleetAssociation.html`,
 		Resolver:    fetchAppstreamApplicationFleetAssociations,
-		Multiplex:   client.ServiceAccountRegionMultiplexer(tableName, "appstream2"),
 		Transform:   transformers.TransformWithStruct(&types.ApplicationFleetAssociation{}),
 		Columns: []schema.Column{
 			client.DefaultAccountIDColumn(false),

--- a/plugins/source/aws/resources/services/appstream/stack_entitlements.go
+++ b/plugins/source/aws/resources/services/appstream/stack_entitlements.go
@@ -18,7 +18,6 @@ func stackEntitlements() *schema.Table {
 		Name:        tableName,
 		Description: `https://docs.aws.amazon.com/appstream2/latest/APIReference/API_Entitlement.html`,
 		Resolver:    fetchAppstreamStackEntitlements,
-		Multiplex:   client.ServiceAccountRegionMultiplexer(tableName, "appstream2"),
 		Transform:   transformers.TransformWithStruct(&types.Entitlement{}),
 		Columns: []schema.Column{
 			client.DefaultAccountIDColumn(true),

--- a/plugins/source/aws/resources/services/appstream/stack_user_associations.go
+++ b/plugins/source/aws/resources/services/appstream/stack_user_associations.go
@@ -18,7 +18,6 @@ func stackUserAssociations() *schema.Table {
 		Name:        tableName,
 		Description: `https://docs.aws.amazon.com/appstream2/latest/APIReference/API_UserStackAssociation.html`,
 		Resolver:    fetchAppstreamStackUserAssociations,
-		Multiplex:   client.ServiceAccountRegionMultiplexer(tableName, "appstream2"),
 		Transform:   transformers.TransformWithStruct(&types.UserStackAssociation{}),
 		Columns: []schema.Column{
 			client.DefaultAccountIDColumn(true),

--- a/plugins/source/aws/resources/services/athena/data_catalog_database_tables.go
+++ b/plugins/source/aws/resources/services/athena/data_catalog_database_tables.go
@@ -17,7 +17,6 @@ func dataCatalogDatabaseTables() *schema.Table {
 		Name:        tableName,
 		Description: `https://docs.aws.amazon.com/athena/latest/APIReference/API_TableMetadata.html`,
 		Resolver:    fetchAthenaDataCatalogDatabaseTables,
-		Multiplex:   client.ServiceAccountRegionMultiplexer(tableName, "athena"),
 		Transform:   transformers.TransformWithStruct(&types.TableMetadata{}),
 		Columns: []schema.Column{
 			client.DefaultAccountIDColumn(false),

--- a/plugins/source/aws/resources/services/athena/data_catalog_databases.go
+++ b/plugins/source/aws/resources/services/athena/data_catalog_databases.go
@@ -17,7 +17,6 @@ func dataCatalogDatabases() *schema.Table {
 		Name:        tableName,
 		Description: `https://docs.aws.amazon.com/athena/latest/APIReference/API_Database.html`,
 		Resolver:    fetchAthenaDataCatalogDatabases,
-		Multiplex:   client.ServiceAccountRegionMultiplexer(tableName, "athena"),
 		Transform:   transformers.TransformWithStruct(&types.Database{}),
 		Columns: []schema.Column{
 			client.DefaultAccountIDColumn(false),

--- a/plugins/source/aws/resources/services/athena/work_group_named_queries.go
+++ b/plugins/source/aws/resources/services/athena/work_group_named_queries.go
@@ -19,7 +19,6 @@ func workGroupNamedQueries() *schema.Table {
 		Description:         `https://docs.aws.amazon.com/athena/latest/APIReference/API_NamedQuery.html`,
 		Resolver:            fetchAthenaWorkGroupNamedQueries,
 		PreResourceResolver: getWorkGroupNamedQuery,
-		Multiplex:           client.ServiceAccountRegionMultiplexer(tableName, "athena"),
 		Transform:           transformers.TransformWithStruct(&types.NamedQuery{}),
 		Columns: []schema.Column{
 			client.DefaultAccountIDColumn(false),

--- a/plugins/source/aws/resources/services/athena/work_group_prepared_statements.go
+++ b/plugins/source/aws/resources/services/athena/work_group_prepared_statements.go
@@ -18,7 +18,6 @@ func workGroupPreparedStatements() *schema.Table {
 		Description:         `https://docs.aws.amazon.com/athena/latest/APIReference/API_PreparedStatement.html`,
 		Resolver:            fetchAthenaWorkGroupPreparedStatements,
 		PreResourceResolver: getWorkGroupPreparedStatement,
-		Multiplex:           client.ServiceAccountRegionMultiplexer(tableName, "athena"),
 		Transform:           transformers.TransformWithStruct(&types.PreparedStatement{}),
 		Columns: []schema.Column{
 			client.DefaultAccountIDColumn(false),

--- a/plugins/source/aws/resources/services/athena/work_group_query_executions.go
+++ b/plugins/source/aws/resources/services/athena/work_group_query_executions.go
@@ -19,7 +19,6 @@ func workGroupQueryExecutions() *schema.Table {
 		Description:         `https://docs.aws.amazon.com/athena/latest/APIReference/API_QueryExecution.html`,
 		Resolver:            fetchAthenaWorkGroupQueryExecutions,
 		PreResourceResolver: getWorkGroupQueryExecution,
-		Multiplex:           client.ServiceAccountRegionMultiplexer(tableName, "athena"),
 		Transform:           transformers.TransformWithStruct(&types.QueryExecution{}),
 		Columns: []schema.Column{
 			client.DefaultAccountIDColumn(false),

--- a/plugins/source/aws/resources/services/autoscaling/group_lifecycle_hooks.go
+++ b/plugins/source/aws/resources/services/autoscaling/group_lifecycle_hooks.go
@@ -18,7 +18,6 @@ func groupLifecycleHooks() *schema.Table {
 		Name:        tableName,
 		Description: `https://docs.aws.amazon.com/autoscaling/ec2/APIReference/API_LifecycleHook.html`,
 		Resolver:    fetchAutoscalingGroupLifecycleHooks,
-		Multiplex:   client.ServiceAccountRegionMultiplexer(tableName, "autoscaling"),
 		Transform:   transformers.TransformWithStruct(&types.LifecycleHook{}),
 		Columns: []schema.Column{
 			client.DefaultAccountIDColumn(false),

--- a/plugins/source/aws/resources/services/autoscaling/group_scaling_policies.go
+++ b/plugins/source/aws/resources/services/autoscaling/group_scaling_policies.go
@@ -18,7 +18,6 @@ func groupScalingPolicies() *schema.Table {
 		Name:        tableName,
 		Description: `https://docs.aws.amazon.com/autoscaling/ec2/APIReference/API_ScalingPolicy.html`,
 		Resolver:    fetchAutoscalingGroupScalingPolicies,
-		Multiplex:   client.ServiceAccountRegionMultiplexer(tableName, "autoscaling"),
 		Transform:   transformers.TransformWithStruct(&types.ScalingPolicy{}),
 		Columns: []schema.Column{
 			client.DefaultAccountIDColumn(false),

--- a/plugins/source/aws/resources/services/backup/plan_selections.go
+++ b/plugins/source/aws/resources/services/backup/plan_selections.go
@@ -17,7 +17,6 @@ func planSelections() *schema.Table {
 		Name:        tableName,
 		Description: `https://docs.aws.amazon.com/aws-backup/latest/devguide/API_GetBackupSelection.html`,
 		Resolver:    fetchBackupPlanSelections,
-		Multiplex:   client.ServiceAccountRegionMultiplexer(tableName, "backup"),
 		Transform:   transformers.TransformWithStruct(&backup.GetBackupSelectionOutput{}),
 		Columns: []schema.Column{
 			client.DefaultAccountIDColumn(false),

--- a/plugins/source/aws/resources/services/backup/vault_recovery_points.go
+++ b/plugins/source/aws/resources/services/backup/vault_recovery_points.go
@@ -22,7 +22,6 @@ func vaultRecoveryPoints() *schema.Table {
 		Name:        tableName,
 		Description: `https://docs.aws.amazon.com/aws-backup/latest/devguide/API_RecoveryPointByBackupVault.html`,
 		Resolver:    fetchBackupVaultRecoveryPoints,
-		Multiplex:   client.ServiceAccountRegionMultiplexer(tableName, "backup"),
 		Transform:   transformers.TransformWithStruct(&types.RecoveryPointByBackupVault{}),
 		Columns: []schema.Column{
 			client.DefaultAccountIDColumn(false),

--- a/plugins/source/aws/resources/services/batch/jobs.go
+++ b/plugins/source/aws/resources/services/batch/jobs.go
@@ -30,7 +30,6 @@ func jobs() *schema.Table {
 		Name:        tableName,
 		Description: `https://docs.aws.amazon.com/batch/latest/APIReference/API_DescribeJobs.html`,
 		Resolver:    fetchBatchJobs,
-		Multiplex:   client.ServiceAccountRegionMultiplexer(tableName, "batch"),
 		Transform:   transformers.TransformWithStruct(&types.JobDetail{}),
 		Columns: []schema.Column{
 			client.DefaultAccountIDColumn(false),

--- a/plugins/source/aws/resources/services/cloudformation/stack_resources.go
+++ b/plugins/source/aws/resources/services/cloudformation/stack_resources.go
@@ -17,7 +17,6 @@ func stackResources() *schema.Table {
 		Name:        tableName,
 		Description: `https://docs.aws.amazon.com/AWSCloudFormation/latest/APIReference/API_StackResourceSummary.html`,
 		Resolver:    fetchCloudformationStackResources,
-		Multiplex:   client.ServiceAccountRegionMultiplexer(tableName, "cloudformation"),
 		Transform:   transformers.TransformWithStruct(&types.StackResourceSummary{}),
 		Columns: []schema.Column{
 			client.DefaultAccountIDColumn(false),

--- a/plugins/source/aws/resources/services/cloudformation/stack_templates.go
+++ b/plugins/source/aws/resources/services/cloudformation/stack_templates.go
@@ -22,7 +22,6 @@ func stackTemplates() *schema.Table {
 		Name:        tableName,
 		Description: `https://docs.aws.amazon.com/AWSCloudFormation/latest/APIReference/API_GetTemplate.html`,
 		Resolver:    fetchCloudformationStackTemplates,
-		Multiplex:   client.ServiceAccountRegionMultiplexer(tableName, "cloudformation"),
 		Transform:   transformers.TransformWithStruct(&cloudformation.GetTemplateOutput{}, transformers.WithSkipFields("ResultMetadata")),
 		Columns: []schema.Column{
 			client.DefaultAccountIDColumn(false),

--- a/plugins/source/aws/resources/services/cloudformation/stackset_operation_results.go
+++ b/plugins/source/aws/resources/services/cloudformation/stackset_operation_results.go
@@ -19,7 +19,6 @@ func stackSetOperationResults() *schema.Table {
 		Description: `https://docs.aws.amazon.com/AWSCloudFormation/latest/APIReference/API_StackSetOperationResultSummary.html.
 The 'request_account_id' and 'request_region' columns are added to show the account and region of where the request was made from.`,
 		Resolver:  fetchCloudformationStackSetOperationResults,
-		Multiplex: client.ServiceAccountRegionMultiplexer(table_name, "cloudformation"),
 		Transform: transformers.TransformWithStruct(&types.StackSetOperationResultSummary{}),
 		Columns: []schema.Column{
 			{

--- a/plugins/source/aws/resources/services/cloudformation/stackset_operations.go
+++ b/plugins/source/aws/resources/services/cloudformation/stackset_operations.go
@@ -18,7 +18,6 @@ func stackSetOperations() *schema.Table {
 		Description:         `https://docs.aws.amazon.com/AWSCloudFormation/latest/APIReference/API_StackSetOperation.html`,
 		Resolver:            fetchCloudformationStackSetOperations,
 		PreResourceResolver: getStackSetOperation,
-		Multiplex:           client.ServiceAccountRegionMultiplexer(table_name, "cloudformation"),
 		Transform:           transformers.TransformWithStruct(&models.ExpandedStackSetOperation{}, transformers.WithUnwrapStructFields("StackSetOperation"), transformers.WithSkipFields("CallAs"), transformers.WithPrimaryKeys("OperationId", "CreationTimestamp")),
 		Columns: []schema.Column{
 			client.DefaultAccountIDColumn(false),

--- a/plugins/source/aws/resources/services/cloudformation/template_summaries.go
+++ b/plugins/source/aws/resources/services/cloudformation/template_summaries.go
@@ -18,7 +18,6 @@ func templateSummaries() *schema.Table {
 		Name:        tableName,
 		Description: `https://docs.aws.amazon.com/AWSCloudFormation/latest/APIReference/API_GetTemplateSummary.html`,
 		Resolver:    fetchTemplateSummary,
-		Multiplex:   client.ServiceAccountRegionMultiplexer(tableName, "cloudformation"),
 		Transform: transformers.TransformWithStruct(
 			&cloudformation.GetTemplateSummaryOutput{},
 			transformers.WithSkipFields("ResultMetadata"), // This field contains metadata about the API call rather than the template itself, so remove it.

--- a/plugins/source/aws/resources/services/cloudtrail/trail_event_selectors.go
+++ b/plugins/source/aws/resources/services/cloudtrail/trail_event_selectors.go
@@ -18,7 +18,6 @@ func trailEventSelectors() *schema.Table {
 		Name:        tableName,
 		Description: `https://docs.aws.amazon.com/awscloudtrail/latest/APIReference/API_EventSelector.html`,
 		Resolver:    fetchCloudtrailTrailEventSelectors,
-		Multiplex:   client.ServiceAccountRegionMultiplexer(tableName, "cloudtrail"),
 		Transform:   transformers.TransformWithStruct(&types.EventSelector{}),
 		Columns: []schema.Column{
 			client.DefaultAccountIDColumn(false),

--- a/plugins/source/aws/resources/services/cloudwatch/metric_statistics.go
+++ b/plugins/source/aws/resources/services/cloudwatch/metric_statistics.go
@@ -33,8 +33,7 @@ To sync this table you must set the 'use_paid_apis' option to 'true' and set the
 
 Please note that this table is considered **alpha** (experimental) and may have breaking changes or be removed in the future.
 `,
-		Resolver:  fetchCloudwatchMetricStatistics,
-		Multiplex: client.ServiceAccountRegionMultiplexer(tableName, "monitoring"),
+		Resolver: fetchCloudwatchMetricStatistics,
 		Transform: transformers.TransformWithStruct(&statOutput{},
 			transformers.WithPrimaryKeys("Timestamp", "Label"),
 			transformers.WithSkipFields("ResultMetadata"),

--- a/plugins/source/aws/resources/services/cloudwatchlogs/data_protection_policies.go
+++ b/plugins/source/aws/resources/services/cloudwatchlogs/data_protection_policies.go
@@ -17,7 +17,6 @@ func dataProtectionPolicy() *schema.Table {
 		Name:        tableName,
 		Description: `https://docs.aws.amazon.com/AmazonCloudWatchLogs/latest/APIReference/API_GetDataProtectionPolicy.html`,
 		Resolver:    fetchDataProtectionPolicy,
-		Multiplex:   client.ServiceAccountRegionMultiplexer(tableName, "logs"),
 		Transform:   transformers.TransformWithStruct(&cloudwatchlogs.GetDataProtectionPolicyOutput{}, transformers.WithSkipFields("ResultMetadata")),
 		Columns: []schema.Column{
 			client.DefaultAccountIDColumn(false),

--- a/plugins/source/aws/resources/services/cloudwatchlogs/subscription_filters.go
+++ b/plugins/source/aws/resources/services/cloudwatchlogs/subscription_filters.go
@@ -17,7 +17,6 @@ func subscriptionFilters() *schema.Table {
 		Name:        tableName,
 		Description: `https://docs.aws.amazon.com/AmazonCloudWatchLogs/latest/APIReference/API_SubscriptionFilter.html`,
 		Resolver:    fetchCloudwatchlogsSubscriptionFilters,
-		Multiplex:   client.ServiceAccountRegionMultiplexer(tableName, "logs"),
 		Transform:   transformers.TransformWithStruct(&types.SubscriptionFilter{}, transformers.WithPrimaryKeys("FilterName", "CreationTime")),
 		Columns: []schema.Column{
 			client.DefaultAccountIDColumn(false),

--- a/plugins/source/aws/resources/services/cognito/user_pool_identity_providers.go
+++ b/plugins/source/aws/resources/services/cognito/user_pool_identity_providers.go
@@ -18,7 +18,6 @@ func userPoolIdentityProviders() *schema.Table {
 		Description:         `https://docs.aws.amazon.com/cognito-user-identity-pools/latest/APIReference/API_IdentityProviderType.html`,
 		Resolver:            fetchCognitoUserPoolIdentityProviders,
 		PreResourceResolver: getUserPoolIdentityProvider,
-		Multiplex:           client.ServiceAccountRegionMultiplexer(tableName, "cognito-identity"),
 		Transform:           transformers.TransformWithStruct(&types.IdentityProviderType{}),
 		Columns: []schema.Column{
 			client.DefaultAccountIDColumn(false),

--- a/plugins/source/aws/resources/services/config/config_rule_compliance_details.go
+++ b/plugins/source/aws/resources/services/config/config_rule_compliance_details.go
@@ -17,7 +17,6 @@ func configRuleComplianceDetails() *schema.Table {
 		Name:        tableName,
 		Description: `https://docs.aws.amazon.com/config/latest/APIReference/API_EvaluationResult.html`,
 		Resolver:    fetchConfigConfigRuleComplianceDetails,
-		Multiplex:   client.ServiceAccountRegionMultiplexer(tableName, "config"),
 		// no primary key because all the relevant candidate fields can either be null or are not
 		// uniquely identifying of a resource. For example, ResourceEvaluationId can be null,
 		// and so can ResultToken. However, hashing the entire object can work because a combination of

--- a/plugins/source/aws/resources/services/config/config_rule_compliances.go
+++ b/plugins/source/aws/resources/services/config/config_rule_compliances.go
@@ -17,7 +17,6 @@ func configRuleCompliances() *schema.Table {
 		Name:        tableName,
 		Description: `https://docs.aws.amazon.com/config/latest/APIReference/API_ComplianceByConfigRule.html`,
 		Resolver:    fetchConfigConfigRuleCompliances,
-		Multiplex:   client.ServiceAccountRegionMultiplexer(tableName, "config"),
 		Transform:   transformers.TransformWithStruct(&types.ComplianceByConfigRule{}),
 		Columns: []schema.Column{
 			client.DefaultAccountIDColumn(false),

--- a/plugins/source/aws/resources/services/config/conformance_pack_rule_compliances.go
+++ b/plugins/source/aws/resources/services/config/conformance_pack_rule_compliances.go
@@ -18,7 +18,6 @@ func conformancePackRuleCompliances() *schema.Table {
 		Name:        tableName,
 		Description: `https://docs.aws.amazon.com/config/latest/APIReference/API_DescribeConformancePackCompliance.html`,
 		Resolver:    fetchConfigConformancePackRuleCompliances,
-		Multiplex:   client.ServiceAccountRegionMultiplexer(tableName, "config"),
 		Transform:   transformers.TransformWithStruct(&models.ConformancePackComplianceWrapper{}),
 		Columns: []schema.Column{
 			client.DefaultAccountIDColumn(false),

--- a/plugins/source/aws/resources/services/config/deliver_channel_statuses.go
+++ b/plugins/source/aws/resources/services/config/deliver_channel_statuses.go
@@ -17,7 +17,6 @@ func deliveryChannelStatuses() *schema.Table {
 		Name:        tableName,
 		Description: `https://docs.aws.amazon.com/config/latest/APIReference/API_DescribeDeliveryChannelStatus.html`,
 		Resolver:    fetchDeliveryChannelStatuses,
-		Multiplex:   client.ServiceAccountRegionMultiplexer(tableName, "config"),
 		Transform:   transformers.TransformWithStruct(&types.DeliveryChannelStatus{}, transformers.WithPrimaryKeys("Name")),
 		Columns: []schema.Column{
 			client.DefaultAccountIDColumn(true),

--- a/plugins/source/aws/resources/services/config/remediation_configurations.go
+++ b/plugins/source/aws/resources/services/config/remediation_configurations.go
@@ -16,7 +16,6 @@ func remediationConfigurations() *schema.Table {
 		Name:        tableName,
 		Description: `https://docs.aws.amazon.com/config/latest/APIReference/API_RemediationConfiguration.html`,
 		Resolver:    fetchRemediationConfigurations,
-		Multiplex:   client.ServiceAccountRegionMultiplexer(tableName, "config"),
 		Transform: transformers.TransformWithStruct(&types.RemediationConfiguration{},
 			transformers.WithPrimaryKeys("Arn")),
 		Columns: []schema.Column{

--- a/plugins/source/aws/resources/services/detective/members.go
+++ b/plugins/source/aws/resources/services/detective/members.go
@@ -20,7 +20,6 @@ func members() *schema.Table {
 		Description: `https://docs.aws.amazon.com/detective/latest/APIReference/API_GetMembers.html
 The 'request_account_id' and 'request_region' columns are added to show the account and region of where the request was made from.`,
 		Resolver:  fetchMembers,
-		Multiplex: client.ServiceAccountRegionMultiplexer(tableName, "api.detective"),
 		Transform: transformers.TransformWithStruct(&types.MemberDetail{}, transformers.WithPrimaryKeys("AccountId", "GraphArn")),
 		Columns: []schema.Column{
 			{

--- a/plugins/source/aws/resources/services/directconnect/gateway_associations.go
+++ b/plugins/source/aws/resources/services/directconnect/gateway_associations.go
@@ -18,7 +18,6 @@ func gatewayAssociations() *schema.Table {
 		Name:        tableName,
 		Description: `https://docs.aws.amazon.com/directconnect/latest/APIReference/API_DirectConnectGatewayAssociation.html`,
 		Resolver:    fetchDirectconnectGatewayAssociations,
-		Multiplex:   client.ServiceAccountRegionMultiplexer(tableName, "directconnect"),
 		Transform:   transformers.TransformWithStruct(&types.DirectConnectGatewayAssociation{}),
 		Columns: []schema.Column{
 			client.DefaultAccountIDColumn(false),

--- a/plugins/source/aws/resources/services/directconnect/gateway_attachments.go
+++ b/plugins/source/aws/resources/services/directconnect/gateway_attachments.go
@@ -18,7 +18,6 @@ func gatewayAttachments() *schema.Table {
 		Name:        tableName,
 		Description: `https://docs.aws.amazon.com/directconnect/latest/APIReference/API_DirectConnectGatewayAttachment.html`,
 		Resolver:    fetchDirectconnectGatewayAttachments,
-		Multiplex:   client.ServiceAccountRegionMultiplexer(tableName, "directconnect"),
 		Transform:   transformers.TransformWithStruct(&types.DirectConnectGatewayAttachment{}),
 		Columns: []schema.Column{
 			client.DefaultAccountIDColumn(false),

--- a/plugins/source/aws/resources/services/docdb/cluster_parameters.go
+++ b/plugins/source/aws/resources/services/docdb/cluster_parameters.go
@@ -18,7 +18,6 @@ func clusterParameters() *schema.Table {
 		Name:        tableName,
 		Description: `https://docs.aws.amazon.com/documentdb/latest/developerguide/API_Parameter.html`,
 		Resolver:    fetchDocdbClusterParameters,
-		Multiplex:   client.ServiceAccountRegionMultiplexer(tableName, "docdb"),
 		Transform:   transformers.TransformWithStruct(&types.Parameter{}),
 		Columns: []schema.Column{
 			client.DefaultAccountIDColumn(false),

--- a/plugins/source/aws/resources/services/docdb/cluster_snapshots.go
+++ b/plugins/source/aws/resources/services/docdb/cluster_snapshots.go
@@ -19,7 +19,6 @@ func clusterSnapshots() *schema.Table {
 		Name:        tableName,
 		Description: `https://docs.aws.amazon.com/documentdb/latest/developerguide/API_DBClusterSnapshot.html`,
 		Resolver:    fetchDocdbClusterSnapshots,
-		Multiplex:   client.ServiceAccountRegionMultiplexer(tableName, "docdb"),
 		Transform:   transformers.TransformWithStruct(&types.DBClusterSnapshot{}),
 		Columns: []schema.Column{
 			client.DefaultAccountIDColumn(false),

--- a/plugins/source/aws/resources/services/docdb/instances.go
+++ b/plugins/source/aws/resources/services/docdb/instances.go
@@ -20,7 +20,6 @@ func instances() *schema.Table {
 		Name:        tableName,
 		Description: `https://docs.aws.amazon.com/documentdb/latest/developerguide/API_DBInstance.html`,
 		Resolver:    fetchDocdbInstances,
-		Multiplex:   client.ServiceAccountRegionMultiplexer(tableName, "docdb"),
 		Transform:   transformers.TransformWithStruct(&types.DBInstance{}),
 		Columns: []schema.Column{
 			client.DefaultAccountIDColumn(false),

--- a/plugins/source/aws/resources/services/docdb/orderable_db_instance_options.go
+++ b/plugins/source/aws/resources/services/docdb/orderable_db_instance_options.go
@@ -16,7 +16,6 @@ func orderableDbInstanceOptions() *schema.Table {
 		Name:        tableName,
 		Description: `https://docs.aws.amazon.com/documentdb/latest/developerguide/API_OrderableDBInstanceOption.html`,
 		Resolver:    fetchDocdbOrderableDbInstanceOptions,
-		Multiplex:   client.ServiceAccountRegionMultiplexer(tableName, "docdb"),
 		Transform:   transformers.TransformWithStruct(&types.OrderableDBInstanceOption{}),
 		Columns:     []schema.Column{},
 	}

--- a/plugins/source/aws/resources/services/dynamodb/table_continuous_backups.go
+++ b/plugins/source/aws/resources/services/dynamodb/table_continuous_backups.go
@@ -14,7 +14,6 @@ func tableContinuousBackups() *schema.Table {
 		Name:        tableName,
 		Description: `https://docs.aws.amazon.com/amazondynamodb/latest/APIReference/API_ContinuousBackupsDescription.html`,
 		Resolver:    fetchDynamodbTableContinuousBackups,
-		Multiplex:   client.ServiceAccountRegionMultiplexer(tableName, "dynamodb"),
 		Transform:   transformers.TransformWithStruct(&types.ContinuousBackupsDescription{}),
 		Columns: []schema.Column{
 			client.DefaultAccountIDColumn(false),

--- a/plugins/source/aws/resources/services/dynamodb/table_replica_auto_scalings.go
+++ b/plugins/source/aws/resources/services/dynamodb/table_replica_auto_scalings.go
@@ -14,7 +14,6 @@ func tableReplicaAutoScalings() *schema.Table {
 		Name:        tableName,
 		Description: `https://docs.aws.amazon.com/amazondynamodb/latest/APIReference/API_ReplicaAutoScalingDescription.html`,
 		Resolver:    fetchDynamodbTableReplicaAutoScalings,
-		Multiplex:   client.ServiceAccountRegionMultiplexer(tableName, "dynamodb"),
 		Transform:   transformers.TransformWithStruct(&types.ReplicaAutoScalingDescription{}),
 		Columns: []schema.Column{
 			client.DefaultAccountIDColumn(false),

--- a/plugins/source/aws/resources/services/ec2/ebs_snapshot_attributes.go
+++ b/plugins/source/aws/resources/services/ec2/ebs_snapshot_attributes.go
@@ -18,7 +18,6 @@ func ebsSnapshotAttributes() *schema.Table {
 		Name:        tableName,
 		Description: `https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_DescribeSnapshotAttribute.html`,
 		Resolver:    fetchEbsSnapshotAttributes,
-		Multiplex:   client.ServiceAccountRegionMultiplexer(tableName, "ec2"),
 		Transform:   transformers.TransformWithStruct(&ec2.DescribeSnapshotAttributeOutput{}, transformers.WithSkipFields("ResultMetadata")),
 		Columns: []schema.Column{
 			client.DefaultAccountIDColumn(false),

--- a/plugins/source/aws/resources/services/ec2/launch_template_versions.go
+++ b/plugins/source/aws/resources/services/ec2/launch_template_versions.go
@@ -18,7 +18,6 @@ func launchTemplateVersions() *schema.Table {
 		Description: `https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_LaunchTemplateVersion.html`,
 		Resolver:    fetchEc2LaunchTemplateVersions,
 		Transform:   transformers.TransformWithStruct(&types.LaunchTemplateVersion{}),
-		Multiplex:   client.ServiceAccountRegionMultiplexer(tableName, "ec2"),
 		Columns: []schema.Column{
 			client.DefaultAccountIDColumn(false),
 			client.DefaultRegionColumn(false),

--- a/plugins/source/aws/resources/services/ec2/spot_fleet_instances.go
+++ b/plugins/source/aws/resources/services/ec2/spot_fleet_instances.go
@@ -19,7 +19,6 @@ func spotFleetInstances() *schema.Table {
 		Name:        tableName,
 		Description: `https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_ActiveInstance.html`,
 		Resolver:    fetchEC2SpotFleetInstances,
-		Multiplex:   client.ServiceAccountRegionMultiplexer(tableName, "ec2"),
 		Transform:   transformers.TransformWithStruct(&types.ActiveInstance{}),
 		Columns: []schema.Column{
 			client.DefaultAccountIDColumn(false),

--- a/plugins/source/aws/resources/services/ec2/transit_gateway_attachments.go
+++ b/plugins/source/aws/resources/services/ec2/transit_gateway_attachments.go
@@ -20,7 +20,6 @@ func transitGatewayAttachments() *schema.Table {
 		Name:        tableName,
 		Description: `https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_TransitGatewayAttachment.html`,
 		Resolver:    fetchEc2TransitGatewayAttachments,
-		Multiplex:   client.ServiceAccountRegionMultiplexer(tableName, "ec2"),
 		Transform:   transformers.TransformWithStruct(&types.TransitGatewayAttachment{}),
 		Columns: []schema.Column{
 			client.DefaultAccountIDColumn(false),

--- a/plugins/source/aws/resources/services/ec2/transit_gateway_multicast_domains.go
+++ b/plugins/source/aws/resources/services/ec2/transit_gateway_multicast_domains.go
@@ -20,7 +20,6 @@ func transitGatewayMulticastDomains() *schema.Table {
 		Name:        tableName,
 		Description: `https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_TransitGatewayMulticastDomain.html`,
 		Resolver:    fetchEc2TransitGatewayMulticastDomains,
-		Multiplex:   client.ServiceAccountRegionMultiplexer(tableName, "ec2"),
 		Transform:   transformers.TransformWithStruct(&types.TransitGatewayMulticastDomain{}),
 		Columns: []schema.Column{
 			client.DefaultAccountIDColumn(false),

--- a/plugins/source/aws/resources/services/ec2/transit_gateway_peering_attachments.go
+++ b/plugins/source/aws/resources/services/ec2/transit_gateway_peering_attachments.go
@@ -20,7 +20,6 @@ func transitGatewayPeeringAttachments() *schema.Table {
 		Name:        tableName,
 		Description: `https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_TransitGatewayPeeringAttachment.html`,
 		Resolver:    fetchEc2TransitGatewayPeeringAttachments,
-		Multiplex:   client.ServiceAccountRegionMultiplexer(tableName, "ec2"),
 		Transform:   transformers.TransformWithStruct(&types.TransitGatewayPeeringAttachment{}),
 		Columns: []schema.Column{
 			client.DefaultAccountIDColumn(false),

--- a/plugins/source/aws/resources/services/ec2/transit_gateway_route_tables.go
+++ b/plugins/source/aws/resources/services/ec2/transit_gateway_route_tables.go
@@ -20,7 +20,6 @@ func transitGatewayRouteTables() *schema.Table {
 		Name:        tableName,
 		Description: `https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_TransitGatewayRouteTable.html`,
 		Resolver:    fetchEc2TransitGatewayRouteTables,
-		Multiplex:   client.ServiceAccountRegionMultiplexer(tableName, "ec2"),
 		Transform:   transformers.TransformWithStruct(&types.TransitGatewayRouteTable{}),
 		Columns: []schema.Column{
 			client.DefaultAccountIDColumn(false),

--- a/plugins/source/aws/resources/services/ec2/transit_gateway_vpc_attachments.go
+++ b/plugins/source/aws/resources/services/ec2/transit_gateway_vpc_attachments.go
@@ -20,7 +20,6 @@ func transitGatewayVpcAttachments() *schema.Table {
 		Name:        tableName,
 		Description: `https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_TransitGatewayVpcAttachment.html`,
 		Resolver:    fetchEc2TransitGatewayVpcAttachments,
-		Multiplex:   client.ServiceAccountRegionMultiplexer(tableName, "ec2"),
 		Transform:   transformers.TransformWithStruct(&types.TransitGatewayVpcAttachment{}),
 		Columns: []schema.Column{
 			client.DefaultAccountIDColumn(false),

--- a/plugins/source/aws/resources/services/ec2/vpc_endpoint_service_permissions.go
+++ b/plugins/source/aws/resources/services/ec2/vpc_endpoint_service_permissions.go
@@ -19,7 +19,6 @@ func vpcEndpointServicePermissions() *schema.Table {
 		Name:        tableName,
 		Description: `https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_AllowedPrincipal.html`,
 		Resolver:    fetchEc2VpcEndpointServicePermissions,
-		Multiplex:   client.ServiceAccountRegionMultiplexer(tableName, "ec2"),
 		Transform:   transformers.TransformWithStruct(&types.AllowedPrincipal{}, transformers.WithPrimaryKeys("ServiceId", "ServicePermissionId")),
 		Columns: []schema.Column{
 			client.DefaultAccountIDColumn(true),

--- a/plugins/source/aws/resources/services/ecs/cluster_container_instances.go
+++ b/plugins/source/aws/resources/services/ecs/cluster_container_instances.go
@@ -19,7 +19,6 @@ func clusterContainerInstances() *schema.Table {
 		Name:        tableName,
 		Description: `https://docs.aws.amazon.com/AmazonECS/latest/APIReference/API_ContainerInstance.html`,
 		Resolver:    fetchEcsClusterContainerInstances,
-		Multiplex:   client.ServiceAccountRegionMultiplexer(tableName, "ecs"),
 		Transform:   transformers.TransformWithStruct(&types.ContainerInstance{}),
 		Columns: []schema.Column{
 			client.DefaultAccountIDColumn(false),

--- a/plugins/source/aws/resources/services/ecs/cluster_services.go
+++ b/plugins/source/aws/resources/services/ecs/cluster_services.go
@@ -19,7 +19,6 @@ func clusterServices() *schema.Table {
 		Name:        tableName,
 		Description: `https://docs.aws.amazon.com/AmazonECS/latest/APIReference/API_Service.html`,
 		Resolver:    fetchEcsClusterServices,
-		Multiplex:   client.ServiceAccountRegionMultiplexer(tableName, "ecs"),
 		Transform:   transformers.TransformWithStruct(&types.Service{}, transformers.WithPrimaryKeys("ClusterArn")),
 		Columns: []schema.Column{
 			client.DefaultAccountIDColumn(false),

--- a/plugins/source/aws/resources/services/ecs/cluster_task_sets.go
+++ b/plugins/source/aws/resources/services/ecs/cluster_task_sets.go
@@ -19,7 +19,6 @@ func clusterTaskSets() *schema.Table {
 		Name:        tableName,
 		Description: `https://docs.aws.amazon.com/AmazonECS/latest/APIReference/API_TaskSet.html`,
 		Resolver:    fetchEcsClusterTaskSets,
-		Multiplex:   client.ServiceAccountRegionMultiplexer(tableName, "ecs"),
 		Transform:   transformers.TransformWithStruct(&types.TaskSet{}),
 		Columns: []schema.Column{
 			client.DefaultAccountIDColumn(false),

--- a/plugins/source/aws/resources/services/ecs/cluster_tasks.go
+++ b/plugins/source/aws/resources/services/ecs/cluster_tasks.go
@@ -21,7 +21,6 @@ func clusterTasks() *schema.Table {
 		Name:        tableName,
 		Description: `https://docs.aws.amazon.com/AmazonECS/latest/APIReference/API_Task.html`,
 		Resolver:    fetchEcsClusterTasks,
-		Multiplex:   client.ServiceAccountRegionMultiplexer(tableName, "ecs"),
 		Transform:   transformers.TransformWithStruct(&types.Task{}),
 		Columns: []schema.Column{
 			client.DefaultAccountIDColumn(false),

--- a/plugins/source/aws/resources/services/eks/add_ons.go
+++ b/plugins/source/aws/resources/services/eks/add_ons.go
@@ -18,7 +18,6 @@ func addOns() *schema.Table {
 		Description:         `https://docs.aws.amazon.com/eks/latest/APIReference/API_Addon.html`,
 		Resolver:            fetchAddOns,
 		PreResourceResolver: getAddOn,
-		Multiplex:           client.ServiceAccountRegionMultiplexer(tableName, "eks"),
 		Transform:           transformers.TransformWithStruct(&types.Addon{}),
 		Columns: []schema.Column{
 			client.DefaultAccountIDColumn(false),

--- a/plugins/source/aws/resources/services/eks/fargate_profiles.go
+++ b/plugins/source/aws/resources/services/eks/fargate_profiles.go
@@ -18,7 +18,6 @@ func fargateProfiles() *schema.Table {
 		Description:         `https://docs.aws.amazon.com/eks/latest/APIReference/API_FargateProfile.html`,
 		Resolver:            fetchFargateProfiles,
 		PreResourceResolver: getFargateProfile,
-		Multiplex:           client.ServiceAccountRegionMultiplexer(tableName, "eks"),
 		Transform:           transformers.TransformWithStruct(&types.FargateProfile{}),
 		Columns: []schema.Column{
 			client.DefaultAccountIDColumn(false),

--- a/plugins/source/aws/resources/services/eks/identity_provider_configs.go
+++ b/plugins/source/aws/resources/services/eks/identity_provider_configs.go
@@ -19,7 +19,6 @@ func identityProviderConfigs() *schema.Table {
 		Description:         `https://docs.aws.amazon.com/eks/latest/APIReference/API_OidcIdentityProviderConfig.html`,
 		Resolver:            fetchIdentityProviderConfigs,
 		PreResourceResolver: getIdentityProviderConfigs,
-		Multiplex:           client.ServiceAccountRegionMultiplexer(tableName, "eks"),
 		Transform:           transformers.TransformWithStruct(&types.OidcIdentityProviderConfig{}),
 		Columns: []schema.Column{
 			client.DefaultAccountIDColumn(false),

--- a/plugins/source/aws/resources/services/eks/node_groups.go
+++ b/plugins/source/aws/resources/services/eks/node_groups.go
@@ -18,7 +18,6 @@ func nodeGroups() *schema.Table {
 		Description:         `https://docs.aws.amazon.com/eks/latest/APIReference/API_Nodegroup.html`,
 		Resolver:            fetchNodeGroups,
 		PreResourceResolver: getNodeGroup,
-		Multiplex:           client.ServiceAccountRegionMultiplexer(tableName, "eks"),
 		Transform:           transformers.TransformWithStruct(&types.Nodegroup{}),
 		Columns: []schema.Column{
 			client.DefaultAccountIDColumn(false),

--- a/plugins/source/aws/resources/services/elasticbeanstalk/configuration_options.go
+++ b/plugins/source/aws/resources/services/elasticbeanstalk/configuration_options.go
@@ -21,7 +21,6 @@ func configurationOptions() *schema.Table {
 		Name:        tableName,
 		Description: `https://docs.aws.amazon.com/elasticbeanstalk/latest/api/API_ConfigurationOptionDescription.html`,
 		Resolver:    fetchElasticbeanstalkConfigurationOptions,
-		Multiplex:   client.ServiceAccountRegionMultiplexer(tableName, "elasticbeanstalk"),
 		Transform:   transformers.TransformWithStruct(&models.ConfigurationOptionDescriptionWrapper{}, transformers.WithUnwrapAllEmbeddedStructs()),
 		Columns: []schema.Column{
 			client.DefaultAccountIDColumn(false),

--- a/plugins/source/aws/resources/services/elasticbeanstalk/configuration_settings.go
+++ b/plugins/source/aws/resources/services/elasticbeanstalk/configuration_settings.go
@@ -21,7 +21,6 @@ func configurationSettings() *schema.Table {
 		Name:        tableName,
 		Description: `https://docs.aws.amazon.com/elasticbeanstalk/latest/api/API_ConfigurationSettingsDescription.html`,
 		Resolver:    fetchElasticbeanstalkConfigurationSettings,
-		Multiplex:   client.ServiceAccountRegionMultiplexer(tableName, "elasticbeanstalk"),
 		Transform:   transformers.TransformWithStruct(models.ConfigurationSettingsDescriptionWrapper{}, transformers.WithUnwrapAllEmbeddedStructs()),
 		Columns: []schema.Column{
 			client.DefaultAccountIDColumn(false),

--- a/plugins/source/aws/resources/services/elbv1/load_balancer_policies.go
+++ b/plugins/source/aws/resources/services/elbv1/load_balancer_policies.go
@@ -20,7 +20,6 @@ func loadBalancerPolicies() *schema.Table {
 		Name:        tableName,
 		Description: `https://docs.aws.amazon.com/elasticloadbalancing/2012-06-01/APIReference/API_PolicyDescription.html`,
 		Resolver:    fetchElbv1LoadBalancerPolicies,
-		Multiplex:   client.ServiceAccountRegionMultiplexer(tableName, "elasticloadbalancing"),
 		Transform:   transformers.TransformWithStruct(&types.PolicyDescription{}),
 		Columns: []schema.Column{
 			client.DefaultAccountIDColumn(false),

--- a/plugins/source/aws/resources/services/elbv2/listener_certificates.go
+++ b/plugins/source/aws/resources/services/elbv2/listener_certificates.go
@@ -18,7 +18,6 @@ func listenerCertificates() *schema.Table {
 		Name:        tableName,
 		Description: `https://docs.aws.amazon.com/elasticloadbalancing/latest/APIReference/API_Certificate.html`,
 		Resolver:    fetchListenerCertificates,
-		Multiplex:   client.ServiceAccountRegionMultiplexer(tableName, "elasticloadbalancing"),
 		Transform:   transformers.TransformWithStruct(&types.Certificate{}),
 		Columns: []schema.Column{
 			client.DefaultAccountIDColumn(false),

--- a/plugins/source/aws/resources/services/elbv2/listener_rules.go
+++ b/plugins/source/aws/resources/services/elbv2/listener_rules.go
@@ -18,7 +18,6 @@ func listenerRules() *schema.Table {
 		Name:        tableName,
 		Description: `https://docs.aws.amazon.com/elasticloadbalancing/latest/APIReference/API_Rule.html`,
 		Resolver:    fetchListenerRules,
-		Multiplex:   client.ServiceAccountRegionMultiplexer(tableName, "elasticloadbalancing"),
 		Transform:   transformers.TransformWithStruct(&types.Rule{}),
 		Columns: []schema.Column{
 			client.DefaultAccountIDColumn(false),

--- a/plugins/source/aws/resources/services/elbv2/listeners.go
+++ b/plugins/source/aws/resources/services/elbv2/listeners.go
@@ -19,7 +19,6 @@ func listeners() *schema.Table {
 		Name:        tableName,
 		Description: `https://docs.aws.amazon.com/elasticloadbalancing/latest/APIReference/API_Listener.html`,
 		Resolver:    fetchElbv2Listeners,
-		Multiplex:   client.ServiceAccountRegionMultiplexer(tableName, "elasticloadbalancing"),
 		Transform:   transformers.TransformWithStruct(&types.Listener{}),
 		Columns: []schema.Column{
 			client.DefaultAccountIDColumn(false),

--- a/plugins/source/aws/resources/services/elbv2/load_balancer_attributes.go
+++ b/plugins/source/aws/resources/services/elbv2/load_balancer_attributes.go
@@ -17,7 +17,6 @@ func loadBalancerAttributes() *schema.Table {
 		Name:        tableName,
 		Description: `https://docs.aws.amazon.com/elasticloadbalancing/latest/APIReference/API_LoadBalancerAttribute.html`,
 		Resolver:    fetchLoadBalancerAttributes,
-		Multiplex:   client.ServiceAccountRegionMultiplexer(tableName, "elasticloadbalancing"),
 		Transform:   transformers.TransformWithStruct(&types.LoadBalancerAttribute{}),
 		Columns: []schema.Column{
 			client.DefaultAccountIDColumn(false),

--- a/plugins/source/aws/resources/services/elbv2/load_balancer_web_acls.go
+++ b/plugins/source/aws/resources/services/elbv2/load_balancer_web_acls.go
@@ -20,7 +20,6 @@ func webACLs() *schema.Table {
 		Name:        tableName,
 		Description: `https://docs.aws.amazon.com/waf/latest/APIReference/API_GetWebACLForResource.html`,
 		Resolver:    resolveLoadBalancerWebACL,
-		Multiplex:   client.ServiceAccountRegionMultiplexer(tableName, "waf-regional"),
 		Transform:   transformers.TransformWithStruct(&wafv2types.WebACL{}, transformers.WithPrimaryKeys("ARN")),
 		Columns: []schema.Column{
 			client.DefaultAccountIDColumn(false),

--- a/plugins/source/aws/resources/services/elbv2/target_group_target_health_descriptions.go
+++ b/plugins/source/aws/resources/services/elbv2/target_group_target_health_descriptions.go
@@ -17,7 +17,6 @@ func targetGroupTargetHealthDescriptions() *schema.Table {
 		Name:        tableName,
 		Description: `https://docs.aws.amazon.com/elasticloadbalancing/latest/APIReference/API_TargetHealthDescription.html`,
 		Resolver:    fetchTargetGroupTargetHealthDescriptions,
-		Multiplex:   client.ServiceAccountRegionMultiplexer(tableName, "elasticloadbalancing"),
 		Transform:   transformers.TransformWithStruct(&types.TargetHealthDescription{}),
 		Columns: []schema.Column{
 			client.DefaultAccountIDColumn(false),

--- a/plugins/source/aws/resources/services/emr/cluster_instance_fleets.go
+++ b/plugins/source/aws/resources/services/emr/cluster_instance_fleets.go
@@ -17,7 +17,6 @@ func clusterInstanceFleets() *schema.Table {
 		Name:        tableName,
 		Description: `https://docs.aws.amazon.com/emr/latest/APIReference/API_InstanceFleet.html`,
 		Resolver:    fetchClusterInstanceFleets,
-		Multiplex:   client.ServiceAccountRegionMultiplexer(tableName, "elasticmapreduce"),
 		Transform:   transformers.TransformWithStruct(&types.InstanceFleet{}, transformers.WithPrimaryKeys("Id")),
 		Columns: []schema.Column{
 			client.DefaultAccountIDColumn(false),

--- a/plugins/source/aws/resources/services/emr/cluster_instance_groups.go
+++ b/plugins/source/aws/resources/services/emr/cluster_instance_groups.go
@@ -17,7 +17,6 @@ func clusterInstanceGroups() *schema.Table {
 		Name:        tableName,
 		Description: `https://docs.aws.amazon.com/emr/latest/APIReference/API_InstanceGroup.html`,
 		Resolver:    fetchClusterInstanceGroups,
-		Multiplex:   client.ServiceAccountRegionMultiplexer(tableName, "elasticmapreduce"),
 		Transform:   transformers.TransformWithStruct(&types.InstanceGroup{}, transformers.WithPrimaryKeys("Id")),
 		Columns: []schema.Column{
 			client.DefaultAccountIDColumn(false),

--- a/plugins/source/aws/resources/services/emr/cluster_instances.go
+++ b/plugins/source/aws/resources/services/emr/cluster_instances.go
@@ -19,7 +19,6 @@ func clusterInstances() *schema.Table {
 		Name:        tableName,
 		Description: `https://docs.aws.amazon.com/emr/latest/APIReference/API_Instance.html`,
 		Resolver:    fetchClusterInstances,
-		Multiplex:   client.ServiceAccountRegionMultiplexer(tableName, "elasticmapreduce"),
 		Transform:   transformers.TransformWithStruct(&types.Instance{}),
 		Columns: []schema.Column{
 			{

--- a/plugins/source/aws/resources/services/glacier/vault_access_policies.go
+++ b/plugins/source/aws/resources/services/glacier/vault_access_policies.go
@@ -20,7 +20,6 @@ func vaultAccessPolicies() *schema.Table {
 		Description: `https://docs.aws.amazon.com/amazonglacier/latest/dev/api-GetVaultAccessPolicy.html`,
 		Resolver:    fetchGlacierVaultAccessPolicies,
 		Transform:   transformers.TransformWithStruct(&types.VaultAccessPolicy{}),
-		Multiplex:   client.ServiceAccountRegionMultiplexer(tableName, "glacier"),
 		Columns: []schema.Column{
 			client.DefaultAccountIDColumn(false),
 			client.DefaultRegionColumn(false),

--- a/plugins/source/aws/resources/services/glacier/vault_lock_policies.go
+++ b/plugins/source/aws/resources/services/glacier/vault_lock_policies.go
@@ -20,7 +20,6 @@ func vaultLockPolicies() *schema.Table {
 		Description: `https://docs.aws.amazon.com/amazonglacier/latest/dev/api-GetVaultLock.html`,
 		Resolver:    fetchGlacierVaultLockPolicies,
 		Transform:   transformers.TransformWithStruct(&glacier.GetVaultLockOutput{}, transformers.WithSkipFields("ResultMetadata")),
-		Multiplex:   client.ServiceAccountRegionMultiplexer(tableName, "glacier"),
 		Columns: []schema.Column{
 			client.DefaultAccountIDColumn(false),
 			client.DefaultRegionColumn(false),

--- a/plugins/source/aws/resources/services/glacier/vault_notifications.go
+++ b/plugins/source/aws/resources/services/glacier/vault_notifications.go
@@ -18,7 +18,6 @@ func vaultNotifications() *schema.Table {
 		Description: `https://docs.aws.amazon.com/amazonglacier/latest/dev/api-vault-notifications-get.html`,
 		Resolver:    fetchGlacierVaultNotifications,
 		Transform:   transformers.TransformWithStruct(&types.VaultNotificationConfig{}),
-		Multiplex:   client.ServiceAccountRegionMultiplexer(tableName, "glacier"),
 		Columns: []schema.Column{
 			client.DefaultAccountIDColumn(false),
 			client.DefaultRegionColumn(false),

--- a/plugins/source/aws/resources/services/glue/database_table_indexes.go
+++ b/plugins/source/aws/resources/services/glue/database_table_indexes.go
@@ -15,7 +15,6 @@ func databaseTableIndexes() *schema.Table {
 		Description: `https://docs.aws.amazon.com/glue/latest/webapi/API_PartitionIndexDescriptor.html`,
 		Resolver:    fetchGlueDatabaseTableIndexes,
 		Transform:   transformers.TransformWithStruct(&types.PartitionIndexDescriptor{}),
-		Multiplex:   client.ServiceAccountRegionMultiplexer(tableName, "glue"),
 		Columns: []schema.Column{
 			client.DefaultAccountIDColumn(false),
 			client.DefaultRegionColumn(false),

--- a/plugins/source/aws/resources/services/glue/database_tables.go
+++ b/plugins/source/aws/resources/services/glue/database_tables.go
@@ -15,7 +15,6 @@ func databaseTables() *schema.Table {
 		Description: `https://docs.aws.amazon.com/glue/latest/webapi/API_Table.html`,
 		Resolver:    fetchGlueDatabaseTables,
 		Transform:   transformers.TransformWithStruct(&types.Table{}),
-		Multiplex:   client.ServiceAccountRegionMultiplexer(tableName, "glue"),
 		Columns: []schema.Column{
 			client.DefaultAccountIDColumn(false),
 			client.DefaultRegionColumn(false),

--- a/plugins/source/aws/resources/services/glue/job_runs.go
+++ b/plugins/source/aws/resources/services/glue/job_runs.go
@@ -20,7 +20,6 @@ func jobRuns() *schema.Table {
 		Description: `https://docs.aws.amazon.com/glue/latest/webapi/API_JobRun.html`,
 		Resolver:    fetchGlueJobRuns,
 		Transform:   transformers.TransformWithStruct(&types.JobRun{}),
-		Multiplex:   client.ServiceAccountRegionMultiplexer(tableName, "glue"),
 		Columns: []schema.Column{
 			client.DefaultAccountIDColumn(false),
 			client.DefaultRegionColumn(false),

--- a/plugins/source/aws/resources/services/glue/ml_transform_task_runs.go
+++ b/plugins/source/aws/resources/services/glue/ml_transform_task_runs.go
@@ -21,7 +21,6 @@ func mlTransformTaskRuns() *schema.Table {
 		Description: `https://docs.aws.amazon.com/glue/latest/webapi/API_TaskRun.html`,
 		Resolver:    fetchGlueMlTransformTaskRuns,
 		Transform:   transformers.TransformWithStruct(&types.TaskRun{}),
-		Multiplex:   client.ServiceAccountRegionMultiplexer(tableName, "glue"),
 		Columns: []schema.Column{
 			client.DefaultAccountIDColumn(false),
 			client.DefaultRegionColumn(false),

--- a/plugins/source/aws/resources/services/glue/registry_schema_versions.go
+++ b/plugins/source/aws/resources/services/glue/registry_schema_versions.go
@@ -22,7 +22,6 @@ func registrySchemaVersions() *schema.Table {
 		Resolver:            fetchGlueRegistrySchemaVersions,
 		PreResourceResolver: getRegistrySchemaVersion,
 		Transform:           transformers.TransformWithStruct(&glue.GetSchemaVersionOutput{}),
-		Multiplex:           client.ServiceAccountRegionMultiplexer(tableName, "glue"),
 		Columns: []schema.Column{
 			client.DefaultAccountIDColumn(false),
 			client.DefaultRegionColumn(false),

--- a/plugins/source/aws/resources/services/glue/registry_schemas.go
+++ b/plugins/source/aws/resources/services/glue/registry_schemas.go
@@ -22,7 +22,6 @@ func registrySchemas() *schema.Table {
 		Resolver:            fetchGlueRegistrySchemas,
 		PreResourceResolver: getRegistrySchema,
 		Transform:           transformers.TransformWithStruct(&glue.GetSchemaOutput{}),
-		Multiplex:           client.ServiceAccountRegionMultiplexer(tableName, "glue"),
 		Columns: []schema.Column{
 			client.DefaultAccountIDColumn(false),
 			client.DefaultRegionColumn(false),

--- a/plugins/source/aws/resources/services/guardduty/detector_filters.go
+++ b/plugins/source/aws/resources/services/guardduty/detector_filters.go
@@ -19,7 +19,6 @@ func detectorFilters() *schema.Table {
 		Resolver:            fetchDetectorFilters,
 		PreResourceResolver: getDetectorFilter,
 		Transform:           transformers.TransformWithStruct(&guardduty.GetFilterOutput{}, transformers.WithPrimaryKeys("Name"), transformers.WithSkipFields("ResultMetadata")),
-		Multiplex:           client.ServiceAccountRegionMultiplexer(tableName, "guardduty"),
 		Columns: []schema.Column{
 			{
 				Name:       "detector_arn",

--- a/plugins/source/aws/resources/services/guardduty/detector_findings.go
+++ b/plugins/source/aws/resources/services/guardduty/detector_findings.go
@@ -23,7 +23,6 @@ func detectorFindings() *schema.Table {
 			transformers.WithResolverTransformer(client.TimestampResolverTransformer),
 			transformers.WithPrimaryKeys("Arn"),
 		),
-		Multiplex: client.ServiceAccountRegionMultiplexer(tableName, "guardduty"),
 		Columns: []schema.Column{
 			{
 				Name:       "detector_arn",

--- a/plugins/source/aws/resources/services/guardduty/detector_ipsets.go
+++ b/plugins/source/aws/resources/services/guardduty/detector_ipsets.go
@@ -19,7 +19,6 @@ func detectorIPSets() *schema.Table {
 		Resolver:            fetchDetectorIPSets,
 		PreResourceResolver: getDetectorIPSet,
 		Transform:           transformers.TransformWithStruct(&guardduty.GetIPSetOutput{}, transformers.WithPrimaryKeys("Name"), transformers.WithSkipFields("ResultMetadata")),
-		Multiplex:           client.ServiceAccountRegionMultiplexer(tableName, "guardduty"),
 		Columns: []schema.Column{
 			{
 				Name:       "detector_arn",

--- a/plugins/source/aws/resources/services/guardduty/detector_publishing_destinations.go
+++ b/plugins/source/aws/resources/services/guardduty/detector_publishing_destinations.go
@@ -20,7 +20,6 @@ func detectorPublishingDestinations() *schema.Table {
 		Description: `https://docs.aws.amazon.com/guardduty/latest/APIReference/API_DescribePublishingDestination.html`,
 		Resolver:    fetchGuarddutyDetectorPublishingDestinations,
 		Transform:   transformers.TransformWithStruct(&types.Destination{}, transformers.WithPrimaryKeys("DestinationId")),
-		Multiplex:   client.ServiceAccountRegionMultiplexer(tableName, "guardduty"),
 		Columns: []schema.Column{
 			{
 				Name:       "detector_arn",

--- a/plugins/source/aws/resources/services/guardduty/detector_threat_intel_sets.go
+++ b/plugins/source/aws/resources/services/guardduty/detector_threat_intel_sets.go
@@ -20,7 +20,6 @@ func detectorThreatIntelSets() *schema.Table {
 		Resolver:            fetchDetectorThreatIntelSets,
 		PreResourceResolver: getDetectorThreatIntelSet,
 		Transform:           transformers.TransformWithStruct(&guardduty.GetThreatIntelSetOutput{}, transformers.WithPrimaryKeys("Name"), transformers.WithSkipFields("ResultMetadata")),
-		Multiplex:           client.ServiceAccountRegionMultiplexer(tableName, "guardduty"),
 		Columns: []schema.Column{
 			{
 				Name:       "detector_arn",

--- a/plugins/source/aws/resources/services/iam/user_access_keys.go
+++ b/plugins/source/aws/resources/services/iam/user_access_keys.go
@@ -20,7 +20,6 @@ func userAccessKeys() *schema.Table {
 		Resolver:             fetchIamUserAccessKeys,
 		PostResourceResolver: postIamUserAccessKeyResolver,
 		Transform:            transformers.TransformWithStruct(&models.AccessKeyWrapper{}, transformers.WithUnwrapAllEmbeddedStructs()),
-		Multiplex:            client.ServiceAccountRegionMultiplexer(tableName, "iam"),
 		Columns: []schema.Column{
 			client.DefaultAccountIDColumn(true),
 			{

--- a/plugins/source/aws/resources/services/identitystore/group_memberships.go
+++ b/plugins/source/aws/resources/services/identitystore/group_memberships.go
@@ -18,7 +18,6 @@ func groupMemberships() *schema.Table {
 		Description: `https://docs.aws.amazon.com/singlesignon/latest/IdentityStoreAPIReference/API_GroupMembership.html`,
 		Resolver:    fetchIdentitystoreGroupMemberships,
 		Transform:   transformers.TransformWithStruct(&types.GroupMembership{}),
-		Multiplex:   client.ServiceAccountRegionMultiplexer(tableName, "identitystore"),
 		Columns: []schema.Column{
 			{
 				Name:     "member_id",

--- a/plugins/source/aws/resources/services/kafka/cluster_operations.go
+++ b/plugins/source/aws/resources/services/kafka/cluster_operations.go
@@ -20,7 +20,6 @@ func clusterOperations() *schema.Table {
 		Description: `https://docs.aws.amazon.com/msk/1.0/apireference/clusters-clusterarn-operations.html`,
 		Resolver:    fetchKafkaClusterOperations,
 		Transform:   transformers.TransformWithStruct(&types.ClusterOperationInfo{}),
-		Multiplex:   client.ServiceAccountRegionMultiplexer(tableName, "kafka"),
 		Columns: []schema.Column{
 			client.DefaultAccountIDColumn(false),
 			{

--- a/plugins/source/aws/resources/services/kafka/nodes.go
+++ b/plugins/source/aws/resources/services/kafka/nodes.go
@@ -18,7 +18,6 @@ func nodes() *schema.Table {
 		Description: `https://docs.aws.amazon.com/msk/1.0/apireference/clusters-clusterarn-nodes.html#ListNodes`,
 		Resolver:    fetchKafkaNodes,
 		Transform:   transformers.TransformWithStruct(&types.NodeInfo{}),
-		Multiplex:   client.ServiceAccountRegionMultiplexer(tableName, "kafka"),
 		Columns: []schema.Column{
 			client.DefaultAccountIDColumn(false),
 			{

--- a/plugins/source/aws/resources/services/kms/key_grants.go
+++ b/plugins/source/aws/resources/services/kms/key_grants.go
@@ -19,7 +19,6 @@ func keyGrants() *schema.Table {
 		Description: `https://docs.aws.amazon.com/kms/latest/APIReference/API_GrantListEntry.html`,
 		Resolver:    fetchKmsKeyGrants,
 		Transform:   transformers.TransformWithStruct(&types.GrantListEntry{}),
-		Multiplex:   client.ServiceAccountRegionMultiplexer(tableName, "kms"),
 		Columns: []schema.Column{
 			client.DefaultAccountIDColumn(false),
 			client.DefaultRegionColumn(false),

--- a/plugins/source/aws/resources/services/kms/key_policies.go
+++ b/plugins/source/aws/resources/services/kms/key_policies.go
@@ -26,7 +26,6 @@ func keyPolicies() *schema.Table {
 		Description: `https://docs.aws.amazon.com/kms/latest/APIReference/API_GetKeyPolicy.html`,
 		Resolver:    fetchKeyPolicies,
 		Transform:   transformers.TransformWithStruct(&KeyPolicy{}),
-		Multiplex:   client.ServiceAccountRegionMultiplexer(tableName, "kms"),
 		Columns: []schema.Column{
 			client.DefaultAccountIDColumn(false),
 			client.DefaultRegionColumn(false),

--- a/plugins/source/aws/resources/services/lambda/function_aliases.go
+++ b/plugins/source/aws/resources/services/lambda/function_aliases.go
@@ -20,7 +20,6 @@ func functionAliases() *schema.Table {
 		Resolver:            fetchLambdaFunctionAliases,
 		PreResourceResolver: getFunctionAliasURLConfig,
 		Transform:           transformers.TransformWithStruct(&models.AliasWrapper{}, transformers.WithUnwrapAllEmbeddedStructs()),
-		Multiplex:           client.ServiceAccountRegionMultiplexer(tableName, "lambda"),
 		Columns: []schema.Column{
 			client.DefaultAccountIDColumn(false),
 			client.DefaultRegionColumn(false),

--- a/plugins/source/aws/resources/services/lambda/function_concurrency_configs.go
+++ b/plugins/source/aws/resources/services/lambda/function_concurrency_configs.go
@@ -18,7 +18,6 @@ func functionConcurrencyConfigs() *schema.Table {
 		Description: `https://docs.aws.amazon.com/lambda/latest/dg/API_ProvisionedConcurrencyConfigListItem.html`,
 		Resolver:    fetchLambdaFunctionConcurrencyConfigs,
 		Transform:   transformers.TransformWithStruct(&types.ProvisionedConcurrencyConfigListItem{}),
-		Multiplex:   client.ServiceAccountRegionMultiplexer(tableName, "lambda"),
 		Columns: []schema.Column{
 			client.DefaultAccountIDColumn(false),
 			client.DefaultRegionColumn(false),

--- a/plugins/source/aws/resources/services/lambda/function_event_invoke_configs.go
+++ b/plugins/source/aws/resources/services/lambda/function_event_invoke_configs.go
@@ -18,7 +18,6 @@ func functionEventInvokeConfigs() *schema.Table {
 		Description: `https://docs.aws.amazon.com/lambda/latest/dg/API_FunctionEventInvokeConfig.html`,
 		Resolver:    fetchLambdaFunctionEventInvokeConfigs,
 		Transform:   transformers.TransformWithStruct(&types.FunctionEventInvokeConfig{}),
-		Multiplex:   client.ServiceAccountRegionMultiplexer(tableName, "lambda"),
 		Columns: []schema.Column{
 			client.DefaultAccountIDColumn(false),
 			client.DefaultRegionColumn(false),

--- a/plugins/source/aws/resources/services/lambda/function_event_source_mappings.go
+++ b/plugins/source/aws/resources/services/lambda/function_event_source_mappings.go
@@ -18,7 +18,6 @@ func functionEventSourceMappings() *schema.Table {
 		Description: `https://docs.aws.amazon.com/lambda/latest/dg/API_EventSourceMappingConfiguration.html`,
 		Resolver:    fetchLambdaFunctionEventSourceMappings,
 		Transform:   transformers.TransformWithStruct(&types.EventSourceMappingConfiguration{}),
-		Multiplex:   client.ServiceAccountRegionMultiplexer(tableName, "lambda"),
 		Columns: []schema.Column{
 			client.DefaultAccountIDColumn(false),
 			client.DefaultRegionColumn(false),

--- a/plugins/source/aws/resources/services/lambda/function_versions.go
+++ b/plugins/source/aws/resources/services/lambda/function_versions.go
@@ -18,7 +18,6 @@ func functionVersions() *schema.Table {
 		Description: `https://docs.aws.amazon.com/lambda/latest/dg/API_FunctionConfiguration.html`,
 		Resolver:    fetchLambdaFunctionVersions,
 		Transform:   transformers.TransformWithStruct(&types.FunctionConfiguration{}),
-		Multiplex:   client.ServiceAccountRegionMultiplexer(tableName, "lambda"),
 		Columns: []schema.Column{
 			client.DefaultAccountIDColumn(false),
 			client.DefaultRegionColumn(false),

--- a/plugins/source/aws/resources/services/lambda/layer_version_policies.go
+++ b/plugins/source/aws/resources/services/lambda/layer_version_policies.go
@@ -15,7 +15,6 @@ func layerVersionPolicies() *schema.Table {
 		Description: `https://docs.aws.amazon.com/lambda/latest/dg/API_GetLayerVersionPolicy.html`,
 		Resolver:    fetchLambdaLayerVersionPolicies,
 		Transform:   transformers.TransformWithStruct(&lambda.GetLayerVersionPolicyOutput{}),
-		Multiplex:   client.ServiceAccountRegionMultiplexer(tableName, "lambda"),
 		Columns: []schema.Column{
 			client.DefaultAccountIDColumn(false),
 			client.DefaultRegionColumn(false),

--- a/plugins/source/aws/resources/services/lambda/layer_versions.go
+++ b/plugins/source/aws/resources/services/lambda/layer_versions.go
@@ -15,7 +15,6 @@ func layerVersions() *schema.Table {
 		Description: `https://docs.aws.amazon.com/lambda/latest/dg/API_LayerVersionsListItem.html`,
 		Resolver:    fetchLambdaLayerVersions,
 		Transform:   transformers.TransformWithStruct(&types.LayerVersionsListItem{}),
-		Multiplex:   client.ServiceAccountRegionMultiplexer(tableName, "lambda"),
 		Columns: []schema.Column{
 			client.DefaultAccountIDColumn(false),
 			client.DefaultRegionColumn(false),

--- a/plugins/source/aws/resources/services/lightsail/bucket_access_keys.go
+++ b/plugins/source/aws/resources/services/lightsail/bucket_access_keys.go
@@ -18,7 +18,6 @@ func bucketAccessKeys() *schema.Table {
 		Description: `https://docs.aws.amazon.com/lightsail/2016-11-28/api-reference/API_AccessKey.html`,
 		Resolver:    fetchLightsailBucketAccessKeys,
 		Transform:   transformers.TransformWithStruct(&types.AccessKey{}),
-		Multiplex:   client.ServiceAccountRegionMultiplexer(tableName, "lightsail"),
 		Columns: []schema.Column{
 			client.DefaultAccountIDColumn(false),
 			client.DefaultRegionColumn(false),

--- a/plugins/source/aws/resources/services/lightsail/container_service_deployments.go
+++ b/plugins/source/aws/resources/services/lightsail/container_service_deployments.go
@@ -18,7 +18,6 @@ func containerServiceDeployments() *schema.Table {
 		Description: `https://docs.aws.amazon.com/lightsail/2016-11-28/api-reference/API_ContainerServiceDeployment.html`,
 		Resolver:    fetchLightsailContainerServiceDeployments,
 		Transform:   transformers.TransformWithStruct(&types.ContainerServiceDeployment{}),
-		Multiplex:   client.ServiceAccountRegionMultiplexer(tableName, "lightsail"),
 		Columns: []schema.Column{
 			client.DefaultAccountIDColumn(false),
 			client.DefaultRegionColumn(false),

--- a/plugins/source/aws/resources/services/lightsail/container_service_images.go
+++ b/plugins/source/aws/resources/services/lightsail/container_service_images.go
@@ -18,7 +18,6 @@ func containerServiceImages() *schema.Table {
 		Description: `https://docs.aws.amazon.com/lightsail/2016-11-28/api-reference/API_ContainerImage.html`,
 		Resolver:    fetchLightsailContainerServiceImages,
 		Transform:   transformers.TransformWithStruct(&types.ContainerImage{}),
-		Multiplex:   client.ServiceAccountRegionMultiplexer(tableName, "lightsail"),
 		Columns: []schema.Column{
 			client.DefaultAccountIDColumn(false),
 			client.DefaultRegionColumn(false),

--- a/plugins/source/aws/resources/services/lightsail/database_events.go
+++ b/plugins/source/aws/resources/services/lightsail/database_events.go
@@ -19,7 +19,6 @@ func databaseEvents() *schema.Table {
 		Description: `https://docs.aws.amazon.com/lightsail/2016-11-28/api-reference/API_RelationalDatabaseEvent.html`,
 		Resolver:    fetchLightsailDatabaseEvents,
 		Transform:   transformers.TransformWithStruct(&types.RelationalDatabaseEvent{}),
-		Multiplex:   client.ServiceAccountRegionMultiplexer(tableName, "lightsail"),
 		Columns: []schema.Column{
 			client.DefaultAccountIDColumn(false),
 			client.DefaultRegionColumn(false),

--- a/plugins/source/aws/resources/services/lightsail/database_log_events.go
+++ b/plugins/source/aws/resources/services/lightsail/database_log_events.go
@@ -22,7 +22,6 @@ func databaseLogEvents() *schema.Table {
 		Description: `https://docs.aws.amazon.com/lightsail/2016-11-28/api-reference/API_GetRelationalDatabaseLogEvents.html`,
 		Resolver:    fetchLightsailDatabaseLogEvents,
 		Transform:   transformers.TransformWithStruct(&models.LogEventWrapper{}, transformers.WithUnwrapAllEmbeddedStructs()),
-		Multiplex:   client.ServiceAccountRegionMultiplexer(tableName, "lightsail"),
 		Columns: []schema.Column{
 			client.DefaultAccountIDColumn(false),
 			client.DefaultRegionColumn(false),

--- a/plugins/source/aws/resources/services/lightsail/database_parameters.go
+++ b/plugins/source/aws/resources/services/lightsail/database_parameters.go
@@ -19,7 +19,6 @@ func databaseParameters() *schema.Table {
 		Description: `https://docs.aws.amazon.com/lightsail/2016-11-28/api-reference/API_RelationalDatabaseParameter.html`,
 		Resolver:    fetchLightsailDatabaseParameters,
 		Transform:   transformers.TransformWithStruct(&types.RelationalDatabaseParameter{}),
-		Multiplex:   client.ServiceAccountRegionMultiplexer(tableName, "lightsail"),
 		Columns: []schema.Column{
 			client.DefaultAccountIDColumn(false),
 			client.DefaultRegionColumn(false),

--- a/plugins/source/aws/resources/services/lightsail/disk_snapshots.go
+++ b/plugins/source/aws/resources/services/lightsail/disk_snapshots.go
@@ -21,7 +21,6 @@ func diskSnapshots() *schema.Table {
 		Description: `https://docs.aws.amazon.com/lightsail/2016-11-28/api-reference/API_DiskSnapshot.html`,
 		Resolver:    fetchLightsailDiskSnapshots,
 		Transform:   transformers.TransformWithStruct(&types.DiskSnapshot{}, transformers.WithPrimaryKeys("Arn")),
-		Multiplex:   client.ServiceAccountRegionMultiplexer(tableName, "lightsail"),
 		Columns: []schema.Column{
 			client.DefaultAccountIDColumn(false),
 			client.DefaultRegionColumn(false),

--- a/plugins/source/aws/resources/services/lightsail/instance_port_states.go
+++ b/plugins/source/aws/resources/services/lightsail/instance_port_states.go
@@ -18,7 +18,6 @@ func instancePortStates() *schema.Table {
 		Description: `https://docs.aws.amazon.com/lightsail/2016-11-28/api-reference/API_InstancePortState.html`,
 		Resolver:    fetchLightsailInstancePortStates,
 		Transform:   transformers.TransformWithStruct(&types.InstancePortState{}),
-		Multiplex:   client.ServiceAccountRegionMultiplexer(tableName, "lightsail"),
 		Columns: []schema.Column{
 			client.DefaultAccountIDColumn(false),
 			client.DefaultRegionColumn(false),

--- a/plugins/source/aws/resources/services/lightsail/load_balancer_tls_certificates.go
+++ b/plugins/source/aws/resources/services/lightsail/load_balancer_tls_certificates.go
@@ -20,7 +20,6 @@ func loadBalancerTlsCertificates() *schema.Table {
 		Description: `https://docs.aws.amazon.com/lightsail/2016-11-28/api-reference/API_LoadBalancerTlsCertificate.html`,
 		Resolver:    fetchLightsailLoadBalancerTlsCertificates,
 		Transform:   transformers.TransformWithStruct(&types.LoadBalancerTlsCertificate{}, transformers.WithPrimaryKeys("Arn")),
-		Multiplex:   client.ServiceAccountRegionMultiplexer(tableName, "lightsail"),
 		Columns: []schema.Column{
 			client.DefaultAccountIDColumn(false),
 			client.DefaultRegionColumn(false),

--- a/plugins/source/aws/resources/services/mq/broker_configuration_revisions.go
+++ b/plugins/source/aws/resources/services/mq/broker_configuration_revisions.go
@@ -28,7 +28,6 @@ func brokerConfigurationRevisions() *schema.Table {
 		Resolver:            fetchMqBrokerConfigurationRevisions,
 		PreResourceResolver: getMqBrokerConfigurationRevision,
 		Transform:           transformers.TransformWithStruct(&mq.DescribeConfigurationRevisionOutput{}),
-		Multiplex:           client.ServiceAccountRegionMultiplexer(tableName, "mq"),
 		Columns: []schema.Column{
 			client.DefaultAccountIDColumn(false),
 			client.DefaultRegionColumn(false),

--- a/plugins/source/aws/resources/services/mq/broker_configurations.go
+++ b/plugins/source/aws/resources/services/mq/broker_configurations.go
@@ -17,7 +17,6 @@ func brokerConfigurations() *schema.Table {
 		Description: `https://docs.aws.amazon.com/amazon-mq/latest/api-reference/configurations-configuration-id.html`,
 		Resolver:    fetchMqBrokerConfigurations,
 		Transform:   transformers.TransformWithStruct(&mq.DescribeConfigurationOutput{}, transformers.WithSkipFields("ResultMetadata"), transformers.WithPrimaryKeys("Arn")),
-		Multiplex:   client.ServiceAccountRegionMultiplexer(tableName, "mq"),
 		Columns: []schema.Column{
 			client.DefaultAccountIDColumn(false),
 			client.DefaultRegionColumn(false),

--- a/plugins/source/aws/resources/services/mq/broker_users.go
+++ b/plugins/source/aws/resources/services/mq/broker_users.go
@@ -17,7 +17,6 @@ func brokerUsers() *schema.Table {
 		Description: `https://docs.aws.amazon.com/amazon-mq/latest/api-reference/brokers-broker-id-users-username.html`,
 		Resolver:    fetchMqBrokerUsers,
 		Transform:   transformers.TransformWithStruct(&mq.DescribeUserOutput{}),
-		Multiplex:   client.ServiceAccountRegionMultiplexer(tableName, "mq"),
 		Columns: []schema.Column{
 			client.DefaultAccountIDColumn(false),
 			client.DefaultRegionColumn(false),

--- a/plugins/source/aws/resources/services/neptune/cluster_parameter_group_parameters.go
+++ b/plugins/source/aws/resources/services/neptune/cluster_parameter_group_parameters.go
@@ -18,7 +18,6 @@ func clusterParameterGroupParameters() *schema.Table {
 		Description: `https://docs.aws.amazon.com/neptune/latest/userguide/api-parameters.html#DescribeDBParameterGroups`,
 		Resolver:    fetchNeptuneClusterParameterGroupParameters,
 		Transform:   transformers.TransformWithStruct(&types.Parameter{}),
-		Multiplex:   client.ServiceAccountRegionMultiplexer(tableName, "neptune"),
 		Columns: []schema.Column{
 			client.DefaultAccountIDColumn(false),
 			client.DefaultRegionColumn(false),

--- a/plugins/source/aws/resources/services/neptune/db_parameter_group_db_parameters.go
+++ b/plugins/source/aws/resources/services/neptune/db_parameter_group_db_parameters.go
@@ -15,7 +15,6 @@ func DbParameterGroupDbParameters() *schema.Table {
 		Description: `https://docs.aws.amazon.com/neptune/latest/userguide/api-parameters.html#DescribeDBClusterParameters`,
 		Resolver:    fetchNeptuneDbParameterGroupDbParameters,
 		Transform:   transformers.TransformWithStruct(&types.Parameter{}),
-		Multiplex:   client.ServiceAccountRegionMultiplexer(tableName, "neptune"),
 		Columns: []schema.Column{
 			client.DefaultAccountIDColumn(false),
 			client.DefaultRegionColumn(false),

--- a/plugins/source/aws/resources/services/qldb/ledger_journal_kinesis_streams.go
+++ b/plugins/source/aws/resources/services/qldb/ledger_journal_kinesis_streams.go
@@ -19,7 +19,6 @@ func ledgerJournalKinesisStreams() *schema.Table {
 		Description: `https://docs.aws.amazon.com/qldb/latest/developerguide/API_JournalKinesisStreamDescription.html`,
 		Resolver:    fetchQldbLedgerJournalKinesisStreams,
 		Transform:   transformers.TransformWithStruct(&types.JournalKinesisStreamDescription{}, transformers.WithPrimaryKeys("Arn")),
-		Multiplex:   client.ServiceAccountRegionMultiplexer(tableName, "qldb"),
 		Columns: []schema.Column{
 			client.DefaultAccountIDColumn(false),
 			client.DefaultRegionColumn(false),

--- a/plugins/source/aws/resources/services/qldb/ledger_journal_s3_exports.go
+++ b/plugins/source/aws/resources/services/qldb/ledger_journal_s3_exports.go
@@ -19,7 +19,6 @@ func ledgerJournalS3Exports() *schema.Table {
 		Description: `https://docs.aws.amazon.com/qldb/latest/developerguide/API_JournalS3ExportDescription.html`,
 		Resolver:    fetchQldbLedgerJournalS3Exports,
 		Transform:   transformers.TransformWithStruct(&types.JournalS3ExportDescription{}),
-		Multiplex:   client.ServiceAccountRegionMultiplexer(tableName, "qldb"),
 		Columns: []schema.Column{
 			client.DefaultAccountIDColumn(false),
 			client.DefaultRegionColumn(false),

--- a/plugins/source/aws/resources/services/quicksight/group_members.go
+++ b/plugins/source/aws/resources/services/quicksight/group_members.go
@@ -19,7 +19,6 @@ func groupMembers() *schema.Table {
 		Description: "https://docs.aws.amazon.com/quicksight/latest/APIReference/API_GroupMember.html",
 		Resolver:    fetchQuicksightGroupMembers,
 		Transform:   transformers.TransformWithStruct(&types.GroupMember{}, transformers.WithPrimaryKeys("Arn")),
-		Multiplex:   client.ServiceAccountRegionMultiplexer(tableName, "quicksight"),
 		Columns: []schema.Column{
 			client.DefaultAccountIDColumn(true),
 			client.DefaultRegionColumn(true),

--- a/plugins/source/aws/resources/services/quicksight/ingestions.go
+++ b/plugins/source/aws/resources/services/quicksight/ingestions.go
@@ -19,7 +19,6 @@ func ingestions() *schema.Table {
 		Description: "https://docs.aws.amazon.com/quicksight/latest/APIReference/API_Ingestion.html",
 		Resolver:    fetchQuicksightIngestions,
 		Transform:   transformers.TransformWithStruct(&types.Ingestion{}, transformers.WithPrimaryKeys("Arn")),
-		Multiplex:   client.ServiceAccountRegionMultiplexer(tableName, "quicksight"),
 		Columns: []schema.Column{
 			client.DefaultAccountIDColumn(true),
 			client.DefaultRegionColumn(true),

--- a/plugins/source/aws/resources/services/rds/cluster_parameter_group_parameters.go
+++ b/plugins/source/aws/resources/services/rds/cluster_parameter_group_parameters.go
@@ -18,7 +18,6 @@ func clusterParameterGroupParameters() *schema.Table {
 		Description: `https://docs.aws.amazon.com/AmazonRDS/latest/APIReference/API_Parameter.html`,
 		Resolver:    fetchRdsClusterParameterGroupParameters,
 		Transform:   transformers.TransformWithStruct(&types.Parameter{}),
-		Multiplex:   client.ServiceAccountRegionMultiplexer(tableName, "rds"),
 		Columns: []schema.Column{
 			client.DefaultAccountIDColumn(false),
 			client.DefaultRegionColumn(false),

--- a/plugins/source/aws/resources/services/rds/cluster_parameters.go
+++ b/plugins/source/aws/resources/services/rds/cluster_parameters.go
@@ -20,7 +20,6 @@ func clusterParameters() *schema.Table {
 		Description: "https://docs.aws.amazon.com/AmazonRDS/latest/APIReference/API_Parameter.html",
 		Resolver:    fetchRdsClusterParameters,
 		Transform:   transformers.TransformWithStruct(&types.Parameter{}),
-		Multiplex:   client.ServiceAccountRegionMultiplexer(tableName, "rds"),
 		Columns: []schema.Column{
 			client.DefaultAccountIDColumn(false),
 			client.DefaultRegionColumn(false),

--- a/plugins/source/aws/resources/services/rds/db_parameter_group_db_parameters.go
+++ b/plugins/source/aws/resources/services/rds/db_parameter_group_db_parameters.go
@@ -15,7 +15,6 @@ func DbParameterGroupDbParameters() *schema.Table {
 		Description: `https://docs.aws.amazon.com/AmazonRDS/latest/APIReference/API_Parameter.html`,
 		Resolver:    fetchRdsDbParameterGroupDbParameters,
 		Transform:   transformers.TransformWithStruct(&types.Parameter{}),
-		Multiplex:   client.ServiceAccountRegionMultiplexer(tableName, "rds"),
 		Columns: []schema.Column{
 			client.DefaultAccountIDColumn(false),
 			client.DefaultRegionColumn(false),

--- a/plugins/source/aws/resources/services/redshift/cluster_parameter_groups.go
+++ b/plugins/source/aws/resources/services/redshift/cluster_parameter_groups.go
@@ -17,7 +17,6 @@ func clusterParameterGroups() *schema.Table {
 		Description: `https://docs.aws.amazon.com/redshift/latest/APIReference/API_ClusterParameterGroupStatus.html`,
 		Resolver:    fetchClusterParameterGroups,
 		Transform:   transformers.TransformWithStruct(&types.ClusterParameterGroupStatus{}),
-		Multiplex:   client.ServiceAccountRegionMultiplexer(tableName, "redshift"),
 		Columns: []schema.Column{
 			client.DefaultAccountIDColumn(false),
 			client.DefaultRegionColumn(false),

--- a/plugins/source/aws/resources/services/redshift/cluster_parameters.go
+++ b/plugins/source/aws/resources/services/redshift/cluster_parameters.go
@@ -18,7 +18,6 @@ func clusterParameters() *schema.Table {
 		Description: `https://docs.aws.amazon.com/redshift/latest/APIReference/API_Parameter.html`,
 		Resolver:    fetchClusterParameters,
 		Transform:   transformers.TransformWithStruct(&types.Parameter{}),
-		Multiplex:   client.ServiceAccountRegionMultiplexer(tableName, "redshift"),
 		Columns: []schema.Column{
 			client.DefaultAccountIDColumn(false),
 			client.DefaultRegionColumn(false),

--- a/plugins/source/aws/resources/services/redshift/endpoint_access.go
+++ b/plugins/source/aws/resources/services/redshift/endpoint_access.go
@@ -19,7 +19,6 @@ func endpointAccess() *schema.Table {
 		Description: `https://docs.aws.amazon.com/redshift/latest/APIReference/API_EndpointAccess.html`,
 		Resolver:    fetchEndpointAccess,
 		Transform:   transformers.TransformWithStruct(&types.EndpointAccess{}),
-		Multiplex:   client.ServiceAccountRegionMultiplexer(tableName, "redshift"),
 		Columns: []schema.Column{
 			client.DefaultAccountIDColumn(false),
 			client.DefaultRegionColumn(false),

--- a/plugins/source/aws/resources/services/redshift/endpoint_authorization.go
+++ b/plugins/source/aws/resources/services/redshift/endpoint_authorization.go
@@ -19,7 +19,6 @@ func endpointAuthorization() *schema.Table {
 		Description: `https://docs.aws.amazon.com/redshift/latest/APIReference/API_EndpointAuthorization.html`,
 		Resolver:    fetchEndpointAuthorization,
 		Transform:   transformers.TransformWithStruct(&types.EndpointAuthorization{}),
-		Multiplex:   client.ServiceAccountRegionMultiplexer(tableName, "redshift"),
 		Columns: []schema.Column{
 			client.DefaultAccountIDColumn(false),
 			client.DefaultRegionColumn(false),

--- a/plugins/source/aws/resources/services/redshift/snapshots.go
+++ b/plugins/source/aws/resources/services/redshift/snapshots.go
@@ -23,7 +23,6 @@ func snapshots() *schema.Table {
 		Description: `https://docs.aws.amazon.com/redshift/latest/APIReference/API_Snapshot.html`,
 		Resolver:    fetchSnapshots,
 		Transform:   transformers.TransformWithStruct(&types.Snapshot{}),
-		Multiplex:   client.ServiceAccountRegionMultiplexer(tableName, "redshift"),
 		Columns: []schema.Column{
 			client.DefaultAccountIDColumn(false),
 			client.DefaultRegionColumn(false),

--- a/plugins/source/aws/resources/services/resiliencehub/alarm_recommendations.go
+++ b/plugins/source/aws/resources/services/resiliencehub/alarm_recommendations.go
@@ -17,7 +17,6 @@ func alarmRecommendations() *schema.Table {
 		Description: `https://docs.aws.amazon.com/resilience-hub/latest/APIReference/API_AlarmRecommendation.html`,
 		Resolver:    fetchAlarmRecommendations,
 		Transform:   transformers.TransformWithStruct(&types.AlarmRecommendation{}, transformers.WithPrimaryKeys("RecommendationId")),
-		Multiplex:   client.ServiceAccountRegionMultiplexer(tableName, "resiliencehub"),
 		Columns:     []schema.Column{client.DefaultAccountIDColumn(false), client.DefaultRegionColumn(false), appARN, assessmentARN},
 	}
 }

--- a/plugins/source/aws/resources/services/resiliencehub/app_assessments.go
+++ b/plugins/source/aws/resources/services/resiliencehub/app_assessments.go
@@ -18,7 +18,6 @@ func appAssesments() *schema.Table {
 		Resolver:            fetchAppAssessments,
 		PreResourceResolver: describeAppAssessments,
 		Transform:           transformers.TransformWithStruct(&types.AppAssessment{}),
-		Multiplex:           client.ServiceAccountRegionMultiplexer(tableName, "resiliencehub"),
 		Columns:             []schema.Column{client.DefaultAccountIDColumn(false), client.DefaultRegionColumn(false), appARNTop, arnColumn("AssessmentArn")},
 		Relations: []*schema.Table{
 			appComponentCompliances(),

--- a/plugins/source/aws/resources/services/resiliencehub/app_component_compliances.go
+++ b/plugins/source/aws/resources/services/resiliencehub/app_component_compliances.go
@@ -17,7 +17,6 @@ func appComponentCompliances() *schema.Table {
 		Description: `https://docs.aws.amazon.com/resilience-hub/latest/APIReference/API_AppComponentCompliance.html`,
 		Resolver:    fetchAppComponentCompliances,
 		Transform:   transformers.TransformWithStruct(&types.AppComponentCompliance{}, transformers.WithPrimaryKeys("AppComponentName")),
-		Multiplex:   client.ServiceAccountRegionMultiplexer(tableName, "resiliencehub"),
 		Columns:     []schema.Column{client.DefaultAccountIDColumn(false), client.DefaultRegionColumn(false), appARN, assessmentARN},
 	}
 }

--- a/plugins/source/aws/resources/services/resiliencehub/app_version_resource_mappings.go
+++ b/plugins/source/aws/resources/services/resiliencehub/app_version_resource_mappings.go
@@ -18,7 +18,6 @@ func appVersionResourceMappings() *schema.Table {
 		Description: `https://docs.aws.amazon.com/resilience-hub/latest/APIReference/API_ResourceMapping.html`,
 		Resolver:    fetchAppVersionResourceMappings,
 		Transform:   transformers.TransformWithStruct(&types.ResourceMapping{}),
-		Multiplex:   client.ServiceAccountRegionMultiplexer(tableName, "resiliencehub"),
 		Columns: []schema.Column{
 			client.DefaultAccountIDColumn(false), client.DefaultRegionColumn(false), appARN, appVersion,
 			{

--- a/plugins/source/aws/resources/services/resiliencehub/app_version_resources.go
+++ b/plugins/source/aws/resources/services/resiliencehub/app_version_resources.go
@@ -19,7 +19,6 @@ func appVersionResources() *schema.Table {
 		Description: `https://docs.aws.amazon.com/resilience-hub/latest/APIReference/API_PhysicalResource.html`,
 		Resolver:    fetchAppVersionResources,
 		Transform:   transformers.TransformWithStruct(&types.PhysicalResource{}),
-		Multiplex:   client.ServiceAccountRegionMultiplexer(tableName, "resiliencehub"),
 		Columns: []schema.Column{
 			client.DefaultAccountIDColumn(false), client.DefaultRegionColumn(false), appARN, appVersion,
 			{

--- a/plugins/source/aws/resources/services/resiliencehub/app_versions.go
+++ b/plugins/source/aws/resources/services/resiliencehub/app_versions.go
@@ -17,7 +17,6 @@ func appVersions() *schema.Table {
 		Description: `https://docs.aws.amazon.com/resilience-hub/latest/APIReference/API_AppVersionSummary.html`,
 		Resolver:    fetchAppVersions,
 		Transform:   transformers.TransformWithStruct(&types.AppVersionSummary{}, transformers.WithPrimaryKeys("AppVersion")),
-		Multiplex:   client.ServiceAccountRegionMultiplexer(tableName, "resiliencehub"),
 		Columns:     []schema.Column{client.DefaultAccountIDColumn(false), client.DefaultRegionColumn(false), appARNTop},
 		Relations:   []*schema.Table{appVersionResources(), appVersionResourceMappings()},
 	}

--- a/plugins/source/aws/resources/services/resiliencehub/component_recommendations.go
+++ b/plugins/source/aws/resources/services/resiliencehub/component_recommendations.go
@@ -17,7 +17,6 @@ func appComponentRecommendations() *schema.Table {
 		Description: `https://docs.aws.amazon.com/resilience-hub/latest/APIReference/API_ComponentRecommendation.html`,
 		Resolver:    fetchComponentRecommendations,
 		Transform:   transformers.TransformWithStruct(&types.ComponentRecommendation{}, transformers.WithPrimaryKeys("AppComponentName")),
-		Multiplex:   client.ServiceAccountRegionMultiplexer(tableName, "resiliencehub"),
 		Columns:     []schema.Column{client.DefaultAccountIDColumn(false), client.DefaultRegionColumn(false), appARN, assessmentARN},
 	}
 }

--- a/plugins/source/aws/resources/services/resiliencehub/recommendation_templates.go
+++ b/plugins/source/aws/resources/services/resiliencehub/recommendation_templates.go
@@ -17,7 +17,6 @@ func recommendationTemplates() *schema.Table {
 		Description: `https://docs.aws.amazon.com/resilience-hub/latest/APIReference/API_RecommendationTemplate.html`,
 		Resolver:    fetchRecommendationTemplates,
 		Transform:   transformers.TransformWithStruct(&types.RecommendationTemplate{}, transformers.WithPrimaryKeys("AppArn", "AssessmentArn")),
-		Multiplex:   client.ServiceAccountRegionMultiplexer(tableName, "resiliencehub"),
 		Columns:     []schema.Column{client.DefaultAccountIDColumn(false), client.DefaultRegionColumn(false), arnColumn("RecommendationTemplateArn")},
 	}
 }

--- a/plugins/source/aws/resources/services/resiliencehub/sop_recommendations.go
+++ b/plugins/source/aws/resources/services/resiliencehub/sop_recommendations.go
@@ -17,7 +17,6 @@ func sopRecommendations() *schema.Table {
 		Description: `https://docs.aws.amazon.com/resilience-hub/latest/APIReference/API_SopRecommendation.html`,
 		Resolver:    fetchSopRecommendations,
 		Transform:   transformers.TransformWithStruct(&types.SopRecommendation{}, transformers.WithPrimaryKeys("RecommendationId")),
-		Multiplex:   client.ServiceAccountRegionMultiplexer(tableName, "resiliencehub"),
 		Columns:     []schema.Column{client.DefaultAccountIDColumn(false), client.DefaultRegionColumn(false), appARN, assessmentARN},
 	}
 }

--- a/plugins/source/aws/resources/services/resiliencehub/test_recommendations.go
+++ b/plugins/source/aws/resources/services/resiliencehub/test_recommendations.go
@@ -17,7 +17,6 @@ func testRecommendations() *schema.Table {
 		Description: `https://docs.aws.amazon.com/resilience-hub/latest/APIReference/API_TestRecommendation.html`,
 		Resolver:    fetchTestRecommendations,
 		Transform:   transformers.TransformWithStruct(&types.TestRecommendation{}, transformers.WithPrimaryKeys("RecommendationId")),
-		Multiplex:   client.ServiceAccountRegionMultiplexer(tableName, "resiliencehub"),
 		Columns:     []schema.Column{client.DefaultAccountIDColumn(false), client.DefaultRegionColumn(false), appARN, assessmentARN},
 	}
 }

--- a/plugins/source/aws/resources/services/route53/hosted_zone_query_logging_configs.go
+++ b/plugins/source/aws/resources/services/route53/hosted_zone_query_logging_configs.go
@@ -22,7 +22,6 @@ func hostedZoneQueryLoggingConfigs() *schema.Table {
 		Description: `https://docs.aws.amazon.com/Route53/latest/APIReference/API_QueryLoggingConfig.html`,
 		Resolver:    fetchRoute53HostedZoneQueryLoggingConfigs,
 		Transform:   transformers.TransformWithStruct(&types.QueryLoggingConfig{}),
-		Multiplex:   client.ServiceAccountRegionMultiplexer(tableName, "route53"),
 		Columns: []schema.Column{
 			client.DefaultAccountIDColumn(false),
 			{

--- a/plugins/source/aws/resources/services/route53/hosted_zone_resource_record_sets.go
+++ b/plugins/source/aws/resources/services/route53/hosted_zone_resource_record_sets.go
@@ -19,7 +19,6 @@ func hostedZoneResourceRecordSets() *schema.Table {
 		Description: `https://docs.aws.amazon.com/Route53/latest/APIReference/API_ResourceRecordSet.html`,
 		Resolver:    fetchRoute53HostedZoneResourceRecordSets,
 		Transform:   transformers.TransformWithStruct(&types.ResourceRecordSet{}),
-		Multiplex:   client.ServiceAccountRegionMultiplexer(tableName, "route53"),
 		Columns: []schema.Column{
 			client.DefaultAccountIDColumn(false),
 			{

--- a/plugins/source/aws/resources/services/route53/hosted_zone_traffic_policy_instances.go
+++ b/plugins/source/aws/resources/services/route53/hosted_zone_traffic_policy_instances.go
@@ -22,7 +22,6 @@ func hostedZoneTrafficPolicyInstances() *schema.Table {
 		Description: `https://docs.aws.amazon.com/Route53/latest/APIReference/API_TrafficPolicyInstance.html`,
 		Resolver:    fetchRoute53HostedZoneTrafficPolicyInstances,
 		Transform:   transformers.TransformWithStruct(&types.TrafficPolicyInstance{}),
-		Multiplex:   client.ServiceAccountRegionMultiplexer(tableName, "route53"),
 		Columns: []schema.Column{
 			client.DefaultAccountIDColumn(true),
 			{

--- a/plugins/source/aws/resources/services/route53/traffic_policy_versions.go
+++ b/plugins/source/aws/resources/services/route53/traffic_policy_versions.go
@@ -16,7 +16,6 @@ func trafficPolicyVersions() *schema.Table {
 		Description: `https://docs.aws.amazon.com/Route53/latest/APIReference/API_TrafficPolicy.html`,
 		Resolver:    fetchRoute53TrafficPolicyVersions,
 		Transform:   transformers.TransformWithStruct(&types.TrafficPolicy{}),
-		Multiplex:   client.ServiceAccountRegionMultiplexer(tableName, "route53"),
 		Columns: []schema.Column{
 			client.DefaultAccountIDColumn(false),
 			{

--- a/plugins/source/aws/resources/services/secretsmanager/secrets_version.go
+++ b/plugins/source/aws/resources/services/secretsmanager/secrets_version.go
@@ -19,7 +19,6 @@ func secretVersions() *schema.Table {
 		Description: `https://docs.aws.amazon.com/secretsmanager/latest/apireference/API_ListSecretVersionIds.html`,
 		Resolver:    fetchSecretsmanagerSecretsVersions,
 		Transform:   transformers.TransformWithStruct(&types.SecretVersionsListEntry{}, transformers.WithPrimaryKeys("VersionId")),
-		Multiplex:   client.ServiceAccountRegionMultiplexer(tableName, "secretsmanager"),
 		Columns: []schema.Column{
 			client.DefaultAccountIDColumn(false),
 			client.DefaultRegionColumn(false),

--- a/plugins/source/aws/resources/services/ses/configuration_set_event_destinations.go
+++ b/plugins/source/aws/resources/services/ses/configuration_set_event_destinations.go
@@ -18,7 +18,6 @@ func configurationSetEventDestinations() *schema.Table {
 		Description: `https://docs.aws.amazon.com/ses/latest/APIReference-V2/API_EventDestination.html`,
 		Resolver:    fetchSesConfigurationSetEventDestinations,
 		Transform:   transformers.TransformWithStruct(&types.EventDestination{}),
-		Multiplex:   client.ServiceAccountRegionMultiplexer(tableName, "email"),
 		Columns: []schema.Column{
 			client.DefaultAccountIDColumn(true),
 			client.DefaultRegionColumn(true),

--- a/plugins/source/aws/resources/services/ssm/instance_compliance_items.go
+++ b/plugins/source/aws/resources/services/ssm/instance_compliance_items.go
@@ -18,7 +18,6 @@ func instanceComplianceItems() *schema.Table {
 		Description: `https://docs.aws.amazon.com/systems-manager/latest/APIReference/API_ComplianceItem.html`,
 		Resolver:    fetchSsmInstanceComplianceItems,
 		Transform:   transformers.TransformWithStruct(&types.ComplianceItem{}),
-		Multiplex:   client.ServiceAccountRegionMultiplexer(tableName, "ssm"),
 		Columns: []schema.Column{
 			client.DefaultAccountIDColumn(false),
 			client.DefaultRegionColumn(false),

--- a/plugins/source/aws/resources/services/ssm/instance_patches.go
+++ b/plugins/source/aws/resources/services/ssm/instance_patches.go
@@ -18,7 +18,6 @@ func instancePatches() *schema.Table {
 		Description: `https://docs.aws.amazon.com/systems-manager/latest/APIReference/API_PatchComplianceData.html`,
 		Resolver:    fetchSsmInstancePatches,
 		Transform:   transformers.TransformWithStruct(&types.PatchComplianceData{}),
-		Multiplex:   client.ServiceAccountRegionMultiplexer(tableName, "ssm"),
 		Columns: []schema.Column{
 			client.DefaultAccountIDColumn(false),
 			client.DefaultRegionColumn(false),

--- a/plugins/source/aws/resources/services/stepfunctions/executions.go
+++ b/plugins/source/aws/resources/services/stepfunctions/executions.go
@@ -19,7 +19,6 @@ func executions() *schema.Table {
 		Resolver:            fetchStepfunctionsExecutions,
 		PreResourceResolver: getExecution,
 		Transform:           transformers.TransformWithStruct(&sfn.DescribeExecutionOutput{}, transformers.WithSkipFields("ResultMetadata")),
-		Multiplex:           client.ServiceAccountRegionMultiplexer(tableName, "states"),
 		Columns: []schema.Column{
 			client.DefaultAccountIDColumn(false),
 			client.DefaultRegionColumn(false),

--- a/plugins/source/aws/resources/services/stepfunctions/executions_map_runs.go
+++ b/plugins/source/aws/resources/services/stepfunctions/executions_map_runs.go
@@ -19,7 +19,6 @@ func mapRuns() *schema.Table {
 		Resolver:            fetchStepfunctionsMapRuns,
 		PreResourceResolver: getMapRun,
 		Transform:           transformers.TransformWithStruct(&sfn.DescribeMapRunOutput{}, transformers.WithSkipFields("ResultMetadata")),
-		Multiplex:           client.ServiceAccountRegionMultiplexer(tableName, "states"),
 		Columns: []schema.Column{
 			client.DefaultAccountIDColumn(false),
 			client.DefaultRegionColumn(false),

--- a/plugins/source/aws/resources/services/stepfunctions/executions_map_runs_executions.go
+++ b/plugins/source/aws/resources/services/stepfunctions/executions_map_runs_executions.go
@@ -18,7 +18,6 @@ func mapRunExecutions() *schema.Table {
 		Resolver:            fetchStepfunctionsMapRunExecutions,
 		PreResourceResolver: getExecution,
 		Transform:           transformers.TransformWithStruct(&sfn.DescribeExecutionOutput{}, transformers.WithSkipFields("ResultMetadata")),
-		Multiplex:           client.ServiceAccountRegionMultiplexer(tableName, "states"),
 		Columns: []schema.Column{
 			client.DefaultAccountIDColumn(false),
 			client.DefaultRegionColumn(false),

--- a/plugins/source/aws/resources/services/wellarchitected/lens_review_improvements.go
+++ b/plugins/source/aws/resources/services/wellarchitected/lens_review_improvements.go
@@ -19,8 +19,7 @@ func lensReviewImprovements() *schema.Table {
 		Transform: transformers.TransformWithStruct(new(types.ImprovementSummary),
 			transformers.WithPrimaryKeys("PillarId", "QuestionId"),
 		),
-		Multiplex: client.ServiceAccountRegionMultiplexer(name, "wellarchitected"),
-		Resolver:  fetchLensReviewImprovements,
+		Resolver: fetchLensReviewImprovements,
 		Columns: schema.ColumnList{
 			client.DefaultAccountIDColumn(false),
 			client.DefaultRegionColumn(false),

--- a/plugins/source/aws/resources/services/wellarchitected/lens_reviews.go
+++ b/plugins/source/aws/resources/services/wellarchitected/lens_reviews.go
@@ -19,8 +19,7 @@ func lensReviews() *schema.Table {
 		Transform: transformers.TransformWithStruct(new(types.LensReview),
 			transformers.WithPrimaryKeys("LensAlias"),
 		),
-		Multiplex: client.ServiceAccountRegionMultiplexer(name, "wellarchitected"),
-		Resolver:  fetchLensReviews,
+		Resolver: fetchLensReviews,
 		Columns: schema.ColumnList{
 			client.DefaultAccountIDColumn(false),
 			client.DefaultRegionColumn(false),

--- a/plugins/source/aws/resources/services/wellarchitected/workload_milestones.go
+++ b/plugins/source/aws/resources/services/wellarchitected/workload_milestones.go
@@ -21,8 +21,7 @@ func workloadMilestones() *schema.Table {
 			transformers.WithUnwrapAllEmbeddedStructs(),
 			transformers.WithSkipFields("WorkloadSummary"),
 		),
-		Multiplex: client.ServiceAccountRegionMultiplexer(name, "wellarchitected"),
-		Resolver:  fetchWorkloadMilestones,
+		Resolver: fetchWorkloadMilestones,
 		Columns: schema.ColumnList{
 			client.DefaultAccountIDColumn(false),
 			client.DefaultRegionColumn(false),

--- a/plugins/source/aws/resources/services/wellarchitected/workload_shares.go
+++ b/plugins/source/aws/resources/services/wellarchitected/workload_shares.go
@@ -19,8 +19,7 @@ func workloadShares() *schema.Table {
 		Transform: transformers.TransformWithStruct(new(types.WorkloadShareSummary),
 			transformers.WithPrimaryKeys("ShareId"),
 		),
-		Multiplex: client.ServiceAccountRegionMultiplexer(name, "wellarchitected"),
-		Resolver:  fetchWorkloadShares,
+		Resolver: fetchWorkloadShares,
 		Columns: schema.ColumnList{
 			client.DefaultAccountIDColumn(false),
 			client.DefaultRegionColumn(false),


### PR DESCRIPTION
<!-- 🎉 Thank you for making CloudQuery awesome by submitting a PR 🎉 -->

#### Summary

This PR adds back the `tag` validation test and validates that relation tables should not have a multiplexer set