### PR TITLE
fix: Don't use templating in Dockers publish config

### DIFF
--- a/cli/.goreleaser.yaml
+++ b/cli/.goreleaser.yaml
@@ -29,9 +29,9 @@ dockers:
     goarch: arm64
     dockerfile: Dockerfile.goreleaser
     image_templates:
-      - "ghcr.io/cloudquery/cloudquery:latest-linux-amd64"
-      - "ghcr.io/cloudquery/cloudquery:{{.Version}}-linux-amd64"
-      - "ghcr.io/cloudquery/cloudquery:{{ .Major }}.{{ .Minor }}-linux-amd64"
+      - "ghcr.io/cloudquery/cloudquery:latest-linux-arm64"
+      - "ghcr.io/cloudquery/cloudquery:{{.Version}}-linux-arm64"
+      - "ghcr.io/cloudquery/cloudquery:{{ .Major }}.{{ .Minor }}-linux-arm64"
     build_flag_templates:
       - "--label=org.opencontainers.image.source=https://github.com/cloudquery/cloudquery"
 

--- a/cli/.goreleaser.yaml
+++ b/cli/.goreleaser.yaml
@@ -19,9 +19,9 @@ dockers:
       - "ghcr.io/cloudquery/cloudquery:latest"
       - "ghcr.io/cloudquery/cloudquery:{{.Version}}"
       - "ghcr.io/cloudquery/cloudquery:{{ .Major }}.{{ .Minor }}"
-      - "ghcr.io/cloudquery/cloudquery:latest-{{.Runtime.Goos}}-{{.Runtime.Goarch}}"
-      - "ghcr.io/cloudquery/cloudquery:{{.Version}}-{{.Runtime.Goos}}-{{.Runtime.Goarch}}"
-      - "ghcr.io/cloudquery/cloudquery:{{ .Major }}.{{ .Minor }}-{{.Runtime.Goos}}-{{.Runtime.Goarch}}"
+      - "ghcr.io/cloudquery/cloudquery:latest-linux-amd64"
+      - "ghcr.io/cloudquery/cloudquery:{{.Version}}-linux-amd64"
+      - "ghcr.io/cloudquery/cloudquery:{{ .Major }}.{{ .Minor }}-linux-amd64"
     build_flag_templates:
       - "--label=org.opencontainers.image.source=https://github.com/cloudquery/cloudquery"
   -
@@ -29,9 +29,9 @@ dockers:
     goarch: arm64
     dockerfile: Dockerfile.goreleaser
     image_templates:
-      - "ghcr.io/cloudquery/cloudquery:latest-{{.Runtime.Goos}}-{{.Runtime.Goarch}}"
-      - "ghcr.io/cloudquery/cloudquery:{{.Version}}-{{.Runtime.Goos}}-{{.Runtime.Goarch}}"
-      - "ghcr.io/cloudquery/cloudquery:{{ .Major }}.{{ .Minor }}-{{.Runtime.Goos}}-{{.Runtime.Goarch}}"
+      - "ghcr.io/cloudquery/cloudquery:latest-linux-amd64"
+      - "ghcr.io/cloudquery/cloudquery:{{.Version}}-linux-amd64"
+      - "ghcr.io/cloudquery/cloudquery:{{ .Major }}.{{ .Minor }}-linux-amd64"
     build_flag_templates:
       - "--label=org.opencontainers.image.source=https://github.com/cloudquery/cloudquery"
 


### PR DESCRIPTION
<!-- 🎉 Thank you for making CloudQuery awesome by submitting a PR 🎉 -->

#### Summary

Doesn't look like the [previous PR](https://github.com/cloudquery/cloudquery/pull/14515) worked as it published everything as `amd64` https://github.com/cloudquery/cloudquery/actions/runs/6531867504/job/17733917959#step:10:61

<!--
Use the following steps to ensure your PR is ready to be reviewed

- [ ] Read the [contribution guidelines](../blob/main/CONTRIBUTING.md) 🧑‍🎓
- [ ] Run `make lint` to ensure the proposed changes follow the coding style 🚨 (install golangci-lint [here](https://golangci-lint.run/usage/install/#local-installation))
- [ ] Run `make test` to ensure the proposed changes pass the tests 🧪
- [ ] If changing a source plugin run `make gen` to ensure docs are up to date 📝
- [ ] Ensure the status checks below are successful ✅
--->
