### PR TITLE
fix: Return a datadog client instance instead of nil

### DIFF
--- a/plugins/source/datadog/resources/plugin/plugin.go
+++ b/plugins/source/datadog/resources/plugin/plugin.go
@@ -31,24 +31,24 @@ type Client struct {
 }
 
 func newClient(ctx context.Context, logger zerolog.Logger, specBytes []byte, options plugin.NewClientOptions) (plugin.Client, error) {
-	c := &Client{
-		options:   options,
-		allTables: getTables(),
-	}
+	c := &Client{options: options, allTables: getTables()}
 	if options.NoConnection {
 		return c, nil
 	}
+
 	spec := &client.Spec{}
 	if err := json.Unmarshal(specBytes, spec); err != nil {
 		return nil, err
 	}
+
 	clientMeta, err := client.Configure(ctx, logger, spec)
 	if err != nil {
 		return nil, err
 	}
+
 	c.client = clientMeta.(*client.Client)
 	c.scheduler = scheduler.NewScheduler(scheduler.WithLogger(logger), scheduler.WithConcurrency(spec.Concurrency))
-	return nil, nil
+	return c, nil
 }
 
 func (*Client) Close(_ context.Context) error {

--- a/plugins/source/datadog/resources/plugin/plugin_test.go
+++ b/plugins/source/datadog/resources/plugin/plugin_test.go
@@ -1,0 +1,53 @@
+package plugin
+
+import (
+	"context"
+	"github.com/cloudquery/plugin-sdk/v4/plugin"
+	"github.com/rs/zerolog"
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func Test_newClient(t *testing.T) {
+	t.Run("it should build an uninitialized client with no connection", func(t *testing.T) {
+		options := plugin.NewClientOptions{NoConnection: true}
+
+		client, err := newClient(context.TODO(), zerolog.Nop(), nil, options)
+		assert.NoError(t, err)
+
+		if assert.NotNil(t, client) {
+			c := client.(*Client)
+			assert.Nil(t, c.scheduler, "a client with no connection must not have a scheduler set")
+			assert.Nil(t, c.client, "a client with no connection must not have a datadog client set")
+		}
+	})
+
+	t.Run("it should return an error if the spec is not a valid JSON", func(t *testing.T) {
+		invalidSpecFormat := []byte(`not a valid JSON object`)
+
+		client, err := newClient(context.TODO(), zerolog.Nop(), invalidSpecFormat, plugin.NewClientOptions{})
+		assert.ErrorContains(t, err, "invalid character")
+		assert.Nil(t, client)
+	})
+
+	t.Run("it should return an error if the spec is not valid", func(t *testing.T) {
+		specWithNoAccount := []byte(`{}`)
+
+		client, err := newClient(context.TODO(), zerolog.Nop(), specWithNoAccount, plugin.NewClientOptions{})
+		assert.ErrorContains(t, err, "no datadog accounts configured")
+		assert.Nil(t, client)
+	})
+
+	t.Run("it should return an initialized client", func(t *testing.T) {
+		specWithAccount := []byte(`{"accounts": [{ "name": "sample" }]}`)
+
+		client, err := newClient(context.TODO(), zerolog.Nop(), specWithAccount, plugin.NewClientOptions{})
+		assert.NoError(t, err)
+
+		if assert.NotNil(t, client) {
+			c := client.(*Client)
+			assert.NotNil(t, c.scheduler, "a client with a connection must have a scheduler set")
+			assert.NotNil(t, c.client, "a client with a connection must have a datadog client set")
+		}
+	})
+}


### PR DESCRIPTION
<!-- 🎉 Thank you for making CloudQuery awesome by submitting a PR 🎉 -->

#### Summary

The last versions of Datadog plugin do not work and generate the following message:

>  plugin not initialized. call Init() first

The `newClient` function return `nil,nil` if the configuration is good. It should return the client initialized.

I wrote also some extra tests to prevent regression.

<!--
Explain what problem this PR addresses
-->

<!--
Use the following steps to ensure your PR is ready to be reviewed

- [ ] Read the [contribution guidelines](../blob/main/CONTRIBUTING.md) 🧑‍🎓
- [ ] Run `make lint` to ensure the proposed changes follow the coding style 🚨 (install golangci-lint [here](https://golangci-lint.run/usage/install/#local-installation))
- [ ] Run `make test` to ensure the proposed changes pass the tests 🧪
- [ ] If changing a source plugin run `make gen` to ensure docs are up to date 📝
- [ ] Ensure the status checks below are successful ✅
--->
