### PR TITLE
feat: Add pagination support for endpoints

### DIFF
--- a/plugins/source/datadog/resources/services/dashboards/dashboards.go
+++ b/plugins/source/datadog/resources/services/dashboards/dashboards.go
@@ -22,10 +22,6 @@ func Dashboards() *schema.Table {
 func fetchDashboards(ctx context.Context, meta schema.ClientMeta, _ *schema.Resource, res chan<- any) error {
 	c := meta.(*client.Client)
 	ctx = c.BuildContextV1(ctx)
-	resp, _, err := c.DDServices.DashboardsAPI.ListDashboards(ctx)
-	if err != nil {
-		return err
-	}
-	res <- resp.GetDashboards()
-	return nil
+	resp, cancel := c.DDServices.DashboardsAPI.ListDashboardsWithPagination(ctx)
+	return client.ConsumePaginatedResponse(resp, cancel, res)
 }

--- a/plugins/source/datadog/resources/services/dashboards/dashboards_mock_test.go
+++ b/plugins/source/datadog/resources/services/dashboards/dashboards_mock_test.go
@@ -16,14 +16,14 @@ func buildDashboardsMock(t *testing.T, ctrl *gomock.Controller) client.DatadogSe
 		DashboardsAPI: m,
 	}
 
-	var d datadogV1.DashboardSummary
+	var d datadogV1.DashboardSummaryDefinition
 	err := faker.FakeObject(&d)
 	if err != nil {
 		t.Fatal(err)
 	}
 	desc := "test string"
-	d.Dashboards[0].Description.Set(&desc)
-	m.EXPECT().ListDashboards(gomock.Any()).Return(d, nil, nil)
+	d.Description.Set(&desc)
+	m.EXPECT().ListDashboardsWithPagination(gomock.Any()).Return(client.MockPaginatedResponse(d))
 
 	return services
 }

--- a/plugins/source/datadog/resources/services/monitors/monitors.go
+++ b/plugins/source/datadog/resources/services/monitors/monitors.go
@@ -23,10 +23,6 @@ func Monitors() *schema.Table {
 func fetchMonitors(ctx context.Context, meta schema.ClientMeta, _ *schema.Resource, res chan<- any) error {
 	c := meta.(*client.Client)
 	ctx = c.BuildContextV1(ctx)
-	resp, _, err := c.DDServices.MonitorsAPI.ListMonitors(ctx)
-	if err != nil {
-		return err
-	}
-	res <- resp
-	return nil
+	resp, cancel := c.DDServices.MonitorsAPI.ListMonitorsWithPagination(ctx)
+	return client.ConsumePaginatedResponse(resp, cancel, res)
 }

--- a/plugins/source/datadog/resources/services/monitors/monitors_mock_test.go
+++ b/plugins/source/datadog/resources/services/monitors/monitors_mock_test.go
@@ -19,17 +19,17 @@ func buildMonitorsMock(t *testing.T, ctrl *gomock.Controller) client.DatadogServ
 		DowntimesAPI: d,
 	}
 
-	var monitors []datadogV1.Monitor
-	err := faker.FakeObject(&monitors)
+	var monitor datadogV1.Monitor
+	err := faker.FakeObject(&monitor)
 	if err != nil {
 		t.Fatal(err)
 	}
 	now := time.Now()
-	monitors[0].Deleted.Set(&now)
+	monitor.Deleted.Set(&now)
 	priority := int64(123)
-	monitors[0].Priority.Set(&priority)
+	monitor.Priority.Set(&priority)
 
-	m.EXPECT().ListMonitors(gomock.Any()).Return(monitors, nil, nil)
+	m.EXPECT().ListMonitorsWithPagination(gomock.Any()).Return(client.MockPaginatedResponse(monitor))
 
 	var dt []datadogV1.Downtime
 	err = faker.FakeObject(&dt)

--- a/plugins/source/datadog/resources/services/notebooks/notebooks.go
+++ b/plugins/source/datadog/resources/services/notebooks/notebooks.go
@@ -22,10 +22,6 @@ func Notebooks() *schema.Table {
 func fetchNotebooks(ctx context.Context, meta schema.ClientMeta, _ *schema.Resource, res chan<- any) error {
 	c := meta.(*client.Client)
 	ctx = c.BuildContextV1(ctx)
-	resp, _, err := c.DDServices.NotebooksAPI.ListNotebooks(ctx)
-	if err != nil {
-		return err
-	}
-	res <- resp.GetData()
-	return nil
+	resp, cancel := c.DDServices.NotebooksAPI.ListNotebooksWithPagination(ctx)
+	return client.ConsumePaginatedResponse(resp, cancel, res)
 }

--- a/plugins/source/datadog/resources/services/notebooks/notebooks_mock_test.go
+++ b/plugins/source/datadog/resources/services/notebooks/notebooks_mock_test.go
@@ -16,12 +16,12 @@ func buildNotebooksMock(t *testing.T, ctrl *gomock.Controller) client.DatadogSer
 		NotebooksAPI: m,
 	}
 
-	var n datadogV1.NotebooksResponse
+	var n datadogV1.NotebooksResponseData
 	err := faker.FakeObject(&n)
 	if err != nil {
 		t.Fatal(err)
 	}
-	m.EXPECT().ListNotebooks(gomock.Any()).Return(n, nil, nil)
+	m.EXPECT().ListNotebooksWithPagination(gomock.Any()).Return(client.MockPaginatedResponse(n))
 
 	return services
 }

