### PR TITLE
chore: Revert "chore(main): Release plugins-source-bitbucket v1.0.0 (#13493)"

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -115,6 +115,5 @@
   "plugins/source/jira+FILLER": "0.0.0",
   "plugins/source/vault": "1.0.1",
   "plugins/source/vault+FILLER": "0.0.0",
-  "plugins/source/airtable": "1.1.0",
-  "plugins/source/bitbucket": "1.0.0"
+  "plugins/source/airtable": "1.1.0"
 }

--- a/plugins/source/bitbucket/CHANGELOG.md
+++ b/plugins/source/bitbucket/CHANGELOG.md
@@ -1,8 +1,0 @@
-# Changelog
-
-## 1.0.0 (2023-08-31)
-
-
-### Features
-
-* Adding bitbucket source plugin using Java SDK ([#13476](https://github.com/cloudquery/cloudquery/issues/13476)) ([240c999](https://github.com/cloudquery/cloudquery/commit/240c999b0944bc180dc3da4996b66dd8febc959a))


### PR DESCRIPTION
This reverts commit 45af1c9abf7cba031831fcf494e53873a4a94d7b.

<!-- 🎉 Thank you for making CloudQuery awesome by submitting a PR 🎉 -->

#### Summary

So we can re-release v1.0.0 after fixing the CI

<!--
Use the following steps to ensure your PR is ready to be reviewed

- [ ] Read the [contribution guidelines](../blob/main/CONTRIBUTING.md) 🧑‍🎓
- [ ] Run `make lint` to ensure the proposed changes follow the coding style 🚨 (install golangci-lint [here](https://golangci-lint.run/usage/install/#local-installation))
- [ ] Run `make test` to ensure the proposed changes pass the tests 🧪
- [ ] If changing a source plugin run `make gen` to ensure docs are up to date 📝
- [ ] Ensure the status checks below are successful ✅
--->
