### PR TITLE
chore: Use GH_CQ_BOT token for publishing to Homebrew

### DIFF
--- a/.github/workflows/release_cli.yml
+++ b/.github/workflows/release_cli.yml
@@ -2,7 +2,7 @@ name: release-cli
 on:
   push:
     tags:
-      - 'cli-v*.*.*'
+      - "cli-v*.*.*"
 env:
   CGO_ENABLED: 0
 
@@ -64,7 +64,7 @@ jobs:
           GORELEASER_KEY: ${{ secrets.GORELEASER_KEY }}
           GORELEASER_CURRENT_TAG: ${{ github.ref_name }}
           # A custom token is required for publishing to Homebrew
-          GITHUB_TOKEN: ${{ secrets.GORELEASER_GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GH_CQ_BOT }}
 
       # Publish only to GitHub
       - name: Run GoReleaser PreRelease
@@ -74,12 +74,12 @@ jobs:
           GORELEASER_KEY: ${{ secrets.GORELEASER_KEY }}
           GORELEASER_CURRENT_TAG: ${{ github.ref_name }}
           # A custom token is required for publishing to Homebrew
-          GITHUB_TOKEN: ${{ secrets.GORELEASER_GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GH_CQ_BOT }}
 
       - name: Update version file
         if: steps.semver_parser.outputs.prerelease == ''
         run: 'echo "{ \"latest\": \"${{github.ref_name}}\" }" > ./website/versions/cli.json'
-          
+
       - name: Create Pull Request
         if: steps.semver_parser.outputs.prerelease == ''
         uses: peter-evans/create-pull-request@v4

--- a/.github/workflows/release_scaffold.yml
+++ b/.github/workflows/release_scaffold.yml
@@ -2,7 +2,7 @@ name: release-scaffold
 on:
   push:
     tags:
-      - 'scaffold-v*.*.*'
+      - "scaffold-v*.*.*"
 env:
   CGO_ENABLED: 0
 
@@ -59,7 +59,7 @@ jobs:
           GORELEASER_KEY: ${{ secrets.GORELEASER_KEY }}
           GORELEASER_CURRENT_TAG: ${{ github.ref_name }}
           # A custom token is required for publishing to Homebrew
-          GITHUB_TOKEN: ${{ secrets.GORELEASER_GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GH_CQ_BOT }}
 
       # Publish only to GitHub
       - name: Run GoReleaser PreRelease
@@ -69,12 +69,12 @@ jobs:
           GORELEASER_KEY: ${{ secrets.GORELEASER_KEY }}
           GORELEASER_CURRENT_TAG: ${{ github.ref_name }}
           # A custom token is required for publishing to Homebrew
-          GITHUB_TOKEN: ${{ secrets.GORELEASER_GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GH_CQ_BOT }}
 
       - name: Update version file
         if: steps.semver_parser.outputs.prerelease == ''
         run: 'echo "{ \"latest\": \"${{github.ref_name}}\" }" > ./website/versions/scaffold.json'
-          
+
       - name: Create Pull Request
         if: steps.semver_parser.outputs.prerelease == ''
         uses: peter-evans/create-pull-request@v4


### PR DESCRIPTION
<!-- 🎉 Thank you for making CloudQuery awesome by submitting a PR 🎉 -->

#### Summary

Doing this as a part of cleaning up some of the secrets in this repo. I gave the GitHub open source team access to `cloudquery/homebrew-tap`  so now we can use the `GH_CQ_BOT` token to publish to that repo instead of a dedicated token (I'll delete it after the PR is merged)

<!--
Use the following steps to ensure your PR is ready to be reviewed

- [ ] Read the [contribution guidelines](../blob/main/CONTRIBUTING.md) 🧑‍🎓
- [ ] Run `make lint` to ensure the proposed changes follow the coding style 🚨 (install golangci-lint [here](https://golangci-lint.run/usage/install/#local-installation))
- [ ] Run `make test` to ensure the proposed changes pass the tests 🧪
- [ ] If changing a source plugin run `make gen` to ensure docs are up to date 📝
- [ ] Ensure the status checks below are successful ✅
--->
