### PR TITLE
feat(aws)!: Define primary key for dynamodb_table_continuous_backups

### DIFF
--- a/plugins/source/aws/resources/services/dynamodb/table_continuous_backups.go
+++ b/plugins/source/aws/resources/services/dynamodb/table_continuous_backups.go
@@ -19,9 +19,10 @@ func tableContinuousBackups() *schema.Table {
 			client.DefaultAccountIDColumn(false),
 			client.DefaultRegionColumn(false),
 			{
-				Name:     "table_arn",
-				Type:     arrow.BinaryTypes.String,
-				Resolver: schema.ParentColumnResolver("arn"),
+				Name:       "table_arn",
+				Type:       arrow.BinaryTypes.String,
+				Resolver:   schema.ParentColumnResolver("arn"),
+				PrimaryKey: true,
 			},
 		},
 	}

--- a/website/tables/aws/aws_dynamodb_table_continuous_backups.md
+++ b/website/tables/aws/aws_dynamodb_table_continuous_backups.md
@@ -4,7 +4,7 @@ This table shows data for Amazon DynamoDB Table Continuous Backups.
 
 https://docs.aws.amazon.com/amazondynamodb/latest/APIReference/API_ContinuousBackupsDescription.html
 
-The primary key for this table is **_cq_id**.
+The primary key for this table is **table_arn**.
 
 ## Relations
 
@@ -14,11 +14,11 @@ This table depends on [aws_dynamodb_tables](aws_dynamodb_tables).
 
 | Name          | Type          |
 | ------------- | ------------- |
-|_cq_id (PK)|`uuid`|
+|_cq_id|`uuid`|
 |_cq_parent_id|`uuid`|
 |account_id|`utf8`|
 |region|`utf8`|
-|table_arn|`utf8`|
+|table_arn (PK)|`utf8`|
 |continuous_backups_status|`utf8`|
 |point_in_time_recovery_description|`json`|
 


### PR DESCRIPTION
<!-- 🎉 Thank you for making CloudQuery awesome by submitting a PR 🎉 -->

#### Summary

This PR is aimed to address #12395 by creating a primary key (`table_arn`) on `aws_dynamodb_table_continuous_backups` table.