### PR TITLE
chore(deps): Disable `plugin-pb-go` dep updates in plugins

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -20,6 +20,11 @@
       matchPackageNames: ["github.com/jackc/pgx/v4"],
       allowedVersions: "<5",
     },
+    {
+      matchPackageNames: ["github.com/cloudquery/plugin-pb-go"],
+      matchFileNames: ["plugins/**"],
+      enabled: false,
+    },
   ],
   ignorePaths: [],
   gomod: {


### PR DESCRIPTION
<!-- 🎉 Thank you for making CloudQuery awesome by submitting a PR 🎉 -->

#### Summary

This should reduce the noise of PRs such as https://github.com/cloudquery/cloudquery/pull/12166 by not updating `plugin-pb-go` in plugins. `plugin-pb-go` is an indirect dependency for plugins and should be updated via the SDK anyways.

<!--
Use the following steps to ensure your PR is ready to be reviewed

- [ ] Read the [contribution guidelines](../blob/main/CONTRIBUTING.md) 🧑‍🎓
- [ ] Run `make lint` to ensure the proposed changes follow the coding style 🚨 (install golangci-lint [here](https://golangci-lint.run/usage/install/#local-installation))
- [ ] Run `make test` to ensure the proposed changes pass the tests 🧪
- [ ] If changing a source plugin run `make gen` to ensure docs are up to date 📝
- [ ] Ensure the status checks below are successful ✅
--->
