### PR TITLE
chore: Disable setup-go cache in workflows we use cache action directly

### DIFF
--- a/.github/workflows/cli.yml
+++ b/.github/workflows/cli.yml
@@ -79,6 +79,7 @@ jobs:
         uses: actions/setup-go@v4
         with:
           go-version-file: cli/go.mod
+          cache: false
       - name: Install GoReleaser
         if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
         uses: goreleaser/goreleaser-action@v5

--- a/.github/workflows/dest_azblob.yml
+++ b/.github/workflows/dest_azblob.yml
@@ -73,6 +73,7 @@ jobs:
         uses: actions/setup-go@v4
         with:
           go-version-file: plugins/destination/azblob/go.mod
+          cache: false
       - name: Install GoReleaser
         if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
         uses: goreleaser/goreleaser-action@v5

--- a/.github/workflows/dest_bigquery.yml
+++ b/.github/workflows/dest_bigquery.yml
@@ -82,6 +82,7 @@ jobs:
         uses: actions/setup-go@v4
         with:
           go-version-file: plugins/destination/bigquery/go.mod
+          cache: false
       - name: Install GoReleaser
         if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
         uses: goreleaser/goreleaser-action@v5

--- a/.github/workflows/dest_clickhouse.yml
+++ b/.github/workflows/dest_clickhouse.yml
@@ -94,6 +94,7 @@ jobs:
       uses: actions/setup-go@v4
       with:
         go-version-file: plugins/destination/clickhouse/go.mod
+        cache: false
     - name: Install GoReleaser
       if:   startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
       uses: goreleaser/goreleaser-action@v5

--- a/.github/workflows/dest_duckdb.yml
+++ b/.github/workflows/dest_duckdb.yml
@@ -71,6 +71,7 @@ jobs:
         uses: actions/setup-go@v4
         with:
           go-version-file: plugins/destination/duckdb/go.mod
+          cache: false
       - name: Install GoReleaser
         if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
         uses: goreleaser/goreleaser-action@v5

--- a/.github/workflows/dest_elasticsearch.yml
+++ b/.github/workflows/dest_elasticsearch.yml
@@ -81,6 +81,7 @@ jobs:
         uses: actions/setup-go@v4
         with:
           go-version-file: plugins/destination/elasticsearch/go.mod
+          cache: false
       - name: Install GoReleaser
         if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
         uses: goreleaser/goreleaser-action@v5

--- a/.github/workflows/dest_file.yml
+++ b/.github/workflows/dest_file.yml
@@ -71,6 +71,7 @@ jobs:
         uses: actions/setup-go@v4
         with:
           go-version-file: plugins/destination/file/go.mod
+          cache: false
       - name: Install GoReleaser
         if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
         uses: goreleaser/goreleaser-action@v5

--- a/.github/workflows/dest_firehose.yml
+++ b/.github/workflows/dest_firehose.yml
@@ -78,6 +78,7 @@ jobs:
         uses: actions/setup-go@v4
         with:
           go-version-file: plugins/destination/firehose/go.mod
+          cache: false
       - name: Install GoReleaser
         if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
         uses: goreleaser/goreleaser-action@v5

--- a/.github/workflows/dest_gcs.yml
+++ b/.github/workflows/dest_gcs.yml
@@ -77,6 +77,7 @@ jobs:
         uses: actions/setup-go@v4
         with:
           go-version-file: plugins/destination/gcs/go.mod
+          cache: false
       - name: Install GoReleaser
         if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
         uses: goreleaser/goreleaser-action@v5

--- a/.github/workflows/dest_gremlin.yml
+++ b/.github/workflows/dest_gremlin.yml
@@ -74,6 +74,7 @@ jobs:
         uses: actions/setup-go@v4
         with:
           go-version-file: plugins/destination/gremlin/go.mod
+          cache: false
       - name: Install GoReleaser
         if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
         uses: goreleaser/goreleaser-action@v5

--- a/.github/workflows/dest_kafka.yml
+++ b/.github/workflows/dest_kafka.yml
@@ -94,6 +94,7 @@ jobs:
         uses: actions/setup-go@v4
         with:
           go-version-file: plugins/destination/kafka/go.mod
+          cache: false
       - name: Install GoReleaser
         if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
         uses: goreleaser/goreleaser-action@v5

--- a/.github/workflows/dest_meilisearch.yml
+++ b/.github/workflows/dest_meilisearch.yml
@@ -91,6 +91,7 @@ jobs:
       uses: actions/setup-go@v4
       with:
         go-version-file: plugins/destination/meilisearch/go.mod
