### PR TITLE
fix: Don't list Postgres tables during insert

### DIFF
--- a/plugins/destination/postgresql/client/client.go
+++ b/plugins/destination/postgresql/client/client.go
@@ -25,6 +25,8 @@ type Client struct {
 	batchSize           int
 	writer              *mixedbatchwriter.MixedBatchWriter
 
+	pgTablesToPKConstraints map[string]string
+
 	plugin.UnimplementedSource
 }
 
@@ -41,7 +43,8 @@ const (
 
 func New(ctx context.Context, logger zerolog.Logger, specBytes []byte, opts plugin.NewClientOptions) (plugin.Client, error) {
 	c := &Client{
-		logger: logger.With().Str("module", "pg-dest").Logger(),
+		logger:                  logger.With().Str("module", "pg-dest").Logger(),
+		pgTablesToPKConstraints: make(map[string]string),
 	}
 	if opts.NoConnection {
 		return c, nil

--- a/plugins/destination/postgresql/client/insert.go
+++ b/plugins/destination/postgresql/client/insert.go
@@ -20,16 +20,7 @@ func (c *Client) InsertBatch(ctx context.Context, messages message.WriteInserts)
 		return err
 	}
 
-	include := make([]string, len(tables))
-	for i, table := range tables {
-		include[i] = table.Name
-	}
-	var exclude []string
-	pgTables, err := c.listTables(ctx, include, exclude)
-	if err != nil {
-		return err
-	}
-	tables = c.normalizeTables(tables, pgTables)
+	tables = c.normalizeTables(tables)
 	if err != nil {
 		return err
 	}

--- a/plugins/destination/postgresql/client/list_tables.go
+++ b/plugins/destination/postgresql/client/list_tables.go
@@ -89,7 +89,7 @@ func (c *Client) listTables(ctx context.Context, include, exclude []string) (sch
 		}
 		table := tables[len(tables)-1]
 		if pkName != "" {
-			table.PkConstraintName = pkName
+			c.pgTablesToPKConstraints[tableName], table.PkConstraintName = pkName, pkName
 		}
 		table.Columns = append(table.Columns, schema.Column{
 			Name:       columnName,


### PR DESCRIPTION
<!-- 🎉 Thank you for making CloudQuery awesome by submitting a PR 🎉 -->

#### Summary

Extracted from https://github.com/cloudquery/cloudquery/pull/13318. Witnessed the bottleneck using `pprof`.
With default batch settings I'm getting `2m29s` sync time instead of ~`11m`,
With `batch_size_bytes: 100000000` and `batch_timeout: 60s` I'm getting `1m40s`. (Fixed in https://github.com/cloudquery/cloudquery/pull/13324)

Used spec:

```yaml
kind: source
spec:
  name: aws
  path: "cloudquery/aws"
  version: "v19.0.0"
  tables:
    - "*"
  skip_tables:
    - "aws_cloudtrail_*"
    - "aws_iam_*"
    - "aws_servicequotas_*"
  destinations:
    - postgresql
---
kind: destination
spec:
  name: "postgresql"
  registry: "grpc"
  path: localhost:8888
  # path: cloudquery/postgresql
  # version "v5.0.5"
  spec:
    connection_string: "postgresql://postgres:pass@localhost:5432/postgres?sslmode=disable"
    # batch_size_bytes: 100000000
    # batch_timeout: "60s"
```


<!--
Use the following steps to ensure your PR is ready to be reviewed

- [ ] Read the [contribution guidelines](../blob/main/CONTRIBUTING.md) 🧑‍🎓
- [ ] Run `make lint` to ensure the proposed changes follow the coding style 🚨 (install golangci-lint [here](https://golangci-lint.run/usage/install/#local-installation))
- [ ] Run `make test` to ensure the proposed changes pass the tests 🧪
- [ ] If changing a source plugin run `make gen` to ensure docs are up to date 📝
- [ ] Ensure the status checks below are successful ✅
--->
