### PR TITLE
fix: Filter tables in Tables function

### DIFF
--- a/plugins/source/oracledb/client/client.go
+++ b/plugins/source/oracledb/client/client.go
@@ -63,7 +63,7 @@ func Configure(ctx context.Context, logger zerolog.Logger, spec []byte, opts plu
 }
 
 func (c Client) Tables(ctx context.Context, opts plugin.TableOptions) (schema.Tables, error) {
-	return c.tables, nil
+	return c.tables.FilterDfs(opts.Tables, opts.SkipTables, opts.SkipDependentTables)
 }
 
 func (c Client) Close(_ context.Context) error {


### PR DESCRIPTION
<!-- 🎉 Thank you for making CloudQuery awesome by submitting a PR 🎉 -->

#### Summary

I missed this in https://github.com/cloudquery/cloudquery/pull/11711.
Without this fix we will always migrate all tables. The sync still works on the filtered tables, so this only impacts migration

<!--
Use the following steps to ensure your PR is ready to be reviewed

- [ ] Read the [contribution guidelines](../blob/main/CONTRIBUTING.md) 🧑‍🎓
- [ ] Run `make lint` to ensure the proposed changes follow the coding style 🚨 (install golangci-lint [here](https://golangci-lint.run/usage/install/#local-installation))
- [ ] Run `make test` to ensure the proposed changes pass the tests 🧪
- [ ] If changing a source plugin run `make gen` to ensure docs are up to date 📝
- [ ] Ensure the status checks below are successful ✅
--->
