### PR TITLE
fix: Add name of destination to error on init

### DIFF
--- a/cli/cmd/sync_v3.go
+++ b/cli/cmd/sync_v3.go
@@ -77,7 +77,7 @@ func syncConnectionV3(ctx context.Context, sourceClient *managedplugin.Client, d
 		if _, err := destinationsPbClients[i].Init(ctx, &plugin.Init_Request{
 			Spec: destSpecBytes,
 		}); err != nil {
-			return err
+			return fmt.Errorf("failed to init destination %v: %w", destSpec.Name, err)
 		}
 	}
 


### PR DESCRIPTION
Before this change, an error in this part of the code obscures the name of the destination that failed, and can make it seem like it was actually the source inititialization that failed.

Related to https://github.com/cloudquery/cloudquery/issues/12656