### PR TITLE
feat: Add `discovery_concurrency` sync option

### DIFF
--- a/plugins/source/github/client/spec.go
+++ b/plugins/source/github/client/spec.go
@@ -9,7 +9,8 @@ type Spec struct {
 	AppAuth            []AppAuthSpec       `json:"app_auth"`
 	EnterpriseSettings *EnterpriseSettings `json:"enterprise"`
 
-	Concurrency int `json:"concurrency,omitempty"`
+	Concurrency          int `json:"concurrency,omitempty"`
+	DiscoveryConcurrency int `json:"discovery_concurrency,omitempty"`
 }
 
 type EnterpriseSettings struct {
@@ -27,6 +28,9 @@ type AppAuthSpec struct {
 func (s *Spec) SetDefaults() {
 	if s.Concurrency == 0 {
 		s.Concurrency = 10000
+	}
+	if s.DiscoveryConcurrency == 0 {
+		s.DiscoveryConcurrency = 1
 	}
 }
 

--- a/website/pages/docs/plugins/sources/github/_configuration.mdx
+++ b/website/pages/docs/plugins/sources/github/_configuration.mdx
@@ -18,8 +18,8 @@ spec:
     #   private_key_path: <PATH_TO_PRIVATE_KEY> # Path to private key file
     #   app_id: <YOUR_APP_ID> # App ID, required for App Authentication.
     #   installation_id: <ORG_INSTALLATION_ID> # Installation ID for this org
-    orgs: [] # Optional. List of organizations to extract from
-    repos: ["cloudquery/cloudquery"] # Optional. List of repositories to extract from
+    orgs: [] # Optional. List of organizations to sync from
+    repos: ["cloudquery/cloudquery"] # Optional. List of repositories to sync from
     ## GitHub Enterprise
     # In order to enable GHE you have to provide two urls, the base url of the server and the upload url.
     # Quote from GitHub's client:

--- a/website/pages/docs/plugins/sources/github/overview.mdx
+++ b/website/pages/docs/plugins/sources/github/overview.mdx
@@ -26,7 +26,19 @@ The CloudQuery GitHub plugin extracts your GitHub API and loads it into any supp
 
 ## GitHub Spec
 
-This is the (nested) spec used by GCP Source Plugin
+This is the (nested) spec used by GitHub Source Plugin
+
+- `repos` (`[]string`, optional. Default: empty):
+  List of repositories to sync from. The format is `owner/repo` (e.g. `cloudquery/cloudquery`). You must specify either `orgs` or `repos` in the configuration.
+
+- `orgs` (`[]string`, optional. Default: empty):
+  List of organizations to sync from. You must specify either `orgs` or `repos` in the configuration.
 
 - `concurrency` (int, optional, default: 10000):
   A best effort maximum number of Go routines to use. Lower this number to reduce memory usage.
+
+- `discovery_concurrency` (`int`) (default: `1`)
+
+  During initialization the GitHub source plugin discovers all repositories under the organizations configured in `orgs`, to be used later on during the sync process.
+  By default the plugin discovers repositories one organization at a time. You can increase `discovery_concurrency` to discover multiple organizations in parallel, or use a negative value to discover all organizations in parallel.
+  Please note that it's possible to hit GitHub API rate limits when using a high value for `discovery_concurrency`.


### PR DESCRIPTION
<!-- 🎉 Thank you for making CloudQuery awesome by submitting a PR 🎉 -->

#### Summary

Related to https://github.com/cloudquery/cloudquery/issues/13163. Adds `discovery_concurrency` like other plugins to improve discovery speed (currently defaults to `1` as can be considered breaking).

Using the following config I saw a `25%` improvement (Google has ~2.5k repositories and Microsoft has ~5.8K`):

```yaml
kind: source
spec:
   ...
  tables:
    - github_repositories
  skip_dependent_tables: true
  spec:
    discovery_concurrency: -1
    orgs:
      - microsoft
      - google
  destinations:
    - postgresql
``` 

![image](https://github.com/cloudquery/cloudquery/assets/26760571/4df99a1a-a7c2-4525-8346-f3ba886d0dcb)

<!--
Use the following steps to ensure your PR is ready to be reviewed

- [ ] Read the [contribution guidelines](../blob/main/CONTRIBUTING.md) 🧑‍🎓
- [ ] Run `make lint` to ensure the proposed changes follow the coding style 🚨 (install golangci-lint [here](https://golangci-lint.run/usage/install/#local-installation))
- [ ] Run `make test` to ensure the proposed changes pass the tests 🧪
- [ ] If changing a source plugin run `make gen` to ensure docs are up to date 📝
- [ ] Ensure the status checks below are successful ✅
--->
