### PR TITLE
feat: Snowflake private_key config option.

### DIFF
--- a/plugins/destination/snowflake/client/spec.go
+++ b/plugins/destination/snowflake/client/spec.go
@@ -39,9 +39,11 @@ func (s *Spec) SetDefaults() {
 }
 
 func (s Spec) DSN() (string, error) {
-	if s.ConnectionString == "" {
+	cs := s.ConnectionString
+	if cs == "" {
 		return "", fmt.Errorf("connection_string is required")
 	}
+
 	if s.PrivateKey != "" {
 		pk, err := formatPrivateKey(s.PrivateKey)
 		if err != nil {
@@ -49,12 +51,12 @@ func (s Spec) DSN() (string, error) {
 		}
 
 		sep := "?"
-		if strings.Contains(s.ConnectionString, "?") {
+		if strings.Contains(cs, "?") {
 			sep = "&"
 		}
-		s.ConnectionString += sep + "authenticator=snowflake_jwt&privateKey=" + base64.URLEncoding.EncodeToString(pk)
+		cs += sep + "authenticator=snowflake_jwt&privateKey=" + base64.URLEncoding.EncodeToString(pk)
 	}
-	return s.ConnectionString, nil
+	return cs, nil
 }
 
 var whitespace = regexp.MustCompile(`\s+`)

--- a/plugins/destination/snowflake/client/spec.go
+++ b/plugins/destination/snowflake/client/spec.go
@@ -1,6 +1,15 @@
 package client
 
-import "fmt"
+import (
+	"crypto/rsa"
+	"crypto/x509"
+	"encoding/base64"
+	"encoding/pem"
+	"errors"
+	"fmt"
+	"regexp"
+	"strings"
+)
 
 const (
 	defaultBatchSize          = 1000
@@ -10,6 +19,7 @@ const (
 
 type Spec struct {
 	ConnectionString   string `json:"connection_string,omitempty"`
+	PrivateKey         string `json:"private_key,omitempty"`
 	BatchSize          int    `json:"batch_size,omitempty"`
 	BatchSizeBytes     int    `json:"batch_size_bytes,omitempty"`
 	MigrateConcurrency int    `json:"migrate_concurrency,omitempty"`
@@ -28,9 +38,82 @@ func (s *Spec) SetDefaults() {
 	}
 }
 
-func (s *Spec) Validate() error {
+func (s Spec) DSN() (string, error) {
 	if s.ConnectionString == "" {
-		return fmt.Errorf("connection_string is required")
+		return "", fmt.Errorf("connection_string is required")
 	}
-	return nil
+	if s.PrivateKey != "" {
+		pk, err := formatPrivateKey(s.PrivateKey)
+		if err != nil {
+			return "", fmt.Errorf("private_key: %w", err)
+		}
+
+		sep := "?"
+		if strings.Contains(s.ConnectionString, "?") {
+			sep = "&"
+		}
+		s.ConnectionString += sep + "authenticator=snowflake_jwt&privateKey=" + base64.URLEncoding.EncodeToString(pk)
+	}
+	return s.ConnectionString, nil
+}
+
+var whitespace = regexp.MustCompile(`\s+`)
+
+func formatPrivateKey(blob string) ([]byte, error) {
+	// Strip any PEM block headers.
+	const (
+		pemBegin = "-----BEGIN "
+		pemSep   = "-----"
+		pemEnd   = "-----END "
+	)
+	_, rest, hadBegin := strings.Cut(blob, pemBegin)
+	head, rest, hadEnd := strings.Cut(rest, pemSep)
+	key, rest, hadKey := strings.Cut(rest, pemEnd)
+	tail, _, hadTail := strings.Cut(rest, pemSep)
+	if !hadBegin || !hadEnd || !hadKey || !hadTail {
+		return nil, fmt.Errorf("unable to find %s...%s...%s...%s in private key", pemBegin, pemSep, pemEnd, pemSep)
+	}
+
+	// Encrypted private keys aren't supported (TODO: Is this only because
+	// pem.Decode doesn't support it? Does the underlying Snowflake Go SQL
+	// Driver support it?)
+	const pemPrivKey = "PRIVATE KEY"
+	switch strings.ToUpper(head) {
+	case pemPrivKey:
+		// OK.
+	case "ENCRYPTED PRIVATE KEY":
+		return nil, errors.New("encrypted private keys are not supported, use decrypted private key")
+	default:
+		return nil, fmt.Errorf("unrecognised start block %s%s%s, expected %s%s%s", pemBegin, head, pemSep, pemBegin, pemPrivKey, pemSep)
+	}
+
+	// Rebuild the key with the correct line breaks.
+	//
+	// The expansion of ${file:./private.key} in our YAML specs doesn't retain
+	// newlines at the time of writing (unless private.key contains valid JSON,
+	// which it shouldn't here) so we're going to substitute all inner
+	// whitespace with newlines.
+	blob = pemBegin + head + pemSep + "\n" + strings.TrimSpace(whitespace.ReplaceAllString(key, "\n")) + "\n" + pemEnd + tail + pemSep
+
+	// Parse and reformat.
+	//
+	// https://github.com/snowflakedb/gosnowflake/blob/7de6b8d13750ca70667f554335862f97a82720ea/cmd/keypair/keypair.go#L39-L52
+	block, _ := pem.Decode([]byte(blob))
+	if block == nil {
+		return nil, errors.New("could not decode PEM block")
+	}
+	privKey, err := x509.ParsePKCS8PrivateKey(block.Bytes)
+	if err != nil {
+		return nil, fmt.Errorf("parsing private key: %w", err)
+	}
+	rsaPrivateKey, ok := privKey.(*rsa.PrivateKey)
+	if !ok {
+		return nil, fmt.Errorf("expected *rsa.PrivateKey but got %T", privKey)
+	}
+	rsaBytes, err := x509.MarshalPKCS8PrivateKey(rsaPrivateKey)
+	if err != nil {
+		return nil, fmt.Errorf("re-marshalling rsa private key: %w", err)
+	}
+
+	return rsaBytes, nil
 }

--- a/plugins/destination/snowflake/client/spec_test.go
+++ b/plugins/destination/snowflake/client/spec_test.go
@@ -1,0 +1,73 @@
+package client_test
+
+import (
+	"encoding/json"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/cloudquery/cloudquery/plugins/destination/snowflake/client"
+)
+
+func TestSpec_DSN(t *testing.T) {
+	tests := []struct {
+		Spec    client.Spec
+		Extra   map[string]*string
+		WantDSN string
+		WantErr string
+	}{
+		{
+			Spec: client.Spec{
+				ConnectionString: "user@acc/db/schema?warehouse=wh",
+				PrivateKey:       "-----BEGIN PRIVATE KEY-----\nMIIEvAIBADANBgkqhkiG9w0BAQEFAASCBKYwggSiAgEAAoIBAQDAWKgfyKnlEMAm\nbR5Kc5V//3LFJp0rQyR5gVRIxvsU/9RaWi+c/9FBCPVGpi4yJ5TGRRKxoZwX/yCg\nnE76Vxatz26DwM3qagAfNDjtKlyqdLSrMWUNTSj8WVKPd9sPnDErYvIw21Nnx4Sj\nEt0Zku1C+K+GVw0J83Fu7d0dVB3XM1KKguY8+POQ5gs+kOef9p4yaFkwqqCeigdb\nIU7XSw/6A5jFWajKzpdL1mH8H2iidMSVWJ8Pngx4mdk5dVbrLAhgyuIfgsOSdane\nX851+7qozlog67JR6wLbIGWPO7RpJMCYkR0Z2n5BHmpnqJ95qFTOWIAH24XKdeib\n+H2X8+DFAgMBAAECggEAL53zFxU97AGS1CB42n0VQl/6qXB3AcYIMlVQSIkMEQWJ\nbEm91kvlYYiGchRDRPLUC6Z/a36i7jTgfqpbifGD4YkD5rWVNIZD2/W5bwso8CDe\nti/PALU8o4Y4YGCPWGS2LnO7Gdm+Iue7gAR0PHfJaWY3y9XimjdMemYD8pYHoiW6\nATQ4XkLskvlqiLnyNMdb1ByTGxgB8778O/HsoMyNdzYeWgxyZtfaa/CBr0xQr92Q\n9CfcB0YizK0I+nygP4RR5CFPEM+zQ9VEeFHTh4yci0A4+VYs7NRpSUrUW7TVeu4d\nAGKHnooe/EL4DtdcNZVUipZLLy6lHCEAuWvWVAVQEQKBgQDv/Qzj3tKuXOENBmNE\nLluS5dIE+KYMa9chioctiJqIWT9rrHz2/EU7b1W5mxby7WJFppwMzFHJP6GgnFaw\niYgK54YMsPv/5WrXftN4vC3vuw1pOUZIPT41e8Uu30lFcl/crpEfwA3Rg/2m57Fe\nptPPKn0+y50JiQIo3NxcY6LsNQKBgQDNLeONgojsGwen1PoaEtEvAdYhmwI3HVbV\nFyKNifO7T7eISM4rwMP3FstykHzpcTwno/WrC5+jCeNc7q/U1AEudLu2YYpJKRlZ\nbEv4rAfZeJp08f6lxKOuI5SLL7iZ3MqsoAAnv1kwYCztlcYDt4c3LVYTub5tcWHv\n34rWi4cUUQKBgC9sy1pQk0O/uP2Q8Jbtrk0GO42d8Xps6TOIo5P89cTSFjVZ/cv1\nKF1JcCBgpJVXEd9/wEDLM7JYb8FEg+EZHJhDDnt9kh8MoCN7vaCTV2STi1/q4Jev\n+pYpIltT5q/hnU4H9UfX9SMdOUf9a1CwGRVMaTm6lQroV1Pp6WYcjnqtAoGARUO0\nidUDPBFz6ChxtdOcYm4QR4/4k3qIEa+ZroZfjWA/6PYLA6IzhXpge/Bi+ruLPyaO\njIuD/Jod8wVwvjxDmdc2dz8+W6xQLmvsyanpjHS2T7xR5swXJXZFcydM/kQW92ec\nJc7m4PnWsO3axu5x6yKW6FnP+0pHcZ7ZU8wOccECgYA2rkrQVk9qHqBzymZFj47I\nQwD65jlzNeK9xMeKHivsJc4K9cmwec4jRcsu8gEYcWIbhepjHUA5M/4mO0++bnsP\nPP2xIiqseAOt4rI0wTeXqY8AM6YvbfdMq+tN+BlXix0WBEGNFGpab3B9bmv8UK0L\njhuCua5QHoIX6/fasAJ88w==\n-----END PRIVATE KEY-----\n",
+			},
+			WantDSN: "user@acc/db/schema?warehouse=wh&authenticator=snowflake_jwt&privateKey=MIIEvAIBADANBgkqhkiG9w0BAQEFAASCBKYwggSiAgEAAoIBAQDAWKgfyKnlEMAmbR5Kc5V__3LFJp0rQyR5gVRIxvsU_9RaWi-c_9FBCPVGpi4yJ5TGRRKxoZwX_yCgnE76Vxatz26DwM3qagAfNDjtKlyqdLSrMWUNTSj8WVKPd9sPnDErYvIw21Nnx4SjEt0Zku1C-K-GVw0J83Fu7d0dVB3XM1KKguY8-POQ5gs-kOef9p4yaFkwqqCeigdbIU7XSw_6A5jFWajKzpdL1mH8H2iidMSVWJ8Pngx4mdk5dVbrLAhgyuIfgsOSdaneX851-7qozlog67JR6wLbIGWPO7RpJMCYkR0Z2n5BHmpnqJ95qFTOWIAH24XKdeib-H2X8-DFAgMBAAECggEAL53zFxU97AGS1CB42n0VQl_6qXB3AcYIMlVQSIkMEQWJbEm91kvlYYiGchRDRPLUC6Z_a36i7jTgfqpbifGD4YkD5rWVNIZD2_W5bwso8CDeti_PALU8o4Y4YGCPWGS2LnO7Gdm-Iue7gAR0PHfJaWY3y9XimjdMemYD8pYHoiW6ATQ4XkLskvlqiLnyNMdb1ByTGxgB8778O_HsoMyNdzYeWgxyZtfaa_CBr0xQr92Q9CfcB0YizK0I-nygP4RR5CFPEM-zQ9VEeFHTh4yci0A4-VYs7NRpSUrUW7TVeu4dAGKHnooe_EL4DtdcNZVUipZLLy6lHCEAuWvWVAVQEQKBgQDv_Qzj3tKuXOENBmNELluS5dIE-KYMa9chioctiJqIWT9rrHz2_EU7b1W5mxby7WJFppwMzFHJP6GgnFawiYgK54YMsPv_5WrXftN4vC3vuw1pOUZIPT41e8Uu30lFcl_crpEfwA3Rg_2m57FeptPPKn0-y50JiQIo3NxcY6LsNQKBgQDNLeONgojsGwen1PoaEtEvAdYhmwI3HVbVFyKNifO7T7eISM4rwMP3FstykHzpcTwno_WrC5-jCeNc7q_U1AEudLu2YYpJKRlZbEv4rAfZeJp08f6lxKOuI5SLL7iZ3MqsoAAnv1kwYCztlcYDt4c3LVYTub5tcWHv34rWi4cUUQKBgC9sy1pQk0O_uP2Q8Jbtrk0GO42d8Xps6TOIo5P89cTSFjVZ_cv1KF1JcCBgpJVXEd9_wEDLM7JYb8FEg-EZHJhDDnt9kh8MoCN7vaCTV2STi1_q4Jev-pYpIltT5q_hnU4H9UfX9SMdOUf9a1CwGRVMaTm6lQroV1Pp6WYcjnqtAoGARUO0idUDPBFz6ChxtdOcYm4QR4_4k3qIEa-ZroZfjWA_6PYLA6IzhXpge_Bi-ruLPyaOjIuD_Jod8wVwvjxDmdc2dz8-W6xQLmvsyanpjHS2T7xR5swXJXZFcydM_kQW92ecJc7m4PnWsO3axu5x6yKW6FnP-0pHcZ7ZU8wOccECgYA2rkrQVk9qHqBzymZFj47IQwD65jlzNeK9xMeKHivsJc4K9cmwec4jRcsu8gEYcWIbhepjHUA5M_4mO0--bnsPPP2xIiqseAOt4rI0wTeXqY8AM6YvbfdMq-tN-BlXix0WBEGNFGpab3B9bmv8UK0LjhuCua5QHoIX6_fasAJ88w==",
+		},
+		{
+			Spec: client.Spec{
+				ConnectionString: "user@acc/db/schema?warehouse=wh",
+				// This is the key above but with all line breaks replaced with
+				// spaces, which is invalid, but we're going to repair the key.
+				PrivateKey: "-----BEGIN PRIVATE KEY-----  MIIEvAIBADANBgkqhkiG9w0BAQEFAASCBKYwggSiAgEAAoIBAQDAWKgfyKnlEMAm  bR5Kc5V//3LFJp0rQyR5gVRIxvsU/9RaWi+c/9FBCPVGpi4yJ5TGRRKxoZwX/yCg  nE76Vxatz26DwM3qagAfNDjtKlyqdLSrMWUNTSj8WVKPd9sPnDErYvIw21Nnx4Sj  Et0Zku1C+K+GVw0J83Fu7d0dVB3XM1KKguY8+POQ5gs+kOef9p4yaFkwqqCeigdb  IU7XSw/6A5jFWajKzpdL1mH8H2iidMSVWJ8Pngx4mdk5dVbrLAhgyuIfgsOSdane  X851+7qozlog67JR6wLbIGWPO7RpJMCYkR0Z2n5BHmpnqJ95qFTOWIAH24XKdeib  +H2X8+DFAgMBAAECggEAL53zFxU97AGS1CB42n0VQl/6qXB3AcYIMlVQSIkMEQWJ  bEm91kvlYYiGchRDRPLUC6Z/a36i7jTgfqpbifGD4YkD5rWVNIZD2/W5bwso8CDe  ti/PALU8o4Y4YGCPWGS2LnO7Gdm+Iue7gAR0PHfJaWY3y9XimjdMemYD8pYHoiW6  ATQ4XkLskvlqiLnyNMdb1ByTGxgB8778O/HsoMyNdzYeWgxyZtfaa/CBr0xQr92Q  9CfcB0YizK0I+nygP4RR5CFPEM+zQ9VEeFHTh4yci0A4+VYs7NRpSUrUW7TVeu4d  AGKHnooe/EL4DtdcNZVUipZLLy6lHCEAuWvWVAVQEQKBgQDv/Qzj3tKuXOENBmNE  LluS5dIE+KYMa9chioctiJqIWT9rrHz2/EU7b1W5mxby7WJFppwMzFHJP6GgnFaw  iYgK54YMsPv/5WrXftN4vC3vuw1pOUZIPT41e8Uu30lFcl/crpEfwA3Rg/2m57Fe  ptPPKn0+y50JiQIo3NxcY6LsNQKBgQDNLeONgojsGwen1PoaEtEvAdYhmwI3HVbV  FyKNifO7T7eISM4rwMP3FstykHzpcTwno/WrC5+jCeNc7q/U1AEudLu2YYpJKRlZ  bEv4rAfZeJp08f6lxKOuI5SLL7iZ3MqsoAAnv1kwYCztlcYDt4c3LVYTub5tcWHv  34rWi4cUUQKBgC9sy1pQk0O/uP2Q8Jbtrk0GO42d8Xps6TOIo5P89cTSFjVZ/cv1  KF1JcCBgpJVXEd9/wEDLM7JYb8FEg+EZHJhDDnt9kh8MoCN7vaCTV2STi1/q4Jev  +pYpIltT5q/hnU4H9UfX9SMdOUf9a1CwGRVMaTm6lQroV1Pp6WYcjnqtAoGARUO0  idUDPBFz6ChxtdOcYm4QR4/4k3qIEa+ZroZfjWA/6PYLA6IzhXpge/Bi+ruLPyaO  jIuD/Jod8wVwvjxDmdc2dz8+W6xQLmvsyanpjHS2T7xR5swXJXZFcydM/kQW92ec  Jc7m4PnWsO3axu5x6yKW6FnP+0pHcZ7ZU8wOccECgYA2rkrQVk9qHqBzymZFj47I  QwD65jlzNeK9xMeKHivsJc4K9cmwec4jRcsu8gEYcWIbhepjHUA5M/4mO0++bnsP  PP2xIiqseAOt4rI0wTeXqY8AM6YvbfdMq+tN+BlXix0WBEGNFGpab3B9bmv8UK0L  jhuCua5QHoIX6/fasAJ88w==  -----END PRIVATE KEY-----  ",
+			},
+			WantDSN: "user@acc/db/schema?warehouse=wh&authenticator=snowflake_jwt&privateKey=MIIEvAIBADANBgkqhkiG9w0BAQEFAASCBKYwggSiAgEAAoIBAQDAWKgfyKnlEMAmbR5Kc5V__3LFJp0rQyR5gVRIxvsU_9RaWi-c_9FBCPVGpi4yJ5TGRRKxoZwX_yCgnE76Vxatz26DwM3qagAfNDjtKlyqdLSrMWUNTSj8WVKPd9sPnDErYvIw21Nnx4SjEt0Zku1C-K-GVw0J83Fu7d0dVB3XM1KKguY8-POQ5gs-kOef9p4yaFkwqqCeigdbIU7XSw_6A5jFWajKzpdL1mH8H2iidMSVWJ8Pngx4mdk5dVbrLAhgyuIfgsOSdaneX851-7qozlog67JR6wLbIGWPO7RpJMCYkR0Z2n5BHmpnqJ95qFTOWIAH24XKdeib-H2X8-DFAgMBAAECggEAL53zFxU97AGS1CB42n0VQl_6qXB3AcYIMlVQSIkMEQWJbEm91kvlYYiGchRDRPLUC6Z_a36i7jTgfqpbifGD4YkD5rWVNIZD2_W5bwso8CDeti_PALU8o4Y4YGCPWGS2LnO7Gdm-Iue7gAR0PHfJaWY3y9XimjdMemYD8pYHoiW6ATQ4XkLskvlqiLnyNMdb1ByTGxgB8778O_HsoMyNdzYeWgxyZtfaa_CBr0xQr92Q9CfcB0YizK0I-nygP4RR5CFPEM-zQ9VEeFHTh4yci0A4-VYs7NRpSUrUW7TVeu4dAGKHnooe_EL4DtdcNZVUipZLLy6lHCEAuWvWVAVQEQKBgQDv_Qzj3tKuXOENBmNELluS5dIE-KYMa9chioctiJqIWT9rrHz2_EU7b1W5mxby7WJFppwMzFHJP6GgnFawiYgK54YMsPv_5WrXftN4vC3vuw1pOUZIPT41e8Uu30lFcl_crpEfwA3Rg_2m57FeptPPKn0-y50JiQIo3NxcY6LsNQKBgQDNLeONgojsGwen1PoaEtEvAdYhmwI3HVbVFyKNifO7T7eISM4rwMP3FstykHzpcTwno_WrC5-jCeNc7q_U1AEudLu2YYpJKRlZbEv4rAfZeJp08f6lxKOuI5SLL7iZ3MqsoAAnv1kwYCztlcYDt4c3LVYTub5tcWHv34rWi4cUUQKBgC9sy1pQk0O_uP2Q8Jbtrk0GO42d8Xps6TOIo5P89cTSFjVZ_cv1KF1JcCBgpJVXEd9_wEDLM7JYb8FEg-EZHJhDDnt9kh8MoCN7vaCTV2STi1_q4Jev-pYpIltT5q_hnU4H9UfX9SMdOUf9a1CwGRVMaTm6lQroV1Pp6WYcjnqtAoGARUO0idUDPBFz6ChxtdOcYm4QR4_4k3qIEa-ZroZfjWA_6PYLA6IzhXpge_Bi-ruLPyaOjIuD_Jod8wVwvjxDmdc2dz8-W6xQLmvsyanpjHS2T7xR5swXJXZFcydM_kQW92ecJc7m4PnWsO3axu5x6yKW6FnP-0pHcZ7ZU8wOccECgYA2rkrQVk9qHqBzymZFj47IQwD65jlzNeK9xMeKHivsJc4K9cmwec4jRcsu8gEYcWIbhepjHUA5M_4mO0--bnsPPP2xIiqseAOt4rI0wTeXqY8AM6YvbfdMq-tN-BlXix0WBEGNFGpab3B9bmv8UK0LjhuCua5QHoIX6_fasAJ88w==",
+		},
+		{
+			Spec: client.Spec{
+				ConnectionString: "user@acc/db/schema?warehouse=wh",
+				PrivateKey:       "-----BEGIN ENCRYPTED PRIVATE KEY-----  MIIEvAIBADANBgkqhkiG9w0BAQEFAASCBKYwggSiAgEAAoIBAQDAWKgfyKnlEMAm  bR5Kc5V//3LFJp0rQyR5gVRIxvsU/9RaWi+c/9FBCPVGpi4yJ5TGRRKxoZwX/yCg  nE76Vxatz26DwM3qagAfNDjtKlyqdLSrMWUNTSj8WVKPd9sPnDErYvIw21Nnx4Sj  Et0Zku1C+K+GVw0J83Fu7d0dVB3XM1KKguY8+POQ5gs+kOef9p4yaFkwqqCeigdb  IU7XSw/6A5jFWajKzpdL1mH8H2iidMSVWJ8Pngx4mdk5dVbrLAhgyuIfgsOSdane  X851+7qozlog67JR6wLbIGWPO7RpJMCYkR0Z2n5BHmpnqJ95qFTOWIAH24XKdeib  +H2X8+DFAgMBAAECggEAL53zFxU97AGS1CB42n0VQl/6qXB3AcYIMlVQSIkMEQWJ  bEm91kvlYYiGchRDRPLUC6Z/a36i7jTgfqpbifGD4YkD5rWVNIZD2/W5bwso8CDe  ti/PALU8o4Y4YGCPWGS2LnO7Gdm+Iue7gAR0PHfJaWY3y9XimjdMemYD8pYHoiW6  ATQ4XkLskvlqiLnyNMdb1ByTGxgB8778O/HsoMyNdzYeWgxyZtfaa/CBr0xQr92Q  9CfcB0YizK0I+nygP4RR5CFPEM+zQ9VEeFHTh4yci0A4+VYs7NRpSUrUW7TVeu4d  AGKHnooe/EL4DtdcNZVUipZLLy6lHCEAuWvWVAVQEQKBgQDv/Qzj3tKuXOENBmNE  LluS5dIE+KYMa9chioctiJqIWT9rrHz2/EU7b1W5mxby7WJFppwMzFHJP6GgnFaw  iYgK54YMsPv/5WrXftN4vC3vuw1pOUZIPT41e8Uu30lFcl/crpEfwA3Rg/2m57Fe  ptPPKn0+y50JiQIo3NxcY6LsNQKBgQDNLeONgojsGwen1PoaEtEvAdYhmwI3HVbV  FyKNifO7T7eISM4rwMP3FstykHzpcTwno/WrC5+jCeNc7q/U1AEudLu2YYpJKRlZ  bEv4rAfZeJp08f6lxKOuI5SLL7iZ3MqsoAAnv1kwYCztlcYDt4c3LVYTub5tcWHv  34rWi4cUUQKBgC9sy1pQk0O/uP2Q8Jbtrk0GO42d8Xps6TOIo5P89cTSFjVZ/cv1  KF1JcCBgpJVXEd9/wEDLM7JYb8FEg+EZHJhDDnt9kh8MoCN7vaCTV2STi1/q4Jev  +pYpIltT5q/hnU4H9UfX9SMdOUf9a1CwGRVMaTm6lQroV1Pp6WYcjnqtAoGARUO0  idUDPBFz6ChxtdOcYm4QR4/4k3qIEa+ZroZfjWA/6PYLA6IzhXpge/Bi+ruLPyaO  jIuD/Jod8wVwvjxDmdc2dz8+W6xQLmvsyanpjHS2T7xR5swXJXZFcydM/kQW92ec  Jc7m4PnWsO3axu5x6yKW6FnP+0pHcZ7ZU8wOccECgYA2rkrQVk9qHqBzymZFj47I  QwD65jlzNeK9xMeKHivsJc4K9cmwec4jRcsu8gEYcWIbhepjHUA5M/4mO0++bnsP  PP2xIiqseAOt4rI0wTeXqY8AM6YvbfdMq+tN+BlXix0WBEGNFGpab3B9bmv8UK0L  jhuCua5QHoIX6/fasAJ88w==  -----END PRIVATE KEY-----  ",
+			},
+			WantErr: "private_key: encrypted private keys are not supported, use decrypted private key",
+		},
+		{
+			Spec: client.Spec{
+				ConnectionString: "user@acc/db/schema?warehouse=wh",
+				PrivateKey:       "-----BEGIN WEIRD PRIVATE KEY-----  MIIEvAIBADANBgkqhkiG9w0BAQEFAASCBKYwggSiAgEAAoIBAQDAWKgfyKnlEMAm  bR5Kc5V//3LFJp0rQyR5gVRIxvsU/9RaWi+c/9FBCPVGpi4yJ5TGRRKxoZwX/yCg  nE76Vxatz26DwM3qagAfNDjtKlyqdLSrMWUNTSj8WVKPd9sPnDErYvIw21Nnx4Sj  Et0Zku1C+K+GVw0J83Fu7d0dVB3XM1KKguY8+POQ5gs+kOef9p4yaFkwqqCeigdb  IU7XSw/6A5jFWajKzpdL1mH8H2iidMSVWJ8Pngx4mdk5dVbrLAhgyuIfgsOSdane  X851+7qozlog67JR6wLbIGWPO7RpJMCYkR0Z2n5BHmpnqJ95qFTOWIAH24XKdeib  +H2X8+DFAgMBAAECggEAL53zFxU97AGS1CB42n0VQl/6qXB3AcYIMlVQSIkMEQWJ  bEm91kvlYYiGchRDRPLUC6Z/a36i7jTgfqpbifGD4YkD5rWVNIZD2/W5bwso8CDe  ti/PALU8o4Y4YGCPWGS2LnO7Gdm+Iue7gAR0PHfJaWY3y9XimjdMemYD8pYHoiW6  ATQ4XkLskvlqiLnyNMdb1ByTGxgB8778O/HsoMyNdzYeWgxyZtfaa/CBr0xQr92Q  9CfcB0YizK0I+nygP4RR5CFPEM+zQ9VEeFHTh4yci0A4+VYs7NRpSUrUW7TVeu4d  AGKHnooe/EL4DtdcNZVUipZLLy6lHCEAuWvWVAVQEQKBgQDv/Qzj3tKuXOENBmNE  LluS5dIE+KYMa9chioctiJqIWT9rrHz2/EU7b1W5mxby7WJFppwMzFHJP6GgnFaw  iYgK54YMsPv/5WrXftN4vC3vuw1pOUZIPT41e8Uu30lFcl/crpEfwA3Rg/2m57Fe  ptPPKn0+y50JiQIo3NxcY6LsNQKBgQDNLeONgojsGwen1PoaEtEvAdYhmwI3HVbV  FyKNifO7T7eISM4rwMP3FstykHzpcTwno/WrC5+jCeNc7q/U1AEudLu2YYpJKRlZ  bEv4rAfZeJp08f6lxKOuI5SLL7iZ3MqsoAAnv1kwYCztlcYDt4c3LVYTub5tcWHv  34rWi4cUUQKBgC9sy1pQk0O/uP2Q8Jbtrk0GO42d8Xps6TOIo5P89cTSFjVZ/cv1  KF1JcCBgpJVXEd9/wEDLM7JYb8FEg+EZHJhDDnt9kh8MoCN7vaCTV2STi1/q4Jev  +pYpIltT5q/hnU4H9UfX9SMdOUf9a1CwGRVMaTm6lQroV1Pp6WYcjnqtAoGARUO0  idUDPBFz6ChxtdOcYm4QR4/4k3qIEa+ZroZfjWA/6PYLA6IzhXpge/Bi+ruLPyaO  jIuD/Jod8wVwvjxDmdc2dz8+W6xQLmvsyanpjHS2T7xR5swXJXZFcydM/kQW92ec  Jc7m4PnWsO3axu5x6yKW6FnP+0pHcZ7ZU8wOccECgYA2rkrQVk9qHqBzymZFj47I  QwD65jlzNeK9xMeKHivsJc4K9cmwec4jRcsu8gEYcWIbhepjHUA5M/4mO0++bnsP  PP2xIiqseAOt4rI0wTeXqY8AM6YvbfdMq+tN+BlXix0WBEGNFGpab3B9bmv8UK0L  jhuCua5QHoIX6/fasAJ88w==  -----END PRIVATE KEY-----  ",
+			},
+			WantErr: "private_key: unrecognised start block -----BEGIN WEIRD PRIVATE KEY-----, expected -----BEGIN PRIVATE KEY-----",
+		},
+	}
+
+	for i, test := range tests {
+		t.Run(strconv.Itoa(i), func(t *testing.T) {
+			specjson, err := json.Marshal(test.Spec)
+			if err != nil {
+				t.Fatalf("marshalling spec %#v: %s", test.Spec, err)
+			}
+
+			dsn, err := test.Spec.DSN()
+			if err != nil {
+				if test.WantErr == "" {
+					t.Fatalf("Unwanted error %q from spec: %s", err, specjson)
+				} else if !strings.Contains(err.Error(), test.WantErr) {
+					t.Fatalf("Wanted error containing %q but got error %q from spec: %s", test.WantErr, err, specjson)
+				}
+			} else if test.WantErr != "" {
+				t.Fatalf("Wanted error %q but got none from spec: %s", err, specjson)
+			}
+			if dsn != test.WantDSN {
+				t.Fatalf("Wanted DSN:\n\t%q\nbut got\n\t%q\nfrom spec:\n\t%s", test.WantDSN, dsn, specjson)
+			}
+		})
+	}
+}

--- a/website/pages/docs/plugins/destinations/snowflake/overview.mdx
+++ b/website/pages/docs/plugins/destinations/snowflake/overview.mdx
@@ -25,6 +25,81 @@ There are two ways to sync data to Snowflake:
 
 The Snowflake destination utilizes batching, and supports [`batch_size`](/docs/reference/destination-spec#batch_size) and [`batch_size_bytes`](/docs/reference/destination-spec#batch_size_bytes).
 
+
+## Authentication
+
+Authentication of the connection to Snowflake can be specified using:
+
+* A username and password in the DSN:
+
+  ```yaml
+  kind: destination
+  spec:
+    name: snowflake
+    ...
+    spec:
+      connection_string: "user:pass@account/db/schema?warehouse=wh"
+  ```
+
+* A private key inline:
+
+  ```yaml
+  kind: destination
+  spec:
+    name: snowflake
+    ...
+    spec:
+      connection_string: "user@account/database/schema?warehouse=wh"
+      private_key: |
+        -----BEGIN PRIVATE KEY-----
+        MIIEvgIBADANBgkqhkiG9w0BAQEFAASCBKgwggSkAgEAAoIBAQC2ajPRIbPtbxZ1
+        3DONLA02eZJuCzsgIkBWov/Me5TL6cKN0gnY+mbA8OnNCH+9HSzgiU9P8XhTUrIN
+        85diD+rj6uK+E0sSyxGk6HG17TyR5oBq8nz2hbZlbaNi/HO9qYoHQgAgMq908YBz
+        ...
+        DUmOIrBYEMf2nDTlTu/QVcKb
+        -----END PRIVATE KEY-----
+  ```
+
+* A private key included from a file:
+
+  ```yaml
+  kind: destination
+  spec:
+    name: snowflake
+    ...
+    spec:
+      connection_string: "user@account/database/schema?warehouse=wh"
+      private_key: "${file:./private.key}"
+  ```
+
+  where ./private.key is PEM-encoded private key file with contents of the form:
+
+  ```txt
+  -----BEGIN PRIVATE KEY-----
+  MIIEvgIBADANBgkqhkiG9w0BAQEFAASCBKgwggSkAgEAAoIBAQC2ajPRIbPtbxZ1
+  3DONLA02eZJuCzsgIkBWov/Me5TL6cKN0gnY+mbA8OnNCH+9HSzgiU9P8XhTUrIN
+  85diD+rj6uK+E0sSyxGk6HG17TyR5oBq8nz2hbZlbaNi/HO9qYoHQgAgMq908YBz
+  ...
+  DUmOIrBYEMf2nDTlTu/QVcKb
+  -----END PRIVATE KEY-----
+  ```
+
+### Private Key Authentication Setup
+
+The Snowflake guide for [Key Pair
+Authentication](https://docs.snowflake.com/en/user-guide/key-pair-auth)
+demonstrates how to create an RSA private key with the ability to authenticate
+as a Snowflake user.
+
+Note that encrypted private keys are not supported by the Snowflake Go SQL
+driver, and hence not supported by the CloudQuery Snowflake plugin. You can
+decrypt a private key in file enc.key and store it in a file dec.key using the
+following command:
+
+```bash
+openssl pkcs8 -topk8 -nocrypt -in enc.key -out dec.key
+```
+
 ## Snowflake Spec
 
 This is the top level spec used by the Snowflake destination plugin.
@@ -49,6 +124,11 @@ This is the top level spec used by the Snowflake destination plugin.
 
   `account` - Name assigned to your Snowflake account. If you are not on us-west-2 or AWS deployment, append the region and platform to the end, e.g., `<account>.<region> or <account>.<region>.<platform>`.
 
+- `private_key` (`string`) (optional)
+
+  A PEM-encoded private key for connecting to snowflake. Equivalent to adding
+  `authenticator=snowflake_jwt&privateKey=...` to the `connection_string` but
+  parses, validates, and correctly encodes the key for use with snowflake.
 
 - `migrate_concurrency` (`integer`) (optional) (default: `1`)
 


### PR DESCRIPTION
A new `private_key` option for connecting to Snowflake using a keypair. Takes care of properly formatting the key, allowing the user to specify their private key using a `${file:priv.key}` substitution from a raw PEM file.

This change supersedes https://github.com/cloudquery/cloudquery/pull/12965 which attempted to let the user specify [gosnowflake.Config](https://pkg.go.dev/github.com/snowflakedb/gosnowflake#Config) but this proved unwieldy.

Closes  #12598