### PR TITLE
chore: Revert "chore: Update plugin `destination-postgresql` version to v5.0.6"

### DIFF
--- a/website/versions/destination-postgresql.json
+++ b/website/versions/destination-postgresql.json
@@ -1,1 +1,1 @@
-{ "latest": "plugins-destination-postgresql-v5.0.6" }
+{ "latest": "plugins-destination-postgresql-v5.0.5" }


### PR DESCRIPTION
Reverts cloudquery/cloudquery#13325

So I can fix https://github.com/cloudquery/cloudquery/pull/13323 when `--no-migrate` is used