### PR TITLE
chore: Use relative links in `creating-a-new-js-plugin.mdx`

### DIFF
--- a/website/pages/blog/creating-a-new-js-plugin.mdx
+++ b/website/pages/blog/creating-a-new-js-plugin.mdx
@@ -13,14 +13,14 @@ In this blog post, I will walk you through the steps to create a new source plug
 
 ## What You Need to Know
 
-Make sure you go over the core concepts of [CloudQuery](http://cloudquery.io/docs/core-concepts/plugins) and the [JavaScript SDK](http://cloudquery.io/docs/developers/creating-new-plugin/javascript-source).
+Make sure you go over the core concepts of [CloudQuery](/docs/core-concepts/plugins) and the [JavaScript SDK](/docs/developers/creating-new-plugin/javascript-source).
 
 I will be using TypeScript for IDE autocompletion and code type safety.
 
 ### Prerequisites
 
 - [NodeJS LTS](https://nodejs.org/en/download)
-- [CloudQuery](http://cloudquery.io/docs/quickstart)
+- [CloudQuery](/docs/quickstart)
 
 To build and release the plugin for public use, you will need [Docker](https://docker.io) to be installed locally.
 
@@ -499,7 +499,7 @@ spec:
 // ...
 ```
 
-To find out how to release your plugin for use by a wider CloudQuery community, see [Releasing and Deploying your Plugin](https://www.cloudquery.io/docs/developers/creating-new-plugin/javascript-source#releasing-and-deploying-your-plugin) in our documentation.
+To find out how to release your plugin for use by a wider CloudQuery community, see [Releasing and Deploying your Plugin](/docs/developers/creating-new-plugin/javascript-source#releasing-and-deploying-your-plugin) in our documentation.
 
 ## Resources
 
@@ -508,7 +508,7 @@ Starter repository for this blog post and for new plugins:
 
 Check out the [`csv-file-sync`](https://github.com/cloudquery/javascript-plugin-template/tree/csv-file-sync) branch of the repository above to get to the final code for our CSV plugin.
 
-[CloudQuery SDK Documentation](https://www.cloudquery.io/docs/developers/architecture)
+[CloudQuery SDK Documentation](/docs/developers/architecture)
 
 ### Other JavaScript Source Plugin Examples
 


### PR DESCRIPTION
<!-- 🎉 Thank you for making CloudQuery awesome by submitting a PR 🎉 -->

#### Summary

We should use relative links so clicking them doesn't open a new tab and also they work on deploy previews.
Some of the links were also `http` which redirected to `https`

<!--
Use the following steps to ensure your PR is ready to be reviewed

- [ ] Read the [contribution guidelines](../blob/main/CONTRIBUTING.md) 🧑‍🎓
- [ ] Run `make lint` to ensure the proposed changes follow the coding style 🚨 (install golangci-lint [here](https://golangci-lint.run/usage/install/#local-installation))
- [ ] Run `make test` to ensure the proposed changes pass the tests 🧪
- [ ] If changing a source plugin run `make gen` to ensure docs are up to date 📝
- [ ] Ensure the status checks below are successful ✅
--->
