### PR TITLE
chore: Switch to git based diffing instead of API diffing

### DIFF
--- a/.github/workflows/wait_for_required_workflows.yml
+++ b/.github/workflows/wait_for_required_workflows.yml
@@ -17,9 +17,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          persist-credentials: false
           fetch-depth: 0
-          repository: ${{ github.event.pull_request.head.repo.full_name }}
       - name: Get changed files
         id: changed-files
         uses: tj-actions/changed-files@v39

--- a/.github/workflows/wait_for_required_workflows.yml
+++ b/.github/workflows/wait_for_required_workflows.yml
@@ -3,7 +3,7 @@ name: Wait for all required workflows to pass
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
-  
+
 on:
   pull_request:
     branches:
@@ -15,13 +15,17 @@ jobs:
     name: wait-for-required-workflows
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+          fetch-depth: 0
+          repository: ${{ github.event.pull_request.head.repo.full_name }}
       - name: Get changed files
         id: changed-files
-        uses: Ana06/get-changed-files@v2.2.0
+        uses: tj-actions/changed-files@v39
       - uses: actions/github-script@v6
         env:
-          FILES: ${{ steps.changed-files.outputs.all }}
+          FILES: ${{ steps.changed-files.outputs.all_changed_files }}
         with:
           script: |
             const script = require('./scripts/workflows/wait_for_required_workflows.js')

--- a/scripts/workflows/wait_for_required_workflows.js
+++ b/scripts/workflows/wait_for_required_workflows.js
@@ -78,7 +78,7 @@ module.exports = async ({github, context}) => {
         }
         pendingActions = actions.filter(action => !runs.some(({name}) => name === action))
         console.log(`Waiting for ${pendingActions.join(", ")}`)
-        await new Promise(r => setTimeout(r, 5000));
+        await new Promise(r => setTimeout(r, 15000));
         now = new Date().getTime()
     }
     throw new Error(`Timed out waiting for ${pendingActions.join(', ')}`)


### PR DESCRIPTION
<!-- 🎉 Thank you for making CloudQuery awesome by submitting a PR 🎉 -->

#### Summary

Should help with https://github.com/cloudquery/cloudquery/issues/14464 hopefully. This changes our CI to use git based diffing instead of the GitHub API.

Also changes the polling internal to 15s instead of 5s

<!--
Use the following steps to ensure your PR is ready to be reviewed

- [ ] Read the [contribution guidelines](../blob/main/CONTRIBUTING.md) 🧑‍🎓
- [ ] Run `make lint` to ensure the proposed changes follow the coding style 🚨 (install golangci-lint [here](https://golangci-lint.run/usage/install/#local-installation))
- [ ] Run `make test` to ensure the proposed changes pass the tests 🧪
- [ ] If changing a source plugin run `make gen` to ensure docs are up to date 📝
- [ ] Ensure the status checks below are successful ✅
--->
