### PR TITLE
fix: Don't add source name and sync time columns for v2 sources and v3 destinations

### DIFF
--- a/cli/cmd/migrate_v2.go
+++ b/cli/cmd/migrate_v2.go
@@ -23,7 +23,7 @@ func migrateConnectionV2(ctx context.Context, sourceClient *managedplugin.Client
 	defer log.Info().Str("source", sourceSpec.Name).Strs("destinations", destinationStrings).Time("migrate_time", migrateStart).Msg("End migration")
 
 	sourcePbClient := pbSource.NewSourceClient(sourceClient.Conn)
-	destinationsTransformers := getSourceV2DestV3DestinationsTransformers(sourceSpec, destinationSpecs, migrateStart, destinationsVersions)
+	destinationsTransformers := getSourceV2DestV3DestinationsTransformers(destinationSpecs, destinationsVersions)
 	destinationsPbClients := make([]pbdestination.DestinationClient, len(managedDestinationsClients))
 	for i := range managedDestinationsClients {
 		destinationsPbClients[i] = pbdestination.NewDestinationClient(managedDestinationsClients[i].Conn)

--- a/cli/cmd/sync_v2.go
+++ b/cli/cmd/sync_v2.go
@@ -21,7 +21,7 @@ import (
 	"google.golang.org/protobuf/types/known/timestamppb"
 )
 
-func getSourceV2DestV3DestinationsTransformers(sourceSpec specs.Source, destinationSpecs []specs.Destination, syncTime time.Time, destinationsVersions [][]int) []*transformer.RecordTransformer {
+func getSourceV2DestV3DestinationsTransformers(destinationSpecs []specs.Destination, destinationsVersions [][]int) []*transformer.RecordTransformer {
 	destinationsTransformers := make([]*transformer.RecordTransformer, 0, len(destinationsVersions))
 	for i := range destinationsVersions {
 		// We only need to transform to destinations that are v3
@@ -99,7 +99,7 @@ func syncConnectionV2(ctx context.Context, sourceClient *managedplugin.Client, d
 
 	sourcePbClient := source.NewSourceClient(sourceClient.Conn)
 	destinationsPbClients := make([]destination.DestinationClient, len(destinationsClients))
-	destinationsTransformers := getSourceV2DestV3DestinationsTransformers(sourceSpec, destinationSpecs, syncTime, destinationsVersions)
+	destinationsTransformers := getSourceV2DestV3DestinationsTransformers(destinationSpecs, destinationsVersions)
 	for i := range destinationsClients {
 		destinationsPbClients[i] = destination.NewDestinationClient(destinationsClients[i].Conn)
 	}

--- a/cli/cmd/sync_v2.go
+++ b/cli/cmd/sync_v2.go
@@ -29,10 +29,7 @@ func getSourceV2DestV3DestinationsTransformers(sourceSpec specs.Source, destinat
 			destinationsTransformers = append(destinationsTransformers, nil)
 			continue
 		}
-		opts := []transformer.RecordTransformerOption{
-			transformer.WithSourceNameColumn(sourceSpec.Name),
-			transformer.WithSyncTimeColumn(syncTime),
-		}
+		opts := []transformer.RecordTransformerOption{}
 		if destinationSpecs[i].WriteMode == specs.WriteModeAppend {
 			opts = append(opts, transformer.WithRemovePKs())
 		} else if destinationSpecs[i].PKMode == specs.PKModeCQID {


### PR DESCRIPTION
<!-- 🎉 Thank you for making CloudQuery awesome by submitting a PR 🎉 -->

#### Summary

Follow up to https://github.com/cloudquery/cloudquery/pull/13291.
Fixes https://github.com/justmiles/cq-source-crowdstrike/issues/5.

v2 sources already add these columns so we shouldn't duplicate them. I didn't catch this during my tests since I already had the tables in the database so the destination skipped creating them.

<!--
Use the following steps to ensure your PR is ready to be reviewed

- [ ] Read the [contribution guidelines](../blob/main/CONTRIBUTING.md) 🧑‍🎓
- [ ] Run `make lint` to ensure the proposed changes follow the coding style 🚨 (install golangci-lint [here](https://golangci-lint.run/usage/install/#local-installation))
- [ ] Run `make test` to ensure the proposed changes pass the tests 🧪
- [ ] If changing a source plugin run `make gen` to ensure docs are up to date 📝
- [ ] Ensure the status checks below are successful ✅
--->
