### PR TITLE
fix(snowflake)!: Make all quoted column names uppercase to support unquoted queries

### DIFF
--- a/plugins/destination/snowflake/client/deletestale.go
+++ b/plugins/destination/snowflake/client/deletestale.go
@@ -15,9 +15,9 @@ func (c *Client) DeleteStale(ctx context.Context, msgs message.WriteDeleteStales
 		sb.WriteString("delete from ")
 		sb.WriteString(tableName)
 		sb.WriteString(" where ")
-		sb.WriteString(`"` + schema.CqSourceNameColumn.Name + `"`)
+		sb.WriteString(`"` + strings.ToUpper(schema.CqSourceNameColumn.Name) + `"`)
 		sb.WriteString(" = ? and \"")
-		sb.WriteString(schema.CqSyncTimeColumn.Name)
+		sb.WriteString(strings.ToUpper(schema.CqSyncTimeColumn.Name))
 		sb.WriteString("\"::timestamp_tz < ?::timestamp_tz")
 		sql := sb.String()
 		if _, err := c.db.ExecContext(ctx, sql, msg.SourceName, msg.SyncTime); err != nil {

--- a/plugins/destination/snowflake/client/deletestale.go
+++ b/plugins/destination/snowflake/client/deletestale.go
@@ -15,10 +15,10 @@ func (c *Client) DeleteStale(ctx context.Context, msgs message.WriteDeleteStales
 		sb.WriteString("delete from ")
 		sb.WriteString(tableName)
 		sb.WriteString(" where ")
-		sb.WriteString(schema.CqSourceNameColumn.Name)
-		sb.WriteString(" = ? and ")
-		sb.WriteString(schema.CqSyncTimeColumn.Name)
-		sb.WriteString("::timestamp_tz < ?::timestamp_tz")
+		sb.WriteString(`"` + strings.ToUpper(schema.CqSourceNameColumn.Name) + `"`)
+		sb.WriteString(" = ? and \"")
+		sb.WriteString(strings.ToUpper(schema.CqSyncTimeColumn.Name))
+		sb.WriteString("\"::timestamp_tz < ?::timestamp_tz")
 		sql := sb.String()
 		if _, err := c.db.ExecContext(ctx, sql, msg.SourceName, msg.SyncTime); err != nil {
 			return err

--- a/plugins/destination/snowflake/client/deletestale.go
+++ b/plugins/destination/snowflake/client/deletestale.go
@@ -15,10 +15,10 @@ func (c *Client) DeleteStale(ctx context.Context, msgs message.WriteDeleteStales
 		sb.WriteString("delete from ")
 		sb.WriteString(tableName)
 		sb.WriteString(" where ")
-		sb.WriteString(`"` + strings.ToUpper(schema.CqSourceNameColumn.Name) + `"`)
-		sb.WriteString(" = ? and \"")
-		sb.WriteString(strings.ToUpper(schema.CqSyncTimeColumn.Name))
-		sb.WriteString("\"::timestamp_tz < ?::timestamp_tz")
+		sb.WriteString(schema.CqSourceNameColumn.Name)
+		sb.WriteString(" = ? and ")
+		sb.WriteString(schema.CqSyncTimeColumn.Name)
+		sb.WriteString("::timestamp_tz < ?::timestamp_tz")
 		sql := sb.String()
 		if _, err := c.db.ExecContext(ctx, sql, msg.SourceName, msg.SyncTime); err != nil {
 			return err

--- a/plugins/destination/snowflake/client/migrate.go
+++ b/plugins/destination/snowflake/client/migrate.go
@@ -115,7 +115,7 @@ func (c *Client) autoMigrateTable(ctx context.Context, table *schema.Table) erro
 			return fmt.Errorf("column %s on table %s has different type than schema, expected %s got %s. Try dropping the column and re-running", col.Name, tableName, columnType, snowflakeColumn.typ)
 		case snowflakeColumn.name != columnName: // case sensitivity
 			c.logger.Debug().Str("table", tableName).Str("column", columnName).Str("current_name", snowflakeColumn.name).Msg("Column name doesn't match, migrating")
-			sql := fmt.Sprintf("alter table %s rename column %q TO %q", tableName, snowflakeColumn.name, columnName)
+			sql := fmt.Sprintf("alter table %s rename column %q TO %s", tableName, snowflakeColumn.name, columnName)
 			if _, err := c.db.ExecContext(ctx, sql); err != nil {
 				return fmt.Errorf("failed to rename column %s on table %s: %w", snowflakeColumn.name, tableName, err)
 			}
@@ -136,7 +136,7 @@ func (c *Client) createTableIfNotExist(ctx context.Context, table *schema.Table)
 	for i, col := range table.Columns {
 		sqlType := c.SchemaTypeToSnowflake(col.Type)
 		// TODO: sanitize column name
-		fieldDef := `"` + strings.ToUpper(col.Name) + `" ` + sqlType
+		fieldDef := col.Name + " " + sqlType
 		if col.Name == schema.CqIDColumn.Name {
 			// _cq_id column should always have a "unique not null" constraint
 			fieldDef += " UNIQUE NOT NULL"

--- a/plugins/destination/snowflake/client/migrate.go
+++ b/plugins/destination/snowflake/client/migrate.go
@@ -115,7 +115,7 @@ func (c *Client) autoMigrateTable(ctx context.Context, table *schema.Table) erro
 			return fmt.Errorf("column %s on table %s has different type than schema, expected %s got %s. Try dropping the column and re-running", col.Name, tableName, columnType, snowflakeColumn.typ)
 		case snowflakeColumn.name != columnName: // case sensitivity
 			c.logger.Debug().Str("table", tableName).Str("column", columnName).Str("current_name", snowflakeColumn.name).Msg("Column name doesn't match, migrating")
-			sql := fmt.Sprintf("alter table %s rename column %q TO %s", tableName, snowflakeColumn.name, columnName)
+			sql := fmt.Sprintf("alter table %s rename column %q TO %q", tableName, snowflakeColumn.name, columnName)
 			if _, err := c.db.ExecContext(ctx, sql); err != nil {
 				return fmt.Errorf("failed to rename column %s on table %s: %w", snowflakeColumn.name, tableName, err)
 			}
@@ -136,7 +136,7 @@ func (c *Client) createTableIfNotExist(ctx context.Context, table *schema.Table)
 	for i, col := range table.Columns {
 		sqlType := c.SchemaTypeToSnowflake(col.Type)
 		// TODO: sanitize column name
-		fieldDef := col.Name + " " + sqlType
+		fieldDef := `"` + strings.ToUpper(col.Name) + `" ` + sqlType
 		if col.Name == schema.CqIDColumn.Name {
 			// _cq_id column should always have a "unique not null" constraint
 			fieldDef += " UNIQUE NOT NULL"

--- a/plugins/destination/snowflake/client/read.go
+++ b/plugins/destination/snowflake/client/read.go
@@ -182,7 +182,7 @@ func (c *Client) Read(ctx context.Context, table *schema.Table, res chan<- arrow
 	tableName := table.Name
 	colNames := make([]string, 0, len(table.Columns))
 	for _, col := range table.Columns {
-		colNames = append(colNames, `"`+col.Name+`"`)
+		colNames = append(colNames, `"`+strings.ToUpper(col.Name)+`"`)
 	}
 	cols := strings.Join(colNames, ", ")
 	stmt := fmt.Sprintf(readSQL, cols, tableName)

--- a/plugins/destination/snowflake/client/write.go
+++ b/plugins/destination/snowflake/client/write.go
@@ -39,10 +39,11 @@ func (c *Client) WriteTableBatch(ctx context.Context, name string, msgs message.
 		os.Remove(f.Name())
 	}()
 
+	enc := json.NewEncoder(f)
+	enc.SetEscapeHTML(false)
+
 	for _, r := range msgs {
 		arr := array.RecordToStructArray(r.Record)
-		enc := json.NewEncoder(f)
-		enc.SetEscapeHTML(false)
 		for i := 0; i < arr.Len(); i++ {
 			if err := enc.Encode(arr.GetOneForMarshal(i)); err != nil {
 				return err


### PR DESCRIPTION
In Snowflake, quoted uppercase column names are treated as case insensitive as opposed to quoted lowercase names. Lowercase ("cased") column names need to be quoted every time they are referred, uppercase column names don't need to be.

- This PR updates every column from `"column_name"` to be `"COLUMN_NAME"` so they can be queried without quotes.
- Migration improvements:
  - Table listing is limited to current schema (instead of whole database) and it will list the tables just once per migrate batch, instead of running that query for each table separately.
  - If multiple-cased versions of the same column exist (for instance because of running the older Snowflake plugin again, after the migration by this PR) it will auto-correct by dropping the mismatching columns if `migrate_mode: forced` is set.
  - If the type of a column has changed, it will suggest using `migrate_mode: forced` (and if its enabled it will automatically drop the column) 