### PR TITLE
feat: Add configurable site

### DIFF
--- a/plugins/source/datadog/client/spec.go
+++ b/plugins/source/datadog/client/spec.go
@@ -3,6 +3,7 @@ package client
 type Spec struct {
 	Accounts    []Account `json:"accounts"`
 	Concurrency int       `json:"concurrency"`
+	Site        string    `json:"site"`
 }
 
 type Account struct {

--- a/website/pages/docs/plugins/sources/datadog/_configuration.mdx
+++ b/website/pages/docs/plugins/sources/datadog/_configuration.mdx
@@ -14,5 +14,6 @@ spec:
         api_key: <DD_CLIENT_API_KEY> # Required. API key
         app_key: <DD_CLIENT_APP_KEY> # Required. App key
     # Optional parameters
+    # site: datadoghq.eu
     # concurrency: 10000
 ```

--- a/website/pages/docs/plugins/sources/datadog/configuration.mdx
+++ b/website/pages/docs/plugins/sources/datadog/configuration.mdx
@@ -16,6 +16,10 @@ This is the (nested) spec used by the Datadog source plugin.
 
   Specify which accounts to sync data from.
 
+- `site` (`string`, optional, default: "")
+
+  The Datadog site to connect to. This is usually one of `datadoghq.com` or `datadoghq.eu` - see [site](https://docs.datadoghq.com/getting_started/site/) documentation for more information.
+
 - `concurrency` (`int`, optional, default: `10000`)
 
   A best effort maximum number of Go routines to use. Lower this number to reduce memory usage.


### PR DESCRIPTION
Add configurable site to allow other DDog regional sites to be used, if no site is specified the existing behaviour is preserved.

fixes: https://github.com/cloudquery/cloudquery/issues/14265
