### PR TITLE
chore: Update vale linter

### DIFF
--- a/.github/workflows/lint_markdown.yml
+++ b/.github/workflows/lint_markdown.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Git checkout
         uses: actions/checkout@v3
       - name: Vale
-        uses: errata-ai/vale-action@v2
+        uses: errata-ai/vale-action@13d79669d1c7cf33b26fc5607214ef529f071cdc
         with:
           vale_flags: "--glob=!{website/pages/blog/podcast-software-engineer-daily.md,*CHANGELOG.md,*/docs/tables/README.md,plugins/source/test/docs/tables/*.md,.github/styles/proselint/README.md,**/v1-migration.md,website/pages/docs/plugins/sources/*/tables.md,website/pages/docs/plugins/sources/*/policies.md,website/tables/**/*,website/pages/case-studies/*.mdx,cli/internal/docs/testdata/*.md}"
           filter_mode: nofilter
@@ -32,4 +32,4 @@ jobs:
         with:
           files: .
           config_file: .markdownlint.yaml
-          ignore_files: '{website/pages/blog/podcast-software-engineer-daily.md,**/CHANGELOG.md,**/docs/tables/README.md,plugins/source/test/docs/tables/*.md,website/pages/docs/reference/cli/**,website/tables/**/*}'
+          ignore_files: "{website/pages/blog/podcast-software-engineer-daily.md,**/CHANGELOG.md,**/docs/tables/README.md,plugins/source/test/docs/tables/*.md,website/pages/docs/reference/cli/**,website/tables/**/*}"


### PR DESCRIPTION
<!-- 🎉 Thank you for making CloudQuery awesome by submitting a PR 🎉 -->

#### Summary

The version we're using is quite old, as they only pushed changes to the main branch now https://github.com/errata-ai/vale-action. This PR uses the latest commit sha. I'm hoping it can fix some things like 
![image](https://github.com/cloudquery/cloudquery/assets/26760571/af45ce9b-8423-4e5a-80e7-6b84f9997569)


<!--
Use the following steps to ensure your PR is ready to be reviewed

- [ ] Read the [contribution guidelines](../blob/main/CONTRIBUTING.md) 🧑‍🎓
- [ ] Run `make lint` to ensure the proposed changes follow the coding style 🚨 (install golangci-lint [here](https://golangci-lint.run/usage/install/#local-installation))
- [ ] Run `make test` to ensure the proposed changes pass the tests 🧪
- [ ] If changing a source plugin run `make gen` to ensure docs are up to date 📝
- [ ] Ensure the status checks below are successful ✅
--->
