### PR TITLE
chore: Update Vale linter action

### DIFF
--- a/.github/workflows/lint_markdown.yml
+++ b/.github/workflows/lint_markdown.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Git checkout
         uses: actions/checkout@v3
       - name: Vale
-        uses: errata-ai/vale-action@13d79669d1c7cf33b26fc5607214ef529f071cdc
+        uses: errata-ai/vale-action@1edf87ba97278a700ba88ed9619172912ffaac25
         with:
           vale_flags: "--glob=!{website/pages/blog/podcast-software-engineer-daily.md,*CHANGELOG.md,*/docs/tables/README.md,plugins/source/test/docs/tables/*.md,.github/styles/proselint/README.md,**/v1-migration.md,website/pages/docs/plugins/sources/*/tables.md,website/pages/docs/plugins/sources/*/policies.md,website/tables/**/*,website/pages/case-studies/*.mdx,cli/internal/docs/testdata/*.md}"
           filter_mode: nofilter


### PR DESCRIPTION
<!-- 🎉 Thank you for making CloudQuery awesome by submitting a PR 🎉 -->

#### Summary

Not sure why this started failing with https://github.com/cloudquery/cloudquery/actions/runs/6446477635/job/17501705513?pr=14457#step:4:20.

So I'm updating the version to the latest commit to see if that fixes it

<!--
Use the following steps to ensure your PR is ready to be reviewed

- [ ] Read the [contribution guidelines](../blob/main/CONTRIBUTING.md) 🧑‍🎓
- [ ] Run `make lint` to ensure the proposed changes follow the coding style 🚨 (install golangci-lint [here](https://golangci-lint.run/usage/install/#local-installation))
- [ ] Run `make test` to ensure the proposed changes pass the tests 🧪
- [ ] If changing a source plugin run `make gen` to ensure docs are up to date 📝
- [ ] Ensure the status checks below are successful ✅
--->
