### PR TITLE
fix(bigquery): Create less clients per dataset/table

### DIFF
--- a/plugins/source/gcp/resources/services/bigquery/datasets.go
+++ b/plugins/source/gcp/resources/services/bigquery/datasets.go
@@ -8,6 +8,11 @@ import (
 	pb "google.golang.org/api/bigquery/v2"
 )
 
+type datasetWrapper struct {
+	*pb.Dataset
+	svc *pb.Service
+}
+
 func Datasets() *schema.Table {
 	return &schema.Table{
 		Name:                "gcp_bigquery_datasets",
@@ -15,7 +20,7 @@ func Datasets() *schema.Table {
 		PreResourceResolver: datasetGet,
 		Resolver:            fetchDatasets,
 		Multiplex:           client.ProjectMultiplexEnabledServices("bigquery.googleapis.com"),
-		Transform:           client.TransformWithStruct(&pb.Dataset{}, transformers.WithPrimaryKeys("Id")),
+		Transform:           client.TransformWithStruct(&datasetWrapper{}, transformers.WithPrimaryKeys("Id"), transformers.WithUnwrapStructFields("Dataset")),
 		Columns: []schema.Column{
 			{
 				Name:       "project_id",

--- a/plugins/source/gcp/resources/services/bigquery/datasets_fetch.go
+++ b/plugins/source/gcp/resources/services/bigquery/datasets_fetch.go
@@ -47,6 +47,9 @@ func datasetGet(ctx context.Context, meta schema.ClientMeta, r *schema.Resource)
 	if err != nil {
 		return err
 	}
-	r.SetItem(item)
+	r.SetItem(&datasetWrapper{
+		Dataset: item,
+		svc:     wrapped.svc,
+	})
 	return nil
 }

--- a/plugins/source/gcp/resources/services/bigquery/datasets_fetch.go
+++ b/plugins/source/gcp/resources/services/bigquery/datasets_fetch.go
@@ -8,6 +8,11 @@ import (
 	"google.golang.org/api/bigquery/v2"
 )
 
+type datasetPreWrapper struct {
+	datasetID string
+	svc       *bigquery.Service
+}
+
 func fetchDatasets(ctx context.Context, meta schema.ClientMeta, r *schema.Resource, res chan<- any) error {
 	c := meta.(*client.Client)
 	nextPageToken := ""
@@ -20,7 +25,12 @@ func fetchDatasets(ctx context.Context, meta schema.ClientMeta, r *schema.Resour
 		if err != nil {
 			return err
 		}
-		res <- output.Datasets
+		for i := range output.Datasets {
+			res <- &datasetPreWrapper{
+				datasetID: output.Datasets[i].DatasetReference.DatasetId,
+				svc:       bigqueryService,
+			}
+		}
 
 		if output.NextPageToken == "" {
 			break
@@ -32,12 +42,8 @@ func fetchDatasets(ctx context.Context, meta schema.ClientMeta, r *schema.Resour
 
 func datasetGet(ctx context.Context, meta schema.ClientMeta, r *schema.Resource) error {
 	c := meta.(*client.Client)
-	datasetListDataset := r.Item.(*bigquery.DatasetListDatasets)
-	bigqueryService, err := bigquery.NewService(ctx, c.ClientOptions...)
-	if err != nil {
-		return err
-	}
-	item, err := bigqueryService.Datasets.Get(c.ProjectId, datasetListDataset.DatasetReference.DatasetId).Do()
+	wrapped := r.Item.(*datasetPreWrapper)
+	item, err := wrapped.svc.Datasets.Get(c.ProjectId, wrapped.datasetID).Context(ctx).Do()
 	if err != nil {
 		return err
 	}

--- a/plugins/source/gcp/resources/services/bigquery/datasets_mock_test.go
+++ b/plugins/source/gcp/resources/services/bigquery/datasets_mock_test.go
@@ -2,7 +2,6 @@ package bigquery
 
 import (
 	"encoding/json"
-	"fmt"
 	"net/http"
 	"testing"
 
@@ -111,8 +110,6 @@ func createBigqueryDatasets(mux *httprouter.Router) error {
 	}
 
 	mux.GET("/projects/testProject/datasets/testDataset/tables/:table", func(w http.ResponseWriter, r *http.Request, _ httprouter.Params) {
-		fmt.Println("what")
-		fmt.Println(r.URL)
 		b, err := json.Marshal(&table)
 		if err != nil {
 			http.Error(w, "unable to marshal request: "+err.Error(), http.StatusBadRequest)


### PR DESCRIPTION
Seems like we've been creating one extra client per dataset and then one extra client per table.

This PR changes it so that we're creating a single client for all datasets ~~, and another client for all tables per dataset~~ per multiplexer. Should help with the [429 errors](https://discord.com/channels/872925471417962546/873606591335759872/1132870724667834439) as each client authenticates again.

The PreResourceResolver pattern is only used in bigquery resources.