### PR TITLE
chore: Fix link to plugin versioning in AWS config docs

### DIFF
--- a/website/pages/docs/plugins/sources/aws/configuration.md
+++ b/website/pages/docs/plugins/sources/aws/configuration.md
@@ -110,7 +110,7 @@ This is the (nested) spec used by the AWS source plugin.
 
 - **preview** `table_options` (`map`) (default: not used)
 
-  This is a preview feature (for more information about `preview` features look at (Plugin Versioning)[(/docs/plugins/sources/aws/versioning)] ) that enables users to override the default options for specific tables.
+  This is a preview feature (for more information about `preview` features look at [plugin versioning](/docs/plugins/sources/aws/versioning) that enables users to override the default options for specific tables.
   The root of the object takes a table name, and the next level takes an API method name.
   The final level is the actual input object as defined by the API. 
 


### PR DESCRIPTION
<!-- 🎉 Thank you for making CloudQuery awesome by submitting a PR 🎉 -->

#### Summary

Use correct markdown format for links

<!--
Use the following steps to ensure your PR is ready to be reviewed

- [ ] Read the [contribution guidelines](../blob/main/CONTRIBUTING.md) 🧑‍🎓
- [ ] Run `make lint` to ensure the proposed changes follow the coding style 🚨 (install golangci-lint [here](https://golangci-lint.run/usage/install/#local-installation))
- [ ] Run `make test` to ensure the proposed changes pass the tests 🧪
- [ ] If changing a source plugin run `make gen` to ensure docs are up to date 📝
- [ ] Ensure the status checks below are successful ✅
--->
