### PR TITLE
feat(aws)!: Define composite primary key for lambda_function_versions

### DIFF
--- a/plugins/source/aws/resources/services/lambda/function_versions.go
+++ b/plugins/source/aws/resources/services/lambda/function_versions.go
@@ -17,7 +17,7 @@ func functionVersions() *schema.Table {
 		Name:        tableName,
 		Description: `https://docs.aws.amazon.com/lambda/latest/dg/API_FunctionConfiguration.html`,
 		Resolver:    fetchLambdaFunctionVersions,
-		Transform:   transformers.TransformWithStruct(&types.FunctionConfiguration{}),
+		Transform:   transformers.TransformWithStruct(&types.FunctionConfiguration{}, transformers.WithPrimaryKeys("Version")),
 		Columns: []schema.Column{
 			client.DefaultAccountIDColumn(false),
 			client.DefaultRegionColumn(false),
@@ -25,6 +25,7 @@ func functionVersions() *schema.Table {
 				Name:     "function_arn",
 				Type:     arrow.BinaryTypes.String,
 				Resolver: schema.ParentColumnResolver("arn"),
+				PrimaryKey: true,
 			},
 		},
 	}

--- a/plugins/source/aws/resources/services/lambda/function_versions.go
+++ b/plugins/source/aws/resources/services/lambda/function_versions.go
@@ -22,9 +22,9 @@ func functionVersions() *schema.Table {
 			client.DefaultAccountIDColumn(false),
 			client.DefaultRegionColumn(false),
 			{
-				Name:     "function_arn",
-				Type:     arrow.BinaryTypes.String,
-				Resolver: schema.ParentColumnResolver("arn"),
+				Name:       "function_arn",
+				Type:       arrow.BinaryTypes.String,
+				Resolver:   schema.ParentColumnResolver("arn"),
 				PrimaryKey: true,
 			},
 		},

--- a/website/tables/aws/aws_lambda_function_versions.md
+++ b/website/tables/aws/aws_lambda_function_versions.md
@@ -4,7 +4,7 @@ This table shows data for AWS Lambda Function Versions.
 
 https://docs.aws.amazon.com/lambda/latest/dg/API_FunctionConfiguration.html
 
-The primary key for this table is **_cq_id**.
+The composite primary key for this table is (**function_arn**, **version**).
 
 ## Relations
 
@@ -14,11 +14,11 @@ This table depends on [aws_lambda_functions](aws_lambda_functions).
 
 | Name          | Type          |
 | ------------- | ------------- |
-|_cq_id (PK)|`uuid`|
+|_cq_id|`uuid`|
 |_cq_parent_id|`uuid`|
 |account_id|`utf8`|
 |region|`utf8`|
-|function_arn|`utf8`|
+|function_arn (PK)|`utf8`|
 |architectures|`list<item: utf8, nullable>`|
 |code_sha256|`utf8`|
 |code_size|`int64`|
@@ -51,5 +51,5 @@ This table depends on [aws_lambda_functions](aws_lambda_functions).
 |state_reason_code|`utf8`|
 |timeout|`int64`|
 |tracing_config|`json`|
-|version|`utf8`|
+|version (PK)|`utf8`|
 |vpc_config|`json`|


### PR DESCRIPTION
<!-- 🎉 Thank you for making CloudQuery awesome by submitting a PR 🎉 -->

#### Summary

This PR is aimed to address #12391 by creating a composite primary key on `aws_lambda_function_versions` table comprising `function_arn` and `version`.

Since `function_arn` will always be unique, `account_id` or `region` are not required to be part of the primary key.

#### Summary

This is my first PR against the codebase, extra pair of eyes are highly recommended!