### PR TITLE
chore: Fix test plugin docker configuration

### DIFF
--- a/plugins/source/test/Dockerfile.goreleaser
+++ b/plugins/source/test/Dockerfile.goreleaser
@@ -1,3 +1,3 @@
 FROM scratch
 ENTRYPOINT ["/test"]
-COPY ./test /test
+COPY ./plugins/source/test /test


### PR DESCRIPTION
<!-- 🎉 Thank you for making CloudQuery awesome by submitting a PR 🎉 -->

#### Summary

The test plugin release workflow [started failing](https://github.com/cloudquery/cloudquery/actions/runs/5821978644/job/15785571460#step:7:54) with the latest version of Go Releaser (released yesterday).
I believe the change that broke it is this https://github.com/goreleaser/goreleaser/pull/4218.

This PR updates the docker file to match the fix

<!--
Use the following steps to ensure your PR is ready to be reviewed

- [ ] Read the [contribution guidelines](../blob/main/CONTRIBUTING.md) 🧑‍🎓
- [ ] Run `make lint` to ensure the proposed changes follow the coding style 🚨 (install golangci-lint [here](https://golangci-lint.run/usage/install/#local-installation))
- [ ] Run `make test` to ensure the proposed changes pass the tests 🧪
- [ ] If changing a source plugin run `make gen` to ensure docs are up to date 📝
- [ ] Ensure the status checks below are successful ✅
--->
