### PR TITLE
feat: Improve error message on table with PKs

### DIFF
--- a/plugins/destination/bigquery/client/migrate.go
+++ b/plugins/destination/bigquery/client/migrate.go
@@ -24,7 +24,7 @@ func (c *Client) MigrateTables(ctx context.Context, msgs message.WriteMigrateTab
 	eg.SetLimit(concurrentMigrations)
 	for _, msg := range msgs {
 		if len(msg.Table.PrimaryKeys()) > 0 {
-			return fmt.Errorf("primary keys are not supported by the BigQuery plugin (if you are trying to use it as a state backend, this is not currently supported)")
+			return fmt.Errorf("primary keys are not supported by the BigQuery plugin. Hint: try setting `write_mode: append` in the destination spec")
 		}
 	}
 


### PR DESCRIPTION
<!-- 🎉 Thank you for making CloudQuery awesome by submitting a PR 🎉 -->

#### Summary

Related to https://github.com/justmiles/cq-source-crowdstrike/issues/5.
A better way would be for the CLI to get what modes are supported by the destination.
I removed the backend error message as I found it confusing and it seems the `write_mode` error is more common (and it is always correct to set it).

<!--
Use the following steps to ensure your PR is ready to be reviewed

- [ ] Read the [contribution guidelines](../blob/main/CONTRIBUTING.md) 🧑‍🎓
- [ ] Run `make lint` to ensure the proposed changes follow the coding style 🚨 (install golangci-lint [here](https://golangci-lint.run/usage/install/#local-installation))
- [ ] Run `make test` to ensure the proposed changes pass the tests 🧪
- [ ] If changing a source plugin run `make gen` to ensure docs are up to date 📝
- [ ] Ensure the status checks below are successful ✅
--->
