### PR TITLE
fix: Call list tables once on insert if `--no-migrate` was used

### DIFF
--- a/plugins/destination/postgresql/client/client.go
+++ b/plugins/destination/postgresql/client/client.go
@@ -43,8 +43,7 @@ const (
 
 func New(ctx context.Context, logger zerolog.Logger, specBytes []byte, opts plugin.NewClientOptions) (plugin.Client, error) {
 	c := &Client{
-		logger:                  logger.With().Str("module", "pg-dest").Logger(),
-		pgTablesToPKConstraints: make(map[string]string),
+		logger: logger.With().Str("module", "pg-dest").Logger(),
 	}
 	if opts.NoConnection {
 		return c, nil

--- a/plugins/destination/postgresql/client/insert.go
+++ b/plugins/destination/postgresql/client/insert.go
@@ -20,6 +20,15 @@ func (c *Client) InsertBatch(ctx context.Context, messages message.WriteInserts)
 		return err
 	}
 
+	// This happens when the CLI was invoked with `sync --no-migrate`
+	if c.pgTablesToPKConstraints == nil {
+		// Passing nil for include and exclude lists all tables and populates c.pgTablesToPKConstraints
+		_, err := c.listTables(ctx, nil, nil)
+		if err != nil {
+			return err
+		}
+	}
+
 	tables = c.normalizeTables(tables)
 	if err != nil {
 		return err

--- a/plugins/destination/postgresql/client/list_tables.go
+++ b/plugins/destination/postgresql/client/list_tables.go
@@ -63,6 +63,7 @@ ORDER BY
 `
 
 func (c *Client) listTables(ctx context.Context, include, exclude []string) (schema.Tables, error) {
+	c.pgTablesToPKConstraints = map[string]string{}
 	var tables schema.Tables
 	whereClause := c.whereClause(include, exclude)
 	if c.pgType == pgTypeCockroachDB {


### PR DESCRIPTION
<!-- 🎉 Thank you for making CloudQuery awesome by submitting a PR 🎉 -->

#### Summary

Follow up to https://github.com/cloudquery/cloudquery/pull/13323 to handle `--no-migrate`. Thanks @candiduslynx for pointing it out

<!--
Use the following steps to ensure your PR is ready to be reviewed

- [ ] Read the [contribution guidelines](../blob/main/CONTRIBUTING.md) 🧑‍🎓
- [ ] Run `make lint` to ensure the proposed changes follow the coding style 🚨 (install golangci-lint [here](https://golangci-lint.run/usage/install/#local-installation))
- [ ] Run `make test` to ensure the proposed changes pass the tests 🧪
- [ ] If changing a source plugin run `make gen` to ensure docs are up to date 📝
- [ ] Ensure the status checks below are successful ✅
--->
