### PR TITLE
fix: Use latest SQLite plugin version in JS SDK docs

### DIFF
--- a/website/pages/docs/developers/creating-new-plugin/javascript-source.mdx
+++ b/website/pages/docs/developers/creating-new-plugin/javascript-source.mdx
@@ -138,7 +138,7 @@ kind: destination
 spec:
   name: sqlite
   path: cloudquery/sqlite
-  version: "v1.2.1"
+  version: "VERSION_DESTINATION_SQLITE"
   spec:
     connection_string: ./db.sql
 ```


### PR DESCRIPTION
<!-- 🎉 Thank you for making CloudQuery awesome by submitting a PR 🎉 -->

#### Summary

So we always use the latest version

<!--
Use the following steps to ensure your PR is ready to be reviewed

- [ ] Read the [contribution guidelines](../blob/main/CONTRIBUTING.md) 🧑‍🎓
- [ ] Run `make lint` to ensure the proposed changes follow the coding style 🚨 (install golangci-lint [here](https://golangci-lint.run/usage/install/#local-installation))
- [ ] Run `make test` to ensure the proposed changes pass the tests 🧪
- [ ] If changing a source plugin run `make gen` to ensure docs are up to date 📝
- [ ] Ensure the status checks below are successful ✅
--->
