### PR TITLE
feat: Configurable API version, default version to 2023-01

### DIFF
--- a/plugins/source/shopify/client/spec.go
+++ b/plugins/source/shopify/client/spec.go
@@ -20,6 +20,8 @@ type Spec struct {
 	MaxRetries  int64 `json:"max_retries,omitempty"`
 	PageSize    int64 `json:"page_size,omitempty"`
 	Concurrency int   `json:"concurrency,omitempty"`
+
+	APIVersion string `json:"api_version,omitempty"`
 }
 
 func (s *Spec) SetDefaults() {

--- a/plugins/source/shopify/internal/shopify/shopify.go
+++ b/plugins/source/shopify/internal/shopify/shopify.go
@@ -20,7 +20,7 @@ import (
 )
 
 const (
-	APIVersion = "2022-10"
+	defaultAPIVersion = "2023-01"
 )
 
 type Client struct {
@@ -39,6 +39,7 @@ type ClientOptions struct {
 
 	ApiKey, ApiSecret, AccessToken string
 	ShopURL                        string
+	APIVersion                     string
 }
 
 type HTTPDoer interface {
@@ -51,6 +52,9 @@ func New(opts ClientOptions) (*Client, error) {
 	}
 	if opts.ShopURL == "" {
 		return nil, fmt.Errorf("missing shop url")
+	}
+	if opts.APIVersion == "" {
+		opts.APIVersion = defaultAPIVersion
 	}
 
 	return &Client{
@@ -195,7 +199,7 @@ func (s *Client) GetProducts(ctx context.Context, pageUrl string, params url.Val
 	var ret GetProductsResponse
 
 	if pageUrl == "" {
-		pageUrl = fmt.Sprintf("admin/api/%s/products.json", APIVersion)
+		pageUrl = fmt.Sprintf("admin/api/%s/products.json", s.opts.APIVersion)
 	}
 
 	resp, err := s.request(ctx, pageUrl, params)
@@ -220,7 +224,7 @@ func (s *Client) GetOrders(ctx context.Context, pageUrl string, params url.Value
 	var ret GetOrdersResponse
 
 	if pageUrl == "" {
-		pageUrl = fmt.Sprintf("admin/api/%s/orders.json", APIVersion)
+		pageUrl = fmt.Sprintf("admin/api/%s/orders.json", s.opts.APIVersion)
 	}
 
 	resp, err := s.request(ctx, pageUrl, params)
@@ -245,7 +249,7 @@ func (s *Client) GetCustomers(ctx context.Context, pageUrl string, params url.Va
 	var ret GetCustomersResponse
 
 	if pageUrl == "" {
-		pageUrl = fmt.Sprintf("admin/api/%s/customers.json", APIVersion)
+		pageUrl = fmt.Sprintf("admin/api/%s/customers.json", s.opts.APIVersion)
 	}
 
 	resp, err := s.request(ctx, pageUrl, params)
@@ -270,7 +274,7 @@ func (s *Client) GetAbandonedCheckouts(ctx context.Context, pageUrl string, para
 	var ret GetCheckoutsResponse
 
 	if pageUrl == "" {
-		pageUrl = fmt.Sprintf("admin/api/%s/checkouts.json", APIVersion)
+		pageUrl = fmt.Sprintf("admin/api/%s/checkouts.json", s.opts.APIVersion)
 	}
 
 	resp, err := s.request(ctx, pageUrl, params)
@@ -295,7 +299,7 @@ func (s *Client) GetPriceRules(ctx context.Context, pageUrl string, params url.V
 	var ret GetPriceRulesResponse
 
 	if pageUrl == "" {
-		pageUrl = fmt.Sprintf("admin/api/%s/price_rules.json", APIVersion)
+		pageUrl = fmt.Sprintf("admin/api/%s/price_rules.json", s.opts.APIVersion)
 	}
 
 	resp, err := s.request(ctx, pageUrl, params)
@@ -320,7 +324,7 @@ func (s *Client) GetDiscountCodes(ctx context.Context, priceRuleID int64, pageUr
 	var ret GetDiscountCodesResponse
 
 	if pageUrl == "" {
-		pageUrl = fmt.Sprintf("admin/api/%s/price_rules/%d/discount_codes.json", APIVersion, priceRuleID)
+		pageUrl = fmt.Sprintf("admin/api/%s/price_rules/%d/discount_codes.json", s.opts.APIVersion, priceRuleID)
 	}
 
 	resp, err := s.request(ctx, pageUrl, nil)

--- a/plugins/source/shopify/internal/shopify/shopify.go
+++ b/plugins/source/shopify/internal/shopify/shopify.go
@@ -20,7 +20,7 @@ import (
 )
 
 const (
-	defaultAPIVersion = "2023-01"
+	DefaultAPIVersion = "2023-01"
 )
 
 type Client struct {
@@ -54,7 +54,7 @@ func New(opts ClientOptions) (*Client, error) {
 		return nil, fmt.Errorf("missing shop url")
 	}
 	if opts.APIVersion == "" {
-		opts.APIVersion = defaultAPIVersion
+		opts.APIVersion = DefaultAPIVersion
 	}
 
 	return &Client{

--- a/plugins/source/shopify/resources/plugin/client.go
+++ b/plugins/source/shopify/resources/plugin/client.go
@@ -123,6 +123,7 @@ func Configure(_ context.Context, logger zerolog.Logger, specBytes []byte, opts 
 		ApiKey:      config.APIKey,
 		ApiSecret:   config.APISecret,
 		AccessToken: config.AccessToken,
+		APIVersion:  config.APIVersion,
 		ShopURL:     config.ShopURL,
 		MaxRetries:  config.MaxRetries,
 		PageSize:    int(config.PageSize),

--- a/plugins/source/shopify/resources/services/customer/customers_mock_test.go
+++ b/plugins/source/shopify/resources/services/customer/customers_mock_test.go
@@ -17,7 +17,7 @@ func createCustomers(router *mux.Router) error {
 		return err
 	}
 
-	router.HandleFunc("/admin/api/"+shopify.APIVersion+"/customers.json", func(w http.ResponseWriter, r *http.Request) {
+	router.HandleFunc("/admin/api/"+shopify.DefaultAPIVersion+"/customers.json", func(w http.ResponseWriter, r *http.Request) {
 		list := shopify.GetCustomersResponse{
 			Customers: []shopify.Customer{sc},
 			PageSize:  1,

--- a/plugins/source/shopify/resources/services/order/orders_mock_test.go
+++ b/plugins/source/shopify/resources/services/order/orders_mock_test.go
@@ -17,7 +17,7 @@ func createOrders(router *mux.Router) error {
 		return err
 	}
 
-	router.HandleFunc("/admin/api/"+shopify.APIVersion+"/orders.json", func(w http.ResponseWriter, r *http.Request) {
+	router.HandleFunc("/admin/api/"+shopify.DefaultAPIVersion+"/orders.json", func(w http.ResponseWriter, r *http.Request) {
 		list := shopify.GetOrdersResponse{
 			Orders:   []shopify.Order{so},
 			PageSize: 1,

--- a/plugins/source/shopify/resources/services/product/products_mock_test.go
+++ b/plugins/source/shopify/resources/services/product/products_mock_test.go
@@ -18,7 +18,7 @@ func createProducts(router *mux.Router) error {
 	}
 	sp.Tags = shopify.Tags{"tag1", "tag2"}
 
-	router.HandleFunc("/admin/api/"+shopify.APIVersion+"/products.json", func(w http.ResponseWriter, r *http.Request) {
+	router.HandleFunc("/admin/api/"+shopify.DefaultAPIVersion+"/products.json", func(w http.ResponseWriter, r *http.Request) {
 		list := shopify.GetProductsResponse{
 			Products: []shopify.Product{sp},
 			PageSize: 1,

--- a/website/pages/docs/plugins/sources/shopify/overview.mdx
+++ b/website/pages/docs/plugins/sources/shopify/overview.mdx
@@ -46,6 +46,9 @@ This is the (nested) spec used by the Shopify source plugin:
 
 - `shop_url` (string, required): The URL of your Shopify store. Must start with `https://` and end with `.myshopify.com`.
 
+- `api_version` (string, optional. Default: `2023-01`):
+  The Shopify Admin API version to use. See [here](https://shopify.dev/docs/api/usage/versioning) for more information.
+
 - `timeout_secs` (integer in seconds, optional. Default: 10):
   Timeout for requests against the Shopify Admin API.
 


### PR DESCRIPTION
Fixes https://github.com/cloudquery/cloudquery/issues/13867

Also updates the default version to be `2023-01` (no changes to the APIs the plugin currently uses, according to [release notes](https://shopify.dev/docs/api/release-notes/2023-01)). Shopify API versions are usually supported for 1 year so it needs constant 'bumping'.