### PR TITLE
fix: Workaround 10k fetch incident limit in PagerDuty

### DIFF
--- a/plugins/source/pagerduty/resources/services/incidents/incidents_fetch.go
+++ b/plugins/source/pagerduty/resources/services/incidents/incidents_fetch.go
@@ -2,6 +2,7 @@ package incidents
 
 import (
 	"context"
+	"time"
 
 	"github.com/PagerDuty/go-pagerduty"
 	"github.com/cloudquery/cloudquery/plugins/source/pagerduty/client"
@@ -11,27 +12,57 @@ import (
 func fetchIncidents(ctx context.Context, meta schema.ClientMeta, parent *schema.Resource, res chan<- any) error {
 	cqClient := meta.(*client.Client)
 
-	more := true
-	var offset uint
-	for more {
-		response, err := cqClient.PagerdutyClient.ListIncidentsWithContext(ctx, pagerduty.ListIncidentsOptions{
-			Limit:     client.MaxPaginationLimit,
-			Offset:    offset,
-			DateRange: "all",
-			TeamIDs:   cqClient.Spec.TeamIds,
-		})
-		if err != nil {
-			return err
+	// Time step incidents fetching in ±90 days intervals because the list incident API
+	// won't return more than 10 000 incidents when using DateRange: "all".
+	// There isn't any deep rational about the 90 days, it's just a number that should work for most cases
+	// with an average of 111 incidents per day.
+	timeStep := time.Hour * 24 * 90
+
+	// Make an initial request to get the oldest incident.
+	// The list incident endpoint combined with DateRange: "all" returns the incidents in ascending order of creation date.
+	response, err := cqClient.PagerdutyClient.ListIncidentsWithContext(ctx, pagerduty.ListIncidentsOptions{
+		Limit:     1,
+		Offset:    0,
+		DateRange: "all",
+		TeamIDs:   cqClient.Spec.TeamIds,
+	})
+	if err != nil {
+		return err
+	}
+	if len(response.Incidents) == 0 {
+		return nil
+	}
+
+	since, err := time.Parse(time.RFC3339, response.Incidents[0].CreatedAt)
+	if err != nil {
+		return err
+	}
+	until := since.Add(timeStep)
+	now := time.Now()
+
+	for since.Before(now) {
+		more := true
+		offset := uint(0)
+		for more {
+			response, err := cqClient.PagerdutyClient.ListIncidentsWithContext(ctx, pagerduty.ListIncidentsOptions{
+				Limit:   client.MaxPaginationLimit,
+				Offset:  offset,
+				Since:   since.UTC().Format(time.RFC3339), // since is inclusive
+				Until:   until.UTC().Format(time.RFC3339), // until is exclusive
+				TeamIDs: cqClient.Spec.TeamIds,
+			})
+			if err != nil {
+				return err
+			}
+			if len(response.Incidents) == 0 {
+				break
+			}
+			res <- response.Incidents
+			offset += uint(len(response.Incidents))
+			more = response.More
 		}
-
-		if len(response.Incidents) == 0 {
-			return nil
-		}
-
-		res <- response.Incidents
-
-		offset += uint(len(response.Incidents))
-		more = response.More
+		since = until
+		until = since.Add(timeStep)
 	}
 
 	return nil


### PR DESCRIPTION
#### Summary

PagerDuty incidents listing API will fail when trying to retrieve more than 10 000 incidents.
```
HTTP response failed with status code 400, message: Arguments Caused Error (code: 2002): Offset+limit exceeds maximum allowed value of 10000. Please try to refine your search to reduce the returned set of records below this number, like adding a date range.
```
This PR update `fetchIncidents` to fetch incidents in increments of 90 days and workaround this limitation. 

<!--
Use the following steps to ensure your PR is ready to be reviewed

- [ x] Read the [contribution guidelines](../blob/main/CONTRIBUTING.md) 🧑‍🎓
- [ x] Run `make lint` to ensure the proposed changes follow the coding style 🚨 (install golangci-lint [here](https://golangci-lint.run/usage/install/#local-installation))
- [ x] Run `make test` to ensure the proposed changes pass the tests 🧪
- [ x] If changing a source plugin run `make gen` to ensure docs are up to date 📝
- [ ] Ensure the status checks below are successful ✅
--->
