### PR TITLE
chore: Set `write_mode: append` in example configuration

### DIFF
--- a/website/pages/docs/plugins/destinations/clickhouse/_configuration.mdx
+++ b/website/pages/docs/plugins/destinations/clickhouse/_configuration.mdx
@@ -5,7 +5,7 @@ spec:
   registry: "github"
   path: "cloudquery/clickhouse"
   version: "VERSION_DESTINATION_CLICKHOUSE"
-# write_mode: "append"
+  write_mode: "append"
   spec:
     connection_string: "clickhouse://${CH_USER}:${CH_PASSWORD}@localhost:9000/${CH_DATABASE}"
     # Optional parameters


### PR DESCRIPTION
<!-- 🎉 Thank you for making CloudQuery awesome by submitting a PR 🎉 -->

#### Summary

Per the ClickHouse docs only `append` is supported https://www.cloudquery.io/docs/plugins/destinations/clickhouse/overview so we should set it in the config by default

<!--
Use the following steps to ensure your PR is ready to be reviewed

- [ ] Read the [contribution guidelines](../blob/main/CONTRIBUTING.md) 🧑‍🎓
- [ ] Run `make lint` to ensure the proposed changes follow the coding style 🚨 (install golangci-lint [here](https://golangci-lint.run/usage/install/#local-installation))
- [ ] Run `make test` to ensure the proposed changes pass the tests 🧪
- [ ] If changing a source plugin run `make gen` to ensure docs are up to date 📝
- [ ] Ensure the status checks below are successful ✅
--->