+        cache: false
     - name: Install GoReleaser
       if:   startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
       uses: goreleaser/goreleaser-action@v5

--- a/.github/workflows/dest_mongodb.yml
+++ b/.github/workflows/dest_mongodb.yml
@@ -72,6 +72,7 @@ jobs:
         uses: actions/setup-go@v4
         with:
           go-version-file: plugins/destination/mongodb/go.mod
+          cache: false
       - name: Install GoReleaser
         if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
         uses: goreleaser/goreleaser-action@v5

--- a/.github/workflows/dest_mssql.yml
+++ b/.github/workflows/dest_mssql.yml
@@ -98,6 +98,7 @@ jobs:
       uses: actions/setup-go@v4
       with:
         go-version-file: plugins/destination/mssql/go.mod
+        cache: false
     - name: Install GoReleaser
       if:   startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
       uses: goreleaser/goreleaser-action@v5

--- a/.github/workflows/dest_mysql.yml
+++ b/.github/workflows/dest_mysql.yml
@@ -75,6 +75,7 @@ jobs:
         uses: actions/setup-go@v4
         with:
           go-version-file: plugins/destination/mysql/go.mod
+          cache: false
       - name: Install GoReleaser
         if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
         uses: goreleaser/goreleaser-action@v5

--- a/.github/workflows/dest_neo4j.yml
+++ b/.github/workflows/dest_neo4j.yml
@@ -89,6 +89,7 @@ jobs:
         uses: actions/setup-go@v4
         with:
           go-version-file: plugins/destination/neo4j/go.mod
+          cache: false
       - name: Install GoReleaser
         if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
         uses: goreleaser/goreleaser-action@v5

--- a/.github/workflows/dest_postgresql.yml
+++ b/.github/workflows/dest_postgresql.yml
@@ -94,6 +94,7 @@ jobs:
         uses: actions/setup-go@v4
         with:
           go-version-file: plugins/destination/postgresql/go.mod
+          cache: false
       - name: Install GoReleaser
         if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
         uses: goreleaser/goreleaser-action@v5

--- a/.github/workflows/dest_s3.yml
+++ b/.github/workflows/dest_s3.yml
@@ -79,6 +79,7 @@ jobs:
         uses: actions/setup-go@v4
         with:
           go-version-file: plugins/destination/s3/go.mod
+          cache: false
       - name: Install GoReleaser
         if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
         uses: goreleaser/goreleaser-action@v5

--- a/.github/workflows/dest_snowflake.yml
+++ b/.github/workflows/dest_snowflake.yml
@@ -73,6 +73,7 @@ jobs:
         uses: actions/setup-go@v4
         with:
           go-version-file: plugins/destination/snowflake/go.mod
+          cache: false
       - name: Install GoReleaser
         if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
         uses: goreleaser/goreleaser-action@v5

--- a/.github/workflows/dest_sqlite.yml
+++ b/.github/workflows/dest_sqlite.yml
@@ -71,6 +71,7 @@ jobs:
         uses: actions/setup-go@v4
         with:
           go-version-file: plugins/destination/sqlite/go.mod
+          cache: false
       - name: Install GoReleaser
         if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
         uses: goreleaser/goreleaser-action@v5

--- a/.github/workflows/dest_test.yml
+++ b/.github/workflows/dest_test.yml
@@ -69,6 +69,7 @@ jobs:
         uses: actions/setup-go@v4
         with:
           go-version-file: plugins/destination/test/go.mod
+          cache: false
       - name: Install GoReleaser
         if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
         uses: goreleaser/goreleaser-action@v5

--- a/.github/workflows/publish_plugin_to_hub.yml
+++ b/.github/workflows/publish_plugin_to_hub.yml
@@ -80,6 +80,7 @@ jobs:
         uses: actions/setup-go@v4
         with:
           go-version-file: ${{ needs.prepare.outputs.plugin_dir }}/go.mod
+          cache: false
 
       - name: Use Node.js LTS
         uses: actions/setup-node@v3

--- a/.github/workflows/publish_plugin_to_hub_duckdb.yml
+++ b/.github/workflows/publish_plugin_to_hub_duckdb.yml
@@ -59,6 +59,7 @@ jobs:
         uses: actions/setup-go@v4
         with:
           go-version-file: ${{ needs.prepare.outputs.plugin_dir }}/go.mod
