### PR TITLE
fix: Issue #13433 - match on lowercase "redirect" in aws policy 

### DIFF
--- a/plugins/source/aws/policies/queries/elb/elbv2_redirect_http_to_https.sql
+++ b/plugins/source/aws/policies/queries/elb/elbv2_redirect_http_to_https.sql
@@ -8,7 +8,7 @@ select
   arn as resource_id,
   case when
    protocol = 'HTTP' and (
-        da->>'Type' != 'REDIRECT' or da->'RedirectConfig'->>'Protocol' != 'HTTPS')
+        da->>'Type' != 'redirect' or da->'RedirectConfig'->>'Protocol' != 'HTTPS')
     then 'fail'
     else 'pass'
   end as status

--- a/website/tables/aws/aws_elbv2_listeners.md
+++ b/website/tables/aws/aws_elbv2_listeners.md
@@ -48,7 +48,7 @@ SELECT
   CASE
   WHEN protocol = 'HTTP'
   AND (
-      da->>'Type' != 'REDIRECT'
+      da->>'Type' != 'redirect'
       OR da->'RedirectConfig'->>'Protocol' != 'HTTPS'
     )
   THEN 'fail'


### PR DESCRIPTION
#### Summary

Fix a bug in `plugins/source/aws/policies/queries/elb/elbv2_redirect_http_to_https.sql` that tries to match on uppercase "REDIRECT" while the data in `aws_elbv2_listeners` shows the lowercase "redirect" (see issue https://github.com/cloudquery/cloudquery/issues/13433 for detail).  This bug causes false positive matches in the aws policy.

Fixes https://github.com/cloudquery/cloudquery/issues/13433 