### PR TITLE
chore(ci): Escape release notes before passing to package command

### DIFF
--- a/.github/workflows/publish_plugin_to_hub.yml
+++ b/.github/workflows/publish_plugin_to_hub.yml
@@ -78,25 +78,35 @@ jobs:
         with:
           go-version-file: ${{ needs.prepare.outputs.plugin_dir }}/go.mod
 
+      - name: Use Node.js LTS
+        uses: actions/setup-node@v3
+        with:
+          node-version: 'lts/*'
+
+      - name: Install shell escape
+        run: |
+          npm install shell-escape@0.2.0
+
       - name: Get Release Notes
         id: release-notes
         uses: actions/github-script@v6
         with:
           result-encoding: string
           script: |
+            const shellescape = require('shell-escape');
             const { data } = await github.rest.repos.getReleaseByTag({
               owner: "cloudquery",
               repo: context.repo.repo,
               tag: context.ref.replace('refs/tags/', ''),
             });
-            return data.body;
+            return shellescape([data.body]);
 
       - name: Run package command
         working-directory: ${{ needs.prepare.outputs.plugin_dir }}
         run: |
           mkdir -p stubdocs
           touch stubdocs/README.md
-          go run main.go package --docs-dir stubdocs -m "${{ steps.release-notes.outputs.result }}" ${{ needs.prepare.outputs.plugin_kind }} ${{ needs.prepare.outputs.plugin_version }} .
+          go run main.go package --docs-dir stubdocs -m ${{ steps.release-notes.outputs.result }} ${{ needs.prepare.outputs.plugin_kind }} ${{ needs.prepare.outputs.plugin_version }} .
       - name: Setup CloudQuery
         uses: cloudquery/setup-cloudquery@v3
         with:

--- a/.github/workflows/publish_plugin_to_hub_duckdb.yml
+++ b/.github/workflows/publish_plugin_to_hub_duckdb.yml
@@ -60,25 +60,35 @@ jobs:
         with:
           go-version-file: ${{ needs.prepare.outputs.plugin_dir }}/go.mod
 
+      - name: Use Node.js LTS
+        uses: actions/setup-node@v3
+        with:
+          node-version: 'lts/*'
+
+      - name: Install shell escape
+        run: |
+          npm install shell-escape@0.2.0
+
       - name: Get Release Notes
         id: release-notes
         uses: actions/github-script@v6
         with:
           result-encoding: string
           script: |
+            const shellescape = require('shell-escape');
             const { data } = await github.rest.repos.getReleaseByTag({
               owner: "cloudquery",
               repo: context.repo.repo,
               tag: context.ref.replace('refs/tags/', ''),
             });
-            return data.body;
+            return shellescape([data.body]);
 
       - name: Run package command
         working-directory: ${{ needs.prepare.outputs.plugin_dir }}
         run: |
           mkdir -p stubdocs
           touch stubdocs/README.md
-          go run main.go package --docs-dir stubdocs -m "${{ steps.release-notes.outputs.result }}" ${{ needs.prepare.outputs.plugin_kind }} ${{ needs.prepare.outputs.plugin_version }} .
+          go run main.go package --docs-dir stubdocs -m ${{ steps.release-notes.outputs.result }} ${{ needs.prepare.outputs.plugin_kind }} ${{ needs.prepare.outputs.plugin_version }} .
       - name: Setup CloudQuery
         uses: cloudquery/setup-cloudquery@v3
         with:

--- a/.github/workflows/publish_plugin_to_hub_snowflake.yml
+++ b/.github/workflows/publish_plugin_to_hub_snowflake.yml
@@ -61,25 +61,35 @@ jobs:
         with:
           go-version-file: ${{ needs.prepare.outputs.plugin_dir }}/go.mod
 
