### PR TITLE
chore: Replace standard slices package

### DIFF
--- a/cli/cmd/migrate.go
+++ b/cli/cmd/migrate.go
@@ -4,11 +4,12 @@ import (
 	"fmt"
 	"strings"
 
+	"slices"
+
 	"github.com/cloudquery/cloudquery/cli/internal/specs/v0"
 	"github.com/cloudquery/plugin-pb-go/managedplugin"
 	"github.com/rs/zerolog/log"
 	"github.com/spf13/cobra"
-	"golang.org/x/exp/slices"
 )
 
 const (

--- a/cli/cmd/sync.go
+++ b/cli/cmd/sync.go
@@ -5,8 +5,9 @@ import (
 	"math"
 	"strings"
 
+	"slices"
+
 	"github.com/google/uuid"
-	"golang.org/x/exp/slices"
 
 	"github.com/cloudquery/cloudquery/cli/internal/specs/v0"
 	"github.com/cloudquery/plugin-pb-go/managedplugin"

--- a/cli/cmd/sync_v2.go
+++ b/cli/cmd/sync_v2.go
@@ -8,6 +8,8 @@ import (
 	"io"
 	"time"
 
+	"slices"
+
 	"github.com/cloudquery/cloudquery/cli/internal/specs/v0"
 	"github.com/cloudquery/cloudquery/cli/internal/transformer"
 	"github.com/cloudquery/plugin-pb-go/managedplugin"
@@ -17,7 +19,6 @@ import (
 	"github.com/cloudquery/plugin-pb-go/pb/source/v2"
 	"github.com/rs/zerolog/log"
 	"github.com/schollz/progressbar/v3"
-	"golang.org/x/exp/slices"
 	"google.golang.org/protobuf/types/known/timestamppb"
 )
 

--- a/cli/internal/specs/v0/source.go
+++ b/cli/internal/specs/v0/source.go
@@ -6,8 +6,9 @@ import (
 	"fmt"
 	"strings"
 
+	"slices"
+
 	"github.com/thoas/go-funk"
-	"golang.org/x/exp/slices"
 )
 
 const (

--- a/cli/internal/specs/v0/spec_reader.go
+++ b/cli/internal/specs/v0/spec_reader.go
@@ -11,8 +11,9 @@ import (
 	"strconv"
 	"strings"
 
+	"slices"
+
 	"github.com/ghodss/yaml"
-	"golang.org/x/exp/slices"
 )
 
 type SpecReader struct {

--- a/plugins/destination/clickhouse/client/migrate.go
+++ b/plugins/destination/clickhouse/client/migrate.go
@@ -4,13 +4,14 @@ import (
 	"context"
 	"fmt"
 
+	"slices"
+
 	"github.com/cloudquery/cloudquery/plugins/destination/clickhouse/queries"
 	"github.com/cloudquery/cloudquery/plugins/destination/clickhouse/typeconv"
 	"github.com/cloudquery/cloudquery/plugins/destination/clickhouse/util"
 	"github.com/cloudquery/plugin-sdk/v4/message"
 	"github.com/cloudquery/plugin-sdk/v4/schema"
 	"github.com/pkg/errors"
-	"golang.org/x/exp/slices"
 	"golang.org/x/sync/errgroup"
 )
 

--- a/plugins/destination/clickhouse/queries/tables.go
+++ b/plugins/destination/clickhouse/queries/tables.go
@@ -3,10 +3,11 @@ package queries
 import (
 	"strings"
 
+	"slices"
+
 	"github.com/cloudquery/cloudquery/plugins/destination/clickhouse/typeconv/ch/types"
 	"github.com/cloudquery/cloudquery/plugins/destination/clickhouse/util"
 	"github.com/cloudquery/plugin-sdk/v4/schema"
-	"golang.org/x/exp/slices"
 )
 
 func sortKeys(table *schema.Table) []string {

--- a/plugins/destination/meilisearch/client/index.go
+++ b/plugins/destination/meilisearch/client/index.go
@@ -4,9 +4,10 @@ import (
 	"context"
 	"fmt"
 
+	"slices"
+
 	"github.com/cloudquery/plugin-sdk/v4/schema"
 	"github.com/meilisearch/meilisearch-go"
-	"golang.org/x/exp/slices"
 )
 
 type indexSchema struct {

--- a/plugins/destination/mssql/client/changes.go
+++ b/plugins/destination/mssql/client/changes.go
@@ -3,8 +3,9 @@ package client
 import (
 	"strings"
 
+	"slices"
+
 	"github.com/cloudquery/plugin-sdk/v4/schema"
-	"golang.org/x/exp/slices"
 )
 
 func prettifyChanges(name string, changes []schema.TableColumnChange) string {

--- a/plugins/destination/mssql/client/columns.go
+++ b/plugins/destination/mssql/client/columns.go
@@ -4,9 +4,10 @@ import (
 	"context"
 	"database/sql"
 
+	"slices"
+
 	"github.com/cloudquery/cloudquery/plugins/destination/mssql/queries"
 	"github.com/cloudquery/plugin-sdk/v4/schema"
-	"golang.org/x/exp/slices"
 )
 
 func (c *Client) getTableColumns(ctx context.Context, tableName string, pks []string) (schema.ColumnList, error) {

--- a/plugins/destination/mssql/queries/columns.go
+++ b/plugins/destination/mssql/queries/columns.go
@@ -1,8 +1,9 @@
 package queries
 
 import (
+	"slices"
+
 	"github.com/cloudquery/plugin-sdk/v4/schema"
-	"golang.org/x/exp/slices"
 )
 
 type colQueryBuilder struct {

--- a/plugins/destination/postgresql/client/transformer_test.go
+++ b/plugins/destination/postgresql/client/transformer_test.go
@@ -3,7 +3,7 @@ package client
 import (
 	"testing"
 
-	"golang.org/x/exp/slices"
+	"slices"
 )
 
 func TestStripNullsFromMarshalledJson(t *testing.T) {

--- a/plugins/source/aws/client/spec/tableoptions/change_case.go
+++ b/plugins/source/aws/client/spec/tableoptions/change_case.go
@@ -3,7 +3,7 @@ package tableoptions
 import (
 	"reflect"
 
-	"golang.org/x/exp/slices"
+	"slices"
 )
 
 type changeCaseFunc func(string) string

--- a/plugins/source/googleanalytics/client/row.go
+++ b/plugins/source/googleanalytics/client/row.go
@@ -4,8 +4,9 @@ import (
 	"crypto/sha256"
 	"time"
 
+	"slices"
+
 	"golang.org/x/exp/maps"
-	"golang.org/x/exp/slices"
 	analyticsdata "google.golang.org/api/analyticsdata/v1beta"
 )
 

--- a/plugins/source/pagerduty/client/testing.go
+++ b/plugins/source/pagerduty/client/testing.go
@@ -13,13 +13,14 @@ import (
 	"testing"
 	"time"
 
+	"slices"
+
 	"github.com/PagerDuty/go-pagerduty"
 	"github.com/cloudquery/plugin-sdk/v4/plugin"
 	"github.com/cloudquery/plugin-sdk/v4/scheduler"
 	"github.com/cloudquery/plugin-sdk/v4/schema"
 	"github.com/cloudquery/plugin-sdk/v4/transformers"
 	"github.com/rs/zerolog"
-	"golang.org/x/exp/slices"
 )
 
 type MockHttpClient struct {


### PR DESCRIPTION
This commit changes the slices to use the standard slices.


#### Summary

Since go1.21, slices package introduced standard library (see more info https://pkg.go.dev/slices@master)
cloudquery use Go 1.21, so I replaced.

- [x] Read the [contribution guidelines](../blob/main/CONTRIBUTING.md) 🧑‍🎓
- [x] Run `make lint` to ensure the proposed changes follow the coding style 🚨 (install golangci-lint [here](https://golangci-lint.run/usage/install/#local-installation))
- [x] Run `make test` to ensure the proposed changes pass the tests 🧪
- [x] If changing a source plugin run `make gen` to ensure docs are up to date 📝
- [x] Ensure the status checks below are successful ✅

