### PR TITLE
chore: Revert AWS version in docs to `v22.6.0`

### DIFF
--- a/website/versions/source-aws.json
+++ b/website/versions/source-aws.json
@@ -1,1 +1,1 @@
-{ "latest": "plugins-source-aws-v22.8.0" }
+{ "latest": "plugins-source-aws-v22.6.0" }


### PR DESCRIPTION
<!-- 🎉 Thank you for making CloudQuery awesome by submitting a PR 🎉 -->

#### Summary

Due to https://github.com/cloudquery/cloudquery/issues/13389 until https://github.com/cloudquery/cloudquery/pull/13391 is out

<!--
Use the following steps to ensure your PR is ready to be reviewed

- [ ] Read the [contribution guidelines](../blob/main/CONTRIBUTING.md) 🧑‍🎓
- [ ] Run `make lint` to ensure the proposed changes follow the coding style 🚨 (install golangci-lint [here](https://golangci-lint.run/usage/install/#local-installation))
- [ ] Run `make test` to ensure the proposed changes pass the tests 🧪
- [ ] If changing a source plugin run `make gen` to ensure docs are up to date 📝
- [ ] Ensure the status checks below are successful ✅
--->