+      - name: Use Node.js LTS
+        uses: actions/setup-node@v3
+        with:
+          node-version: 'lts/*'
+
+      - name: Install shell escape
+        run: |
+          npm install shell-escape@0.2.0
+
       - name: Get Release Notes
         id: release-notes
         uses: actions/github-script@v6
         with:
           result-encoding: string
           script: |
+            const shellescape = require('shell-escape');
             const { data } = await github.rest.repos.getReleaseByTag({
               owner: "cloudquery",
               repo: context.repo.repo,
               tag: context.ref.replace('refs/tags/', ''),
             });
-            return data.body;
+            return shellescape([data.body]);
 
       - name: Run package command
         working-directory: ${{ needs.prepare.outputs.plugin_dir }}
         run: |
           mkdir -p stubdocs
           touch stubdocs/README.md
-          go run main.go package --docs-dir stubdocs -m "${{ steps.release-notes.outputs.result }}" ${{ needs.prepare.outputs.plugin_kind }} ${{ needs.prepare.outputs.plugin_version }} .
+          go run main.go package --docs-dir stubdocs -m ${{ steps.release-notes.outputs.result }} ${{ needs.prepare.outputs.plugin_kind }} ${{ needs.prepare.outputs.plugin_version }} .
       - name: Setup CloudQuery
         uses: cloudquery/setup-cloudquery@v3
         with:

--- a/.github/workflows/publish_plugin_to_hub_sqlite.yml
+++ b/.github/workflows/publish_plugin_to_hub_sqlite.yml
@@ -60,25 +60,35 @@ jobs:
         with:
           go-version-file: ${{ needs.prepare.outputs.plugin_dir }}/go.mod
 
+      - name: Use Node.js LTS
+        uses: actions/setup-node@v3
+        with:
+          node-version: 'lts/*'
+
+      - name: Install shell escape
+        run: |
+          npm install shell-escape@0.2.0
+
       - name: Get Release Notes
         id: release-notes
         uses: actions/github-script@v6
         with:
           result-encoding: string
           script: |
+            const shellescape = require('shell-escape');
             const { data } = await github.rest.repos.getReleaseByTag({
               owner: "cloudquery",
               repo: context.repo.repo,
               tag: context.ref.replace('refs/tags/', ''),
             });
-            return data.body;
+            return shellescape([data.body]);
 
       - name: Run package command
         working-directory: ${{ needs.prepare.outputs.plugin_dir }}
         run: |
           mkdir -p stubdocs
           touch stubdocs/README.md
-          go run main.go package --docs-dir stubdocs -m "${{ steps.release-notes.outputs.result }}" ${{ needs.prepare.outputs.plugin_kind }} ${{ needs.prepare.outputs.plugin_version }} .
+          go run main.go package --docs-dir stubdocs -m ${{ steps.release-notes.outputs.result }} ${{ needs.prepare.outputs.plugin_kind }} ${{ needs.prepare.outputs.plugin_version }} .
       - name: Setup CloudQuery
         uses: cloudquery/setup-cloudquery@v3
         with:


### PR DESCRIPTION
<!-- 🎉 Thank you for making CloudQuery awesome by submitting a PR 🎉 -->

#### Summary

Fixes https://github.com/cloudquery/cloudquery/actions/runs/6408182243/job/17396605792#step:6:16
Fixes https://github.com/cloudquery/cloud/issues/508 (internal issue)

Uses https://www.npmjs.com/package/shell-escape as it has ~250,000 weekly downloads (despite the repo latest commit being from 2015)

<!--
Use the following steps to ensure your PR is ready to be reviewed

- [ ] Read the [contribution guidelines](../blob/main/CONTRIBUTING.md) 🧑‍🎓
- [ ] Run `make lint` to ensure the proposed changes follow the coding style 🚨 (install golangci-lint [here](https://golangci-lint.run/usage/install/#local-installation))
- [ ] Run `make test` to ensure the proposed changes pass the tests 🧪
- [ ] If changing a source plugin run `make gen` to ensure docs are up to date 📝
- [ ] Ensure the status checks below are successful ✅
--->
