### PR TITLE
fix: Drop include clause from list tables

### DIFF
--- a/plugins/destination/postgresql/client/insert.go
+++ b/plugins/destination/postgresql/client/insert.go
@@ -22,8 +22,8 @@ func (c *Client) InsertBatch(ctx context.Context, messages message.WriteInserts)
 
 	// This happens when the CLI was invoked with `sync --no-migrate`
 	if c.pgTablesToPKConstraints == nil {
-		// Passing nil for include and exclude lists all tables and populates c.pgTablesToPKConstraints
-		_, err := c.listTables(ctx, nil)
+		// listTables populates c.pgTablesToPKConstraints
+		_, err := c.listTables(ctx)
 		if err != nil {
 			return err
 		}

--- a/plugins/destination/postgresql/client/list_tables.go
+++ b/plugins/destination/postgresql/client/list_tables.go
@@ -3,7 +3,6 @@ package client
 import (
 	"context"
 	"fmt"
-	"strings"
 
 	"github.com/cloudquery/plugin-sdk/v4/schema"
 )
@@ -62,12 +61,12 @@ ORDER BY
 	table_name ASC, ordinal_position ASC;
 `
 
-func (c *Client) listTables(ctx context.Context, include []string) (schema.Tables, error) {
+func (c *Client) listTables(ctx context.Context) (schema.Tables, error) {
 	c.pgTablesToPKConstraints = map[string]string{}
 	var tables schema.Tables
-	whereClause := c.whereClause(include)
+	var whereClause string
 	if c.pgType == pgTypeCockroachDB {
-		whereClause += " AND information_schema.columns.is_hidden != 'YES'"
+		whereClause = " AND information_schema.columns.is_hidden != 'YES'"
 	}
 	q := fmt.Sprintf(selectTables, c.currentSchemaName, whereClause)
 	rows, err := c.conn.Query(ctx, q)
@@ -100,29 +99,4 @@ func (c *Client) listTables(ctx context.Context, include []string) (schema.Table
 		})
 	}
 	return tables, nil
-}
-
-func (c *Client) whereClause(include []string) string {
-	if len(include) == 0 {
-		return ""
-	}
-	var where string
-	if len(include) > 0 {
-		where = fmt.Sprintf("AND pg_class.relname IN (%s)", c.inClause(include))
-	}
-	return where
-}
-
-func (*Client) inClause(values []string) string {
-	var inClause string
-	for i, value := range values {
-		value = strings.ReplaceAll(value, "'", "")  // strip single quotes
-		value = strings.ReplaceAll(value, "*", "%") // replace * with %
-		if i == 0 {
-			inClause = fmt.Sprintf("'%s'", value)
-			continue
-		}
-		inClause += fmt.Sprintf(", '%s'", value)
-	}
-	return inClause
 }

--- a/plugins/destination/postgresql/client/migrate.go
+++ b/plugins/destination/postgresql/client/migrate.go
@@ -16,7 +16,7 @@ func (c *Client) MigrateTableBatch(ctx context.Context, messages message.WriteMi
 	if err != nil {
 		return err
 	}
-	pgTables, err := c.listTables(ctx, tables.TableNames())
+	pgTables, err := c.listTables(ctx)
 	if err != nil {
 		return fmt.Errorf("failed listing postgres tables: %w", err)
 	}


### PR DESCRIPTION
Somehow the change in https://github.com/cloudquery/cloudquery/pull/13332 got reverted, I think unintentionally.

This is however necessary as part of a fix for https://github.com/cloudquery/cloudquery/issues/13412