### PR TITLE
fix: Azure query "Ensure that Public access level is set to Privat…

### DIFF
--- a/plugins/source/azure/policies/queries/storage/no_public_blob_container.sql
+++ b/plugins/source/azure/policies/queries/storage/no_public_blob_container.sql
@@ -7,10 +7,10 @@ SELECT
     azsc.subscription_id                                                        AS subscription_id,
     azsc.id                                                                     AS resrouce_id,
     CASE
-        WHEN azsc.properties->>'publicAccess' = 'None'
-         AND NOT (asa.properties->>'allowBlobPublicAccess')::boolean
-        THEN 'pass'
-        ELSE 'fail'
+        WHEN (asa.properties->>'allowBlobPublicAccess')::BOOLEAN = true 
+        AND (azsc.properties->>'publicAccess') <> 'None' 
+        THEN 'fail'
+        ELSE 'pass'
     END                                                                         AS status
 FROM azure_storage_containers azsc
     JOIN azure_storage_accounts asa on azsc._cq_parent_id = asa._cq_id

--- a/website/tables/azure/azure_storage_accounts.md
+++ b/website/tables/azure/azure_storage_accounts.md
@@ -106,10 +106,10 @@ SELECT
   azsc.subscription_id AS subscription_id,
   azsc.id AS resrouce_id,
   CASE
-  WHEN azsc.properties->>'publicAccess' = 'None'
-  AND NOT (asa.properties->>'allowBlobPublicAccess')::BOOL
-  THEN 'pass'
-  ELSE 'fail'
+  WHEN (asa.properties->>'allowBlobPublicAccess')::BOOLEAN = true 
+  AND (azsc.properties->>'publicAccess') <> 'None' 
+  THEN 'fail'
+  ELSE 'pass'
   END
     AS status
 FROM

--- a/website/tables/azure/azure_storage_accounts.md
+++ b/website/tables/azure/azure_storage_accounts.md
@@ -106,8 +106,8 @@ SELECT
   azsc.subscription_id AS subscription_id,
   azsc.id AS resrouce_id,
   CASE
-  WHEN (asa.properties->>'allowBlobPublicAccess')::BOOLEAN = true 
-  AND (azsc.properties->>'publicAccess') <> 'None' 
+  WHEN (asa.properties->>'allowBlobPublicAccess')::BOOL = true
+  AND (azsc.properties->>'publicAccess') != 'None'
   THEN 'fail'
   ELSE 'pass'
   END

--- a/website/tables/azure/azure_storage_containers.md
+++ b/website/tables/azure/azure_storage_containers.md
@@ -36,8 +36,8 @@ SELECT
   azsc.subscription_id AS subscription_id,
   azsc.id AS resrouce_id,
   CASE
-  WHEN (asa.properties->>'allowBlobPublicAccess')::BOOLEAN = true 
-  AND (azsc.properties->>'publicAccess') <> 'None' 
+  WHEN (asa.properties->>'allowBlobPublicAccess')::BOOL = true
+  AND (azsc.properties->>'publicAccess') != 'None'
   THEN 'fail'
   ELSE 'pass'
   END

--- a/website/tables/azure/azure_storage_containers.md
+++ b/website/tables/azure/azure_storage_containers.md
@@ -36,10 +36,10 @@ SELECT
   azsc.subscription_id AS subscription_id,
   azsc.id AS resrouce_id,
   CASE
-  WHEN azsc.properties->>'publicAccess' = 'None'
-  AND NOT (asa.properties->>'allowBlobPublicAccess')::BOOL
-  THEN 'pass'
-  ELSE 'fail'
+  WHEN (asa.properties->>'allowBlobPublicAccess')::BOOLEAN = true 
+  AND (azsc.properties->>'publicAccess') <> 'None' 
+  THEN 'fail'
+  ELSE 'pass'
   END
     AS status
 FROM


### PR DESCRIPTION
Fixing the issue in "Ensure that 'public access level' is set to private for blob containers"

<!-- 🎉 Thank you for making CloudQuery awesome by submitting a PR 🎉 -->

#### Summary

<!--
Explain what problem this PR addresses
-->

<!--
Use the following steps to ensure your PR is ready to be reviewed

- [ ] Read the [contribution guidelines](../blob/main/CONTRIBUTING.md) 🧑‍🎓
- [ ] Run `make lint` to ensure the proposed changes follow the coding style 🚨 (install golangci-lint [here](https://golangci-lint.run/usage/install/#local-installation))
- [ ] Run `make test` to ensure the proposed changes pass the tests 🧪
- [ ] If changing a source plugin run `make gen` to ensure docs are up to date 📝
- [ ] Ensure the status checks below are successful ✅
--->
