### PR TITLE
chore: Use cq-bot token in Summarize changes workflow

### DIFF
--- a/.github/workflows/docs_changes_summary.yml
+++ b/.github/workflows/docs_changes_summary.yml
@@ -58,13 +58,15 @@ jobs:
         uses: peter-evans/find-comment@5cea877144f86ac1aacfe5240ff2390f7135b563
         id: find-comment
         with:
+          token: ${{ secrets.GH_CQ_BOT }}
           issue-number: ${{ github.event.pull_request.number }}
-          comment-author: 'github-actions[bot]'
-          body-includes: '### This PR has the following changes to source plugin(s) tables:'
+          comment-author: "github-actions[bot]"
+          body-includes: "### This PR has the following changes to source plugin(s) tables:"
       - name: Create or update comment
         uses: peter-evans/create-or-update-comment@716151b9579b05352dbf244d48e968d211889bbc
         if: steps.get-changes.outputs.result != ''
         with:
+          token: ${{ secrets.GH_CQ_BOT }}
           comment-id: ${{ steps.find-comment.outputs.comment-id }}
           issue-number: ${{ github.event.pull_request.number }}
           body: |
@@ -77,6 +79,7 @@ jobs:
         uses: actions/github-script@v6
         name: Delete existing comment if there are no changes
         with:
+          github-token: ${{ secrets.GH_CQ_BOT }}
           script: |
             github.rest.issues.deleteComment({
               owner: context.repo.owner,


### PR DESCRIPTION
<!-- 🎉 Thank you for making CloudQuery awesome by submitting a PR 🎉 -->

#### Summary

We're hitting rate limits with the built-in actions token so this switches to our own token. We can do it only for `pull_request_target` events (not `pull_request`)

<!--
Use the following steps to ensure your PR is ready to be reviewed

- [ ] Read the [contribution guidelines](../blob/main/CONTRIBUTING.md) 🧑‍🎓
- [ ] Run `make lint` to ensure the proposed changes follow the coding style 🚨 (install golangci-lint [here](https://golangci-lint.run/usage/install/#local-installation))
- [ ] Run `make test` to ensure the proposed changes pass the tests 🧪
- [ ] If changing a source plugin run `make gen` to ensure docs are up to date 📝
- [ ] Ensure the status checks below are successful ✅
--->
