### PR TITLE
doc: How to build a container with preinstalled plugins

### DIFF
--- a/website/pages/docs/deployment/_meta.json
+++ b/website/pages/docs/deployment/_meta.json
@@ -3,6 +3,7 @@
   "ecs": "Amazon ECS",
   "airflow": "Apache Airflow",
   "docker": "Docker",
+  "docker-offline": "Docker - Offline Installation",
   "github-actions": "GitHub Actions",
   "cloud-run": "Google Cloud Run",
   "google-cloud-vm": "Google Cloud VM",

--- a/website/pages/docs/deployment/docker-offline.mdx
+++ b/website/pages/docs/deployment/docker-offline.mdx
@@ -22,7 +22,6 @@ spec:
 kind: destination
 spec:
   name: "postgresql"
-  registry: "github"
   path: "cloudquery/postgresql"
   version: "v6.0.8"
   spec:

--- a/website/pages/docs/deployment/docker-offline.mdx
+++ b/website/pages/docs/deployment/docker-offline.mdx
@@ -1,0 +1,57 @@
+---
+title: Docker - Offline Installation
+description: Learn how to build a container with plugins pre-installed
+---
+
+# Docker - Offline Installation
+
+You can run CloudQuery in a container with plugins pre-installed. This is useful for isolated deployments where you don't want to download plugins from the internet.
+
+To download the plugins based on your configuration file, use the `cloudquery install` command. Below is an example `Dockerfile` based on the [CloudQuery container](/docs/deployment/docker). It uses a `build.spec.yaml` with the minimum configuration required to download the plugins.
+
+```yaml
+# build.spec.yaml
+kind: source
+spec:
+  name: aws
+  path: cloudquery/aws
+  version: "v22.14.0"
+  tables: ["aws_ec2_instances"]
+  destinations: ["postgresql"]
+---
+kind: destination
+spec:
+  name: "postgresql"
+  registry: "github"
+  path: "cloudquery/postgresql"
+  version: "v6.0.8"
+  spec:
+```
+
+```docker
+# Dockerfile
+FROM ghcr.io/cloudquery/cloudquery:latest
+WORKDIR /app
+COPY ./build.spec.yaml /app/build.spec.yaml
+
+RUN /app/cloudquery install cloudquery.yaml
+```
+
+Build this container as you would normally do:
+
+```bash
+docker build ./ -t my-cq-container:latest
+```
+
+### Run the Container
+
+Run the container as you would run the default CloudQuery container. Here is an example:
+
+```bash copy
+docker run \
+  # you can mount a different config file that uses the same plugins as in the build.spec 
+  -v <ABSOLUTE_PATH_TO_CONFIG_FILE>:/config.yml \
+  # set any env variable with -e <ENV_VAR_NAME>=<ENV_VAR_VALUE>
+  my-cq-container:latest \
+  sync /config.yml
+```


### PR DESCRIPTION
#### Summary

Adding docs explaining how to use `cloudquery install` to build a container that does not download plugins at runtime.