### PR TITLE
doc: Use DESTINATION_NAME in Fastly configuration docs

### DIFF
--- a/website/pages/docs/plugins/sources/fastly/_configuration.mdx
+++ b/website/pages/docs/plugins/sources/fastly/_configuration.mdx
@@ -1,4 +1,4 @@
-This example syncs from Fastly to a destination, using the token provided in an environment variable called `FASTLY_API_KEY`. The (top level) source spec section is described in the [Source Spec Reference](/docs/reference/source-spec).
+This example syncs from Fastly, using the token provided in an environment variable called `FASTLY_API_KEY`. The (top level) source spec section is described in the [Source Spec Reference](/docs/reference/source-spec).
 
 ```yaml copy
 kind: source
@@ -8,7 +8,7 @@ spec:
   path: cloudquery/fastly
   version: "VERSION_SOURCE_FASTLY"
   tables: ["*"]
-  destinations: ["postgresql"]
+  destinations: ["DESTINATION_NAME"]
 
   # Fastly specific configuration
   spec:


### PR DESCRIPTION
Fixing something I noticed while browsing plugin docs. Without this, the integration pages will all show `postgresql` regardless of the destination being synced to.