### PR TITLE
fix: Improve Postgres performance

### DIFF
--- a/plugins/destination/postgresql/client/insert.go
+++ b/plugins/destination/postgresql/client/insert.go
@@ -20,16 +20,7 @@ func (c *Client) InsertBatch(ctx context.Context, messages message.WriteInserts)
 		return err
 	}
 
-	include := make([]string, len(tables))
-	for i, table := range tables {
-		include[i] = table.Name
-	}
-	var exclude []string
-	pgTables, err := c.listTables(ctx, include, exclude)
-	if err != nil {
-		return err
-	}
-	tables = c.normalizeTables(tables, pgTables)
+	tables = c.normalizeTables(tables, tables)
 	if err != nil {
 		return err
 	}

--- a/plugins/destination/postgresql/client/migrate.go
+++ b/plugins/destination/postgresql/client/migrate.go
@@ -94,6 +94,9 @@ func (c *Client) normalizeTable(table *schema.Table, pgTable *schema.Table) *sch
 
 	if pgTable != nil && pgTable.PkConstraintName != "" {
 		normalizedTable.PkConstraintName = pgTable.PkConstraintName
+	} else {
+		// TODO: Check if this is OK
+		normalizedTable.PkConstraintName = table.Name + "_cqpk"
 	}
 
 	return &normalizedTable

--- a/plugins/destination/postgresql/client/spec.go
+++ b/plugins/destination/postgresql/client/spec.go
@@ -8,8 +8,8 @@ import (
 
 const (
 	defaultBatchSize      = 10000
-	defaultBatchSizeBytes = 1000000
-	defaultBatchTimeout   = 10 * time.Second
+	defaultBatchSizeBytes = 100000000
+	defaultBatchTimeout   = 60 * time.Second
 )
 
 type Spec struct {


### PR DESCRIPTION
<!-- 🎉 Thank you for making CloudQuery awesome by submitting a PR 🎉 -->

#### Summary

Still need to figure out how to replace the logic I deleted, but listing information schema on each batch insert is creating a bottleneck (saw it on `pprof`). Probably due to read/write locks or our queries to list tables and columns are slow.
Changes in this PR result in about x10 improvement. 

Spec used (I used an old source since I tested on an old Postgres version to get the expected numbers):

```yaml
kind: source
spec:
  name: aws
  registry: "github"
  path: "cloudquery/aws"
  version: "v19.0.0"
  tables:
    - "*"
  skip_tables:
    - "aws_cloudtrail_*"
    - "aws_iam_*"
    - "aws_servicequotas_*"
  destinations:
    - postgresql
---
kind: destination
spec:
  name: "postgresql"
  path: "cloudquery/postgresql"
  version: "v5.0.5"
  migrate_mode: forced
  spec:
    connection_string: "postgresql://postgres:pass@localhost:5432/postgres?sslmode=disable"
```

Before:
![image](https://github.com/cloudquery/cloudquery/assets/26760571/fc34848c-2f3b-41e7-808c-2fef094f5183)


After (with Postgres running from localhost with this fix):
![image](https://github.com/cloudquery/cloudquery/assets/26760571/2998baf8-5012-44fb-a025-c95071aadad0)






<!--
Use the following steps to ensure your PR is ready to be reviewed

- [ ] Read the [contribution guidelines](../blob/main/CONTRIBUTING.md) 🧑‍🎓
- [ ] Run `make lint` to ensure the proposed changes follow the coding style 🚨 (install golangci-lint [here](https://golangci-lint.run/usage/install/#local-installation))
- [ ] Run `make test` to ensure the proposed changes pass the tests 🧪
- [ ] If changing a source plugin run `make gen` to ensure docs are up to date 📝
- [ ] Ensure the status checks below are successful ✅
--->
