### PR TITLE
feat(aws): Define primary key for aws_organizations and remove accoun…

### DIFF
--- a/plugins/source/aws/resources/services/organizations/organizations.go
+++ b/plugins/source/aws/resources/services/organizations/organizations.go
@@ -20,11 +20,12 @@ func Organizations() *schema.Table {
 			&types.Organization{},
 			transformers.WithSkipFields(
 				"AvailablePolicyTypes", // deprecated and misleading field according to docs
+				"AccountId" // an organization doesn't belong to an account, other way around
 			),
 			transformers.WithPrimaryKeys("Arn"),
 		),
 		Multiplex: client.ServiceAccountRegionMultiplexer(tableName, "organizations"),
-		Columns:   []schema.Column{client.DefaultAccountIDColumn(true)},
+		Columns:   []schema.Column{client.DefaultAccountIDColumn(false)},
 	}
 }
 

--- a/website/tables/aws/aws_organizations.md
+++ b/website/tables/aws/aws_organizations.md
@@ -4,7 +4,7 @@ This table shows data for Organizations.
 
 https://docs.aws.amazon.com/organizations/latest/APIReference/API_Organization.html
 
-The composite primary key for this table is (**account_id**, **arn**).
+The primary key for this table is **arn**.
 
 ## Columns
 
@@ -12,7 +12,6 @@ The composite primary key for this table is (**account_id**, **arn**).
 | ------------- | ------------- |
 |_cq_id|`uuid`|
 |_cq_parent_id|`uuid`|
-|account_id (PK)|`utf8`|
 |arn (PK)|`utf8`|
 |feature_set|`utf8`|
 |id|`utf8`|


### PR DESCRIPTION
<!-- 🎉 Thank you for making CloudQuery awesome by submitting a PR 🎉 -->

#### Summary

This PR is aimed to address #12769 by limiting the primary key on `aws_organizations` table to `arn`.

Additionally it removes `account_id` from the table as an organization can have many accounts.
Indicating the `account_id` from which the organization was discovered isn't necessary.
