### PR TITLE
fix: Create separate plugin client package

### DIFF
--- a/scaffold/cmd/templates/source/client/client.go.tpl
+++ b/scaffold/cmd/templates/source/client/client.go.tpl
@@ -2,25 +2,13 @@ package client
 
 import (
 	"context"
-	"encoding/json"
-	"fmt"
 
-	"github.com/cloudquery/plugin-sdk/v4/message"
-	"github.com/cloudquery/plugin-sdk/v4/plugin"
-	"github.com/cloudquery/plugin-sdk/v4/scheduler"
-	"github.com/cloudquery/plugin-sdk/v4/schema"
-	"github.com/cloudquery/plugin-sdk/v4/transformers"
 	"github.com/rs/zerolog"
-	"github.com/{{.Org}}/cq-source-{{.Name}}/resources"
 )
 
 type Client struct {
-	logger    zerolog.Logger
-	config    Spec
-	tables    schema.Tables
-	scheduler *scheduler.Scheduler
-
-	plugin.UnimplementedDestination
+	logger   zerolog.Logger
+	Spec     Spec
 }
 
 func (c *Client) ID() string {
@@ -32,57 +20,12 @@ func (c *Client) Logger() *zerolog.Logger {
 	return &c.logger
 }
 
-
-func New(_ context.Context, logger zerolog.Logger, spec []byte, opts plugin.NewClientOptions) (plugin.Client, error) {
-	if opts.NoConnection {
-		return &Client{
-			logger: logger,
-			tables: getTables(),
-		}, nil
-	}
-
-	config := &Spec{}
-	if err := json.Unmarshal(spec, config); err != nil {
-		return nil, fmt.Errorf("failed to unmarshal spec: %w", err)
-	}
-
+func New(ctx context.Context, logger zerolog.Logger, s *Spec) (Client, error) {
 	// TODO: Add your client initialization here
-
-	return &Client{logger: logger, config: *config, scheduler: scheduler.NewScheduler(scheduler.WithLogger(logger)), tables: getTables()}, nil
-}
-
-func (c *Client) Sync(ctx context.Context, options plugin.SyncOptions, res chan<- message.SyncMessage) error {
-	tt, err := c.tables.FilterDfs(options.Tables, options.SkipTables, options.SkipDependentTables)
-	if err != nil {
-		return err
+	c := Client{
+		logger:	logger,
+		Spec: 	 *s,
 	}
 
-	return c.scheduler.Sync(ctx, &Client{}, tt, res, scheduler.WithSyncDeterministicCQID(options.DeterministicCQID))
-}
-
-func (c *Client) Tables(_ context.Context, options plugin.TableOptions) (schema.Tables, error) {
-	tt, err := c.tables.FilterDfs(options.Tables, options.SkipTables, options.SkipDependentTables)
-	if err != nil {
-		return nil, err
-	}
-
-	return tt, nil
-}
-
-func (*Client) Close(_ context.Context) error {
-	// TODO: Add your client cleanup here
-	return nil
-}
-
-func getTables() schema.Tables {
-	tables := schema.Tables{
-		resources.SampleTable(),
-	}
-	if err := transformers.TransformTables(tables); err != nil {
-		panic(err)
-	}
-	for _, t := range tables {
-		schema.AddCqIDs(t)
-	}
-	return tables
+	return c, nil
 }

--- a/scaffold/cmd/templates/source/main.go.tpl
+++ b/scaffold/cmd/templates/source/main.go.tpl
@@ -4,7 +4,7 @@ import (
 	"context"
 	"log"
 
-	"github.com/{{.Org}}/cq-source-{{.Name}}/plugin"
+	"github.com/{{.Org}}/cq-source-{{.Name}}/resources/plugin"
 
 	"github.com/cloudquery/plugin-sdk/v4/serve"
 )

--- a/scaffold/cmd/templates/source/resources/plugin/client.go.tpl
+++ b/scaffold/cmd/templates/source/resources/plugin/client.go.tpl
@@ -1,0 +1,88 @@
+package plugin
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"github.com/cloudquery/plugin-sdk/v4/message"
+	"github.com/cloudquery/plugin-sdk/v4/plugin"
+	"github.com/cloudquery/plugin-sdk/v4/scheduler"
+	"github.com/cloudquery/plugin-sdk/v4/schema"
+	"github.com/cloudquery/plugin-sdk/v4/transformers"
+	"github.com/rs/zerolog"
+	"github.com/{{.Org}}/cq-source-{{.Name}}/client"
+	"github.com/{{.Org}}/cq-source-{{.Name}}/resources/services"
+)
+
+type Client struct {
+	logger    zerolog.Logger
+	config    client.Spec
+	tables    schema.Tables
+	syncClient *client.Client
+	scheduler *scheduler.Scheduler
+
+	plugin.UnimplementedDestination
+}
+
+func New(ctx context.Context, logger zerolog.Logger, spec []byte, opts plugin.NewClientOptions) (plugin.Client, error) {
+	if opts.NoConnection {
+		return &Client{
+			logger: logger,
+			tables: getTables(),
+		}, nil
+	}
+
+	config := &client.Spec{}
+	if err := json.Unmarshal(spec, config); err != nil {
+		return nil, fmt.Errorf("failed to unmarshal spec: %w", err)
+	}
+
+	syncClient, err := client.New(ctx, logger, config)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create client: %w", err)
+	}
+	return &Client{
+		logger: logger,
+		config: *config,
+		tables: getTables(),
+		syncClient: &syncClient,
+		scheduler: scheduler.NewScheduler(scheduler.WithLogger(logger)),
+	}, nil
+}
+
+func (c *Client) Sync(ctx context.Context, options plugin.SyncOptions, res chan<- message.SyncMessage) error {
+	tt, err := c.tables.FilterDfs(options.Tables, options.SkipTables, options.SkipDependentTables)
+	if err != nil {
+		return err
+	}
+
+	return c.scheduler.Sync(ctx, c.syncClient, tt, res, scheduler.WithSyncDeterministicCQID(options.DeterministicCQID))
+}
+
+func (c *Client) Tables(_ context.Context, options plugin.TableOptions) (schema.Tables, error) {
+	tt, err := c.tables.FilterDfs(options.Tables, options.SkipTables, options.SkipDependentTables)
+	if err != nil {
+		return nil, err
+	}
+
+	return tt, nil
+}
+
+func (*Client) Close(_ context.Context) error {
+	// TODO: Add your client cleanup here
+	return nil
+}
+
+func getTables() schema.Tables {
+	tables := schema.Tables{
+		services.SampleTable(),
+	}
+	if err := transformers.TransformTables(tables); err != nil {
+		panic(err)
+	}
+	for _, t := range tables {
+		schema.AddCqIDs(t)
+	}
+	return tables
+}

--- a/scaffold/cmd/templates/source/resources/plugin/client.go.tpl
+++ b/scaffold/cmd/templates/source/resources/plugin/client.go.tpl
@@ -25,7 +25,7 @@ type Client struct {
 	plugin.UnimplementedDestination
 }
 
-func New(ctx context.Context, logger zerolog.Logger, spec []byte, opts plugin.NewClientOptions) (plugin.Client, error) {
+func Configure(ctx context.Context, logger zerolog.Logger, spec []byte, opts plugin.NewClientOptions) (plugin.Client, error) {
 	if opts.NoConnection {
 		return &Client{
 			logger: logger,

--- a/scaffold/cmd/templates/source/resources/plugin/plugin.go.tpl
+++ b/scaffold/cmd/templates/source/resources/plugin/plugin.go.tpl
@@ -1,7 +1,6 @@
 package plugin
 
 import (
-	"github.com/{{.Org}}/cq-source-{{.Name}}/client"
 	"github.com/cloudquery/plugin-sdk/v4/plugin"
 )
 
@@ -10,5 +9,5 @@ var (
 )
 
 func Plugin() *plugin.Plugin {
-	return plugin.NewPlugin("{{.Org}}-{{.Name}}", Version, client.New)
+	return plugin.NewPlugin("{{.Org}}-{{.Name}}", Version, New)
 }

--- a/scaffold/cmd/templates/source/resources/plugin/plugin.go.tpl
+++ b/scaffold/cmd/templates/source/resources/plugin/plugin.go.tpl
@@ -9,5 +9,5 @@ var (
 )
 
 func Plugin() *plugin.Plugin {
-	return plugin.NewPlugin("{{.Org}}-{{.Name}}", Version, New)
+	return plugin.NewPlugin("{{.Org}}-{{.Name}}", Version, Configure)
 }

--- a/scaffold/cmd/templates/source/resources/services/table.go.tpl
+++ b/scaffold/cmd/templates/source/resources/services/table.go.tpl
@@ -1,4 +1,4 @@
-package resources
+package services
 
 import (
 	"context"
@@ -6,6 +6,7 @@ import (
 
 	"github.com/apache/arrow/go/v13/arrow"
 	"github.com/cloudquery/plugin-sdk/v4/schema"
+	"github.com/{{.Org}}/cq-source-{{.Name}}/client"
 )
 
 func SampleTable() *schema.Table {
@@ -22,5 +23,6 @@ func SampleTable() *schema.Table {
 }
 
 func fetchSampleTable(ctx context.Context, meta schema.ClientMeta, parent *schema.Resource, res chan <- any) error {
-  return fmt.Errorf("not implemented")
+  cl := meta.(*client.Client)
+  return fmt.Errorf("not implemented. client id: " + cl.ID())
 }


### PR DESCRIPTION
<!-- 🎉 Thank you for making CloudQuery awesome by submitting a PR 🎉 -->

#### Summary

Fixes https://github.com/cloudquery/cloudquery/issues/12643

Had to refactor the templating engine code a bit as now we have different template files with the same name (`client.go.tpl` under `client` and under `resources/plugin`.

Go templating engine doesn't load templates recursively so I used `fs.WalkDir` to avoid having to manually map template files to output files.

<!--
Use the following steps to ensure your PR is ready to be reviewed

- [ ] Read the [contribution guidelines](../blob/main/CONTRIBUTING.md) 🧑‍🎓
- [ ] Run `make lint` to ensure the proposed changes follow the coding style 🚨 (install golangci-lint [here](https://golangci-lint.run/usage/install/#local-installation))
- [ ] Run `make test` to ensure the proposed changes pass the tests 🧪
- [ ] If changing a source plugin run `make gen` to ensure docs are up to date 📝
- [ ] Ensure the status checks below are successful ✅
--->
