### PR TITLE
feat: Simplify value transformation

### DIFF
--- a/plugins/source/postgresql/client/sync.go
+++ b/plugins/source/postgresql/client/sync.go
@@ -2,7 +2,6 @@ package client
 
 import (
 	"context"
-	"database/sql/driver"
 	"errors"
 	"fmt"
 	"strings"
@@ -146,38 +145,6 @@ func syncTable(ctx context.Context, tx pgx.Tx, table *schema.Table, res chan<- m
 	}
 
 	return nil
-}
-
-func prepareValueForResourceSet(dataType arrow.DataType, v any) (any, error) {
-	switch tp := dataType.(type) {
-	case *arrow.StringType:
-		if value, ok := v.(driver.Valuer); ok {
-			if value == driver.Valuer(nil) {
-				v = nil
-			} else {
-				val, err := value.Value()
-				if err != nil {
-					return nil, err
-				}
-				if s, ok := val.(string); ok {
-					v = s
-				}
-			}
-		}
-	case *arrow.Time32Type:
-		t, err := v.(pgtype.Time).TimeValue()
-		if err != nil {
-			return nil, err
-		}
-		v = stringForTime(t, tp.Unit)
-	case *arrow.Time64Type:
-		t, err := v.(pgtype.Time).TimeValue()
-		if err != nil {
-			return nil, err
-		}
-		v = stringForTime(t, tp.Unit)
-	}
-	return v, nil
 }
 
 func stringForTime(t pgtype.Time, unit arrow.TimeUnit) string {

--- a/plugins/source/postgresql/client/transform.go
+++ b/plugins/source/postgresql/client/transform.go
@@ -1,0 +1,61 @@
+package client
+
+import (
+	"database/sql/driver"
+
+	"github.com/apache/arrow/go/v13/arrow"
+	"github.com/jackc/pgx/v5/pgtype"
+)
+
+type transformer func(any) (any, error)
+
+func transformerForDataType(dt arrow.DataType) transformer {
+	switch dt := dt.(type) {
+	case *arrow.StringType:
+		return func(v any) (any, error) {
+			if value, ok := v.(driver.Valuer); ok {
+				if value == driver.Valuer(nil) {
+					return nil, nil
+				}
+
+				val, err := value.Value()
+				if err != nil {
+					return nil, err
+				}
+
+				if s, ok := val.(string); ok {
+					return s, nil
+				}
+			}
+			return v, nil
+		}
+	case *arrow.Time32Type:
+		return func(v any) (any, error) {
+			t, err := v.(pgtype.Time).TimeValue()
+			if err != nil {
+				return nil, err
+			}
+			return stringForTime(t, dt.Unit), nil
+		}
+	case *arrow.Time64Type:
+		return func(v any) (any, error) {
+			t, err := v.(pgtype.Time).TimeValue()
+			if err != nil {
+				return nil, err
+			}
+			return stringForTime(t, dt.Unit), nil
+		}
+	default:
+		return func(v any) (any, error) {
+			return v, nil
+		}
+	}
+}
+
+func transformersForSchema(schema *arrow.Schema) []transformer {
+	res := make([]transformer, schema.NumFields())
+	for i := range res {
+		res[i] = transformerForDataType(schema.Field(i).Type)
+	}
+	return res
+}


### PR DESCRIPTION
1. Instead of performing type switch for every row for every column, just remember it once for the value transformation
2. reuse the record builder (per `NewRecord` resetting the record builder for reuse)