### PR TITLE
feat: Add scheduler option to AWS

### DIFF
--- a/plugins/source/aws/client/spec.go
+++ b/plugins/source/aws/client/spec.go
@@ -130,7 +130,4 @@ func (s *Spec) SetDefaults() {
 		fullSync := true
 		s.EventBasedSync.FullSync = &fullSync
 	}
-	if string(s.Scheduler) == "" {
-		s.Scheduler = scheduler.StrategyDFS
-	}
 }

--- a/plugins/source/aws/client/spec.go
+++ b/plugins/source/aws/client/spec.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/aws/aws-sdk-go-v2/aws/arn"
 	"github.com/cloudquery/cloudquery/plugins/source/aws/client/tableoptions"
+	"github.com/cloudquery/plugin-sdk/v4/scheduler"
 )
 
 const (
@@ -59,7 +60,11 @@ type Spec struct {
 	UsePaidAPIs               bool                       `json:"use_paid_apis"`
 	TableOptions              *tableoptions.TableOptions `json:"table_options,omitempty"`
 	Concurrency               int                        `json:"concurrency"`
+<<<<<<< Updated upstream
 	EventBasedSync            *EventBasedSync            `json:"event_based_sync,omitempty"`
+=======
+	Scheduler                 scheduler.Strategy         `json:"scheduler,omitempty"`
+>>>>>>> Stashed changes
 }
 
 func (s *Spec) Validate() error {
@@ -124,9 +129,14 @@ func (s *Spec) SetDefaults() {
 	if s.Concurrency == 0 {
 		s.Concurrency = defaultMaxConcurrency
 	}
+<<<<<<< Updated upstream
 
 	if s.EventBasedSync != nil && s.EventBasedSync.FullSync == nil {
 		fullSync := true
 		s.EventBasedSync.FullSync = &fullSync
+=======
+	if string(s.Scheduler) == "" {
+		s.Scheduler = scheduler.StrategyDFS
+>>>>>>> Stashed changes
 	}
 }

--- a/plugins/source/aws/client/spec.go
+++ b/plugins/source/aws/client/spec.go
@@ -60,11 +60,8 @@ type Spec struct {
 	UsePaidAPIs               bool                       `json:"use_paid_apis"`
 	TableOptions              *tableoptions.TableOptions `json:"table_options,omitempty"`
 	Concurrency               int                        `json:"concurrency"`
-<<<<<<< Updated upstream
 	EventBasedSync            *EventBasedSync            `json:"event_based_sync,omitempty"`
-=======
 	Scheduler                 scheduler.Strategy         `json:"scheduler,omitempty"`
->>>>>>> Stashed changes
 }
 
 func (s *Spec) Validate() error {
@@ -129,14 +126,11 @@ func (s *Spec) SetDefaults() {
 	if s.Concurrency == 0 {
 		s.Concurrency = defaultMaxConcurrency
 	}
-<<<<<<< Updated upstream
-
 	if s.EventBasedSync != nil && s.EventBasedSync.FullSync == nil {
 		fullSync := true
 		s.EventBasedSync.FullSync = &fullSync
-=======
+	}
 	if string(s.Scheduler) == "" {
 		s.Scheduler = scheduler.StrategyDFS
->>>>>>> Stashed changes
 	}
 }

--- a/plugins/source/aws/resources/plugin/client.go
+++ b/plugins/source/aws/resources/plugin/client.go
@@ -53,6 +53,7 @@ func New(ctx context.Context, logger zerolog.Logger, specBytes []byte, options p
 	c.scheduler = scheduler.NewScheduler(
 		scheduler.WithConcurrency(spec.Concurrency),
 		scheduler.WithLogger(logger),
+		scheduler.WithStrategy(spec.Scheduler),
 	)
 	return c, nil
 }

--- a/website/pages/docs/plugins/sources/aws/configuration.mdx
+++ b/website/pages/docs/plugins/sources/aws/configuration.mdx
@@ -79,6 +79,10 @@ This is the (nested) spec used by the AWS source plugin.
   During initialization the AWS source plugin fetches information about each account and region. This setting controls how many accounts can be initialized concurrently.
   Only configurations with many accounts (either hardcoded or discovered via Organizations) should require modifying this setting, to either lower it to avoid rate limit errors, or to increase it to speed up the initialization process.
 
+- `scheduler` (string) (default: `dfs`):
+
+  The scheduler to use when determining the priority of resources to sync. Currently, the only supported values are `dfs` (depth-first search) and `round-robin`. This is an experimental feature, and may be removed in the future. For more information about this, see [performance tuning](/docs/advanced-topics/performance-tuning).
+
 - `aws_debug` (`bool`) (default: `false`)
 
   If true, will log AWS debug logs, including retries and other request/response metadata


### PR DESCRIPTION
This wasn't moved into the AWS plugin before because there wasn't a strong need for it, but apparently some APIs (like account contacts) can benefit from this scheduler.