### PR TITLE
doc: Replace stripe redirects with links to typeform

### DIFF
--- a/website/pages/buy/aws_cis_v1_5_0_bigquery-extended.mdx
+++ b/website/pages/buy/aws_cis_v1_5_0_bigquery-extended.mdx
@@ -2,14 +2,6 @@
 title: Buy AWS CIS V1.5.0 for BigQuery (Extended License)
 ---
 
-import Head from "next/head";
-
-<Head>
-  <meta httpEquiv="refresh" content="5; url='https://buy.stripe.com/fZe7sw7Q5axFeSQ17V'" />
-</Head>
-
 ## Purchase AWS CIS V1.5.0 for BigQuery (Extended License)
 
-You will be redirected to a Stripe checkout page to complete your purchase in 5 seconds…
-
-If the page does not redirect automatically, please click this link: [https://buy.stripe.com/fZe7sw7Q5axFeSQ17V](https://buy.stripe.com/fZe7sw7Q5axFeSQ17V)
+This policy is available for in early access only. [Get it](/contact-policies).

--- a/website/pages/buy/aws_cis_v1_5_0_bigquery-standard.mdx
+++ b/website/pages/buy/aws_cis_v1_5_0_bigquery-standard.mdx
@@ -2,14 +2,6 @@
 title: Buy AWS CIS V1.5.0 for BigQuery (Standard License)
 ---
 
-import Head from "next/head";
-
-<Head>
-  <meta httpEquiv="refresh" content="5; url='https://buy.stripe.com/4gw8wA2vLbBJ7qoeYK'" />
-</Head>
-
 ## Purchase AWS CIS V1.5.0 for BigQuery (Standard License)
 
-You will be redirected to a Stripe checkout page to complete your purchase in 5 seconds…
-
-If the page does not redirect automatically, please click this link: [https://buy.stripe.com/4gw8wA2vLbBJ7qoeYK](https://buy.stripe.com/4gw8wA2vLbBJ7qoeYK)
+This policy is available for in early access only. [Get it](/contact-policies).

--- a/website/pages/buy/aws_cis_v1_5_0_snowflake-extended.mdx
+++ b/website/pages/buy/aws_cis_v1_5_0_snowflake-extended.mdx
@@ -2,14 +2,6 @@
 title: Buy AWS CIS V1.5.0 for Snowflake (Extended License)
 ---
 
-import Head from "next/head";
-
-<Head>
-  <meta httpEquiv="refresh" content="5; url='https://buy.stripe.com/14k9AE3zPfRZ8usaIx'" />
-</Head>
-
 ## Purchase AWS CIS V1.5.0 for Snowflake (Extended License)
 
-You will be redirected to a Stripe checkout page to complete your purchase in 5 seconds…
-
-If the page does not redirect automatically, please click this link: [https://buy.stripe.com/14k9AE3zPfRZ8usaIx](https://buy.stripe.com/14k9AE3zPfRZ8usaIx)
+This policy is available for in early access only. [Get it](/contact-policies).

--- a/website/pages/buy/aws_cis_v1_5_0_snowflake-standard.mdx
+++ b/website/pages/buy/aws_cis_v1_5_0_snowflake-standard.mdx
@@ -2,14 +2,6 @@
 title: Buy AWS CIS V1.5.0 for Snowflake (Standard License)
 ---
 
-import Head from "next/head";
-
-<Head>
-  <meta httpEquiv="refresh" content="5; url='https://buy.stripe.com/fZe8wAc6laxF5ig6sg'" />
-</Head>
-
 ## Purchase AWS CIS V1.5.0 for Snowflake (Standard License)
 
-You will be redirected to a Stripe checkout page to complete your purchase in 5 seconds…
-
-If the page does not redirect automatically, please click this link: [https://buy.stripe.com/fZe8wAc6laxF5ig6sg](https://buy.stripe.com/fZe8wAc6laxF5ig6sg)
+This policy is available for in early access only. [Get it](/contact-policies).

--- a/website/pages/buy/aws_foundational_security_bigquery-extended.mdx
+++ b/website/pages/buy/aws_foundational_security_bigquery-extended.mdx
@@ -2,14 +2,6 @@
 title: Buy AWS Foundational Security for BigQuery (Extended License)
 ---
 
-import Head from "next/head";
-
-<Head>
-  <meta httpEquiv="refresh" content="5; url='https://buy.stripe.com/cN29AEfix49hfWU2bV'" />
-</Head>
-
 ## Purchase AWS Foundational Security for BigQuery (Extended License)
 
-You will be redirected to a Stripe checkout page to complete your purchase in 5 seconds…
-
-If the page does not redirect automatically, please click this link: [https://buy.stripe.com/cN29AEfix49hfWU2bV](https://buy.stripe.com/cN29AEfix49hfWU2bV)
+This policy is available for in early access only. [Get it](/contact-policies).

--- a/website/pages/buy/aws_foundational_security_bigquery-standard.mdx
+++ b/website/pages/buy/aws_foundational_security_bigquery-standard.mdx
@@ -2,14 +2,6 @@
 title: Buy AWS Foundational Security for BigQuery (Standard License)
 ---
 
-import Head from "next/head";
-
-<Head>
-  <meta httpEquiv="refresh" content="5; url='https://buy.stripe.com/cN2bIM0nD7lt2647we'" />
-</Head>
-
 ## Purchase AWS Foundational Security for BigQuery (Standard License)
 
-You will be redirected to a Stripe checkout page to complete your purchase in 5 seconds…
-
-If the page does not redirect automatically, please click this link: [https://buy.stripe.com/cN2bIM0nD7lt2647we](https://buy.stripe.com/cN2bIM0nD7lt2647we)
+This policy is available for in early access only. [Get it](/contact-policies).

--- a/website/pages/buy/azure-cost-pack-extended.mdx
+++ b/website/pages/buy/azure-cost-pack-extended.mdx
@@ -2,14 +2,6 @@
 title: Buy Azure Cost Optimization Pack (Extended License)
 ---
 
-import Head from "next/head";
-
-<Head>
-  <meta httpEquiv="refresh" content="5; url='https://buy.stripe.com/7sI8wAfix5dldOMaII'" />
-</Head>
-
 ## Purchase Azure Cost Optimization Pack (Extended License)
 
-You will be redirected to a Stripe checkout page to complete your purchase in 5 seconds…
-
-If the page does not redirect automatically, please click this link: [https://buy.stripe.com/7sI8wAfix5dldOMaII](https://buy.stripe.com/7sI8wAfix5dldOMaII)
+This policy is available for in early access only. [Get it](/contact-policies).

--- a/website/pages/buy/azure-cost-pack-standard.mdx
+++ b/website/pages/buy/azure-cost-pack-standard.mdx
@@ -2,14 +2,6 @@
 title: Azure Cost Optimization Pack (Standard License)
 ---
 
-import Head from "next/head";
-
-<Head>
-  <meta httpEquiv="refresh" content="5; url='https://buy.stripe.com/14k8wA8U97lt264eYZ'" />
-</Head>
-
 ## Purchase Azure Cost Optimization Pack (Standard License)
 
-You will be redirected to a Stripe checkout page to complete your purchase in 5 seconds…
-
-If the page does not redirect automatically, please click this link: [https://buy.stripe.com/14k8wA8U97lt264eYZ](https://buy.stripe.com/14k8wA8U97lt264eYZ)
+This policy is available in early access only. [Get it](/contact-policies)

--- a/website/pages/buy/azure_cis_v1_3_0_bigquery-extended.mdx
+++ b/website/pages/buy/azure_cis_v1_3_0_bigquery-extended.mdx
@@ -2,14 +2,6 @@
 title: Buy Azure CIS V1.3.0 for BigQuery (Extended License)
 ---
 
-import Head from "next/head";
-
-<Head>
-  <meta httpEquiv="refresh" content="5; url='https://buy.stripe.com/aEUaEIgmB5dlh0Y03Z'" />
-</Head>
-
 ## Purchase Azure CIS V1.3.0 for BigQuery (Extended License)
 
-You will be redirected to a Stripe checkout page to complete your purchase in 5 seconds…
-
-If the page does not redirect automatically, please click this link: [https://buy.stripe.com/aEUaEIgmB5dlh0Y03Z](https://buy.stripe.com/aEUaEIgmB5dlh0Y03Z)
+This policy is available for in early access only. [Get it](/contact-policies).

--- a/website/pages/buy/azure_cis_v1_3_0_bigquery-standard.mdx
+++ b/website/pages/buy/azure_cis_v1_3_0_bigquery-standard.mdx
@@ -2,14 +2,6 @@
 title: Buy Azure CIS V1.3.0 for BigQuery (Standard License)
 ---
 
-import Head from "next/head";
-
-<Head>
-  <meta httpEquiv="refresh" content="5; url='https://buy.stripe.com/14kbIM6M10X57qog2W'" />
-</Head>
-
 ## Purchase Azure CIS V1.3.0 for BigQuery (Standard License)
 
-You will be redirected to a Stripe checkout page to complete your purchase in 5 seconds…
-
-If the page does not redirect automatically, please click this link: [https://buy.stripe.com/14kbIM6M10X57qog2W](https://buy.stripe.com/14kbIM6M10X57qog2W)
+This policy is available for in early access only. [Get it](/contact-policies).

--- a/website/pages/buy/azure_cis_v1_3_0_snowflake-extended.mdx
+++ b/website/pages/buy/azure_cis_v1_3_0_snowflake-extended.mdx
@@ -2,14 +2,6 @@
 title: Buy Azure CIS V1.3.0 for Snowflake (Extended License)
 ---
 
-import Head from "next/head";
-
-<Head>
-  <meta httpEquiv="refresh" content="5; url='https://buy.stripe.com/eVa28c3zP35ddOMbMJ'" />
-</Head>
-
 ## Purchase Azure CIS V1.3.0 for Snowflake (Extended License)
 
-You will be redirected to a Stripe checkout page to complete your purchase in 5 seconds…
-
-If the page does not redirect automatically, please click this link: [https://buy.stripe.com/eVa28c3zP35ddOMbMJ](https://buy.stripe.com/eVa28c3zP35ddOMbMJ)
+This policy is available for in early access only. [Get it](/contact-policies).

--- a/website/pages/buy/azure_cis_v1_3_0_snowflake-standard.mdx
+++ b/website/pages/buy/azure_cis_v1_3_0_snowflake-standard.mdx
@@ -2,14 +2,6 @@
 title: Buy Azure CIS V1.3.0 for Snowflake (Standard License)
 ---
 
-import Head from "next/head";
-
-<Head>
-  <meta httpEquiv="refresh" content="5; url='https://buy.stripe.com/3cseUY0nDeNVh0Y7ws'" />
-</Head>
-
 ## Purchase Azure CIS V1.3.0 for Snowflake (Standard License)
 
-You will be redirected to a Stripe checkout page to complete your purchase in 5 seconds…
-
-If the page does not redirect automatically, please click this link: [https://buy.stripe.com/3cseUY0nDeNVh0Y7ws](https://buy.stripe.com/3cseUY0nDeNVh0Y7ws)
+This policy is available for in early access only. [Get it](/contact-policies).

--- a/website/pages/buy/azure_hippa_hitrust_v9_2_bigquery-extended.mdx
+++ b/website/pages/buy/azure_hippa_hitrust_v9_2_bigquery-extended.mdx
@@ -2,14 +2,6 @@
 title: Buy Azure HIPPA HITRUST v9.2 for BigQuery (Extended License)
 ---
 
-import Head from "next/head";
-
-<Head>
-  <meta httpEquiv="refresh" content="5; url='https://buy.stripe.com/bIYbIM0nD5dl3a83g7'" />
-</Head>
-
 ## Purchase Azure HIPPA HITRUST v9.2 for BigQuery (Extended License)
 
-You will be redirected to a Stripe checkout page to complete your purchase in 5 seconds…
-
-If the page does not redirect automatically, please click this link: [https://buy.stripe.com/bIYbIM0nD5dl3a83g7](https://buy.stripe.com/bIYbIM0nD5dl3a83g7)
+This policy is available for in early access only. [Get it](/contact-policies).

--- a/website/pages/buy/azure_hippa_hitrust_v9_2_bigquery-standard.mdx
+++ b/website/pages/buy/azure_hippa_hitrust_v9_2_bigquery-standard.mdx
@@ -2,14 +2,6 @@
 title: Buy Azure HIPPA HITRUST v9.2 for BigQuery (Standard License)
 ---
 
-import Head from "next/head";
-
-<Head>
-  <meta httpEquiv="refresh" content="5; url='https://buy.stripe.com/dR69AE8U99tB4ec8Aq'" />
-</Head>
-
 ## Purchase Azure HIPPA HITRUST v9.2 for BigQuery (Standard License)
 
-You will be redirected to a Stripe checkout page to complete your purchase in 5 seconds…
-
-If the page does not redirect automatically, please click this link: [https://buy.stripe.com/dR69AE8U99tB4ec8Aq](https://buy.stripe.com/dR69AE8U99tB4ec8Aq)
+This policy is available for in early access only. [Get it](/contact-policies).

--- a/website/pages/buy/azure_hippa_hitrust_v9_2_snowflake-extended.mdx
+++ b/website/pages/buy/azure_hippa_hitrust_v9_2_snowflake-extended.mdx
@@ -2,14 +2,6 @@
 title: Buy Azure HIPPA HITRUST v9.2 for Snowflake (Extended License)
 ---
 
-import Head from "next/head";
-
-<Head>
-  <meta httpEquiv="refresh" content="5; url='https://buy.stripe.com/dR6eUYeetgW3bGEbMF'" />
-</Head>
-
 ## Purchase Azure HIPPA HITRUST v9.2 for Snowflake (Extended License)
 
-You will be redirected to a Stripe checkout page to complete your purchase in 5 seconds…
-
-If the page does not redirect automatically, please click this link: [https://buy.stripe.com/dR6eUYeetgW3bGEbMF](https://buy.stripe.com/dR6eUYeetgW3bGEbMF)
+This policy is available for in early access only. [Get it](/contact-policies).

--- a/website/pages/buy/azure_hippa_hitrust_v9_2_snowflake-standard.mdx
+++ b/website/pages/buy/azure_hippa_hitrust_v9_2_snowflake-standard.mdx
@@ -2,14 +2,6 @@
 title: Buy Azure HIPPA HITRUST v9.2 for Snowflake (Standard License)
 ---
 
-import Head from "next/head";
-
-<Head>
-  <meta httpEquiv="refresh" content="5; url='https://buy.stripe.com/9AQ28cb2hgW34eccQI'" />
-</Head>
-
 ## Purchase Azure HIPPA HITRUST v9.2 for Snowflake (Standard License)
 
-You will be redirected to a Stripe checkout page to complete your purchase in 5 seconds…
-
-If the page does not redirect automatically, please click this link: [https://buy.stripe.com/9AQ28cb2hgW34eccQI](https://buy.stripe.com/9AQ28cb2hgW34eccQI)
+This policy is available for in early access only. [Get it](/contact-policies).

--- a/website/pages/buy/gcp-cost-pack-standard.mdx
+++ b/website/pages/buy/gcp-cost-pack-standard.mdx
@@ -2,14 +2,6 @@
 title: Buy GCP Cost Optimization Pack (Standard License)
 ---
 
-import Head from "next/head";
-
-<Head>
-  <meta httpEquiv="refresh" content="5; url='https://buy.stripe.com/28ocMQ2vL49hh0Y2ce'" />
-</Head>
-
 ## Purchase GCP Cost Optimization Pack (Standard License)
 
-You will be redirected to a Stripe checkout page to complete your purchase in 5 seconds…
-
-If the page does not redirect automatically, please click this link: [https://buy.stripe.com/28ocMQ2vL49hh0Y2ce](https://buy.stripe.com/28ocMQ2vL49hh0Y2ce)
+This policy is available for in early access only. [Get it](/contact-policies).

--- a/website/pages/buy/gcp_cis_v1_2_0_bigquery-standard.mdx
+++ b/website/pages/buy/gcp_cis_v1_2_0_bigquery-standard.mdx
@@ -2,14 +2,6 @@
 title: Buy GCP CIS V1.2.0 for BigQuery (Standard License)
 ---
 
-import Head from "next/head";
-
-<Head>
-  <meta httpEquiv="refresh" content="5; url='https://buy.stripe.com/7sI3cg5HX8px120dUy'" />
-</Head>
-
 ## Purchase GCP CIS V1.2.0 for BigQuery (Standard License)
 
-You will be redirected to a Stripe checkout page to complete your purchase in 5 seconds…
-
-If the page does not redirect automatically, please click this link: [https://buy.stripe.com/7sI3cg5HX8px120dUy](https://buy.stripe.com/7sI3cg5HX8px120dUy)
+This policy is available for in early access only. [Get it](/contact-policies).

--- a/website/pages/buy/gcp_cis_v1_2_0_snowflake-standard.mdx
+++ b/website/pages/buy/gcp_cis_v1_2_0_snowflake-standard.mdx
@@ -2,14 +2,6 @@
 title: Buy GCP CIS V1.2.0 for Snowflake (Standard License)
 ---
 
-import Head from "next/head";
-
-<Head>
-  <meta httpEquiv="refresh" content="5; url='https://buy.stripe.com/fZeeUY2vL8pxeSQ5o4'" />
-</Head>
-
 ## Purchase GCP CIS V1.2.0 for Snowflake (Standard License)
 
-You will be redirected to a Stripe checkout page to complete your purchase in 5 seconds…
-
-If the page does not redirect automatically, please click this link: [https://buy.stripe.com/fZeeUY2vL8pxeSQ5o4](https://buy.stripe.com/fZeeUY2vL8pxeSQ5o4)
+This policy is available for in early access only. [Get it](/contact-policies).

--- a/website/pages/buy/k8s_nsa_cisa_v1_bigquery-extended.mdx
+++ b/website/pages/buy/k8s_nsa_cisa_v1_bigquery-extended.mdx
@@ -2,14 +2,6 @@
 title: Buy K8S NSA CISA V1 for BigQuery (Extended License)
 ---
 
-import Head from "next/head";
-
-<Head>
-  <meta httpEquiv="refresh" content="5; url='https://buy.stripe.com/8wM148fix2196mk03F'" />
-</Head>
-
 ## Purchase K8S NSA CISA V1 for BigQuery (Extended License)
 
-You will be redirected to a Stripe checkout page to complete your purchase in 5 seconds…
-
-If the page does not redirect automatically, please click this link: [https://buy.stripe.com/8wM148fix2196mk03F](https://buy.stripe.com/8wM148fix2196mk03F)
+This policy is available for in early access only. [Get it](/contact-policies).

--- a/website/pages/buy/k8s_nsa_cisa_v1_bigquery-standard.mdx
+++ b/website/pages/buy/k8s_nsa_cisa_v1_bigquery-standard.mdx
@@ -2,14 +2,6 @@
 title: Buy K8S NSA CISA V1 for BigQuery (Standard License)
 ---
 
-import Head from "next/head";
-
-<Head>
-  <meta httpEquiv="refresh" content="5; url='https://buy.stripe.com/9AQ4gk4DT35deSQ5nY'" />
-</Head>
-
 ## Purchase K8S NSA CISA V1 for BigQuery (Standard License)
 
-You will be redirected to a Stripe checkout page to complete your purchase in 5 seconds…
-
-If the page does not redirect automatically, please click this link: [https://buy.stripe.com/9AQ4gk4DT35deSQ5nY](https://buy.stripe.com/9AQ4gk4DT35deSQ5nY)
+This policy is available for in early access only. [Get it](/contact-policies).

--- a/website/pages/buy/k8s_nsa_cisa_v1_snowflake-extended.mdx
+++ b/website/pages/buy/k8s_nsa_cisa_v1_snowflake-extended.mdx
@@ -1,15 +1,7 @@
 ---
-title: Buy K8S NSA CISA V1 for snowflake (Extended License)
+title: Buy K8S NSA CISA V1 for Snowflake (Extended License)
 ---
 
-import Head from "next/head";
+## Purchase K8S NSA CISA V1 for Snowflake (Extended License)
 
-<Head>
-  <meta httpEquiv="refresh" content="5; url='https://buy.stripe.com/cN27sw1rH9tBfWU7w9'" />
-</Head>
-
-## Purchase K8S NSA CISA V1 for snowflake (Extended License)
-
-You will be redirected to a Stripe checkout page to complete your purchase in 5 seconds…
-
-If the page does not redirect automatically, please click this link: [https://buy.stripe.com/cN27sw1rH9tBfWU7w9](https://buy.stripe.com/cN27sw1rH9tBfWU7w9)
+This policy is available for in early access only. [Get it](/contact-policies).

--- a/website/pages/buy/k8s_nsa_cisa_v1_snowflake-standard.mdx
+++ b/website/pages/buy/k8s_nsa_cisa_v1_snowflake-standard.mdx
@@ -1,15 +1,7 @@
 ---
-title: Buy K8S NSA CISA V1 for snowflake (Standard License)
+title: Buy K8S NSA CISA V1 for Snowflake (Standard License)
 ---
 
-import Head from "next/head";
+## Purchase K8S NSA CISA V1 for Snowflake (Standard License)
 
-<Head>
-  <meta httpEquiv="refresh" content="5; url='https://buy.stripe.com/00g9AE5HXdJRbGEeYA'" />
-</Head>
-
-## Purchase K8S NSA CISA V1 for snowflake (Standard License)
-
-You will be redirected to a Stripe checkout page to complete your purchase in 5 seconds…
-
-If the page does not redirect automatically, please click this link: [https://buy.stripe.com/00g9AE5HXdJRbGEeYA](https://buy.stripe.com/00g9AE5HXdJRbGEeYA)
+This policy is available for in early access only. [Get it](/contact-policies).


### PR DESCRIPTION
#### Summary

Fixes https://github.com/cloudquery/cloudquery-issues/issues/596

Removed stripe redirects from premium policies in early access and replaced them with links to a signup form