+          cache: false
 
       - name: Use Node.js LTS
         uses: actions/setup-node@v3

--- a/.github/workflows/publish_plugin_to_hub_snowflake.yml
+++ b/.github/workflows/publish_plugin_to_hub_snowflake.yml
@@ -60,6 +60,7 @@ jobs:
         uses: actions/setup-go@v4
         with:
           go-version-file: ${{ needs.prepare.outputs.plugin_dir }}/go.mod
+          cache: false
 
       - name: Use Node.js LTS
         uses: actions/setup-node@v3

--- a/.github/workflows/publish_plugin_to_hub_sqlite.yml
+++ b/.github/workflows/publish_plugin_to_hub_sqlite.yml
@@ -59,6 +59,7 @@ jobs:
         uses: actions/setup-go@v4
         with:
           go-version-file: ${{ needs.prepare.outputs.plugin_dir }}/go.mod
+          cache: false
 
       - name: Use Node.js LTS
         uses: actions/setup-node@v3

--- a/.github/workflows/release_cli.yml
+++ b/.github/workflows/release_cli.yml
@@ -39,6 +39,7 @@ jobs:
         uses: actions/setup-go@v4
         with:
           go-version-file: cli/go.mod
+          cache: false
       - name: Install GoReleaser
         uses: goreleaser/goreleaser-action@v5
         with:

--- a/.github/workflows/release_plugin.yml
+++ b/.github/workflows/release_plugin.yml
@@ -147,6 +147,7 @@ jobs:
         uses: actions/setup-go@v4
         with:
           go-version-file: ${{needs.prepare.outputs.plugin_dir}}/go.mod
+          cache: false
       - name: Install GoReleaser
         uses: goreleaser/goreleaser-action@v5
         with:

--- a/.github/workflows/release_plugin_dest_duckdb.yml
+++ b/.github/workflows/release_plugin_dest_duckdb.yml
@@ -41,6 +41,7 @@ jobs:
         uses: actions/setup-go@v4
         with:
           go-version-file: plugins/destination/duckdb/go.mod
+          cache: false
       - name: Install GoReleaser
         uses: goreleaser/goreleaser-action@v5
         with:

--- a/.github/workflows/release_plugin_dest_snowflake.yml
+++ b/.github/workflows/release_plugin_dest_snowflake.yml
@@ -41,6 +41,7 @@ jobs:
         uses: actions/setup-go@v4
         with:
           go-version-file: plugins/destination/snowflake/go.mod
+          cache: false
       - name: Install GoReleaser
         uses: goreleaser/goreleaser-action@v5
         with:

--- a/.github/workflows/release_plugin_dest_sqlite.yml
+++ b/.github/workflows/release_plugin_dest_sqlite.yml
@@ -41,6 +41,7 @@ jobs:
         uses: actions/setup-go@v4
         with:
           go-version-file: plugins/destination/sqlite/go.mod
+          cache: false
       - name: Install GoReleaser
         uses: goreleaser/goreleaser-action@v5
         with:

--- a/.github/workflows/release_plugin_source_test.yml
+++ b/.github/workflows/release_plugin_source_test.yml
@@ -40,6 +40,7 @@ jobs:
         uses: actions/setup-go@v4
         with:
           go-version-file: plugins/source/test/go.mod
+          cache: false
       - name: Login to Docker Registry
         run: |
           echo "${{ secrets.GITHUB_TOKEN }}" | \

--- a/.github/workflows/release_scaffold.yml
+++ b/.github/workflows/release_scaffold.yml
@@ -39,6 +39,7 @@ jobs:
         uses: actions/setup-go@v4
         with:
           go-version-file: scaffold/go.mod
+          cache: false
       - name: Install GoReleaser
         uses: goreleaser/goreleaser-action@v5
         with:

--- a/.github/workflows/scaffold.yml
+++ b/.github/workflows/scaffold.yml
@@ -68,6 +68,7 @@ jobs:
         uses: actions/setup-go@v4
         with:
           go-version-file: scaffold/go.mod
+          cache: false
       - name: Install GoReleaser
         if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
         uses: goreleaser/goreleaser-action@v5

--- a/.github/workflows/source_alicloud.yml
+++ b/.github/workflows/source_alicloud.yml
@@ -80,6 +80,7 @@ jobs:
         uses: actions/setup-go@v4
         with:
           go-version-file: plugins/source/alicloud/go.mod
