### PR TITLE
chore: Increase polling time in wait for all workflow to avoid rate limits

### DIFF
--- a/scripts/workflows/wait_for_required_workflows.js
+++ b/scripts/workflows/wait_for_required_workflows.js
@@ -78,7 +78,7 @@ module.exports = async ({github, context}) => {
         }
         pendingActions = actions.filter(action => !runs.some(({name}) => name === action))
         console.log(`Waiting for ${pendingActions.join(", ")}`)
-        await new Promise(r => setTimeout(r, 15000));
+        await new Promise(r => setTimeout(r, 60000));
         now = new Date().getTime()
     }
     throw new Error(`Timed out waiting for ${pendingActions.join(', ')}`)


### PR DESCRIPTION
<!-- 🎉 Thank you for making CloudQuery awesome by submitting a PR 🎉 -->

#### Summary

We're still hitting rate limits in this workflow so hopefully this helps

<!--
Use the following steps to ensure your PR is ready to be reviewed

- [ ] Read the [contribution guidelines](../blob/main/CONTRIBUTING.md) 🧑‍🎓
- [ ] Run `make lint` to ensure the proposed changes follow the coding style 🚨 (install golangci-lint [here](https://golangci-lint.run/usage/install/#local-installation))
- [ ] Run `make test` to ensure the proposed changes pass the tests 🧪
- [ ] If changing a source plugin run `make gen` to ensure docs are up to date 📝
- [ ] Ensure the status checks below are successful ✅
--->
