### PR TITLE
chore(website): Exclude Regex101 from broken links check

### DIFF
--- a/.github/workflows/broken_links.yml
+++ b/.github/workflows/broken_links.yml
@@ -89,5 +89,6 @@ jobs:
             --exclude localhost \
             --exclude twitter.com \
             --exclude mongodb.com \
+            --exclude regex101.com \
             ${{ steps.vercel.outputs.url }} \
             | grep -v '───OK───' | grep -v '──SKIP──' | grep -v '0 broken'

--- a/website/pages/how-to-guides/update-plugins-using-renovate.mdx
+++ b/website/pages/how-to-guides/update-plugins-using-renovate.mdx
@@ -72,7 +72,7 @@ You can see that we have three 'keys', meaning fields that are static across all
 
 Now that we've identified the fields we need to extract from the configuration file to create the custom regex, next we need to construct the regex statement to extract those 'keys' into named capture groups.
 
-For this it's recommended to use a regex testing tool to ensure your regex is actually working. Regex101 is a popular one but feel free to use any others as long as they support the PCRE2 regex engine. So taking our sample configuration file from above, we begin to play around with various regex until we meet the following criteria:
+For this it's recommended to use a regex testing tool to ensure your regex is actually working. [Regex101](https://regex101.com/) is a popular one but feel free to use any others as long as they support the PCRE2 regex engine. So taking our sample configuration file from above, we begin to play around with various regex until we meet the following criteria:
 
 - a named capture group for the plugin type (source or destination) which we will reference as 'kind' in this tutorial.
 - a named capture group for the plugin name (aws, gcp, etc..) which we will reference as 'plugin' in this tutorial.

--- a/website/pages/how-to-guides/update-plugins-using-renovate.mdx
+++ b/website/pages/how-to-guides/update-plugins-using-renovate.mdx
@@ -72,7 +72,7 @@ You can see that we have three 'keys', meaning fields that are static across all
 
 Now that we've identified the fields we need to extract from the configuration file to create the custom regex, next we need to construct the regex statement to extract those 'keys' into named capture groups.
 
-For this it's recommended to use a regex testing tool to ensure your regex is actually working. [Regex101](https://regex101.com/) is a popular one but feel free to use any others as long as they support the PCRE2 regex engine. So taking our sample configuration file from above, we begin to play around with various regex until we meet the following criteria:
+For this it's recommended to use a regex testing tool to ensure your regex is actually working. Regex101 is a popular one but feel free to use any others as long as they support the PCRE2 regex engine. So taking our sample configuration file from above, we begin to play around with various regex until we meet the following criteria:
 
 - a named capture group for the plugin type (source or destination) which we will reference as 'kind' in this tutorial.
 - a named capture group for the plugin name (aws, gcp, etc..) which we will reference as 'plugin' in this tutorial.


### PR DESCRIPTION
The regex101 site has been down on and off for at least a week now and it affects our broken links checker. I think let's exclude it from the checks for the time being. Time will tell whether regex101 will come back online or not