### PR TITLE
fix: Handle NoConnection

### DIFF
--- a/plugins/source/firestore/client/client.go
+++ b/plugins/source/firestore/client/client.go
@@ -85,6 +85,9 @@ func Configure(ctx context.Context, logger zerolog.Logger, spec []byte, opts plu
 }
 
 func (c Client) Tables(ctx context.Context, opts plugin.TableOptions) (schema.Tables, error) {
+	if c.options.NoConnection {
+		return schema.Tables{}, nil
+	}
 	return c.tables.FilterDfs(opts.Tables, opts.SkipTables, opts.SkipDependentTables)
 }
 


### PR DESCRIPTION
<!-- 🎉 Thank you for making CloudQuery awesome by submitting a PR 🎉 -->

#### Summary

See https://github.com/cloudquery/cloudquery/actions/runs/6328679225/job/17187394279#step:6:89 I missed this in https://github.com/cloudquery/cloudquery/pull/14102.

If we pass empty tables to `FilterDfs` it fails since there are no matches.

<!--
Use the following steps to ensure your PR is ready to be reviewed

- [ ] Read the [contribution guidelines](../blob/main/CONTRIBUTING.md) 🧑‍🎓
- [ ] Run `make lint` to ensure the proposed changes follow the coding style 🚨 (install golangci-lint [here](https://golangci-lint.run/usage/install/#local-installation))
- [ ] Run `make test` to ensure the proposed changes pass the tests 🧪
- [ ] If changing a source plugin run `make gen` to ensure docs are up to date 📝
- [ ] Ensure the status checks below are successful ✅
--->