+          cache: false
       - name: Install GoReleaser
         if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
         uses: goreleaser/goreleaser-action@v5

--- a/.github/workflows/source_aws.yml
+++ b/.github/workflows/source_aws.yml
@@ -93,6 +93,7 @@ jobs:
         uses: actions/setup-go@v4
         with:
           go-version-file: plugins/source/aws/go.mod
+          cache: false
       - name: Install GoReleaser
         if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
         uses: goreleaser/goreleaser-action@v5

--- a/.github/workflows/source_awspricing.yml
+++ b/.github/workflows/source_awspricing.yml
@@ -80,6 +80,7 @@ jobs:
         uses: actions/setup-go@v4
         with:
           go-version-file: plugins/source/awspricing/go.mod
+          cache: false
       - name: Install GoReleaser
         if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
         uses: goreleaser/goreleaser-action@v5

--- a/.github/workflows/source_azure.yml
+++ b/.github/workflows/source_azure.yml
@@ -81,6 +81,7 @@ jobs:
         uses: actions/setup-go@v4
         with:
           go-version-file: plugins/source/azure/go.mod
+          cache: false
       - name: Install GoReleaser
         if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
         uses: goreleaser/goreleaser-action@v5

--- a/.github/workflows/source_azuredevops.yml
+++ b/.github/workflows/source_azuredevops.yml
@@ -80,6 +80,7 @@ jobs:
         uses: actions/setup-go@v4
         with:
           go-version-file: plugins/source/azuredevops/go.mod
+          cache: false
       - name: Install GoReleaser
         if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
         uses: goreleaser/goreleaser-action@v5

--- a/.github/workflows/source_cloudflare.yml
+++ b/.github/workflows/source_cloudflare.yml
@@ -80,6 +80,7 @@ jobs:
         uses: actions/setup-go@v4
         with:
           go-version-file: plugins/source/cloudflare/go.mod
+          cache: false
       - name: Install GoReleaser
         if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
         uses: goreleaser/goreleaser-action@v5

--- a/.github/workflows/source_datadog.yml
+++ b/.github/workflows/source_datadog.yml
@@ -80,6 +80,7 @@ jobs:
         uses: actions/setup-go@v4
         with:
           go-version-file: plugins/source/datadog/go.mod
+          cache: false
       - name: Install GoReleaser
         if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
         uses: goreleaser/goreleaser-action@v5

--- a/.github/workflows/source_digitalocean.yml
+++ b/.github/workflows/source_digitalocean.yml
@@ -80,6 +80,7 @@ jobs:
         uses: actions/setup-go@v4
         with:
           go-version-file: plugins/source/digitalocean/go.mod
+          cache: false
       - name: Install GoReleaser
         if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
         uses: goreleaser/goreleaser-action@v5

--- a/.github/workflows/source_facebookmarketing.yml
+++ b/.github/workflows/source_facebookmarketing.yml
@@ -80,6 +80,7 @@ jobs:
         uses: actions/setup-go@v4
         with:
           go-version-file: plugins/source/facebookmarketing/go.mod
+          cache: false
       - name: Install GoReleaser
         if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
         uses: goreleaser/goreleaser-action@v5

--- a/.github/workflows/source_fastly.yml
+++ b/.github/workflows/source_fastly.yml
@@ -80,6 +80,7 @@ jobs:
         uses: actions/setup-go@v4
         with:
           go-version-file: plugins/source/fastly/go.mod
+          cache: false
       - name: Install GoReleaser
         if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
         uses: goreleaser/goreleaser-action@v5

--- a/.github/workflows/source_firestore.yml
+++ b/.github/workflows/source_firestore.yml
@@ -79,6 +79,7 @@ jobs:
         uses: actions/setup-go@v4
         with:
           go-version-file: plugins/source/firestore/go.mod
+          cache: false
       - name: Install GoReleaser
         if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
         uses: goreleaser/goreleaser-action@v5

--- a/.github/workflows/source_gcp.yml
+++ b/.github/workflows/source_gcp.yml
@@ -81,6 +81,7 @@ jobs:
         uses: actions/setup-go@v4
         with:
           go-version-file: plugins/source/gcp/go.mod
+          cache: false
       - name: Install GoReleaser
         if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
         uses: goreleaser/goreleaser-action@v5

--- a/.github/workflows/source_github.yml
+++ b/.github/workflows/source_github.yml
@@ -80,6 +80,7 @@ jobs:
         uses: actions/setup-go@v4
         with:
           go-version-file: plugins/source/github/go.mod
