### PR TITLE
fix(aws): Make S3 column resolvers non-blocking

### DIFF
--- a/plugins/source/aws/resources/services/s3/buckets.go
+++ b/plugins/source/aws/resources/services/s3/buckets.go
@@ -109,11 +109,11 @@ func resolveS3BucketsAttributes(ctx context.Context, meta schema.ClientMeta, r *
 	}
 	for _, resolver := range resolvers {
 		if err := resolver(ctx, meta, resource); err != nil {
-			r.Item = resource
 			if isBucketNotFoundError(cl, err) {
+				r.Item = resource
 				return nil
 			}
-			// This enables 403 errors to be recorded, but not block subsequent
+			// This enables 403 errors to be recorded, but not block subsequent resolver calls
 			errAll = errors.Join(errAll, err)
 		}
 	}

--- a/plugins/source/aws/resources/services/s3/buckets.go
+++ b/plugins/source/aws/resources/services/s3/buckets.go
@@ -95,7 +95,7 @@ func resolveS3BucketsAttributes(ctx context.Context, meta schema.ClientMeta, r *
 	if output != nil && output.LocationConstraint != "" {
 		resource.Region = string(output.LocationConstraint)
 	}
-	var errAll error
+	var errAll []error
 
 	resolvers := []func(context.Context, schema.ClientMeta, *models.WrappedBucket) error{
 		resolveBucketLogging,
@@ -116,11 +116,11 @@ func resolveS3BucketsAttributes(ctx context.Context, meta schema.ClientMeta, r *
 				return nil
 			}
 			// This enables 403 errors to be recorded, but not block subsequent resolver calls
-			errAll = errors.Join(errAll, err)
+			errAll = append(errAll, err)
 		}
 	}
 	r.Item = resource
-	return errAll
+	return errors.Join(errAll...)
 }
 
 func resolveBucketLogging(ctx context.Context, meta schema.ClientMeta, resource *models.WrappedBucket) error {

--- a/plugins/source/aws/resources/services/s3/buckets.go
+++ b/plugins/source/aws/resources/services/s3/buckets.go
@@ -109,6 +109,8 @@ func resolveS3BucketsAttributes(ctx context.Context, meta schema.ClientMeta, r *
 	}
 	for _, resolver := range resolvers {
 		if err := resolver(ctx, meta, resource); err != nil {
+			// If we received any error other than NoSuchBucketError, we return as this indicates that the bucket has been deleted
+			// and therefore no other attributes can be resolved
 			if isBucketNotFoundError(cl, err) {
 				r.Item = resource
 				return nil


### PR DESCRIPTION
<!-- 🎉 Thank you for making CloudQuery awesome by submitting a PR 🎉 -->

#### Summary
closes #12163 

Now that we are using go v1.20 we can use the `err.join` that allows us to group errors together. 

S3 columns are resolved sequentially by grouping errors we can try each one and return all of the errors at once