### PR TITLE
fix(website): Fix bold policies menu

### DIFF
--- a/website/pages/_meta.json
+++ b/website/pages/_meta.json
@@ -31,7 +31,8 @@
   },
   "policies": {
     "title": "Policies",
-    "href": "/docs/core-concepts/policies"
+    "href": "/docs/core-concepts/policies",
+    "route": "/docs/core-concepts/policies"
   },
   "case-studies": {
     "title": "Case Studies",
@@ -50,10 +51,6 @@
     "title": "Solutions",
     "type": "menu",
     "items": {
-      "cspm": {
-        "title": "Cloud Security Posture Management",
-        "href": "/solutions/open-source-cspm"
-      },
       "policies": {
         "title": "Policies",
         "href": "/docs/core-concepts/policies"
@@ -73,6 +70,10 @@
       "glossary": {
         "title": "Glossary",
         "href": "/docs/glossary/overview"
+      },
+      "cspm": {
+        "title": "Cloud Security Posture Management",
+        "href": "/solutions/open-source-cspm"
       }
     }
   },


### PR DESCRIPTION
Policies menu item is always bolded, this fixes it.

I also moved CSPM to the bottom of the menu because I think this makes it look a bit better (the long text stands out against the other text otherwise)