### PR TITLE
fix: Rename spec option from `api_key` to `access_token`

### DIFF
--- a/plugins/source/airtable/src/spec.ts
+++ b/plugins/source/airtable/src/spec.ts
@@ -6,17 +6,17 @@ const spec = {
   properties: {
     concurrency: { type: 'integer' },
     // eslint-disable-next-line @typescript-eslint/naming-convention
-    api_key: { type: 'string' },
+    access_token: { type: 'string' },
     // eslint-disable-next-line @typescript-eslint/naming-convention
     endpoint_url: { type: 'string' },
   },
-  required: ['api_key'],
+  required: ['access_token'],
 };
 
 type JSONSpec = {
   concurrency: number;
   // eslint-disable-next-line @typescript-eslint/naming-convention
-  api_key: string;
+  access_token: string;
   // eslint-disable-next-line @typescript-eslint/naming-convention
   endpoint_url: string;
 };
@@ -36,6 +36,6 @@ export const parseSpec = (spec: string): Spec => {
   if (!valid) {
     throw new Error(`Invalid spec: ${JSON.stringify(validate.errors)}`);
   }
-  const { concurrency = 10_000, apiKey = '', endpointUrl = 'https://api.airtable.com' } = camelcaseKeys(parsed);
-  return { concurrency, apiKey, endpointUrl };
+  const { concurrency = 10_000, accessToken = '', endpointUrl = 'https://api.airtable.com' } = camelcaseKeys(parsed);
+  return { concurrency, apiKey: accessToken, endpointUrl };
 };


### PR DESCRIPTION
<!-- 🎉 Thank you for making CloudQuery awesome by submitting a PR 🎉 -->

#### Summary

The Airtable JS SDK calls it API key, but the official term is access token

<!--
Use the following steps to ensure your PR is ready to be reviewed

- [ ] Read the [contribution guidelines](../blob/main/CONTRIBUTING.md) 🧑‍🎓
- [ ] Run `make lint` to ensure the proposed changes follow the coding style 🚨 (install golangci-lint [here](https://golangci-lint.run/usage/install/#local-installation))
- [ ] Run `make test` to ensure the proposed changes pass the tests 🧪
- [ ] If changing a source plugin run `make gen` to ensure docs are up to date 📝
- [ ] Ensure the status checks below are successful ✅
--->
