### PR TITLE
feat: Support date types

### DIFF
--- a/plugins/destination/duckdb/client/client_test.go
+++ b/plugins/destination/duckdb/client/client_test.go
@@ -41,8 +41,6 @@ func TestPlugin(t *testing.T) {
 			SkipDurations: true,
 			SkipIntervals: true,
 			// not supported in duckDB for now
-			SkipTimes:      true,
-			SkipDates:      true,
 			SkipLargeTypes: true,
 		}),
 	)

--- a/plugins/destination/duckdb/client/read.go
+++ b/plugins/destination/duckdb/client/read.go
@@ -118,6 +118,12 @@ func reverseTransformArray(dt arrow.DataType, arr arrow.Array) arrow.Array {
 		return reverseTransformUint8(arr.(*array.Uint32))
 	case *arrow.TimestampType:
 		return transformTimestamp(dt, arr.(*array.Timestamp))
+	case *arrow.Date32Type:
+		// We save date types as Timestamp
+		return reverseTransformDate32(arr.(*array.Timestamp))
+	case *arrow.Date64Type:
+		// We save date types as Timestamp
+		return reverseTransformDate64(arr.(*array.Timestamp))
 	case *arrow.StructType:
 		arr := arr.(*array.Struct)
 		children := make([]arrow.ArrayData, arr.NumField())
@@ -183,6 +189,32 @@ func reverseTransformUint16(arr *array.Uint32) arrow.Array {
 			continue
 		}
 		builder.Append(uint16(arr.Value(i)))
+	}
+
+	return builder.NewArray()
+}
+
+func reverseTransformDate32(arr *array.Timestamp) arrow.Array {
+	builder := array.NewDate32Builder(memory.DefaultAllocator)
+	for i := 0; i < arr.Len(); i++ {
+		if arr.IsNull(i) {
+			builder.AppendNull()
+			continue
+		}
+		builder.Append(arrow.Date32FromTime(arr.Value(i).ToTime(arrow.Microsecond)))
+	}
+
+	return builder.NewArray()
+}
+
+func reverseTransformDate64(arr *array.Timestamp) arrow.Array {
+	builder := array.NewDate64Builder(memory.DefaultAllocator)
+	for i := 0; i < arr.Len(); i++ {
+		if arr.IsNull(i) {
+			builder.AppendNull()
+			continue
+		}
+		builder.Append(arrow.Date64FromTime(arr.Value(i).ToTime(arrow.Microsecond)))
 	}
 
 	return builder.NewArray()

--- a/plugins/destination/duckdb/client/transform.go
+++ b/plugins/destination/duckdb/client/transform.go
@@ -54,7 +54,10 @@ func transformArray(arr arrow.Array) arrow.Array {
 			[]arrow.ArrayData{transformArray(arr.ListValues()).Data()},
 			arr.NullN(), arr.Data().Offset(),
 		))
-
+	case *array.Date32:
+		return transformDate32ToTimestamp(arr)
+	case *array.Date64:
+		return transformDate64ToTimestamp(arr)
 	default:
 		return transformToStringArray(arr)
 	}
@@ -109,5 +112,29 @@ func transformTimestamp(dt *arrow.TimestampType, arr *array.Timestamp) arrow.Arr
 		builder.Append(arrow.Timestamp(arrow.ConvertTimestampValue(in, out, int64(arr.Value(i)))))
 	}
 
+	return builder.NewArray()
+}
+
+func transformDate32ToTimestamp(arr *array.Date32) arrow.Array {
+	builder := array.NewTimestampBuilder(memory.DefaultAllocator, &arrow.TimestampType{Unit: arrow.Microsecond, TimeZone: "UTC"})
+	for i := 0; i < arr.Len(); i++ {
+		if arr.IsNull(i) {
+			builder.AppendNull()
+			continue
+		}
+		builder.AppendTime(arr.Value(i).ToTime())
+	}
+	return builder.NewArray()
+}
+
+func transformDate64ToTimestamp(arr *array.Date64) arrow.Array {
+	builder := array.NewTimestampBuilder(memory.DefaultAllocator, &arrow.TimestampType{Unit: arrow.Microsecond, TimeZone: "UTC"})
+	for i := 0; i < arr.Len(); i++ {
+		if arr.IsNull(i) {
+			builder.AppendNull()
+			continue
+		}
+		builder.AppendTime(arr.Value(i).ToTime())
+	}
 	return builder.NewArray()
 }

--- a/plugins/destination/duckdb/client/types.go
+++ b/plugins/destination/duckdb/client/types.go
@@ -82,10 +82,8 @@ func arrowToDuckDB(dt arrow.DataType) string {
 		return "uuid"
 	case *types.JSONType:
 		return "json"
-	case *arrow.TimestampType:
+	case *arrow.Date32Type, *arrow.Date64Type, *arrow.TimestampType:
 		return "timestamp"
-	case *arrow.Date32Type, *arrow.Date64Type:
-		return "date"
 	case *arrow.DayTimeIntervalType:
 		return "interval"
 	default:
@@ -128,8 +126,6 @@ func duckDBToArrow(t string) arrow.DataType {
 		return arrow.PrimitiveTypes.Float32
 	case "blob", "bytea", "binary", "varbinary":
 		return arrow.BinaryTypes.Binary
-	case "date":
-		return arrow.FixedWidthTypes.Date64
 	case "timestamp", "datetime", "timestamp with time zone", "timestamptz":
 		return arrow.FixedWidthTypes.Timestamp_us
 	case "interval":


### PR DESCRIPTION
<!-- 🎉 Thank you for making CloudQuery awesome by submitting a PR 🎉 -->

#### Summary

Fixes https://github.com/cloudquery/cloudquery/issues/12524

When reading `parquet` files, DuckDB seems to be failing to identify `date` types, thinks those are `timestamp without timezone` and fails since it doesn't know how to convert a timestamp to date. Found https://github.com/duckdb/duckdb/issues/1291 and other `parquet` related issues:
https://github.com/duckdb/duckdb/issues?q=is%3Aissue+is%3Aopen+parquet+
https://github.com/marcboeker/go-duckdb/issues?q=is%3Aissue+parquet+is%3Aclosed

The solution I found is to use `timestamp` to store date types when writing/reading to/from the temporary `parquet` file. It might take up a bit more space in the `parquet` file but it works.

We might want to look into skipping the temporary file if it's not a huge effort to do

<!--
Use the following steps to ensure your PR is ready to be reviewed

- [ ] Read the [contribution guidelines](../blob/main/CONTRIBUTING.md) 🧑‍🎓
- [ ] Run `make lint` to ensure the proposed changes follow the coding style 🚨 (install golangci-lint [here](https://golangci-lint.run/usage/install/#local-installation))
- [ ] Run `make test` to ensure the proposed changes pass the tests 🧪
- [ ] If changing a source plugin run `make gen` to ensure docs are up to date 📝
- [ ] Ensure the status checks below are successful ✅
--->
