### PR TITLE
feat: Adding support for OIDC Token in Azure plugin

### DIFF
--- a/plugins/source/azure/client/client.go
+++ b/plugins/source/azure/client/client.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"os"
 	"strings"
 	"sync"
 
@@ -265,14 +266,30 @@ func New(ctx context.Context, logger zerolog.Logger, s *Spec) (schema.ClientMeta
 		}
 	})
 
+	oidcToken := c.pluginSpec.OIDCToken
 	var credsOptions *azidentity.DefaultAzureCredentialOptions
 	if c.Options != nil {
 		credsOptions = &azidentity.DefaultAzureCredentialOptions{ClientOptions: c.Options.ClientOptions}
 	}
 	var err error
-	c.Creds, err = azidentity.NewDefaultAzureCredential(credsOptions)
-	if err != nil {
-		return nil, err
+	if oidcToken == "" {
+		c.Creds, err = azidentity.NewDefaultAzureCredential(credsOptions)
+		if err != nil {
+			return nil, err
+		}
+	} else {
+		// Accessing Azure using OIDC token
+		tenantID := os.Getenv("AZURE_TENANT_ID")
+		clientID := os.Getenv("AZURE_CLIENT_ID")
+		if tenantID == "" {
+			return nil, errors.New("AZURE_TENANT_ID is empty")
+		}
+		c.Creds, err = azidentity.NewClientAssertionCredential(tenantID, clientID, func(ctx context.Context) (string, error) {
+			return oidcToken, nil
+		}, nil)
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	log.SetListener(nil)

--- a/plugins/source/azure/client/spec.go
+++ b/plugins/source/azure/client/spec.go
@@ -11,6 +11,7 @@ type Spec struct {
 	SkipSubscriptions    []string `json:"skip_subscriptions"`
 	NormalizeIDs         bool     `json:"normalize_ids"`
 	Concurrency          int      `json:"concurrency"`
+	OIDCToken            string   `json:"oidc_token"`
 }
 
 func (s *Spec) SetDefaults() {

--- a/website/pages/docs/plugins/sources/azure/_configuration.mdx
+++ b/website/pages/docs/plugins/sources/azure/_configuration.mdx
@@ -15,4 +15,5 @@ spec:
     # discovery_concurrency: 400
     # skip_subscriptions: []
     # normalize_ids: false
+    # oidc_token: ""
 ```

--- a/website/pages/docs/plugins/sources/azure/configuration.mdx
+++ b/website/pages/docs/plugins/sources/azure/configuration.mdx
@@ -39,3 +39,7 @@ This is the (nested) spec used by the Azure source plugin.
 - `normalize_ids` (`bool`) (default: `false`)
 
   Enabling this setting will force all `id` column values to be lowercase. This is useful to avoid case sensitivity and uniqueness issues around the `id` primary keys.
+
+- `oidc_token` (`string`) (default: empty)
+
+An OIDC token can be used to authenticate with Azure instead of `AZURE_CLIENT_SECRET`, This is useful for Azure AD workload identity federation. When using this option, the `AZURE_CLIENT_ID` and `AZURE_TENANT_ID` environment variables must be set.


### PR DESCRIPTION
This PR is created to support OIDC Token in Azure plugin. This PR would enable Azure plugin to be used without AZURE_CLIENT_SECRET. This follows principle of Azure AD workload identity federation with AWS.

