### PR TITLE
fix: Skip incremental tables when performing delete-stale

### DIFF
--- a/cli/cmd/sync_v3.go
+++ b/cli/cmd/sync_v3.go
@@ -44,7 +44,7 @@ func syncConnectionV3(ctx context.Context, source v3source, destinations []v3des
 		destinationSpecs[i] = destinations[i].spec
 		destinationsClients[i] = destinations[i].client
 	}
-	
+
 	defer func() {
 		if analyticsClient != nil {
 			log.Info().Msg("Sending sync summary to " + analyticsClient.Host())


### PR DESCRIPTION
This fixes a bug introduced with the migration to SDK v4 / Protocol v3; when `overwrite-delete-stale` write mode is used, stale entries should not be removed from incremental tables when a state backend is active.