### PR TITLE
feat(migrate): Add `migrate_concurrency`

### DIFF
--- a/plugins/destination/snowflake/client/migrate.go
+++ b/plugins/destination/snowflake/client/migrate.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/cloudquery/plugin-sdk/v4/message"
 	"github.com/cloudquery/plugin-sdk/v4/schema"
+	"golang.org/x/sync/errgroup"
 )
 
 const (
@@ -40,23 +41,30 @@ func (c *Client) MigrateTables(ctx context.Context, msgs message.WriteMigrateTab
 		return fmt.Errorf("failed to get list of tables: %w", err)
 	}
 
+	g, gctx := errgroup.WithContext(ctx)
+	g.SetLimit(c.spec.MigrateConcurrency)
 	for _, msg := range msgs {
 		table := msg.Table
+		migrateForce := msg.MigrateForce
 		tableName := table.Name
-		c.logger.Debug().Str("table", tableName).Msg("Migrating table")
-		if tableExists(tableList, tableName) {
-			c.logger.Debug().Str("table", tableName).Msg("Table exists, auto-migrating")
-			if err := c.autoMigrateTable(ctx, table, msg.MigrateForce); err != nil {
-				return err
+		g.Go(func() error {
+			c.logger.Debug().Str("table", tableName).Msg("Migrating table")
+			if tableExists(tableList, tableName) {
+				c.logger.Debug().Str("table", tableName).Msg("Table exists, auto-migrating")
+				if err := c.autoMigrateTable(gctx, table, migrateForce); err != nil {
+					return err
+				}
+			} else {
+				c.logger.Debug().Str("table", tableName).Msg("Table doesn't exist, creating")
+				if err := c.createTableIfNotExist(gctx, table); err != nil {
+					return err
+				}
 			}
-		} else {
-			c.logger.Debug().Str("table", tableName).Msg("Table doesn't exist, creating")
-			if err := c.createTableIfNotExist(ctx, table); err != nil {
-				return err
-			}
-		}
+			return nil
+		})
+
 	}
-	return nil
+	return g.Wait()
 }
 
 func (c *Client) listTables(ctx context.Context) ([]string, error) {

--- a/plugins/destination/snowflake/client/migrate.go
+++ b/plugins/destination/snowflake/client/migrate.go
@@ -62,7 +62,6 @@ func (c *Client) MigrateTables(ctx context.Context, msgs message.WriteMigrateTab
 			}
 			return nil
 		})
-
 	}
 	return g.Wait()
 }

--- a/plugins/destination/snowflake/client/spec.go
+++ b/plugins/destination/snowflake/client/spec.go
@@ -3,14 +3,16 @@ package client
 import "fmt"
 
 const (
-	defaultBatchSize      = 1000
-	defaultBatchSizeBytes = 4 * 1024 * 1024
+	defaultBatchSize          = 1000
+	defaultBatchSizeBytes     = 4 * 1024 * 1024
+	defaultMigrateConcurrency = 1
 )
 
 type Spec struct {
-	ConnectionString string `json:"connection_string,omitempty"`
-	BatchSize        int    `json:"batch_size,omitempty"`
-	BatchSizeBytes   int    `json:"batch_size_bytes,omitempty"`
+	ConnectionString   string `json:"connection_string,omitempty"`
+	BatchSize          int    `json:"batch_size,omitempty"`
+	BatchSizeBytes     int    `json:"batch_size_bytes,omitempty"`
+	MigrateConcurrency int    `json:"migrate_concurrency,omitempty"`
 }
 
 func (s *Spec) SetDefaults() {
@@ -20,6 +22,9 @@ func (s *Spec) SetDefaults() {
 	}
 	if s.BatchSizeBytes == 0 {
 		s.BatchSizeBytes = defaultBatchSizeBytes
+	}
+	if s.MigrateConcurrency == 0 {
+		s.MigrateConcurrency = defaultMigrateConcurrency
 	}
 }
 

--- a/website/pages/docs/plugins/destinations/snowflake/_configuration.mdx
+++ b/website/pages/docs/plugins/destinations/snowflake/_configuration.mdx
@@ -11,4 +11,5 @@ spec:
     connection_string: ${SNOWFLAKE_CONNECTION_STRING}
 #    batch_size: 1000 # optional
 #    batch_size_bytes: 4194304 # optional
+#    migrate_concurrency: 1 # optional
 ```

--- a/website/pages/docs/plugins/destinations/snowflake/overview.mdx
+++ b/website/pages/docs/plugins/destinations/snowflake/overview.mdx
@@ -58,6 +58,11 @@ This is the top level spec used by the Snowflake destination plugin.
 
   Number of bytes (as Arrow buffer size) to batch together before sending to the database.
 
+- `migrate_concurrency` (integer, optional. default: 1)
+
+  By default tables are migrated one at a time. This option allows you to migrate multiple tables concurrently. This can be useful if you have a lot of tables to migrate and want to speed up the process.
+  Setting this to a negative number means no limit.
+
 ## Underlying library
 
 We use the official [github.com/snowflakedb/gosnowflake](https://github.com/snowflakedb/gosnowflake) package for database connection.


### PR DESCRIPTION
<!-- 🎉 Thank you for making CloudQuery awesome by submitting a PR 🎉 -->

#### Summary

With no limit (negative value) I get on latest AWS:
```
go run main.go migrate examples/aws-to-snowflake.yml  1.14s user 0.73s system 4% cpu 45.335 total
```

With the default (1 table at the time):
```
go run main.go migrate examples/aws-to-snowflake.yml  1.33s user 0.83s system 0% cpu 11:42.94 total
```

I made the default 1 to avoid what could be considered a breaking change. We can change it later if we need to

<!--
Use the following steps to ensure your PR is ready to be reviewed

- [ ] Read the [contribution guidelines](../blob/main/CONTRIBUTING.md) 🧑‍🎓
- [ ] Run `make lint` to ensure the proposed changes follow the coding style 🚨 (install golangci-lint [here](https://golangci-lint.run/usage/install/#local-installation))
- [ ] Run `make test` to ensure the proposed changes pass the tests 🧪
- [ ] If changing a source plugin run `make gen` to ensure docs are up to date 📝
- [ ] Ensure the status checks below are successful ✅
--->
