### PR TITLE
fix: Flush state backend so that state is persisted

### DIFF
--- a/plugins/source/googleanalytics/client/client.go
+++ b/plugins/source/googleanalytics/client/client.go
@@ -98,10 +98,11 @@ func (c *Client) Sync(ctx context.Context, options plugin.SyncOptions, res chan<
 	if err != nil {
 		return err
 	}
-	if err := c.scheduler.Sync(ctx, c, tables, res, scheduler.WithSyncDeterministicCQID(options.DeterministicCQID)); err != nil {
+	err = c.scheduler.Sync(ctx, c, tables, res, scheduler.WithSyncDeterministicCQID(options.DeterministicCQID))
+	if err != nil {
 		return fmt.Errorf("failed to sync: %w", err)
 	}
-	return nil
+	return stateClient.Flush(ctx)
 }
 
 func Configure(ctx context.Context, logger zerolog.Logger, specBytes []byte, options plugin.NewClientOptions) (plugin.Client, error) {


### PR DESCRIPTION
This ensures that the backend state is persisted between syncs