+          cache: false
       - name: Install GoReleaser
         if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
         uses: goreleaser/goreleaser-action@v5

--- a/.github/workflows/source_gitlab.yml
+++ b/.github/workflows/source_gitlab.yml
@@ -80,6 +80,7 @@ jobs:
         uses: actions/setup-go@v4
         with:
           go-version-file: plugins/source/gitlab/go.mod
+          cache: false
       - name: Install GoReleaser
         if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
         uses: goreleaser/goreleaser-action@v5

--- a/.github/workflows/source_hackernews.yml
+++ b/.github/workflows/source_hackernews.yml
@@ -80,6 +80,7 @@ jobs:
         uses: actions/setup-go@v4
         with:
           go-version-file: plugins/source/hackernews/go.mod
+          cache: false
       - name: Install GoReleaser
         if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
         uses: goreleaser/goreleaser-action@v5

--- a/.github/workflows/source_homebrew.yml
+++ b/.github/workflows/source_homebrew.yml
@@ -80,6 +80,7 @@ jobs:
         uses: actions/setup-go@v4
         with:
           go-version-file: plugins/source/homebrew/go.mod
+          cache: false
       - name: Install GoReleaser
         if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
         uses: goreleaser/goreleaser-action@v5

--- a/.github/workflows/source_hubspot.yml
+++ b/.github/workflows/source_hubspot.yml
@@ -80,6 +80,7 @@ jobs:
         uses: actions/setup-go@v4
         with:
           go-version-file: plugins/source/hubspot/go.mod
+          cache: false
       - name: Install GoReleaser
         if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
         uses: goreleaser/goreleaser-action@v5

--- a/.github/workflows/source_jira.yml
+++ b/.github/workflows/source_jira.yml
@@ -81,6 +81,7 @@ jobs:
         uses: actions/setup-go@v4
         with:
           go-version-file: plugins/source/jira/go.mod
+          cache: false
       - name: Install GoReleaser
         if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
         uses: goreleaser/goreleaser-action@v5

--- a/.github/workflows/source_k8s.yml
+++ b/.github/workflows/source_k8s.yml
@@ -81,6 +81,7 @@ jobs:
         uses: actions/setup-go@v4
         with:
           go-version-file: plugins/source/k8s/go.mod
+          cache: false
       - name: Install GoReleaser
         if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
         uses: goreleaser/goreleaser-action@v5

--- a/.github/workflows/source_mysql.yml
+++ b/.github/workflows/source_mysql.yml
@@ -75,6 +75,7 @@ jobs:
         uses: actions/setup-go@v4
         with:
           go-version-file: plugins/source/mysql/go.mod
+          cache: false
       - name: Install GoReleaser
         if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
         uses: goreleaser/goreleaser-action@v5

--- a/.github/workflows/source_notion.yml
+++ b/.github/workflows/source_notion.yml
@@ -80,6 +80,7 @@ jobs:
         uses: actions/setup-go@v4
         with:
           go-version-file: plugins/source/notion/go.mod
+          cache: false
       - name: Install GoReleaser
         if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
         uses: goreleaser/goreleaser-action@v5

--- a/.github/workflows/source_okta.yml
+++ b/.github/workflows/source_okta.yml
@@ -80,6 +80,7 @@ jobs:
         uses: actions/setup-go@v4
         with:
           go-version-file: plugins/source/okta/go.mod
+          cache: false
       - name: Install GoReleaser
         if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
         uses: goreleaser/goreleaser-action@v5

--- a/.github/workflows/source_oracle.yml
+++ b/.github/workflows/source_oracle.yml
@@ -80,6 +80,7 @@ jobs:
         uses: actions/setup-go@v4
         with:
           go-version-file: plugins/source/oracle/go.mod
+          cache: false
       - name: Install GoReleaser
         if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
         uses: goreleaser/goreleaser-action@v5

--- a/.github/workflows/source_oracledb.yml
+++ b/.github/workflows/source_oracledb.yml
@@ -85,6 +85,7 @@ jobs:
         uses: actions/setup-go@v4
         with:
           go-version-file: plugins/source/oracledb/go.mod
+          cache: false
       - name: Install GoReleaser
         if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
         uses: goreleaser/goreleaser-action@v5

--- a/.github/workflows/source_pagerduty.yml
+++ b/.github/workflows/source_pagerduty.yml
@@ -80,6 +80,7 @@ jobs:
         uses: actions/setup-go@v4
         with:
           go-version-file: plugins/source/pagerduty/go.mod
