### PR TITLE
fix: Fix JSON logging

### DIFF
--- a/plugins/source/typeform/plugin/plugin.py
+++ b/plugins/source/typeform/plugin/plugin.py
@@ -1,6 +1,7 @@
 import json
 from typing import List, Generator
 
+import structlog
 from cloudquery.sdk import message
 from cloudquery.sdk import plugin
 from cloudquery.sdk import schema
@@ -20,6 +21,10 @@ class TypeformPlugin(plugin.Plugin):
         self._spec = None
         self._scheduler = None
         self._client = None
+        self._logger = structlog.get_logger()
+
+    def set_logger(self, logger) -> None:
+        self._logger = logger
 
     def init(self, spec_bytes, no_connection: bool = False):
         if no_connection:
@@ -27,7 +32,9 @@ class TypeformPlugin(plugin.Plugin):
         self._spec_json = json.loads(spec_bytes)
         self._spec = Spec(**self._spec_json)
         self._spec.validate()
-        self._scheduler = Scheduler(self._spec.concurrency, self._spec.queue_size)
+        self._scheduler = Scheduler(
+            self._spec.concurrency, self._spec.queue_size, logger=self._logger
+        )
         self._client = Client(self._spec)
 
     def get_tables(self, options: plugin.TableOptions) -> List[plugin.Table]:


### PR DESCRIPTION
Fix JSON login by instantiating a logger and passing it in to the scheduler.

Closes https://github.com/cloudquery/plugin-sdk-python/issues/44