### PR TITLE
feat(aws)!: Define primary key for s3_bucket_encryption_rules

### DIFF
--- a/plugins/source/aws/resources/services/s3/bucket_encryption_rules.go
+++ b/plugins/source/aws/resources/services/s3/bucket_encryption_rules.go
@@ -22,9 +22,10 @@ func bucketEncryptionRules() *schema.Table {
 		Columns: []schema.Column{
 			client.DefaultAccountIDColumn(false),
 			{
-				Name:     "bucket_arn",
-				Type:     arrow.BinaryTypes.String,
-				Resolver: schema.ParentColumnResolver("arn"),
+				Name:       "bucket_arn",
+				Type:       arrow.BinaryTypes.String,
+				Resolver:   schema.ParentColumnResolver("arn"),
+				PrimaryKey: true,
 			},
 		},
 	}

--- a/website/tables/aws/aws_s3_bucket_encryption_rules.md
+++ b/website/tables/aws/aws_s3_bucket_encryption_rules.md
@@ -4,7 +4,7 @@ This table shows data for S3 Bucket Encryption Rules.
 
 https://docs.aws.amazon.com/AmazonS3/latest/API/API_ServerSideEncryptionRule.html
 
-The primary key for this table is **_cq_id**.
+The primary key for this table is **bucket_arn**.
 
 ## Relations
 
@@ -14,10 +14,10 @@ This table depends on [aws_s3_buckets](aws_s3_buckets).
 
 | Name          | Type          |
 | ------------- | ------------- |
-|_cq_id (PK)|`uuid`|
+|_cq_id|`uuid`|
 |_cq_parent_id|`uuid`|
 |account_id|`utf8`|
-|bucket_arn|`utf8`|
+|bucket_arn (PK)|`utf8`|
 |apply_server_side_encryption_by_default|`json`|
 |bucket_key_enabled|`bool`|
 


### PR DESCRIPTION
<!-- 🎉 Thank you for making CloudQuery awesome by submitting a PR 🎉 -->

#### Summary

This PR is aimed to address #12392 by creating a primary key (`bucket_arn`) on `aws_s3_bucket_encryption_rules` table.
