### PR TITLE
chore: Use  for wait for all workflow

### DIFF
--- a/.github/workflows/wait_for_required_workflows.yml
+++ b/.github/workflows/wait_for_required_workflows.yml
@@ -23,6 +23,7 @@ jobs:
         env:
           FILES: ${{ steps.changed-files.outputs.all }}
         with:
+          github-token: ${{ secrets.GH_CQ_BOT }}
           script: |
             const script = require('./scripts/workflows/wait_for_required_workflows.js')
             await script({github, context})

--- a/scripts/workflows/wait_for_required_workflows.js
+++ b/scripts/workflows/wait_for_required_workflows.js
@@ -78,7 +78,7 @@ module.exports = async ({github, context}) => {
         }
         pendingActions = actions.filter(action => !runs.some(({name}) => name === action))
         console.log(`Waiting for ${pendingActions.join(", ")}`)
-        await new Promise(r => setTimeout(r, 5000));
+        await new Promise(r => setTimeout(r, 10000));
         now = new Date().getTime()
     }
     throw new Error(`Timed out waiting for ${pendingActions.join(', ')}`)


### PR DESCRIPTION
<!-- 🎉 Thank you for making CloudQuery awesome by submitting a PR 🎉 -->

#### Summary

We only get [1000 requests per hour per repository](https://docs.github.com/en/rest/overview/resources-in-the-rest-api?apiVersion=2022-11-28#rate-limits-for-requests-from-github-actions) with the built-in token, so this should help avoid reaching rate limits (personal access tokens get 5000 requests per hour).

I also contacted GitHub support to see if they can increase the limit for us

<!--
Use the following steps to ensure your PR is ready to be reviewed

- [ ] Read the [contribution guidelines](../blob/main/CONTRIBUTING.md) 🧑‍🎓
- [ ] Run `make lint` to ensure the proposed changes follow the coding style 🚨 (install golangci-lint [here](https://golangci-lint.run/usage/install/#local-installation))
- [ ] Run `make test` to ensure the proposed changes pass the tests 🧪
- [ ] If changing a source plugin run `make gen` to ensure docs are up to date 📝
- [ ] Ensure the status checks below are successful ✅
--->
