### PR TITLE
fix(resources): Add `details` field to `gcp_containeranalysis_occurrences`

### DIFF
--- a/plugins/source/gcp/resources/services/containeranalysis/occurrences.go
+++ b/plugins/source/gcp/resources/services/containeranalysis/occurrences.go
@@ -7,7 +7,6 @@ import (
 	pb "cloud.google.com/go/containeranalysis/apiv1beta1/grafeas/grafeaspb"
 	"github.com/apache/arrow/go/v13/arrow"
 	"github.com/cloudquery/plugin-sdk/v4/schema"
-	common "google.golang.org/genproto/googleapis/devtools/containeranalysis/v1beta1/common"
 
 	"github.com/cloudquery/plugin-sdk/v4/transformers"
 	sdkTypes "github.com/cloudquery/plugin-sdk/v4/types"
@@ -64,26 +63,5 @@ func fetchOccurrences(ctx context.Context, meta schema.ClientMeta, parent *schem
 // details column resolver
 func resolveDetails(ctx context.Context, meta schema.ClientMeta, r *schema.Resource, col schema.Column) error {
 	occurrence := r.Item.(*pb.Occurrence)
-	switch occurrence.GetKind() {
-	// The note and occurrence represent a package vulnerability.
-	case common.NoteKind_VULNERABILITY:
-		return r.Set(col.Name, occurrence.GetVulnerability())
-	// The note and occurrence assert build provenance.
-	case common.NoteKind_BUILD:
-		return r.Set(col.Name, occurrence.GetBuild())
-	// This represents an image basis relationship.
-	case common.NoteKind_IMAGE:
-		return r.Set(col.Name, occurrence.GetDerivedImage())
-	// The note and occurrence track deployment events.
-	case common.NoteKind_DEPLOYMENT:
-		return r.Set(col.Name, occurrence.GetDeployment())
-	// The note and occurrence track the initial discovery status of a resource.
-	case common.NoteKind_DISCOVERY:
-		return r.Set(col.Name, occurrence.GetDiscovered())
-	// This represents a logical "role" that can attest to artifacts.
-	case common.NoteKind_ATTESTATION:
-		return r.Set(col.Name, occurrence.GetAttestation())
-	}
-	return nil
-
+	return r.Set(col.Name, occurrence.GetDetails())
 }

--- a/plugins/source/gcp/resources/services/containeranalysis/occurrences_mock_test.go
+++ b/plugins/source/gcp/resources/services/containeranalysis/occurrences_mock_test.go
@@ -22,12 +22,19 @@ type fakeOccurrencesServer struct {
 }
 
 func (*fakeOccurrencesServer) ListOccurrences(context.Context, *pb.ListOccurrencesRequest) (*pb.ListOccurrencesResponse, error) {
-	resp := pb.ListOccurrencesResponse{}
-	if err := faker.FakeObject(&resp); err != nil {
+	occ := pb.Occurrence{}
+	if err := faker.FakeObject(&occ); err != nil {
 		return nil, fmt.Errorf("failed to fake data: %w", err)
 	}
-	resp.NextPageToken = ""
-	return &resp, nil
+	occVul := pb.Occurrence_Vulnerability{}
+
+	if err := faker.FakeObject(&occVul); err != nil {
+		return nil, fmt.Errorf("failed to fake data: %w", err)
+	}
+	occ.Details = &occVul
+	return &pb.ListOccurrencesResponse{
+		Occurrences: []*pb.Occurrence{&occ},
+	}, nil
 }
 
 func TestOccurrences(t *testing.T) {

--- a/website/tables/gcp/gcp_containeranalysis_occurrences.md
+++ b/website/tables/gcp/gcp_containeranalysis_occurrences.md
@@ -13,6 +13,7 @@ The primary key for this table is **name**.
 |_cq_id|`uuid`|
 |_cq_parent_id|`uuid`|
 |project_id|`utf8`|
+|details|`json`|
 |name (PK)|`utf8`|
 |resource|`json`|
 |note_name|`utf8`|


### PR DESCRIPTION
<!-- 🎉 Thank you for making CloudQuery awesome by submitting a PR 🎉 -->

#### Summary

closes #12759 

The type of the field in the GCP struct is an `interface` which CQ automatically (and silently) skips during table generation. This generates a `json` field  and calls the exposed function to grab the data