### PR TITLE
fix: Apply schema and record transformations for v2 sources with v3 destinations

### DIFF
--- a/cli/cmd/migrate.go
+++ b/cli/cmd/migrate.go
@@ -119,6 +119,7 @@ func migrate(cmd *cobra.Command, args []string) error {
 				return fmt.Errorf("failed to migrate v3 source %s: %w", cl.Name(), err)
 			}
 		case 2:
+			destinationsVersions := make([][]int, 0, len(destinationClientsForSource))
 			for _, destination := range destinationClientsForSource {
 				versions, err := destination.Versions(ctx)
 				if err != nil {
@@ -127,8 +128,9 @@ func migrate(cmd *cobra.Command, args []string) error {
 				if !slices.Contains(versions, 1) {
 					return fmt.Errorf("destination plugin %[1]s does not support CloudQuery SDK version 1. Please upgrade to a newer version of the %[1]s destination plugin", destination.Name())
 				}
+				destinationsVersions = append(destinationsVersions, versions)
 			}
-			if err := migrateConnectionV2(ctx, cl, destinationClientsForSource, *source, destinationForSourceSpec); err != nil {
+			if err := migrateConnectionV2(ctx, cl, destinationClientsForSource, *source, destinationForSourceSpec, destinationsVersions); err != nil {
 				return fmt.Errorf("failed to migrate source %v@%v: %w", source.Name, source.Version, err)
 			}
 		case 1:

--- a/cli/cmd/sync.go
+++ b/cli/cmd/sync.go
@@ -214,6 +214,7 @@ func sync(cmd *cobra.Command, args []string) error {
 				return fmt.Errorf("failed to sync v3 source %s: %w", cl.Name(), err)
 			}
 		case 2:
+			destinationsVersions := make([][]int, 0, len(destinationClientsForSource))
 			for _, destination := range destinationClientsForSource {
 				versions, err := destination.Versions(ctx)
 				if err != nil {
@@ -222,8 +223,9 @@ func sync(cmd *cobra.Command, args []string) error {
 				if !slices.Contains(versions, 1) {
 					return fmt.Errorf("destination plugin %[1]s does not support CloudQuery SDK version 1. Please upgrade to a newer version of the %[1]s destination plugin", destination.Name())
 				}
+				destinationsVersions = append(destinationsVersions, versions)
 			}
-			if err := syncConnectionV2(ctx, cl, destinationClientsForSource, *source, destinationForSourceSpec, invocationUUID.String(), noMigrate); err != nil {
+			if err := syncConnectionV2(ctx, cl, destinationClientsForSource, *source, destinationForSourceSpec, invocationUUID.String(), noMigrate, destinationsVersions); err != nil {
 				return fmt.Errorf("failed to sync v2 source %s: %w", cl.Name(), err)
 			}
 		case 1:

--- a/cli/cmd/sync_v2.go
+++ b/cli/cmd/sync_v2.go
@@ -44,8 +44,8 @@ func getSourceV2DestV3DestinationsTransformers(sourceSpec specs.Source, destinat
 	return destinationsTransformers
 }
 
-func transformSourceV2DestV3Schemas(originalSchemas [][]byte, transformer *transformer.RecordTransformer) ([][]byte, error) {
-	if transformer == nil {
+func transformSourceV2DestV3Schemas(originalSchemas [][]byte, recordTransformer *transformer.RecordTransformer) ([][]byte, error) {
+	if recordTransformer == nil {
 		return originalSchemas, nil
 	}
 	transformedSchemasBytes := make([][]byte, 0, len(originalSchemas))
@@ -54,7 +54,7 @@ func transformSourceV2DestV3Schemas(originalSchemas [][]byte, transformer *trans
 		if err != nil {
 			return nil, err
 		}
-		transformedSchema := transformer.TransformSchema(schema)
+		transformedSchema := recordTransformer.TransformSchema(schema)
 		transformedSchemaBytes, err := pluginv3.SchemaToBytes(transformedSchema)
 		if err != nil {
 			return nil, err
@@ -64,15 +64,15 @@ func transformSourceV2DestV3Schemas(originalSchemas [][]byte, transformer *trans
 	return transformedSchemasBytes, nil
 }
 
-func transformSourceV2DestV3Resource(originalResourceBytes []byte, transformer *transformer.RecordTransformer) ([]byte, error) {
-	if transformer == nil {
+func transformSourceV2DestV3Resource(originalResourceBytes []byte, recordTransformer *transformer.RecordTransformer) ([]byte, error) {
+	if recordTransformer == nil {
 		return originalResourceBytes, nil
 	}
 	resource, err := pluginv3.NewRecordFromBytes(originalResourceBytes)
 	if err != nil {
 		return nil, err
 	}
-	transformedResource := transformer.Transform(resource)
+	transformedResource := recordTransformer.Transform(resource)
 	transformedResourceBytes, err := pluginv3.RecordToBytes(transformedResource)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
<!-- 🎉 Thank you for making CloudQuery awesome by submitting a PR 🎉 -->

#### Summary

Fixes https://github.com/justmiles/cq-source-crowdstrike/issues/5.
We should apply the schema and record transformations when the source is v2 and the destination is v3, otherwise pks are not removed in `append` mode, sync time and source name columns are not added, etc.

**This probably impacts all community/partners plugins as I believe those haven't upgraded to SDK v4.**

Tried to do this the less possible ugly way I could think of.
Tested with:

```yaml
kind: source
spec:
  name: azure
  path: cloudquery/azure
  version: v8.3.0 # v2 source
  destinations: ["bigquery", "postgresql"]
  tables: ["azure_storage_*"]
---
kind: destination
spec:
  name: bigquery
  path: cloudquery/bigquery
  version: "v3.3.0" # v3 destination
  write_mode: "append"
  spec:
    project_id: ****
    dataset_id: ****
---
kind: destination
spec:
  name: "postgresql"
  registry: "github"
  path: "cloudquery/postgresql"
  version: "v4.2.2" # v2 destination
  spec:
    connection_string: ****
```

<!--
Use the following steps to ensure your PR is ready to be reviewed

- [ ] Read the [contribution guidelines](../blob/main/CONTRIBUTING.md) 🧑‍🎓
- [ ] Run `make lint` to ensure the proposed changes follow the coding style 🚨 (install golangci-lint [here](https://golangci-lint.run/usage/install/#local-installation))
- [ ] Run `make test` to ensure the proposed changes pass the tests 🧪
- [ ] If changing a source plugin run `make gen` to ensure docs are up to date 📝
- [ ] Ensure the status checks below are successful ✅
--->
