### PR TITLE
fix: Fetch all fields for `gcp_compute_osconfig_inventories`

### DIFF
--- a/plugins/source/gcp/resources/services/compute/osconfig_inventories.go
+++ b/plugins/source/gcp/resources/services/compute/osconfig_inventories.go
@@ -29,6 +29,7 @@ func fetchOSConfigInventories(ctx context.Context, meta schema.ClientMeta, paren
 	zone := parent.Item.(*computepb.Zone)
 	req := &pb.ListInventoriesRequest{
 		Parent: "projects/" + c.ProjectId + "/locations/" + *zone.Name + "/instances/-",
+		View:   pb.InventoryView_FULL,
 	}
 
 	gcpClient, err := osconfig.NewOsConfigZonalRESTClient(ctx, c.ClientOptions...)


### PR DESCRIPTION
Should fix https://github.com/cloudquery/cloudquery/issues/13945