### PR TITLE
fix: Support syncing tables with a single column

### DIFF
--- a/plugins/source/postgresql/client/sync.go
+++ b/plugins/source/postgresql/client/sync.go
@@ -108,7 +108,7 @@ func (c *Client) syncTables(ctx context.Context, snapshotName string, filteredTa
 }
 
 func syncTable(ctx context.Context, tx pgx.Tx, table *schema.Table, res chan<- message.SyncMessage) error {
-	colNames := make([]string, 0, len(table.Columns)-2)
+	colNames := make([]string, 0, len(table.Columns))
 	for _, col := range table.Columns {
 		colNames = append(colNames, pgx.Identifier{col.Name}.Sanitize())
 	}


### PR DESCRIPTION
<!-- 🎉 Thank you for making CloudQuery awesome by submitting a PR 🎉 -->

#### Summary

Discovered this while working on https://github.com/cloudquery/cloudquery/issues/12524.
If the table has a single column the PostgreSQL source fails to sync it

<!--
Use the following steps to ensure your PR is ready to be reviewed

- [ ] Read the [contribution guidelines](../blob/main/CONTRIBUTING.md) 🧑‍🎓
- [ ] Run `make lint` to ensure the proposed changes follow the coding style 🚨 (install golangci-lint [here](https://golangci-lint.run/usage/install/#local-installation))
- [ ] Run `make test` to ensure the proposed changes pass the tests 🧪
- [ ] If changing a source plugin run `make gen` to ensure docs are up to date 📝
- [ ] Ensure the status checks below are successful ✅
--->