--- a/plugins/source/datadog/resources/services/slos/corrections.go
+++ b/plugins/source/datadog/resources/services/slos/corrections.go
@@ -22,10 +22,6 @@ func Corrections() *schema.Table {
 func fetchCorrections(ctx context.Context, meta schema.ClientMeta, _ *schema.Resource, res chan<- any) error {
 	c := meta.(*client.Client)
 	ctx = c.BuildContextV2(ctx)
-	resp, _, err := c.DDServices.ServiceLevelObjectiveCorrectionsAPI.ListSLOCorrection(ctx)
-	if err != nil {
-		return err
-	}
-	res <- resp.GetData()
-	return nil
+	resp, cancel := c.DDServices.ServiceLevelObjectiveCorrectionsAPI.ListSLOCorrectionWithPagination(ctx)
+	return client.ConsumePaginatedResponse(resp, cancel, res)
 }

--- a/plugins/source/datadog/resources/services/slos/corrections_mock_test.go
+++ b/plugins/source/datadog/resources/services/slos/corrections_mock_test.go
@@ -17,13 +17,13 @@ func buildCorrectionsMock(t *testing.T, ctrl *gomock.Controller) client.DatadogS
 		ServiceLevelObjectiveCorrectionsAPI: m,
 	}
 
-	var d datadogV1.SLOCorrectionListResponse
+	var d datadogV1.SLOCorrection
 	err := faker.FakeObject(&d)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	m.EXPECT().ListSLOCorrection(gomock.Any()).Return(d, nil, nil)
+	m.EXPECT().ListSLOCorrectionWithPagination(gomock.Any()).Return(client.MockPaginatedResponse(d))
 
 	return services
 }

--- a/plugins/source/datadog/resources/services/slos/slos.go
+++ b/plugins/source/datadog/resources/services/slos/slos.go
@@ -22,10 +22,6 @@ func Objectives() *schema.Table {
 func fetchObjectives(ctx context.Context, meta schema.ClientMeta, _ *schema.Resource, res chan<- any) error {
 	c := meta.(*client.Client)
 	ctx = c.BuildContextV2(ctx)
-	resp, _, err := c.DDServices.ServiceLevelObjectivesAPI.ListSLOs(ctx)
-	if err != nil {
-		return err
-	}
-	res <- resp.GetData()
-	return nil
+	resp, cancel := c.DDServices.ServiceLevelObjectivesAPI.ListSLOsWithPagination(ctx)
+	return client.ConsumePaginatedResponse(resp, cancel, res)
 }

--- a/plugins/source/datadog/resources/services/slos/slos_mock_test.go
+++ b/plugins/source/datadog/resources/services/slos/slos_mock_test.go
@@ -17,15 +17,15 @@ func buildObjectivesMock(t *testing.T, ctrl *gomock.Controller) client.DatadogSe
 		ServiceLevelObjectivesAPI: m,
 	}
 
-	var d datadogV1.SLOListResponse
+	var d datadogV1.ServiceLevelObjective
 	err := faker.FakeObject(&d)
 	if err != nil {
 		t.Fatal(err)
 	}
 	str := "test"
-	d.Data[0].Description.Set(&str)
+	d.Description.Set(&str)
 
-	m.EXPECT().ListSLOs(gomock.Any()).Return(d, nil, nil)
+	m.EXPECT().ListSLOsWithPagination(gomock.Any()).Return(client.MockPaginatedResponse(d))
 
 	return services
 }

--- a/plugins/source/datadog/resources/services/synthetics/synthetics.go
+++ b/plugins/source/datadog/resources/services/synthetics/synthetics.go
@@ -22,10 +22,6 @@ func Synthetics() *schema.Table {
 func fetchSynthetics(ctx context.Context, meta schema.ClientMeta, _ *schema.Resource, res chan<- any) error {
 	c := meta.(*client.Client)
 	ctx = c.BuildContextV1(ctx)
-	resp, _, err := c.DDServices.SyntheticsAPI.ListTests(ctx)
-	if err != nil {
-		return err
-	}
-	res <- resp.GetTests()
-	return nil
+	resp, cancel := c.DDServices.SyntheticsAPI.ListTestsWithPagination(ctx)
+	return client.ConsumePaginatedResponse(resp, cancel, res)
 }

--- a/plugins/source/datadog/resources/services/synthetics/synthetics_mock_test.go
+++ b/plugins/source/datadog/resources/services/synthetics/synthetics_mock_test.go
@@ -17,12 +17,12 @@ func buildSyntheticsMock(t *testing.T, ctrl *gomock.Controller) client.DatadogSe
 		SyntheticsAPI: m,
 	}
 
-	var s datadogV1.SyntheticsListTestsResponse
+	var s datadogV1.SyntheticsTestDetails
 	err := faker.FakeObject(&s)
 	if err != nil {
 		t.Fatal(err)
 	}
-	m.EXPECT().ListTests(gomock.Any()).Return(s, nil, nil)
+	m.EXPECT().ListTestsWithPagination(gomock.Any()).Return(client.MockPaginatedResponse(s))
 
 	return services
 }


### PR DESCRIPTION
Following on from https://github.com/cloudquery/cloudquery/issues/14187, adding support for other pagination calls which have been introduced in recent SDK versions.

fixes: https://github.com/cloudquery/cloudquery/issues/14190