+          cache: false
       - name: Install GoReleaser
         if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
         uses: goreleaser/goreleaser-action@v5

--- a/.github/workflows/source_postgresql.yml
+++ b/.github/workflows/source_postgresql.yml
@@ -75,6 +75,7 @@ jobs:
         uses: actions/setup-go@v4
         with:
           go-version-file: plugins/source/postgresql/go.mod
+          cache: false
       - name: Install GoReleaser
         if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
         uses: goreleaser/goreleaser-action@v5

--- a/.github/workflows/source_salesforce.yml
+++ b/.github/workflows/source_salesforce.yml
@@ -80,6 +80,7 @@ jobs:
         uses: actions/setup-go@v4
         with:
           go-version-file: plugins/source/salesforce/go.mod
+          cache: false
       - name: Install GoReleaser
         if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
         uses: goreleaser/goreleaser-action@v5

--- a/.github/workflows/source_shopify.yml
+++ b/.github/workflows/source_shopify.yml
@@ -80,6 +80,7 @@ jobs:
         uses: actions/setup-go@v4
         with:
           go-version-file: plugins/source/shopify/go.mod
+          cache: false
       - name: Install GoReleaser
         if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
         uses: goreleaser/goreleaser-action@v5

--- a/.github/workflows/source_snyk.yml
+++ b/.github/workflows/source_snyk.yml
@@ -80,6 +80,7 @@ jobs:
         uses: actions/setup-go@v4
         with:
           go-version-file: plugins/source/snyk/go.mod
+          cache: false
       - name: Install GoReleaser
         if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
         uses: goreleaser/goreleaser-action@v5

--- a/.github/workflows/source_stripe.yml
+++ b/.github/workflows/source_stripe.yml
@@ -80,6 +80,7 @@ jobs:
         uses: actions/setup-go@v4
         with:
           go-version-file: plugins/source/stripe/go.mod
+          cache: false
       - name: Install GoReleaser
         if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
         uses: goreleaser/goreleaser-action@v5

--- a/.github/workflows/source_terraform.yml
+++ b/.github/workflows/source_terraform.yml
@@ -80,6 +80,7 @@ jobs:
         uses: actions/setup-go@v4
         with:
           go-version-file: plugins/source/terraform/go.mod
+          cache: false
       - name: Install GoReleaser
         if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
         uses: goreleaser/goreleaser-action@v5

--- a/.github/workflows/source_test.yml
+++ b/.github/workflows/source_test.yml
@@ -80,6 +80,7 @@ jobs:
         uses: actions/setup-go@v4
         with:
           go-version-file: plugins/source/test/go.mod
+          cache: false
       - name: Install GoReleaser
         if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
         uses: goreleaser/goreleaser-action@v5

--- a/.github/workflows/source_vault.yml
+++ b/.github/workflows/source_vault.yml
@@ -76,6 +76,7 @@ jobs:
         uses: actions/setup-go@v4
         with:
           go-version-file: plugins/source/vault/go.mod
+          cache: false
       - name: Install GoReleaser
         if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
         uses: goreleaser/goreleaser-action@v5


### PR DESCRIPTION
<!-- 🎉 Thank you for making CloudQuery awesome by submitting a PR 🎉 -->

#### Summary

`setup-go` has caching enabled by default. In the validate-release/release workflows we use the cache action directly to control the cache key, so we should disable it for `setup-go`. Please note `setup-go` cache didn't work for these workflows anyway since it couldn't find the `go.sum` file. This PR doesn't change any cache related behavior it only fixes the warnings we're getting like:
https://github.com/cloudquery/cloudquery/actions/runs/6531867504
![image](https://github.com/cloudquery/cloudquery/assets/26760571/361c3e1e-bbed-4095-bd00-021c7e4ba7fc)


<!--
Use the following steps to ensure your PR is ready to be reviewed

- [ ] Read the [contribution guidelines](../blob/main/CONTRIBUTING.md) 🧑‍🎓
- [ ] Run `make lint` to ensure the proposed changes follow the coding style 🚨 (install golangci-lint [here](https://golangci-lint.run/usage/install/#local-installation))
- [ ] Run `make test` to ensure the proposed changes pass the tests 🧪
- [ ] If changing a source plugin run `make gen` to ensure docs are up to date 📝
- [ ] Ensure the status checks below are successful ✅
--->
