### PR TITLE
fix(resources): Link to Go docs in `gcp_storage_buckets`

### DIFF
--- a/plugins/source/gcp/resources/services/storage/buckets.go
+++ b/plugins/source/gcp/resources/services/storage/buckets.go
@@ -11,7 +11,7 @@ import (
 func Buckets() *schema.Table {
 	return &schema.Table{
 		Name:        "gcp_storage_buckets",
-		Description: `https://cloud.google.com/storage/docs/json_api/v1/buckets#resource`,
+		Description: `https://pkg.go.dev/cloud.google.com/go/storage#BucketAttrs`,
 		Resolver:    fetchBuckets,
 		Multiplex:   client.ProjectMultiplexEnabledServices("storage.googleapis.com"),
 		Transform:   client.TransformWithStruct(&pb.BucketAttrs{}, transformers.WithPrimaryKeys("Name")),

--- a/website/tables/gcp/gcp_storage_buckets.md
+++ b/website/tables/gcp/gcp_storage_buckets.md
@@ -2,7 +2,7 @@
 
 This table shows data for GCP Storage Buckets.
 
-https://cloud.google.com/storage/docs/json_api/v1/buckets#resource
+https://pkg.go.dev/cloud.google.com/go/storage#BucketAttrs
 
 The primary key for this table is **name**.
 


### PR DESCRIPTION
<!-- 🎉 Thank you for making CloudQuery awesome by submitting a PR 🎉 -->

#### Summary

Context in https://discord.com/channels/872925471417962546/1141351009545879612/1141361426284425246.
The GO SDK for buckets doesn't mimic the JSON API, they have a different object struct for some reason, see https://github.com/googleapis/google-cloud-go/blob/fbe78a28e01043b059e86c6e960d092b299ac9a4/storage/bucket.go#L753

Not sure why they wrap is and normalize some properties instead of retuning the raw bucket (which they have).
This PR links to the Go docs instead of the JSON API docs so it's easier to understand the data CloudQuery sync

<!--
Use the following steps to ensure your PR is ready to be reviewed

- [ ] Read the [contribution guidelines](../blob/main/CONTRIBUTING.md) 🧑‍🎓
- [ ] Run `make lint` to ensure the proposed changes follow the coding style 🚨 (install golangci-lint [here](https://golangci-lint.run/usage/install/#local-installation))
- [ ] Run `make test` to ensure the proposed changes pass the tests 🧪
- [ ] If changing a source plugin run `make gen` to ensure docs are up to date 📝
- [ ] Ensure the status checks below are successful ✅
--->
