### PR TITLE
feat(resources): Add Support for AWS IPAM

### DIFF
--- a/plugins/source/aws/docs/tables/README.md
+++ b/plugins/source/aws/docs/tables/README.md
@@ -223,6 +223,8 @@
 - [aws_ec2_instance_types](../../../../../website/tables/aws/aws_ec2_instance_types.md)
 - [aws_ec2_instances](../../../../../website/tables/aws/aws_ec2_instances.md)
 - [aws_ec2_internet_gateways](../../../../../website/tables/aws/aws_ec2_internet_gateways.md)
+- [aws_ec2_ipam_pools](../../../../../website/tables/aws/aws_ec2_ipam_pools.md)
+- [aws_ec2_ipams](../../../../../website/tables/aws/aws_ec2_ipams.md)
 - [aws_ec2_key_pairs](../../../../../website/tables/aws/aws_ec2_key_pairs.md)
 - [aws_ec2_launch_templates](../../../../../website/tables/aws/aws_ec2_launch_templates.md)
   - [aws_ec2_launch_template_versions](../../../../../website/tables/aws/aws_ec2_launch_template_versions.md)

--- a/plugins/source/aws/resources/plugin/plugin.go
+++ b/plugins/source/aws/resources/plugin/plugin.go
@@ -64,6 +64,7 @@ var awsExceptions = map[string]string{
 	"fsx":                          "Amazon FSx",
 	"guardduty":                    "Amazon GuardDuty",
 	"identitystore":                "Identity Store",
+	"ipam":                         "Amazon VPC IP Address Manager (IPAM)",
 	"iot":                          "AWS IoT",
 	"kms":                          "AWS Key Management Service (AWS KMS)",
 	"lambda":                       "AWS Lambda",

--- a/plugins/source/aws/resources/plugin/tables.go
+++ b/plugins/source/aws/resources/plugin/tables.go
@@ -267,6 +267,8 @@ func getTables() schema.Tables {
 		ec2.InstanceStatuses(),
 		ec2.InstanceTypes(),
 		ec2.InternetGateways(),
+		ec2.IPAMPools(),
+		ec2.IPAMs(),
 		ec2.KeyPairs(),
 		ec2.LaunchTemplates(),
 		ec2.ManagedPrefixLists(),

--- a/plugins/source/aws/resources/plugin/tables.go
+++ b/plugins/source/aws/resources/plugin/tables.go
@@ -267,8 +267,9 @@ func getTables() schema.Tables {
 		ec2.InstanceStatuses(),
 		ec2.InstanceTypes(),
 		ec2.InternetGateways(),
-		ec2.IPAMPools(),
-		ec2.IPAMs(),
+		ec2.IpamPools(),
+		ec2.IpamResourceDiscoveries()
+		ec2.Ipams(),
 		ec2.KeyPairs(),
 		ec2.LaunchTemplates(),
 		ec2.ManagedPrefixLists(),

--- a/plugins/source/aws/resources/services/ec2/ipam_pools.go
+++ b/plugins/source/aws/resources/services/ec2/ipam_pools.go
@@ -13,7 +13,7 @@ import (
 	"github.com/cloudquery/plugin-sdk/v4/transformers"
 )
 
-func IPAMPools() *schema.Table {
+func IpamPools() *schema.Table {
 	tableName := "aws_ec2_ipam_pools"
 	return &schema.Table{
 		Name:        tableName,

--- a/plugins/source/aws/resources/services/ec2/ipam_pools.go
+++ b/plugins/source/aws/resources/services/ec2/ipam_pools.go
@@ -1,0 +1,72 @@
+package ec2
+
+import (
+	"context"
+
+	sdkTypes "github.com/cloudquery/plugin-sdk/v4/types"
+
+	"github.com/apache/arrow/go/v13/arrow"
+	"github.com/aws/aws-sdk-go-v2/service/ec2"
+	"github.com/aws/aws-sdk-go-v2/service/ec2/types"
+	"github.com/cloudquery/cloudquery/plugins/source/aws/client"
+	"github.com/cloudquery/plugin-sdk/v4/schema"
+	"github.com/cloudquery/plugin-sdk/v4/transformers"
+)
+
+func IPAMPools() *schema.Table {
+	tableName := "aws_ec2_ipam_pools"
+	return &schema.Table{
+		Name:        tableName,
+		Description: `https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_IpamPool.html`,
+		Resolver:    fetchIPAMPools,
+		Multiplex:   client.ServiceAccountRegionMultiplexer(tableName, "ec2"),
+		Transform:   transformers.TransformWithStruct(&types.IpamPool{}),
+		Columns: []schema.Column{
+			{
+				Name:       "request_account_id",
+				Type:       arrow.BinaryTypes.String,
+				Resolver:   client.ResolveAWSAccount,
+				PrimaryKey: true,
+			},
+			{
+				Name:       "request_region",
+				Type:       arrow.BinaryTypes.String,
+				Resolver:   client.ResolveAWSRegion,
+				PrimaryKey: true,
+			},
+			{
+				Name:       "arn",
+				Type:       arrow.BinaryTypes.String,
+				Resolver:   schema.PathResolver("IpamPoolArn"),
+				PrimaryKey: true,
+			},
+
+			{
+				Name:     "tags",
+				Type:     sdkTypes.ExtensionTypes.JSON,
+				Resolver: client.ResolveTags,
+			},
+		},
+		Relations: schema.Tables{
+			// poolAllocations(),
+			// poolCidrs(),
+		},
+	}
+}
+
+func fetchIPAMPools(ctx context.Context, meta schema.ClientMeta, _ *schema.Resource, res chan<- any) error {
+	cl := meta.(*client.Client)
+	svc := cl.Services().Ec2
+	paginator := ec2.NewDescribeIpamPoolsPaginator(svc, &ec2.DescribeIpamPoolsInput{})
+	for paginator.HasMorePages() {
+		output, err := paginator.NextPage(ctx, func(options *ec2.Options) {
+			options.Region = cl.Region
+		})
+		if err != nil {
+			return err
+		}
+		res <- output.IpamPools
+	}
+
+	return nil
+}

--- a/plugins/source/aws/resources/services/ec2/ipam_pools_mock_test.go
+++ b/plugins/source/aws/resources/services/ec2/ipam_pools_mock_test.go
@@ -27,5 +27,5 @@ func buildIpamPools(t *testing.T, ctrl *gomock.Controller) client.Services {
 }
 
 func TestIpamPools(t *testing.T) {
-	client.AwsMockTestHelper(t, IPAMPools(), buildIpamPools, client.TestOptions{})
+	client.AwsMockTestHelper(t, IpamPools(), buildIpamPools, client.TestOptions{})
 }

--- a/plugins/source/aws/resources/services/ec2/ipam_pools_mock_test.go
+++ b/plugins/source/aws/resources/services/ec2/ipam_pools_mock_test.go
@@ -1,0 +1,31 @@
+package ec2
+
+import (
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/service/ec2"
+	"github.com/aws/aws-sdk-go-v2/service/ec2/types"
+	"github.com/cloudquery/cloudquery/plugins/source/aws/client"
+	"github.com/cloudquery/cloudquery/plugins/source/aws/client/mocks"
+	"github.com/cloudquery/plugin-sdk/v4/faker"
+	"github.com/golang/mock/gomock"
+	"github.com/stretchr/testify/require"
+)
+
+func buildIpamPools(t *testing.T, ctrl *gomock.Controller) client.Services {
+	m := mocks.NewMockEc2Client(ctrl)
+	ip := types.IpamPool{}
+	require.NoError(t, faker.FakeObject(&ip))
+
+	m.EXPECT().DescribeIpamPools(gomock.Any(), gomock.Any(), gomock.Any()).Return(
+		&ec2.DescribeIpamPoolsOutput{
+			IpamPools: []types.IpamPool{ip},
+		}, nil)
+	return client.Services{
+		Ec2: m,
+	}
+}
+
+func TestIpamPools(t *testing.T) {
+	client.AwsMockTestHelper(t, IPAMPools(), buildIpamPools, client.TestOptions{})
+}

--- a/plugins/source/aws/resources/services/ec2/ipam_resource_discoveries.go
+++ b/plugins/source/aws/resources/services/ec2/ipam_resource_discoveries.go
@@ -13,14 +13,14 @@ import (
 	"github.com/cloudquery/plugin-sdk/v4/transformers"
 )
 
-func Ipams() *schema.Table {
-	tableName := "aws_ec2_ipams"
+func IpamResourceDiscoveries() *schema.Table {
+	tableName := "aws_ec2_ipam_resource_discoveries"
 	return &schema.Table{
 		Name:        tableName,
-		Description: `https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_Ipam.html`,
-		Resolver:    fetchIPAMS,
+		Description: `https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_IpamResourceDiscovery.html`,
+		Resolver:    fetchIPAMResourceDiscoveries,
 		Multiplex:   client.ServiceAccountRegionMultiplexer(tableName, "ec2"),
-		Transform:   transformers.TransformWithStruct(&types.Ipam{}),
+		Transform:   transformers.TransformWithStruct(&types.IpamResourceDiscovery{}),
 		Columns: []schema.Column{
 			{
 				Name:       "request_account_id",
@@ -37,7 +37,7 @@ func Ipams() *schema.Table {
 			{
 				Name:       "arn",
 				Type:       arrow.BinaryTypes.String,
-				Resolver:   schema.PathResolver("IpamArn"),
+				Resolver:   schema.PathResolver("IpamResourceDiscoveryArn"),
 				PrimaryKey: true,
 			},
 
@@ -50,10 +50,10 @@ func Ipams() *schema.Table {
 	}
 }
 
-func fetchIPAMS(ctx context.Context, meta schema.ClientMeta, _ *schema.Resource, res chan<- any) error {
+func fetchIPAMResourceDiscoveries(ctx context.Context, meta schema.ClientMeta, _ *schema.Resource, res chan<- any) error {
 	cl := meta.(*client.Client)
 	svc := cl.Services().Ec2
-	paginator := ec2.NewDescribeIpamsPaginator(svc, &ec2.DescribeIpamsInput{})
+	paginator := ec2.NewDescribeIpamResourceDiscoveriesPaginator(svc, &ec2.DescribeIpamResourceDiscoveriesInput{})
 	for paginator.HasMorePages() {
 		output, err := paginator.NextPage(ctx, func(options *ec2.Options) {
 			options.Region = cl.Region
@@ -61,7 +61,7 @@ func fetchIPAMS(ctx context.Context, meta schema.ClientMeta, _ *schema.Resource,
 		if err != nil {
 			return err
 		}
-		res <- output.Ipams
+		res <- output.IpamResourceDiscoveries
 	}
 
 	return nil

--- a/plugins/source/aws/resources/services/ec2/ipam_resource_discoveries_mock_test.go
+++ b/plugins/source/aws/resources/services/ec2/ipam_resource_discoveries_mock_test.go
@@ -1,0 +1,31 @@
+package ec2
+
+import (
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/service/ec2"
+	"github.com/aws/aws-sdk-go-v2/service/ec2/types"
+	"github.com/cloudquery/cloudquery/plugins/source/aws/client"
+	"github.com/cloudquery/cloudquery/plugins/source/aws/client/mocks"
+	"github.com/cloudquery/plugin-sdk/v4/faker"
+	"github.com/golang/mock/gomock"
+	"github.com/stretchr/testify/require"
+)
+
+func buildIpamResourceDiscoveries(t *testing.T, ctrl *gomock.Controller) client.Services {
+	m := mocks.NewMockEc2Client(ctrl)
+	ird := types.IpamResourceDiscovery{}
+	require.NoError(t, faker.FakeObject(&ird))
+
+	m.EXPECT().DescribeIpamResourceDiscoveries(gomock.Any(), gomock.Any(), gomock.Any()).Return(
+		&ec2.DescribeIpamResourceDiscoveriesOutput{
+			IpamResourceDiscoveries: []types.IpamResourceDiscovery{ird},
+		}, nil)
+	return client.Services{
+		Ec2: m,
+	}
+}
+
+func TestIpamResourceDiscoveries(t *testing.T) {
+	client.AwsMockTestHelper(t, IpamResourceDiscoveries(), buildIpamResourceDiscoveries, client.TestOptions{})
+}

--- a/plugins/source/aws/resources/services/ec2/ipam_resource_discovery_associations.go
+++ b/plugins/source/aws/resources/services/ec2/ipam_resource_discovery_associations.go
@@ -13,14 +13,14 @@ import (
 	"github.com/cloudquery/plugin-sdk/v4/transformers"
 )
 
-func Ipams() *schema.Table {
-	tableName := "aws_ec2_ipams"
+func IpamResourceDiscoveryAssociations() *schema.Table {
+	tableName := "aws_ec2_ipam_resource_discovery_associations"
 	return &schema.Table{
 		Name:        tableName,
-		Description: `https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_Ipam.html`,
-		Resolver:    fetchIPAMS,
+		Description: `https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_IpamResourceDiscovery.html`,
+		Resolver:    fetchIpamResourceDiscoveryAssociations,
 		Multiplex:   client.ServiceAccountRegionMultiplexer(tableName, "ec2"),
-		Transform:   transformers.TransformWithStruct(&types.Ipam{}),
+		Transform:   transformers.TransformWithStruct(&types.IpamResourceDiscoveryAssociation{}),
 		Columns: []schema.Column{
 			{
 				Name:       "request_account_id",
@@ -37,7 +37,7 @@ func Ipams() *schema.Table {
 			{
 				Name:       "arn",
 				Type:       arrow.BinaryTypes.String,
-				Resolver:   schema.PathResolver("IpamArn"),
+				Resolver:   schema.PathResolver("IpamResourceDiscoveryAssociationArn"),
 				PrimaryKey: true,
 			},
 
@@ -50,10 +50,10 @@ func Ipams() *schema.Table {
 	}
 }
 
-func fetchIPAMS(ctx context.Context, meta schema.ClientMeta, _ *schema.Resource, res chan<- any) error {
+func fetchIpamResourceDiscoveryAssociations(ctx context.Context, meta schema.ClientMeta, _ *schema.Resource, res chan<- any) error {
 	cl := meta.(*client.Client)
 	svc := cl.Services().Ec2
-	paginator := ec2.NewDescribeIpamsPaginator(svc, &ec2.DescribeIpamsInput{})
+	paginator := ec2.NewDescribeIpamResourceDiscoveryAssociationsPaginator(svc, &ec2.DescribeIpamResourceDiscoveryAssociationsInput{})
 	for paginator.HasMorePages() {
 		output, err := paginator.NextPage(ctx, func(options *ec2.Options) {
 			options.Region = cl.Region
@@ -61,7 +61,7 @@ func fetchIPAMS(ctx context.Context, meta schema.ClientMeta, _ *schema.Resource,
 		if err != nil {
 			return err
 		}
-		res <- output.Ipams
+		res <- output.IpamResourceDiscoveryAssociations
 	}
 
 	return nil

--- a/plugins/source/aws/resources/services/ec2/ipam_resource_discovery_associations_mock_test.go
+++ b/plugins/source/aws/resources/services/ec2/ipam_resource_discovery_associations_mock_test.go
@@ -1,0 +1,31 @@
+package ec2
+
+import (
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/service/ec2"
+	"github.com/aws/aws-sdk-go-v2/service/ec2/types"
+	"github.com/cloudquery/cloudquery/plugins/source/aws/client"
+	"github.com/cloudquery/cloudquery/plugins/source/aws/client/mocks"
+	"github.com/cloudquery/plugin-sdk/v4/faker"
+	"github.com/golang/mock/gomock"
+	"github.com/stretchr/testify/require"
+)
+
+func buildIpamResourceDiscoveryAssociations(t *testing.T, ctrl *gomock.Controller) client.Services {
+	m := mocks.NewMockEc2Client(ctrl)
+	ird := types.IpamResourceDiscoveryAssociation{}
+	require.NoError(t, faker.FakeObject(&ird))
+
+	m.EXPECT().DescribeIpamResourceDiscoveryAssociations(gomock.Any(), gomock.Any(), gomock.Any()).Return(
+		&ec2.DescribeIpamResourceDiscoveryAssociationsOutput{
+			IpamResourceDiscoveryAssociations: []types.IpamResourceDiscoveryAssociation{ird},
+		}, nil)
+	return client.Services{
+		Ec2: m,
+	}
+}
+
+func TestIpamResourceDiscoveryAssociations(t *testing.T) {
+	client.AwsMockTestHelper(t, IpamResourceDiscoveryAssociations(), buildIpamResourceDiscoveryAssociations, client.TestOptions{})
+}

--- a/plugins/source/aws/resources/services/ec2/ipam_scopes.go
+++ b/plugins/source/aws/resources/services/ec2/ipam_scopes.go
@@ -13,11 +13,11 @@ import (
 	"github.com/cloudquery/plugin-sdk/v4/transformers"
 )
 
-func Ipams() *schema.Table {
-	tableName := "aws_ec2_ipams"
+func IpamScopes() *schema.Table {
+	tableName := "aws_ec2_ipam_scopes"
 	return &schema.Table{
 		Name:        tableName,
-		Description: `https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_Ipam.html`,
+		Description: `https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_IpamScope.html`,
 		Resolver:    fetchIPAMS,
 		Multiplex:   client.ServiceAccountRegionMultiplexer(tableName, "ec2"),
 		Transform:   transformers.TransformWithStruct(&types.Ipam{}),

--- a/plugins/source/aws/resources/services/ec2/ipams.go
+++ b/plugins/source/aws/resources/services/ec2/ipams.go
@@ -1,0 +1,68 @@
+package ec2
+
+import (
+	"context"
+
+	sdkTypes "github.com/cloudquery/plugin-sdk/v4/types"
+
+	"github.com/apache/arrow/go/v13/arrow"
+	"github.com/aws/aws-sdk-go-v2/service/ec2"
+	"github.com/aws/aws-sdk-go-v2/service/ec2/types"
+	"github.com/cloudquery/cloudquery/plugins/source/aws/client"
+	"github.com/cloudquery/plugin-sdk/v4/schema"
+	"github.com/cloudquery/plugin-sdk/v4/transformers"
+)
+
+func IPAMs() *schema.Table {
+	tableName := "aws_ec2_ipams"
+	return &schema.Table{
+		Name:        tableName,
+		Description: `https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_Ipam.html`,
+		Resolver:    fetchIPAMS,
+		Multiplex:   client.ServiceAccountRegionMultiplexer(tableName, "ec2"),
+		Transform:   transformers.TransformWithStruct(&types.Ipam{}),
+		Columns: []schema.Column{
+			{
+				Name:       "request_account_id",
+				Type:       arrow.BinaryTypes.String,
+				Resolver:   client.ResolveAWSAccount,
+				PrimaryKey: true,
+			},
+			{
+				Name:       "request_region",
+				Type:       arrow.BinaryTypes.String,
+				Resolver:   client.ResolveAWSRegion,
+				PrimaryKey: true,
+			},
+			{
+				Name:       "arn",
+				Type:       arrow.BinaryTypes.String,
+				Resolver:   schema.PathResolver("IpamArn"),
+				PrimaryKey: true,
+			},
+
+			{
+				Name:     "tags",
+				Type:     sdkTypes.ExtensionTypes.JSON,
+				Resolver: client.ResolveTags,
+			},
+		},
+	}
+}
+
+func fetchIPAMS(ctx context.Context, meta schema.ClientMeta, _ *schema.Resource, res chan<- any) error {
+	cl := meta.(*client.Client)
+	svc := cl.Services().Ec2
+	paginator := ec2.NewDescribeIpamsPaginator(svc, &ec2.DescribeIpamsInput{})
+	for paginator.HasMorePages() {
+		output, err := paginator.NextPage(ctx, func(options *ec2.Options) {
+			options.Region = cl.Region
+		})
+		if err != nil {
+			return err
+		}
+		res <- output.Ipams
+	}
+
+	return nil
+}

--- a/plugins/source/aws/resources/services/ec2/ipams_mock_test.go
+++ b/plugins/source/aws/resources/services/ec2/ipams_mock_test.go
@@ -27,5 +27,5 @@ func buildIpams(t *testing.T, ctrl *gomock.Controller) client.Services {
 }
 
 func TestIpams(t *testing.T) {
-	client.AwsMockTestHelper(t, IPAMs(), buildIpams, client.TestOptions{})
+	client.AwsMockTestHelper(t, Ipams(), buildIpams, client.TestOptions{})
 }

--- a/plugins/source/aws/resources/services/ec2/ipams_mock_test.go
+++ b/plugins/source/aws/resources/services/ec2/ipams_mock_test.go
@@ -1,0 +1,31 @@
+package ec2
+
+import (
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/service/ec2"
+	"github.com/aws/aws-sdk-go-v2/service/ec2/types"
+	"github.com/cloudquery/cloudquery/plugins/source/aws/client"
+	"github.com/cloudquery/cloudquery/plugins/source/aws/client/mocks"
+	"github.com/cloudquery/plugin-sdk/v4/faker"
+	"github.com/golang/mock/gomock"
+	"github.com/stretchr/testify/require"
+)
+
+func buildIpams(t *testing.T, ctrl *gomock.Controller) client.Services {
+	m := mocks.NewMockEc2Client(ctrl)
+	i := types.Ipam{}
+	require.NoError(t, faker.FakeObject(&i))
+
+	m.EXPECT().DescribeIpams(gomock.Any(), gomock.Any(), gomock.Any()).Return(
+		&ec2.DescribeIpamsOutput{
+			Ipams: []types.Ipam{i},
+		}, nil)
+	return client.Services{
+		Ec2: m,
+	}
+}
+
+func TestIpams(t *testing.T) {
+	client.AwsMockTestHelper(t, IPAMs(), buildIpams, client.TestOptions{})
+}

--- a/website/pages/docs/plugins/sources/aws/tables.md
+++ b/website/pages/docs/plugins/sources/aws/tables.md
@@ -223,6 +223,8 @@
 - [aws_ec2_instance_types](tables/aws_ec2_instance_types)
 - [aws_ec2_instances](tables/aws_ec2_instances)
 - [aws_ec2_internet_gateways](tables/aws_ec2_internet_gateways)
+- [aws_ec2_ipam_pools](tables/aws_ec2_ipam_pools)
+- [aws_ec2_ipams](tables/aws_ec2_ipams)
 - [aws_ec2_key_pairs](tables/aws_ec2_key_pairs)
 - [aws_ec2_launch_templates](tables/aws_ec2_launch_templates)
   - [aws_ec2_launch_template_versions](tables/aws_ec2_launch_template_versions)

--- a/website/tables/aws/aws_ec2_ipam_pools.md
+++ b/website/tables/aws/aws_ec2_ipam_pools.md
@@ -1,0 +1,40 @@
+# Table: aws_ec2_ipam_pools
+
+This table shows data for Amazon Elastic Compute Cloud (EC2) Amazon VPC IP Address Manager (IPAM) Pools.
+
+https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_IpamPool.html
+
+The composite primary key for this table is (**request_account_id**, **request_region**, **arn**).
+
+## Columns
+
+| Name          | Type          |
+| ------------- | ------------- |
+|_cq_id|`uuid`|
+|_cq_parent_id|`uuid`|
+|request_account_id (PK)|`utf8`|
+|request_region (PK)|`utf8`|
+|arn (PK)|`utf8`|
+|tags|`json`|
+|address_family|`utf8`|
+|allocation_default_netmask_length|`int64`|
+|allocation_max_netmask_length|`int64`|
+|allocation_min_netmask_length|`int64`|
+|allocation_resource_tags|`json`|
+|auto_import|`bool`|
+|aws_service|`utf8`|
+|description|`utf8`|
+|ipam_arn|`utf8`|
+|ipam_pool_arn|`utf8`|
+|ipam_pool_id|`utf8`|
+|ipam_region|`utf8`|
+|ipam_scope_arn|`utf8`|
+|ipam_scope_type|`utf8`|
+|locale|`utf8`|
+|owner_id|`utf8`|
+|pool_depth|`int64`|
+|public_ip_source|`utf8`|
+|publicly_advertisable|`bool`|
+|source_ipam_pool_id|`utf8`|
+|state|`utf8`|
+|state_message|`utf8`|

--- a/website/tables/aws/aws_ec2_ipams.md
+++ b/website/tables/aws/aws_ec2_ipams.md
@@ -1,0 +1,31 @@
+# Table: aws_ec2_ipams
+
+This table shows data for Amazon Elastic Compute Cloud (EC2) Ipams.
+
+https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_Ipam.html
+
+The composite primary key for this table is (**request_account_id**, **request_region**, **arn**).
+
+## Columns
+
+| Name          | Type          |
+| ------------- | ------------- |
+|_cq_id|`uuid`|
+|_cq_parent_id|`uuid`|
+|request_account_id (PK)|`utf8`|
+|request_region (PK)|`utf8`|
+|arn (PK)|`utf8`|
+|tags|`json`|
+|default_resource_discovery_association_id|`utf8`|
+|default_resource_discovery_id|`utf8`|
+|description|`utf8`|
+|ipam_arn|`utf8`|
+|ipam_id|`utf8`|
+|ipam_region|`utf8`|
+|operating_regions|`json`|
+|owner_id|`utf8`|
+|private_default_scope_id|`utf8`|
+|public_default_scope_id|`utf8`|
+|resource_discovery_association_count|`int64`|
+|scope_count|`int64`|
+|state|`utf8`|


### PR DESCRIPTION
<!-- 🎉 Thank you for making CloudQuery awesome by submitting a PR 🎉 -->

#### Summary

The applicable read-only API calls are:
- [x] describe-ipams
- [x] describe-ipam-pools
    - [ ] get-ipam-pool-allocations
    - [ ] get-ipam-pool-cidrs
- [x] describe-ipam-resource-discoveries
    - [ ] get-ipam-discovered-accounts
    - [ ] get-ipam-discovered-resource-cidrs
- [x] describe-ipam-resource-discovery-associations
- [ ] describe-ipam-scopes
    - [ ] get-ipam-address-history
    - [ ] get-ipam-resource-cidrs
