### PR TITLE
fix(broken-links-checker): Exclude `register_for_cloud`

### DIFF
--- a/.github/workflows/broken_links.yml
+++ b/.github/workflows/broken_links.yml
@@ -76,6 +76,7 @@ jobs:
             --exclude "${{ steps.vercel.outputs.url }}/integrations/*" \
             --exclude "${{ steps.vercel.outputs.url }}/buy/*" \
             --exclude "${{ steps.vercel.outputs.url }}/contact" \
+            --exclude "${{ steps.vercel.outputs.url }}/register_for_cloud" \
             --exclude linkedin \
             --exclude cloudquery.io/discord \
             --exclude cloudquery.io/buy \


### PR DESCRIPTION
<!-- 🎉 Thank you for making CloudQuery awesome by submitting a PR 🎉 -->

#### Summary

Our broken links checker considers redirects as broken links, so we need to exclude them.

<!--
Use the following steps to ensure your PR is ready to be reviewed

- [ ] Read the [contribution guidelines](../blob/main/CONTRIBUTING.md) 🧑‍🎓
- [ ] Run `make lint` to ensure the proposed changes follow the coding style 🚨 (install golangci-lint [here](https://golangci-lint.run/usage/install/#local-installation))
- [ ] Run `make test` to ensure the proposed changes pass the tests 🧪
- [ ] If changing a source plugin run `make gen` to ensure docs are up to date 📝
- [ ] Ensure the status checks below are successful ✅
--->
