### PR TITLE
chore: Remove plugin_releaser from Hub CI for SQLite,Snowflake,DuckDB

### DIFF
--- a/.github/workflows/publish_plugin_to_hub_duckdb.yml
+++ b/.github/workflows/publish_plugin_to_hub_duckdb.yml
@@ -12,7 +12,6 @@ jobs:
       plugin_version: ${{ steps.split.outputs.plugin_version }}
       plugin_dir: ${{ steps.split.outputs.plugin_dir }}
       prerelease: ${{ steps.semver_parser.outputs.prerelease }}
-      plugin_releaser: ${{ steps.set-result.outputs.result }}
     steps:
       - name: Split tag
         id: split
@@ -31,25 +30,6 @@ jobs:
         id: semver_parser
         with:
           input_string: ${{steps.split.outputs.plugin_version}}
-      - name: Checkout
-        uses: actions/checkout@v3
-
-      - uses: actions/github-script@v6
-        id: set-result
-        env:
-          PLUGIN_DIR: ${{steps.split.outputs.plugin_dir}}
-        with:
-          script: |
-            const fs = require('fs').promises;
-            const path = require('path');
-            const pluginFiles = await fs.readdir(process.env.PLUGIN_DIR);
-            if (pluginFiles.includes('Dockerfile')) {
-              return 'docker';
-            }
-            if (pluginFiles.includes('.goreleaser.yaml')) {
-              return 'go';
-            }
-          result-encoding: string
   publish-plugin-to-hub:
     timeout-minutes: 60
     runs-on: large-ubuntu-monorepo
@@ -60,7 +40,6 @@ jobs:
         CC: /usr/bin/gencc.sh
         CXX: /usr/bin/gencpp.sh
     needs: prepare
-    if: needs.prepare.outputs.plugin_releaser == 'go'
     steps:
       - name: Checkout
         uses: actions/checkout@v3

--- a/.github/workflows/publish_plugin_to_hub_snowflake.yml
+++ b/.github/workflows/publish_plugin_to_hub_snowflake.yml
@@ -12,7 +12,6 @@ jobs:
       plugin_version: ${{ steps.split.outputs.plugin_version }}
       plugin_dir: ${{ steps.split.outputs.plugin_dir }}
       prerelease: ${{ steps.semver_parser.outputs.prerelease }}
-      plugin_releaser: ${{ steps.set-result.outputs.result }}
     steps:
       - name: Split tag
         id: split
@@ -31,25 +30,6 @@ jobs:
         id: semver_parser
         with:
           input_string: ${{steps.split.outputs.plugin_version}}
-      - name: Checkout
-        uses: actions/checkout@v3
-
-      - uses: actions/github-script@v6
-        id: set-result
-        env:
-          PLUGIN_DIR: ${{steps.split.outputs.plugin_dir}}
-        with:
-          script: |
-            const fs = require('fs').promises;
-            const path = require('path');
-            const pluginFiles = await fs.readdir(process.env.PLUGIN_DIR);
-            if (pluginFiles.includes('Dockerfile')) {
-              return 'docker';
-            }
-            if (pluginFiles.includes('.goreleaser.yaml')) {
-              return 'go';
-            }
-          result-encoding: string
   publish-plugin-to-hub:
     timeout-minutes: 60
     runs-on: large-ubuntu-monorepo
@@ -61,7 +41,6 @@ jobs:
         CXX: /usr/bin/gencpp.sh
         GOAMD64: v1
     needs: prepare
-    if: needs.prepare.outputs.plugin_releaser == 'go'
     steps:
       - name: Checkout
         uses: actions/checkout@v3

--- a/.github/workflows/publish_plugin_to_hub_sqlite.yml
+++ b/.github/workflows/publish_plugin_to_hub_sqlite.yml
@@ -12,7 +12,6 @@ jobs:
       plugin_version: ${{ steps.split.outputs.plugin_version }}
       plugin_dir: ${{ steps.split.outputs.plugin_dir }}
       prerelease: ${{ steps.semver_parser.outputs.prerelease }}
-      plugin_releaser: ${{ steps.set-result.outputs.result }}
     steps:
       - name: Split tag
         id: split
@@ -31,25 +30,6 @@ jobs:
         id: semver_parser
         with:
           input_string: ${{steps.split.outputs.plugin_version}}
-      - name: Checkout
-        uses: actions/checkout@v3
-
-      - uses: actions/github-script@v6
-        id: set-result
-        env:
-          PLUGIN_DIR: ${{steps.split.outputs.plugin_dir}}
-        with:
-          script: |
-            const fs = require('fs').promises;
-            const path = require('path');
-            const pluginFiles = await fs.readdir(process.env.PLUGIN_DIR);
-            if (pluginFiles.includes('Dockerfile')) {
-              return 'docker';
-            }
-            if (pluginFiles.includes('.goreleaser.yaml')) {
-              return 'go';
-            }
-          result-encoding: string
   publish-plugin-to-hub:
     timeout-minutes: 60
     runs-on: large-ubuntu-monorepo
@@ -60,7 +40,6 @@ jobs:
         CC: /usr/bin/gencc.sh
         CXX: /usr/bin/gencpp.sh
     needs: prepare
-    if: needs.prepare.outputs.plugin_releaser == 'go'
     steps:
       - name: Checkout
         uses: actions/checkout@v3


### PR DESCRIPTION
<!-- 🎉 Thank you for making CloudQuery awesome by submitting a PR 🎉 -->

#### Summary

We don't need to check the releaser type as we want to always publish these plugins to the Hub. This caused SQLite and DuckDB to be skipped as they have a Dockerfile preset:
https://github.com/cloudquery/cloudquery/actions/runs/6338691053
https://github.com/cloudquery/cloudquery/actions/runs/6339408118

Snowflake worked fine but doesn't need this part either:
https://github.com/cloudquery/cloudquery/actions/runs/6341384187

<!--
Use the following steps to ensure your PR is ready to be reviewed

- [ ] Read the [contribution guidelines](../blob/main/CONTRIBUTING.md) 🧑‍🎓
- [ ] Run `make lint` to ensure the proposed changes follow the coding style 🚨 (install golangci-lint [here](https://golangci-lint.run/usage/install/#local-installation))
- [ ] Run `make test` to ensure the proposed changes pass the tests 🧪
- [ ] If changing a source plugin run `make gen` to ensure docs are up to date 📝
- [ ] Ensure the status checks below are successful ✅
--->
