### PR TITLE
refactor: Clean up list tables method

### DIFF
--- a/plugins/destination/postgresql/client/insert.go
+++ b/plugins/destination/postgresql/client/insert.go
@@ -15,7 +15,7 @@ import (
 
 // InsertBatch inserts records into the destination table. It forms part of the writer.MixedBatchWriter interface.
 func (c *Client) InsertBatch(ctx context.Context, messages message.WriteInserts) error {
-	tables, err := tablesFromMessages[*message.WriteInsert](messages)
+	tables, err := tablesFromMessages(messages)
 	if err != nil {
 		return err
 	}
@@ -23,7 +23,7 @@ func (c *Client) InsertBatch(ctx context.Context, messages message.WriteInserts)
 	// This happens when the CLI was invoked with `sync --no-migrate`
 	if c.pgTablesToPKConstraints == nil {
 		// Passing nil for include and exclude lists all tables and populates c.pgTablesToPKConstraints
-		_, err := c.listTables(ctx, nil, nil)
+		_, err := c.listTables(ctx, nil)
 		if err != nil {
 			return err
 		}

--- a/plugins/destination/postgresql/client/list_tables.go
+++ b/plugins/destination/postgresql/client/list_tables.go
@@ -62,10 +62,10 @@ ORDER BY
 	table_name ASC, ordinal_position ASC;
 `
 
-func (c *Client) listTables(ctx context.Context, include, exclude []string) (schema.Tables, error) {
+func (c *Client) listTables(ctx context.Context, include []string) (schema.Tables, error) {
 	c.pgTablesToPKConstraints = map[string]string{}
 	var tables schema.Tables
-	whereClause := c.whereClause(include, exclude)
+	whereClause := c.whereClause(include)
 	if c.pgType == pgTypeCockroachDB {
 		whereClause += " AND information_schema.columns.is_hidden != 'YES'"
 	}
@@ -102,16 +102,13 @@ func (c *Client) listTables(ctx context.Context, include, exclude []string) (sch
 	return tables, nil
 }
 
-func (c *Client) whereClause(include, exclude []string) string {
-	if len(include) == 0 && len(exclude) == 0 {
+func (c *Client) whereClause(include []string) string {
+	if len(include) == 0 {
 		return ""
 	}
 	var where string
 	if len(include) > 0 {
 		where = fmt.Sprintf("AND pg_class.relname IN (%s)", c.inClause(include))
-	}
-	if len(exclude) > 0 {
-		where = fmt.Sprintf("AND pg_class.relname NOT IN (%s)", c.inClause(exclude))
 	}
 	return where
 }

--- a/plugins/destination/postgresql/client/migrate.go
+++ b/plugins/destination/postgresql/client/migrate.go
@@ -16,12 +16,7 @@ func (c *Client) MigrateTableBatch(ctx context.Context, messages message.WriteMi
 	if err != nil {
 		return err
 	}
-	include := make([]string, len(tables))
-	for i, table := range tables {
-		include[i] = table.Name
-	}
-	var exclude []string
-	pgTables, err := c.listTables(ctx, include, exclude)
+	pgTables, err := c.listTables(ctx, tables.TableNames())
 	if err != nil {
 		return fmt.Errorf("failed listing postgres tables: %w", err)
 	}


### PR DESCRIPTION
<!-- 🎉 Thank you for making CloudQuery awesome by submitting a PR 🎉 -->

#### Summary

`exclude` was always passed as an empty list. Also we can use `tables.TableNames()`

<!--
Use the following steps to ensure your PR is ready to be reviewed

- [ ] Read the [contribution guidelines](../blob/main/CONTRIBUTING.md) 🧑‍🎓
- [ ] Run `make lint` to ensure the proposed changes follow the coding style 🚨 (install golangci-lint [here](https://golangci-lint.run/usage/install/#local-installation))
- [ ] Run `make test` to ensure the proposed changes pass the tests 🧪
- [ ] If changing a source plugin run `make gen` to ensure docs are up to date 📝
- [ ] Ensure the status checks below are successful ✅
--->
