### PR TITLE
fix: Don't use row index for accessing chunk data

### DIFF
--- a/plugins/destination/mssql/queries/values.go
+++ b/plugins/destination/mssql/queries/values.go
@@ -14,14 +14,13 @@ func GetRows(table arrow.Table) ([][]any, error) {
 	for n := 0; n < int(table.NumCols()); n++ {
 		col := table.Column(n)
 		row := 0
-		for _, chunk := range col.Data().Chunks() {
-			for i := 0; i < chunk.Len(); i++ {
-				rows[row][n], err = getColValue(chunk, row)
-				if err != nil {
-					return nil, err
-				}
-				row++
+		for _, chunkArray := range col.Data().Chunks() {
+			// We only support records with arrays of length == 1
+			rows[row][n], err = getColValue(chunkArray, 0)
+			if err != nil {
+				return nil, err
 			}
+			row++
 		}
 	}
 	return rows, nil

--- a/plugins/destination/mssql/queries/values.go
+++ b/plugins/destination/mssql/queries/values.go
@@ -15,7 +15,7 @@ func GetRows(table arrow.Table) ([][]any, error) {
 		col := table.Column(n)
 		row := 0
 		for _, chunkArray := range col.Data().Chunks() {
-			// We only support records with arrays of length == 1
+			// We only support records with arrays of length == 1, so we always extract the first value
 			rows[row][n], err = getColValue(chunkArray, 0)
 			if err != nil {
 				return nil, err


### PR DESCRIPTION
<!-- 🎉 Thank you for making CloudQuery awesome by submitting a PR 🎉 -->

#### Summary

Fixes https://github.com/cloudquery/cloudquery/issues/12577 (can also be reproduces by syncing only `azure_compute_skus`)

It was a bit hard to for me to understand the code, but it seems we use `NewTableFromRecords` to map an array of records with length of `batch_size` to a single Arrow table. This means the resulting table will have `batch_size` number of rows, with each column having `number_of_schema_columns` chunks, where each chunk of arrays is of `batch_size` length. Each array that is a part of the chunk of arrays has the underlying data from the source (think of a chunk of a way to manage a collection of arrays).

See
https://github.com/cloudquery/arrow/blob/b7ee35bf784acdf7af50f7776ce8b9dd8117a4c2/go/arrow/array/table.go#L177
https://github.com/cloudquery/arrow/blob/b7ee35bf784acdf7af50f7776ce8b9dd8117a4c2/go/arrow/array/table.go#L193

The current code increments the row index for each array in the chunk:
https://github.com/cloudquery/cloudquery/blob/5fa1af103a6e0e0b62d05f4d5d6f902c23a9e03e/plugins/destination/mssql/queries/values.go#L17

and for each value in the chunk data array:
https://github.com/cloudquery/cloudquery/blob/5fa1af103a6e0e0b62d05f4d5d6f902c23a9e03e/plugins/destination/mssql/queries/values.go#L18

then uses that value as an index to access the data in each chunk.

As mentioned before each column's chunk references `batch_size` number of arrays so we cannot use that length as a indicator on how to access each array's data.

**The fix is to use the `row` index as the index to the preallocated row array, and `0` as the index to access the underlying data of each array in the chunk. This works since sources don't save data in arrays longer than 1, so we know there's always a single value.**

> Technically we should be "unwrapping" each data array, but that can be done in a follow up (and maybe remove the usage of `NewTableFromRecords` as we could create the query rows directly from the records array).


<!--
Use the following steps to ensure your PR is ready to be reviewed

- [ ] Read the [contribution guidelines](../blob/main/CONTRIBUTING.md) 🧑‍🎓
- [ ] Run `make lint` to ensure the proposed changes follow the coding style 🚨 (install golangci-lint [here](https://golangci-lint.run/usage/install/#local-installation))
- [ ] Run `make test` to ensure the proposed changes pass the tests 🧪
- [ ] If changing a source plugin run `make gen` to ensure docs are up to date 📝
- [ ] Ensure the status checks below are successful ✅
--->
