### PR TITLE
fix: Airtable `dateTime` type handling

### DIFF
--- a/plugins/source/airtable/src/airtable.ts
+++ b/plugins/source/airtable/src/airtable.ts
@@ -14,7 +14,7 @@ export enum APIFieldType {
   createdTime = 'createdTime',
   currency = 'currency',
   date = 'date',
-  dateTime = 'datetime',
+  dateTime = 'dateTime',
   duration = 'duration',
   email = 'email',
   externalSyncSource = 'externalSyncSource',
@@ -95,11 +95,11 @@ export type APIFieldCreatedTime = APIBaseField & {
   options: {
     result:
       | {
-          type: 'date';
+          type: APIFieldType.date;
           options: APIDateOptions;
         }
       | {
-          type: 'dateTime';
+          type: APIFieldType.dateTime;
           options: APIDateTimeOptions;
         };
   };
@@ -650,11 +650,11 @@ export type APILastModifiedTime = APIBaseField & {
     referencedFieldIds: Array<string>;
     result:
       | {
-          type: 'date';
+          type: APIFieldType.date;
           options: APIDateOptions;
         }
       | {
-          type: 'dateTime';
+          type: APIFieldType.dateTime;
           options: APIDateTimeOptions;
         };
   };

--- a/plugins/source/airtable/src/plugin.ts
+++ b/plugins/source/airtable/src/plugin.ts
@@ -64,9 +64,17 @@ export const newAirtablePlugin = () => {
   const newClient: NewClientFunction = async (logger, spec, { noConnection }) => {
     pluginClient.spec = parseSpec(spec);
     pluginClient.client = { id: () => 'airtable' };
-    pluginClient.allTables = noConnection
-      ? []
-      : await getTables(pluginClient.spec.apiKey, pluginClient.spec.endpointUrl, pluginClient.spec.concurrency);
+    if (noConnection) {
+      pluginClient.allTables = [];
+      return pluginClient;
+    }
+    logger.info('Getting tables from Airtable');
+    pluginClient.allTables = await getTables(
+      pluginClient.spec.apiKey,
+      pluginClient.spec.endpointUrl,
+      pluginClient.spec.concurrency,
+    );
+    logger.info('Done getting tables from Airtable');
 
     return pluginClient;
   };


### PR DESCRIPTION
<!-- 🎉 Thank you for making CloudQuery awesome by submitting a PR 🎉 -->

#### Summary

Fixes detecting and parsing of Airtable `dateTime` type. Also adds a log message when getting the tables

<!--
Use the following steps to ensure your PR is ready to be reviewed

- [ ] Read the [contribution guidelines](../blob/main/CONTRIBUTING.md) 🧑‍🎓
- [ ] Run `make lint` to ensure the proposed changes follow the coding style 🚨 (install golangci-lint [here](https://golangci-lint.run/usage/install/#local-installation))
- [ ] Run `make test` to ensure the proposed changes pass the tests 🧪
- [ ] If changing a source plugin run `make gen` to ensure docs are up to date 📝
- [ ] Ensure the status checks below are successful ✅
--->
