### PR TITLE
fix: Normalization logic for new & existing tables differences

### DIFF
--- a/plugins/destination/postgresql/client/client.go
+++ b/plugins/destination/postgresql/client/client.go
@@ -107,15 +107,13 @@ func (c *Client) Write(ctx context.Context, res <-chan message.WriteMessage) err
 }
 
 func (c *Client) Close(ctx context.Context) error {
-	var err error
 	if c.conn == nil {
 		return fmt.Errorf("client already closed or not initialized")
 	}
-	if c.conn != nil {
-		c.conn.Close()
-		c.conn = nil
-	}
-	return err
+
+	c.conn.Close()
+	c.conn = nil
+	return nil
 }
 
 func (c *Client) currentDatabase(ctx context.Context) (string, error) {

--- a/plugins/destination/postgresql/client/list_tables.go
+++ b/plugins/destination/postgresql/client/list_tables.go
@@ -23,6 +23,9 @@ SELECT
 	pg_class.relname AS table_name,
 	pg_attribute.attname AS column_name,
 	CASE
+	    -- This is required per the differences in pg_catalog.format_type implementations
+	    -- between PostgreSQL & CockroachDB.
+	    -- namely, numeric(20,0)[] is returned as numeric[] unless we use the typelem format + []
 	    WHEN pg_type.typcategory = 'A' AND pg_type.typelem != 0
 		THEN pg_catalog.format_type(pg_type.typelem, pg_attribute.atttypmod) || '[]'
 		ELSE pg_catalog.format_type(pg_attribute.atttypid, pg_attribute.atttypmod)

--- a/plugins/destination/postgresql/client/list_tables.go
+++ b/plugins/destination/postgresql/client/list_tables.go
@@ -22,7 +22,11 @@ SELECT
 	columns.ordinal_position AS ordinal_position,
 	pg_class.relname AS table_name,
 	pg_attribute.attname AS column_name,
-	pg_catalog.format_type(pg_attribute.atttypid, pg_attribute.atttypmod) AS data_type,
+	CASE
+	    WHEN pg_type.typcategory = 'A' AND pg_type.typelem != 0
+		THEN pg_catalog.format_type(pg_type.typelem, pg_attribute.atttypmod) || '[]'
+		ELSE pg_catalog.format_type(pg_attribute.atttypid, pg_attribute.atttypmod)
+	END AS data_type,
 	CASE 
 		WHEN conkey IS NOT NULL AND array_position(conkey, pg_attribute.attnum) > 0 THEN true
 		ELSE false
@@ -34,6 +38,8 @@ SELECT
 	COALESCE(pg_constraint.conname, '') AS primary_key_constraint_name
 FROM
 	pg_catalog.pg_attribute
+	INNER JOIN
+	pg_catalog.pg_type ON pg_type.oid = pg_attribute.atttypid
 	INNER JOIN
 	pg_catalog.pg_class ON pg_class.oid = pg_attribute.attrelid
 	INNER JOIN

--- a/plugins/destination/postgresql/client/migrate.go
+++ b/plugins/destination/postgresql/client/migrate.go
@@ -143,14 +143,9 @@ func (*Client) canAutoMigrate(changes []schema.TableColumnChange) bool {
 
 // normalize the requested schema to be compatible with what Postgres supports
 func (c *Client) normalizeTables(tables schema.Tables, pgTables schema.Tables) schema.Tables {
-	var result schema.Tables
-	for _, table := range tables {
-		pgTable := pgTables.Get(table.Name)
-		if pgTable == nil {
-			result = append(result, table)
-		} else {
-			result = append(result, c.normalizeTable(table, pgTable))
-		}
+	result := make(schema.Tables, len(tables))
+	for i, table := range tables {
+		result[i] = c.normalizeTable(table, pgTables.Get(table.Name))
 	}
 	return result
 }

--- a/plugins/destination/postgresql/client/types.go
+++ b/plugins/destination/postgresql/client/types.go
@@ -17,7 +17,7 @@ func (c *Client) SchemaTypeToPg(t arrow.DataType) string {
 func (c *Client) PgToSchemaType(t string) arrow.DataType {
 	switch c.pgType {
 	case pgTypeCockroachDB:
-		return pgarrow.Pg10ToCockroach(t)
+		return pgarrow.CockroachToArrow(t)
 	default:
 		return pgarrow.Pg10ToArrow(t)
 	}

--- a/plugins/destination/postgresql/pgarrow/to_arrow.go
+++ b/plugins/destination/postgresql/pgarrow/to_arrow.go
@@ -45,6 +45,10 @@ func Pg10ToArrow(t string) arrow.DataType {
 		return arrow.PrimitiveTypes.Int32
 	case "bigint", "int8":
 		return arrow.PrimitiveTypes.Int64
+	case "numeric(20,0)":
+		// special case.
+		// TODO: add Decimal128/256 support
+		return arrow.PrimitiveTypes.Uint64
 	case "double precision", "float8":
 		return arrow.PrimitiveTypes.Float64
 	case "real", "float4":
@@ -68,10 +72,10 @@ func Pg10ToArrow(t string) arrow.DataType {
 	}
 }
 
-func Pg10ToCockroach(t string) arrow.DataType {
+func CockroachToArrow(t string) arrow.DataType {
 	t = normalize(t)
 	if strings.HasSuffix(t, "[]") {
-		return arrow.ListOf(Pg10ToCockroach(t[:len(t)-2]))
+		return arrow.ListOf(CockroachToArrow(t[:len(t)-2]))
 	}
 
 	parsers := []func(string) (arrow.DataType, bool){
@@ -101,6 +105,10 @@ func Pg10ToCockroach(t string) arrow.DataType {
 	case "int", "bigint", "int8", "int64", "integer":
 		// Cockroach has different aliases for ints
 		return arrow.PrimitiveTypes.Int64
+	case "numeric(20,0)":
+		// special case.
+		// TODO: add Decimal128/256 support
+		return arrow.PrimitiveTypes.Uint64
 	case "double precision", "float8":
 		return arrow.PrimitiveTypes.Float64
 	case "real", "float4":

--- a/plugins/destination/postgresql/pgarrow/to_arrow_test.go
+++ b/plugins/destination/postgresql/pgarrow/to_arrow_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/cloudquery/plugin-sdk/v4/types"
 )
 
-func TestPg10ToSchemaType(t *testing.T) {
+func TestPg10ToArrow(t *testing.T) {
 	cases := []struct {
 		pgType string
 		want   arrow.DataType
@@ -91,6 +91,8 @@ func TestPg10ToSchemaType(t *testing.T) {
 		{"time(4) with time zone", arrow.FixedWidthTypes.Time64us},
 		{"time(5) with time zone", arrow.FixedWidthTypes.Time64us},
 		{"time(6) with time zone", arrow.FixedWidthTypes.Time64us},
+		// special case for uint64
+		{"numeric(20,0)", arrow.PrimitiveTypes.Uint64},
 
 		// types that are converted to string for now - more specific support for these types
 		// may be added in the future
@@ -135,6 +137,140 @@ func TestPg10ToSchemaType(t *testing.T) {
 			got := Pg10ToArrow(c.pgType)
 			if !arrow.TypeEqual(got, c.want) {
 				t.Errorf("Pg10ToArrow(%q) = %v, want %v", c.pgType, got, c.want)
+			}
+		})
+	}
+}
+func TestCockroachToArrow(t *testing.T) {
+	cases := []struct {
+		pgType string
+		want   arrow.DataType
+	}{
+		{"boolean", arrow.FixedWidthTypes.Boolean},
+		{"bigint", arrow.PrimitiveTypes.Int64},
+		{"double precision", arrow.PrimitiveTypes.Float64},
+		{"uuid", types.ExtensionTypes.UUID},
+		{"bytea", arrow.BinaryTypes.Binary},
+		{"text[]", arrow.ListOf(arrow.BinaryTypes.String)},
+		{"json", types.ExtensionTypes.JSON},
+		{"jsonb", types.ExtensionTypes.JSON},
+		{"uuid[]", arrow.ListOf(types.ExtensionTypes.UUID)},
+		{"cidr", types.ExtensionTypes.Inet},
+		{"cidr[]", arrow.ListOf(types.ExtensionTypes.Inet)},
+		{"inet", types.ExtensionTypes.Inet},
+		{"inet[]", arrow.ListOf(types.ExtensionTypes.Inet)},
+		{"timestamp", arrow.FixedWidthTypes.Timestamp_us},
+		{"text[][]", arrow.ListOf(arrow.ListOf(arrow.BinaryTypes.String))},
+		{"varchar(50)", arrow.BinaryTypes.String},
+		{"varchar(50)[][]", arrow.ListOf(arrow.ListOf(arrow.BinaryTypes.String))},
+		{"character(10)", arrow.BinaryTypes.String},
+		{"integer[]", arrow.ListOf(arrow.PrimitiveTypes.Int64)},
+		{"timestamp", arrow.FixedWidthTypes.Timestamp_us},
+		{"timestamp with time zone", arrow.FixedWidthTypes.Timestamp_us},
+		{"timestamptz", arrow.FixedWidthTypes.Timestamp_us},
+		{"TIMESTAMPTZ USING timestamp(0)", arrow.FixedWidthTypes.Timestamp_s},
+		{"TIMESTAMPTZ USING timestamp(3)", arrow.FixedWidthTypes.Timestamp_ms},
+		{"TIMESTAMPTZ USING timestamp(6)", arrow.FixedWidthTypes.Timestamp_us},
+		{"timestamp(0)", arrow.FixedWidthTypes.Timestamp_s},
+		{"timestamp(1)", arrow.FixedWidthTypes.Timestamp_ms},
+		{"timestamp(2)", arrow.FixedWidthTypes.Timestamp_ms},
+		{"timestamp(3)", arrow.FixedWidthTypes.Timestamp_ms},
+		{"timestamp(4)", arrow.FixedWidthTypes.Timestamp_us},
+		{"timestamp(5)", arrow.FixedWidthTypes.Timestamp_us},
+		{"timestamp(6)", arrow.FixedWidthTypes.Timestamp_us},
+		{"timestamp(0) without time zone", arrow.FixedWidthTypes.Timestamp_s},
+		{"timestamp(1) without time zone", arrow.FixedWidthTypes.Timestamp_ms},
+		{"timestamp(2) without time zone", arrow.FixedWidthTypes.Timestamp_ms},
+		{"timestamp(3) without time zone", arrow.FixedWidthTypes.Timestamp_ms},
+		{"timestamp(4) without time zone", arrow.FixedWidthTypes.Timestamp_us},
+		{"timestamp(5) without time zone", arrow.FixedWidthTypes.Timestamp_us},
+		{"timestamp(6) without time zone", arrow.FixedWidthTypes.Timestamp_us},
+		{"timestamp(0) with time zone", arrow.FixedWidthTypes.Timestamp_s},
+		{"timestamp(1) with time zone", arrow.FixedWidthTypes.Timestamp_ms},
+		{"timestamp(2) with time zone", arrow.FixedWidthTypes.Timestamp_ms},
+		{"timestamp(3) with time zone", arrow.FixedWidthTypes.Timestamp_ms},
+		{"timestamp(4) with time zone", arrow.FixedWidthTypes.Timestamp_us},
+		{"timestamp(5) with time zone", arrow.FixedWidthTypes.Timestamp_us},
+		{"timestamp(6) with time zone", arrow.FixedWidthTypes.Timestamp_us},
+		{"date", arrow.FixedWidthTypes.Date32},
+		{"date[]", arrow.ListOf(arrow.FixedWidthTypes.Date32)},
+		{"time", arrow.FixedWidthTypes.Time64us},
+		{"time[]", arrow.ListOf(arrow.FixedWidthTypes.Time64us)},
+		{"time with time zone", arrow.FixedWidthTypes.Time64us},
+		{"time with time zone[]", arrow.ListOf(arrow.FixedWidthTypes.Time64us)},
+		{"time without time zone", arrow.FixedWidthTypes.Time64us},
+		{"time without time zone[]", arrow.ListOf(arrow.FixedWidthTypes.Time64us)},
+		{"time(0)", arrow.FixedWidthTypes.Time32s},
+		{"time(1)", arrow.FixedWidthTypes.Time32ms},
+		{"time(2)", arrow.FixedWidthTypes.Time32ms},
+		{"time(3)", arrow.FixedWidthTypes.Time32ms},
+		{"time(4)", arrow.FixedWidthTypes.Time64us},
+		{"time(5)", arrow.FixedWidthTypes.Time64us},
+		{"time(6)", arrow.FixedWidthTypes.Time64us},
+		{"time(0) without time zone", arrow.FixedWidthTypes.Time32s},
+		{"time(1) without time zone", arrow.FixedWidthTypes.Time32ms},
+		{"time(2) without time zone", arrow.FixedWidthTypes.Time32ms},
+		{"time(3) without time zone", arrow.FixedWidthTypes.Time32ms},
+		{"time(4) without time zone", arrow.FixedWidthTypes.Time64us},
+		{"time(5) without time zone", arrow.FixedWidthTypes.Time64us},
+		{"time(6) without time zone", arrow.FixedWidthTypes.Time64us},
+		{"time(0) with time zone", arrow.FixedWidthTypes.Time32s},
+		{"time(1) with time zone", arrow.FixedWidthTypes.Time32ms},
+		{"time(2) with time zone", arrow.FixedWidthTypes.Time32ms},
+		{"time(3) with time zone", arrow.FixedWidthTypes.Time32ms},
+		{"time(4) with time zone", arrow.FixedWidthTypes.Time64us},
+		{"time(5) with time zone", arrow.FixedWidthTypes.Time64us},
+		{"time(6) with time zone", arrow.FixedWidthTypes.Time64us},
+		// special case for uint64
+		{"numeric(20,0)", arrow.PrimitiveTypes.Uint64},
+
+		// types that are converted to string for now - more specific support for these types
+		// may be added in the future
+		{"macaddr", arrow.BinaryTypes.String},
+		{"macaddr8", arrow.BinaryTypes.String},
+		{"macaddr[]", arrow.ListOf(arrow.BinaryTypes.String)},
+		{"macaddr8[]", arrow.ListOf(arrow.BinaryTypes.String)},
+		{"numeric", arrow.BinaryTypes.String},
+		{"numeric (1, 0)", arrow.BinaryTypes.String},
+		{"numeric (1000, 1000)", arrow.BinaryTypes.String},
+		{"interval", arrow.BinaryTypes.String},
+		{"interval YEAR", arrow.BinaryTypes.String},
+		{"interval YEAR TO MONTH", arrow.BinaryTypes.String},
+		{"interval SECOND", arrow.BinaryTypes.String},
+		{"interval MINUTE TO SECOND", arrow.BinaryTypes.String},
+		{"interval MINUTE TO SECOND (0)", arrow.BinaryTypes.String},
+		{"interval MINUTE TO SECOND (3)", arrow.BinaryTypes.String},
+		{"interval SECOND (6)", arrow.BinaryTypes.String},
+		{"interval HOUR TO MINUTE", arrow.BinaryTypes.String},
+		{"interval YEAR", arrow.BinaryTypes.String},
+		{"interval MONTH", arrow.BinaryTypes.String},
+		{"interval DAY", arrow.BinaryTypes.String},
+		{"interval HOUR", arrow.BinaryTypes.String},
+		{"interval MINUTE", arrow.BinaryTypes.String},
+		{"interval SECOND", arrow.BinaryTypes.String},
+		{"interval YEAR TO MONTH", arrow.BinaryTypes.String},
+		{"interval DAY TO HOUR", arrow.BinaryTypes.String},
+		{"interval DAY TO MINUTE", arrow.BinaryTypes.String},
+		{"interval DAY TO SECOND", arrow.BinaryTypes.String},
+		{"interval HOUR TO MINUTE", arrow.BinaryTypes.String},
+		{"interval HOUR TO SECOND", arrow.BinaryTypes.String},
+		{"interval MINUTE TO SECOND", arrow.BinaryTypes.String},
+		{"money", arrow.BinaryTypes.String},
+		{"box", arrow.BinaryTypes.String},
+		{"bit", arrow.BinaryTypes.String},
+		{"bit varying(10)", arrow.BinaryTypes.String},
+		{"circle", arrow.BinaryTypes.String},
+		{"line", arrow.BinaryTypes.String},
+		{"point", arrow.BinaryTypes.String},
+		{"path", arrow.BinaryTypes.String},
+		{"polygon", arrow.BinaryTypes.String},
+	}
+
+	for _, c := range cases {
+		t.Run(c.pgType, func(t *testing.T) {
+			got := CockroachToArrow(c.pgType)
+			if !arrow.TypeEqual(got, c.want) {
+				t.Errorf("CockroachToArrow(%q) = %v, want %v", c.pgType, got, c.want)
 			}
 		})
 	}


### PR DESCRIPTION
Based on the findings from #12765 & #12870:
1. Handle `numeric(20,0)` as `uint64` from the database schema
2. Fix `numeric(20,0)[]` reported as `numeric[]` from CockroachDB
3. Always perform normalization even for the new tables