### PR TITLE
fix(resources): Handle Pagination for AWS Code Commit Repositories

### DIFF
--- a/plugins/source/aws/resources/services/codecommit/repositories.go
+++ b/plugins/source/aws/resources/services/codecommit/repositories.go
@@ -36,8 +36,6 @@ func Repositories() *schema.Table {
 func fetchRepositories(ctx context.Context, meta schema.ClientMeta, parent *schema.Resource, res chan<- any) error {
 	cl := meta.(*client.Client)
 	svc := cl.Services().Codecommit
-	// Note: this API doesn't support limiting the number of results in a single call and the nested BatchRepositories doesn't have a listed limit
-	// So we are assuming that the number of repositories is not too large and we can fetch (`BatchGet`) all of their details in a single call
 	config := codecommit.ListRepositoriesInput{}
 	paginator := codecommit.NewListRepositoriesPaginator(svc, &config)
 	for paginator.HasMorePages() {


### PR DESCRIPTION
<!-- 🎉 Thank you for making CloudQuery awesome by submitting a PR 🎉 -->

#### Summary

In initial version we made an erroneous assumption about ListRepos not returning more than BatchGetRepos could handle. It turns out if more than 100 repos are returned by ListRepositories, then BatchGetRepos will fail... 