### PR TITLE
feat: Adding GitHub Actions workflowRuns, RunUsage, and Jobs

### DIFF
--- a/plugins/source/github/client/client.go
+++ b/plugins/source/github/client/client.go
@@ -70,7 +70,11 @@ func (c *Client) WithRepository(repository *github.Repository) *Client {
 
 func limitDetectedCallback(logger zerolog.Logger) github_ratelimit.OnLimitDetected {
 	return func(callbackContext *github_ratelimit.CallbackContext) {
-		logger.Warn().Msgf("GitHub secondary rate limit detected. Sleeping until %s", callbackContext.SleepUntil.Format(time.RFC3339))
+		apiCall := ""
+		if callbackContext.Request != nil {
+			apiCall = callbackContext.Request.URL.String()
+		}
+		logger.Warn().Msgf("GitHub secondary rate limit detected for API call: %s. Sleeping until %s", apiCall, callbackContext.SleepUntil.Format(time.RFC3339))
 	}
 }
 

--- a/plugins/source/github/client/mocks/mock_actions.go
+++ b/plugins/source/github/client/mocks/mock_actions.go
@@ -35,6 +35,54 @@ func (m *MockActionsService) EXPECT() *MockActionsServiceMockRecorder {
 	return m.recorder
 }
 
+// GetWorkflowRunUsageByID mocks base method.
+func (m *MockActionsService) GetWorkflowRunUsageByID(arg0 context.Context, arg1, arg2 string, arg3 int64) (*github.WorkflowRunUsage, *github.Response, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetWorkflowRunUsageByID", arg0, arg1, arg2, arg3)
+	ret0, _ := ret[0].(*github.WorkflowRunUsage)
+	ret1, _ := ret[1].(*github.Response)
+	ret2, _ := ret[2].(error)
+	return ret0, ret1, ret2
+}
+
+// GetWorkflowRunUsageByID indicates an expected call of GetWorkflowRunUsageByID.
+func (mr *MockActionsServiceMockRecorder) GetWorkflowRunUsageByID(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetWorkflowRunUsageByID", reflect.TypeOf((*MockActionsService)(nil).GetWorkflowRunUsageByID), arg0, arg1, arg2, arg3)
+}
+
+// ListRepositoryWorkflowRuns mocks base method.
+func (m *MockActionsService) ListRepositoryWorkflowRuns(arg0 context.Context, arg1, arg2 string, arg3 *github.ListWorkflowRunsOptions) (*github.WorkflowRuns, *github.Response, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ListRepositoryWorkflowRuns", arg0, arg1, arg2, arg3)
+	ret0, _ := ret[0].(*github.WorkflowRuns)
+	ret1, _ := ret[1].(*github.Response)
+	ret2, _ := ret[2].(error)
+	return ret0, ret1, ret2
+}
+
+// ListRepositoryWorkflowRuns indicates an expected call of ListRepositoryWorkflowRuns.
+func (mr *MockActionsServiceMockRecorder) ListRepositoryWorkflowRuns(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListRepositoryWorkflowRuns", reflect.TypeOf((*MockActionsService)(nil).ListRepositoryWorkflowRuns), arg0, arg1, arg2, arg3)
+}
+
+// ListWorkflowJobs mocks base method.
+func (m *MockActionsService) ListWorkflowJobs(arg0 context.Context, arg1, arg2 string, arg3 int64, arg4 *github.ListWorkflowJobsOptions) (*github.Jobs, *github.Response, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ListWorkflowJobs", arg0, arg1, arg2, arg3, arg4)
+	ret0, _ := ret[0].(*github.Jobs)
+	ret1, _ := ret[1].(*github.Response)
+	ret2, _ := ret[2].(error)
+	return ret0, ret1, ret2
+}
+
+// ListWorkflowJobs indicates an expected call of ListWorkflowJobs.
+func (mr *MockActionsServiceMockRecorder) ListWorkflowJobs(arg0, arg1, arg2, arg3, arg4 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListWorkflowJobs", reflect.TypeOf((*MockActionsService)(nil).ListWorkflowJobs), arg0, arg1, arg2, arg3, arg4)
+}
+
 // ListWorkflows mocks base method.
 func (m *MockActionsService) ListWorkflows(arg0 context.Context, arg1, arg2 string, arg3 *github.ListOptions) (*github.Workflows, *github.Response, error) {
 	m.ctrl.T.Helper()

--- a/plugins/source/github/client/services.go
+++ b/plugins/source/github/client/services.go
@@ -68,6 +68,9 @@ type IssuesService interface {
 //go:generate mockgen -package=mocks -destination=./mocks/mock_actions.go . ActionsService
 type ActionsService interface {
 	ListWorkflows(ctx context.Context, owner, repo string, opts *github.ListOptions) (*github.Workflows, *github.Response, error)
+	ListRepositoryWorkflowRuns(ctx context.Context, owner, repo string, opts *github.ListWorkflowRunsOptions) (*github.WorkflowRuns, *github.Response, error)
+	GetWorkflowRunUsageByID(ctx context.Context, owner, repo string, runID int64) (*github.WorkflowRunUsage, *github.Response, error)
+	ListWorkflowJobs(ctx context.Context, owner, repo string, runID int64, opts *github.ListWorkflowJobsOptions) (*github.Jobs, *github.Response, error)
 }
 
 //go:generate mockgen -package=mocks -destination=./mocks/mock_dependabot.go . DependabotService

--- a/plugins/source/github/docs/tables/README.md
+++ b/plugins/source/github/docs/tables/README.md
@@ -28,4 +28,7 @@
 - [github_traffic_paths](../../../../../website/tables/github/github_traffic_paths.md)
 - [github_traffic_referrers](../../../../../website/tables/github/github_traffic_referrers.md)
 - [github_traffic_views](../../../../../website/tables/github/github_traffic_views.md)
+- [github_workflow_runs](../../../../../website/tables/github/github_workflow_runs.md)
+  - [github_workflow_jobs](../../../../../website/tables/github/github_workflow_jobs.md)
+  - [github_workflow_run_usage](../../../../../website/tables/github/github_workflow_run_usage.md)
 - [github_workflows](../../../../../website/tables/github/github_workflows.md)

--- a/plugins/source/github/resources/plugin/tables.go
+++ b/plugins/source/github/resources/plugin/tables.go
@@ -19,6 +19,7 @@ import (
 func getTables() []*schema.Table {
 	tables := []*schema.Table{
 		actions.Workflows(),
+		actions.WorkflowRuns(),
 		billing.Action(),
 		billing.Storage(),
 		billing.Package(),

--- a/plugins/source/github/resources/services/actions/workflowJobs.go
+++ b/plugins/source/github/resources/services/actions/workflowJobs.go
@@ -10,7 +10,7 @@ import (
 	"github.com/google/go-github/v49/github"
 )
 
-func WorkflowJobs() *schema.Table {
+func workflowJobs() *schema.Table {
 	return &schema.Table{
 		Name:      "github_workflow_jobs",
 		Resolver:  fetchWorkflowJobs,

--- a/plugins/source/github/resources/services/actions/workflowJobs.go
+++ b/plugins/source/github/resources/services/actions/workflowJobs.go
@@ -1,0 +1,51 @@
+package actions
+
+import (
+	"context"
+
+	"github.com/apache/arrow/go/v14/arrow"
+	"github.com/cloudquery/cloudquery/plugins/source/github/client"
+	"github.com/cloudquery/plugin-sdk/v4/schema"
+	"github.com/cloudquery/plugin-sdk/v4/transformers"
+	"github.com/google/go-github/v49/github"
+)
+
+func WorkflowJobs() *schema.Table {
+	return &schema.Table{
+		Name:      "github_workflow_jobs",
+		Resolver:  fetchWorkflowJobs,
+		Transform: client.TransformWithStruct(&github.WorkflowJob{}, transformers.WithPrimaryKeys("ID")),
+		Columns: []schema.Column{
+			client.OrgColumn,
+			client.RepositoryIDColumn,
+			{
+				Name:        "run_id",
+				Type:        arrow.PrimitiveTypes.Int64,
+				Resolver:    schema.ParentColumnResolver("id"),
+				Description: `Run ID`,
+			},
+		},
+	}
+}
+
+func fetchWorkflowJobs(ctx context.Context, meta schema.ClientMeta, resource *schema.Resource, res chan<- any) error {
+	c := meta.(*client.Client)
+	repo := c.Repository
+	run := resource.Item.(*github.WorkflowRun)
+
+	listOpts := &github.ListOptions{PerPage: 100}
+	listWorkflowJobOptions := &github.ListWorkflowJobsOptions{Filter: "all", ListOptions: *listOpts}
+	for {
+		workflowJobs, resp, err := c.Github.Actions.ListWorkflowJobs(ctx, c.Org, *repo.Name, *run.ID, listWorkflowJobOptions)
+		if err != nil {
+			return err
+		}
+		res <- workflowJobs.Jobs
+
+		if resp.NextPage == 0 {
+			break
+		}
+		listWorkflowJobOptions.Page = resp.NextPage
+	}
+	return nil
+}

--- a/plugins/source/github/resources/services/actions/workflowRunUsage.go
+++ b/plugins/source/github/resources/services/actions/workflowRunUsage.go
@@ -1,0 +1,44 @@
+package actions
+
+import (
+	"context"
+
+	"github.com/apache/arrow/go/v14/arrow"
+	"github.com/cloudquery/cloudquery/plugins/source/github/client"
+	"github.com/cloudquery/plugin-sdk/v4/schema"
+	"github.com/google/go-github/v49/github"
+)
+
+func WorkflowRunUsage() *schema.Table {
+	return &schema.Table{
+		Name:      "github_workflow_run_usage",
+		Resolver:  fetchWorkflowRunUsage,
+		Transform: client.TransformWithStruct(&github.WorkflowRunUsage{}),
+		Columns: []schema.Column{
+			client.OrgColumn,
+			client.RepositoryIDColumn,
+			{
+				Name:        "run_id",
+				Type:        arrow.PrimitiveTypes.Int64,
+				Resolver:    schema.ParentColumnResolver("id"),
+				Description: `Run ID`,
+				PrimaryKey:  true,
+			},
+		},
+	}
+}
+
+func fetchWorkflowRunUsage(ctx context.Context, meta schema.ClientMeta, resource *schema.Resource, res chan<- any) error {
+	c := meta.(*client.Client)
+	repo := c.Repository
+	run := resource.Item.(*github.WorkflowRun)
+
+	workflowRunUsage, _, err := c.Github.Actions.GetWorkflowRunUsageByID(ctx, c.Org, *repo.Name, *run.ID)
+	if err != nil {
+		return err
+	}
+
+	res <- workflowRunUsage
+
+	return nil
+}

--- a/plugins/source/github/resources/services/actions/workflowRunUsage.go
+++ b/plugins/source/github/resources/services/actions/workflowRunUsage.go
@@ -9,7 +9,7 @@ import (
 	"github.com/google/go-github/v49/github"
 )
 
-func WorkflowRunUsage() *schema.Table {
+func workflowRunUsage() *schema.Table {
 	return &schema.Table{
 		Name:      "github_workflow_run_usage",
 		Resolver:  fetchWorkflowRunUsage,

--- a/plugins/source/github/resources/services/actions/workflowRuns.go
+++ b/plugins/source/github/resources/services/actions/workflowRuns.go
@@ -20,8 +20,8 @@ func WorkflowRuns() *schema.Table {
 			client.RepositoryIDColumn,
 		},
 		Relations: []*schema.Table{
-			WorkflowRunUsage(),
-			WorkflowJobs(),
+			workflowRunUsage(),
+			workflowJobs(),
 		},
 	}
 }

--- a/plugins/source/github/resources/services/actions/workflowRuns.go
+++ b/plugins/source/github/resources/services/actions/workflowRuns.go
@@ -1,0 +1,47 @@
+package actions
+
+import (
+	"context"
+
+	"github.com/cloudquery/cloudquery/plugins/source/github/client"
+	"github.com/cloudquery/plugin-sdk/v4/schema"
+	"github.com/cloudquery/plugin-sdk/v4/transformers"
+	"github.com/google/go-github/v49/github"
+)
+
+func WorkflowRuns() *schema.Table {
+	return &schema.Table{
+		Name:      "github_workflow_runs",
+		Resolver:  fetchWorkflowRuns,
+		Multiplex: client.OrgRepositoryMultiplex,
+		Transform: client.TransformWithStruct(&github.WorkflowRun{}, transformers.WithPrimaryKeys("ID")),
+		Columns: []schema.Column{
+			client.OrgColumn,
+			client.RepositoryIDColumn,
+		},
+		Relations: []*schema.Table{
+			WorkflowRunUsage(),
+			WorkflowJobs(),
+		},
+	}
+}
+
+func fetchWorkflowRuns(ctx context.Context, meta schema.ClientMeta, _ *schema.Resource, res chan<- any) error {
+	c := meta.(*client.Client)
+	repo := c.Repository
+	listOpts := &github.ListOptions{PerPage: 100}
+	actionOpts := &github.ListWorkflowRunsOptions{ListOptions: *listOpts}
+	for {
+		workflowRuns, resp, err := c.Github.Actions.ListRepositoryWorkflowRuns(ctx, *repo.Owner.Login, *repo.Name, actionOpts)
+		if err != nil {
+			return err
+		}
+		res <- workflowRuns.WorkflowRuns
+
+		if resp.NextPage == 0 {
+			break
+		}
+		actionOpts.Page = resp.NextPage
+	}
+	return nil
+}

--- a/website/pages/docs/plugins/sources/github/_authentication.mdx
+++ b/website/pages/docs/plugins/sources/github/_authentication.mdx
@@ -1,5 +1,7 @@
 The GitHub source plugin supports two authentication methods: Personal Access Token and App authentication. Which one you use is up to and the security requirements of your organization.
 
+Keep in mind rate limits for GitHub Apps are higher than for personal access tokens.  Review [GitHub rate limits documentation](https://docs.github.com/en/apps/creating-github-apps/registering-a-github-app/rate-limits-for-github-apps) for details. 
+
 CloudQuery requires only *read* permissions (we will never make any changes to your GitHub account or organizations),
 so, following the principle of least privilege, it's recommended to grant it read-only permissions to all the resources you wish to sync.
 

--- a/website/pages/docs/plugins/sources/github/tables.md
+++ b/website/pages/docs/plugins/sources/github/tables.md
@@ -28,4 +28,7 @@
 - [github_traffic_paths](tables/github_traffic_paths)
 - [github_traffic_referrers](tables/github_traffic_referrers)
 - [github_traffic_views](tables/github_traffic_views)
+- [github_workflow_runs](tables/github_workflow_runs)
+  - [github_workflow_jobs](tables/github_workflow_jobs)
+  - [github_workflow_run_usage](tables/github_workflow_run_usage)
 - [github_workflows](tables/github_workflows)

--- a/website/tables/github/github_workflow_jobs.md
+++ b/website/tables/github/github_workflow_jobs.md
@@ -1,0 +1,38 @@
+# Table: github_workflow_jobs
+
+This table shows data for Github Workflow Jobs.
+
+The composite primary key for this table is (**org**, **repository_id**, **id**).
+
+## Relations
+
+This table depends on [github_workflow_runs](github_workflow_runs).
+
+## Columns
+
+| Name          | Type          |
+| ------------- | ------------- |
+|_cq_id|`uuid`|
+|_cq_parent_id|`uuid`|
+|org (PK)|`utf8`|
+|repository_id (PK)|`int64`|
+|run_id|`int64`|
+|id (PK)|`int64`|
+|run_url|`utf8`|
+|node_id|`utf8`|
+|head_sha|`utf8`|
+|url|`utf8`|
+|html_url|`utf8`|
+|status|`utf8`|
+|conclusion|`utf8`|
+|started_at|`timestamp[us, tz=UTC]`|
+|completed_at|`timestamp[us, tz=UTC]`|
+|name|`utf8`|
+|steps|`json`|
+|check_run_url|`utf8`|
+|labels|`list<item: utf8, nullable>`|
+|runner_id|`int64`|
+|runner_name|`utf8`|
+|runner_group_id|`int64`|
+|runner_group_name|`utf8`|
+|run_attempt|`int64`|

--- a/website/tables/github/github_workflow_run_usage.md
+++ b/website/tables/github/github_workflow_run_usage.md
@@ -1,0 +1,21 @@
+# Table: github_workflow_run_usage
+
+This table shows data for Github Workflow Run Usage.
+
+The composite primary key for this table is (**org**, **repository_id**, **run_id**).
+
+## Relations
+
+This table depends on [github_workflow_runs](github_workflow_runs).
+
+## Columns
+
+| Name          | Type          |
+| ------------- | ------------- |
+|_cq_id|`uuid`|
+|_cq_parent_id|`uuid`|
+|org (PK)|`utf8`|
+|repository_id (PK)|`int64`|
+|run_id (PK)|`int64`|
+|billable|`json`|
+|run_duration_ms|`int64`|

--- a/website/tables/github/github_workflow_runs.md
+++ b/website/tables/github/github_workflow_runs.md
@@ -1,0 +1,51 @@
+# Table: github_workflow_runs
+
+This table shows data for Github Workflow Runs.
+
+The composite primary key for this table is (**org**, **repository_id**, **id**).
+
+## Relations
+
+The following tables depend on github_workflow_runs:
+  - [github_workflow_jobs](github_workflow_jobs)
+  - [github_workflow_run_usage](github_workflow_run_usage)
+
+## Columns
+
+| Name          | Type          |
+| ------------- | ------------- |
+|_cq_id|`uuid`|
+|_cq_parent_id|`uuid`|
+|org (PK)|`utf8`|
+|repository_id (PK)|`int64`|
+|id (PK)|`int64`|
+|name|`utf8`|
+|node_id|`utf8`|
+|head_branch|`utf8`|
+|head_sha|`utf8`|
+|run_number|`int64`|
+|run_attempt|`int64`|
+|event|`utf8`|
+|status|`utf8`|
+|conclusion|`utf8`|
+|workflow_id|`int64`|
+|check_suite_id|`int64`|
+|check_suite_node_id|`utf8`|
+|url|`utf8`|
+|html_url|`utf8`|
+|pull_requests|`json`|
+|created_at|`timestamp[us, tz=UTC]`|
+|updated_at|`timestamp[us, tz=UTC]`|
+|run_started_at|`timestamp[us, tz=UTC]`|
+|jobs_url|`utf8`|
+|logs_url|`utf8`|
+|check_suite_url|`utf8`|
+|artifacts_url|`utf8`|
+|cancel_url|`utf8`|
+|rerun_url|`utf8`|
+|previous_attempt_url|`utf8`|
+|head_commit|`json`|
+|workflow_url|`utf8`|
+|repository|`json`|
+|head_repository|`json`|
+|actor|`json`|


### PR DESCRIPTION
<!-- 🎉 Thank you for making CloudQuery awesome by submitting a PR 🎉 -->

#### Summary

Closes #14311 

Adds tables for github_workflow_runs, github_workflow_run_usage, and github_workflow_jobs allowing to analyze GitHub Actions usage.  

In addition, added URL output to log for rate limiting for easier troubleshooting of secondary rate limits.  


<!--
Use the following steps to ensure your PR is ready to be reviewed

- [x] Read the [contribution guidelines](../blob/main/CONTRIBUTING.md) 🧑‍🎓
- [x] Run `make lint` to ensure the proposed changes follow the coding style 🚨 (install golangci-lint [here](https://golangci-lint.run/usage/install/#local-installation))
- [x] Run `make test` to ensure the proposed changes pass the tests 🧪
- [x] If changing a source plugin run `make gen` to ensure docs are up to date 📝
- [ ] Ensure the status checks below are successful ✅
--->
