### PR TITLE
fix: Duplicate columns when multiple contraints

### DIFF
--- a/plugins/source/postgresql/resources/plugin/plugin_test.go
+++ b/plugins/source/postgresql/resources/plugin/plugin_test.go
@@ -202,7 +202,7 @@ func createTestTable(ctx context.Context, conn *pgxpool.Pool, tableName string) 
 }
 
 func createTableWithUniqueKeys(ctx context.Context, conn *pgxpool.Pool, tableName string) error {
-	var query = `
+	var createTableQuery = `
 	create table %s (
 		column1 int primary key,
 		column2 int unique,
@@ -222,10 +222,16 @@ func createTableWithUniqueKeys(ctx context.Context, conn *pgxpool.Pool, tableNam
 		column16 int,
 		column17 int,
 		unique(column16, column17)
-	 )
- `
+	);
+`
+	var addAdditionalConstraints = `
+	alter table %s add constraint additional_constraint unique(column1);
+`
 
-	if _, err := conn.Exec(ctx, fmt.Sprintf(query, tableName)); err != nil {
+	if _, err := conn.Exec(ctx, fmt.Sprintf(createTableQuery, tableName)); err != nil {
+		return err
+	}
+	if _, err := conn.Exec(ctx, fmt.Sprintf(addAdditionalConstraints, tableName)); err != nil {
 		return err
 	}
 	return nil


### PR DESCRIPTION
Duplicate columns can occur if multiple constraints are added to a single column. Adding `group by` terms to remove duplicate constraint columns. Boolean fields in the `group by` are aggregated using `bool_or`, the `constraint_name` resolves to the primary key constraint name or an empty string if there is no named constraint. This is all that is required by [this](https://github.com/cloudquery/cloudquery/blob/51e4d572ec343f2bceefae21f0a16963bd8e1d2a/plugins/source/postgresql/client/list_tables.go#L52-L54) part of the code.

fixes: #13459
