### PR TITLE
Chore: bump plugin-pb-go to v1.12.3 and plugin-sdk to v4.13.0

### DIFF
--- a/plugins/source/alicloud/go.mod
+++ b/plugins/source/alicloud/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/aliyun/aliyun-oss-go-sdk v2.2.7+incompatible
 	github.com/apache/arrow/go/v14 v14.0.0-20230929201650-00efb06dc0de
 	github.com/cloudquery/codegen v0.3.8
-	github.com/cloudquery/plugin-sdk/v4 v4.12.5
+	github.com/cloudquery/plugin-sdk/v4 v4.13.0
 	github.com/golang/mock v1.5.0
 	github.com/pkg/errors v0.9.1
 	github.com/rs/zerolog v1.29.1
@@ -33,7 +33,7 @@ require (
 	github.com/chenzhuoyu/base64x v0.0.0-20230717121745-296ad89f973d // indirect
 	github.com/chenzhuoyu/iasm v0.9.0 // indirect
 	github.com/cloudquery/cloudquery-api-go v1.2.8 // indirect
-	github.com/cloudquery/plugin-pb-go v1.12.2 // indirect
+	github.com/cloudquery/plugin-pb-go v1.12.3 // indirect
 	github.com/cloudquery/plugin-sdk/v2 v2.7.0 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/deepmap/oapi-codegen v1.15.0 // indirect

--- a/plugins/source/alicloud/go.sum
+++ b/plugins/source/alicloud/go.sum
@@ -104,12 +104,12 @@ github.com/cloudquery/cloudquery-api-go v1.2.8 h1:kzTuHxA/CwNFiCeg+rUZN+pe7lIi4w
 github.com/cloudquery/cloudquery-api-go v1.2.8/go.mod h1:oyNUZZ6CKjPapxMbmE/qR2vdo9/G+tuCdF7uXT1LYuM=
 github.com/cloudquery/codegen v0.3.8 h1:SViYwHVhjTzTAHkAtTPxFJ+vxhZOB6BZAXk9DtczeBk=
 github.com/cloudquery/codegen v0.3.8/go.mod h1:ovC0nEJ5a1CO+sUWTsvkizVgZaO6yUBbACRmy0d+v5Y=
-github.com/cloudquery/plugin-pb-go v1.12.2 h1:zDu+ClcuPLDcsyjiosyGpCADipPLhXNrc/sEC1WvWAU=
-github.com/cloudquery/plugin-pb-go v1.12.2/go.mod h1:CYorX3zCHF9ByoOgdBOuwLX/2vVCDH6/FoREOE3oH+w=
+github.com/cloudquery/plugin-pb-go v1.12.3 h1:rLK3/RR70/BX8tj2QzTnrjkxQhzfAT7SXEEEGuKr7Rk=
+github.com/cloudquery/plugin-pb-go v1.12.3/go.mod h1:CYorX3zCHF9ByoOgdBOuwLX/2vVCDH6/FoREOE3oH+w=
 github.com/cloudquery/plugin-sdk/v2 v2.7.0 h1:hRXsdEiaOxJtsn/wZMFQC9/jPfU1MeMK3KF+gPGqm7U=
 github.com/cloudquery/plugin-sdk/v2 v2.7.0/go.mod h1:pAX6ojIW99b/Vg4CkhnsGkRIzNaVEceYMR+Bdit73ug=
-github.com/cloudquery/plugin-sdk/v4 v4.12.5 h1:YLTIfYqnlaT5gz+Bv+CRrs9dX63e8mQNYNu3eteee+M=
-github.com/cloudquery/plugin-sdk/v4 v4.12.5/go.mod h1:WL9cNSAGEiEaUI5Go02hC5ZWUhei6TQJy/QEvbE1cCA=
+github.com/cloudquery/plugin-sdk/v4 v4.13.0 h1:ieTNPVPdzHAH6xQTOGz2sIS3WGtbfII6Rj4c9eBxQcs=
+github.com/cloudquery/plugin-sdk/v4 v4.13.0/go.mod h1:m7UY//dEzq2b/F6wDAqU2Vd9DLfZRrMjgn4qlnOrkPY=
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
 github.com/cncf/udpa/go v0.0.0-20201120205902-5459f2c99403/go.mod h1:WmhPx2Nbnhtbo57+VJT5O0JRkEi1Wbu0z5j0R8u5Hbk=
 github.com/cncf/udpa/go v0.0.0-20210930031921-04548b0d99d4/go.mod h1:6pvJx4me5XPnfI9Z40ddWsdw2W/uZgQLFXToKeRcDiI=

--- a/plugins/source/aws/go.mod
+++ b/plugins/source/aws/go.mod
@@ -131,7 +131,7 @@ require (
 	github.com/aws/smithy-go v1.14.1
 	github.com/basgys/goxml2json v1.1.0
 	github.com/cloudquery/codegen v0.3.8
-	github.com/cloudquery/plugin-sdk/v4 v4.12.5
+	github.com/cloudquery/plugin-sdk/v4 v4.13.0
 	github.com/cockroachdb/cockroachdb-parser v0.0.0-20230705064001-302c9ad52e1a
 	github.com/gertd/go-pluralize v0.2.1
 	github.com/ghodss/yaml v1.0.0
@@ -191,7 +191,7 @@ require (
 	github.com/chenzhuoyu/base64x v0.0.0-20230717121745-296ad89f973d // indirect
 	github.com/chenzhuoyu/iasm v0.9.0 // indirect
 	github.com/cloudquery/cloudquery-api-go v1.2.8 // indirect
-	github.com/cloudquery/plugin-pb-go v1.12.2 // indirect
+	github.com/cloudquery/plugin-pb-go v1.12.3 // indirect
 	github.com/cloudquery/plugin-sdk/v2 v2.7.0 // indirect
 	github.com/cockroachdb/apd/v3 v3.1.0 // indirect
 	github.com/cockroachdb/errors v1.9.0 // indirect

--- a/plugins/source/aws/go.sum
+++ b/plugins/source/aws/go.sum
@@ -412,12 +412,12 @@ github.com/cloudquery/codegen v0.3.8 h1:SViYwHVhjTzTAHkAtTPxFJ+vxhZOB6BZAXk9Dtcz
 github.com/cloudquery/codegen v0.3.8/go.mod h1:ovC0nEJ5a1CO+sUWTsvkizVgZaO6yUBbACRmy0d+v5Y=
 github.com/cloudquery/jsonschema v0.0.0-20231012111802-b28735982a93 h1:Rgtj0YMsk5BGD76Y38xCAHEtfOguxntnJO/q+oCAry4=
 github.com/cloudquery/jsonschema v0.0.0-20231012111802-b28735982a93/go.mod h1:ffZ5Km5SWWRAIN6wbDXItl95euhFz2uON45H2qjYt+0=
-github.com/cloudquery/plugin-pb-go v1.12.2 h1:zDu+ClcuPLDcsyjiosyGpCADipPLhXNrc/sEC1WvWAU=
-github.com/cloudquery/plugin-pb-go v1.12.2/go.mod h1:CYorX3zCHF9ByoOgdBOuwLX/2vVCDH6/FoREOE3oH+w=
+github.com/cloudquery/plugin-pb-go v1.12.3 h1:rLK3/RR70/BX8tj2QzTnrjkxQhzfAT7SXEEEGuKr7Rk=
+github.com/cloudquery/plugin-pb-go v1.12.3/go.mod h1:CYorX3zCHF9ByoOgdBOuwLX/2vVCDH6/FoREOE3oH+w=
 github.com/cloudquery/plugin-sdk/v2 v2.7.0 h1:hRXsdEiaOxJtsn/wZMFQC9/jPfU1MeMK3KF+gPGqm7U=
 github.com/cloudquery/plugin-sdk/v2 v2.7.0/go.mod h1:pAX6ojIW99b/Vg4CkhnsGkRIzNaVEceYMR+Bdit73ug=
-github.com/cloudquery/plugin-sdk/v4 v4.12.5 h1:YLTIfYqnlaT5gz+Bv+CRrs9dX63e8mQNYNu3eteee+M=
-github.com/cloudquery/plugin-sdk/v4 v4.12.5/go.mod h1:WL9cNSAGEiEaUI5Go02hC5ZWUhei6TQJy/QEvbE1cCA=
+github.com/cloudquery/plugin-sdk/v4 v4.13.0 h1:ieTNPVPdzHAH6xQTOGz2sIS3WGtbfII6Rj4c9eBxQcs=
+github.com/cloudquery/plugin-sdk/v4 v4.13.0/go.mod h1:m7UY//dEzq2b/F6wDAqU2Vd9DLfZRrMjgn4qlnOrkPY=
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
 github.com/cncf/udpa/go v0.0.0-20201120205902-5459f2c99403/go.mod h1:WmhPx2Nbnhtbo57+VJT5O0JRkEi1Wbu0z5j0R8u5Hbk=
 github.com/cncf/udpa/go v0.0.0-20210930031921-04548b0d99d4/go.mod h1:6pvJx4me5XPnfI9Z40ddWsdw2W/uZgQLFXToKeRcDiI=

--- a/plugins/source/awspricing/go.mod
+++ b/plugins/source/awspricing/go.mod
@@ -3,7 +3,7 @@ module github.com/cloudquery/cloudquery/plugins/source/awspricing
 go 1.21.1
 
 require (
-	github.com/cloudquery/plugin-sdk/v4 v4.12.5
+	github.com/cloudquery/plugin-sdk/v4 v4.13.0
 	github.com/rs/zerolog v1.29.1
 )
 
@@ -27,7 +27,7 @@ require (
 	github.com/chenzhuoyu/base64x v0.0.0-20230717121745-296ad89f973d // indirect
 	github.com/chenzhuoyu/iasm v0.9.0 // indirect
 	github.com/cloudquery/cloudquery-api-go v1.2.8 // indirect
-	github.com/cloudquery/plugin-pb-go v1.12.2 // indirect
+	github.com/cloudquery/plugin-pb-go v1.12.3 // indirect
 	github.com/cloudquery/plugin-sdk/v2 v2.7.0 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/deepmap/oapi-codegen v1.15.0 // indirect

--- a/plugins/source/awspricing/go.sum
+++ b/plugins/source/awspricing/go.sum
@@ -88,12 +88,12 @@ github.com/cloudquery/arrow/go/v14 v14.0.0-20231014001145-dbcb1498009c h1:z0ZtXv
 github.com/cloudquery/arrow/go/v14 v14.0.0-20231014001145-dbcb1498009c/go.mod h1:EkHPhLB+98ANnPojOy2sUhM0rzYbPEmrtuA9v8aZp/c=
 github.com/cloudquery/cloudquery-api-go v1.2.8 h1:kzTuHxA/CwNFiCeg+rUZN+pe7lIi4w6FgbG2T+abGlI=
 github.com/cloudquery/cloudquery-api-go v1.2.8/go.mod h1:oyNUZZ6CKjPapxMbmE/qR2vdo9/G+tuCdF7uXT1LYuM=
-github.com/cloudquery/plugin-pb-go v1.12.2 h1:zDu+ClcuPLDcsyjiosyGpCADipPLhXNrc/sEC1WvWAU=
-github.com/cloudquery/plugin-pb-go v1.12.2/go.mod h1:CYorX3zCHF9ByoOgdBOuwLX/2vVCDH6/FoREOE3oH+w=
+github.com/cloudquery/plugin-pb-go v1.12.3 h1:rLK3/RR70/BX8tj2QzTnrjkxQhzfAT7SXEEEGuKr7Rk=
+github.com/cloudquery/plugin-pb-go v1.12.3/go.mod h1:CYorX3zCHF9ByoOgdBOuwLX/2vVCDH6/FoREOE3oH+w=
 github.com/cloudquery/plugin-sdk/v2 v2.7.0 h1:hRXsdEiaOxJtsn/wZMFQC9/jPfU1MeMK3KF+gPGqm7U=
 github.com/cloudquery/plugin-sdk/v2 v2.7.0/go.mod h1:pAX6ojIW99b/Vg4CkhnsGkRIzNaVEceYMR+Bdit73ug=
-github.com/cloudquery/plugin-sdk/v4 v4.12.5 h1:YLTIfYqnlaT5gz+Bv+CRrs9dX63e8mQNYNu3eteee+M=
-github.com/cloudquery/plugin-sdk/v4 v4.12.5/go.mod h1:WL9cNSAGEiEaUI5Go02hC5ZWUhei6TQJy/QEvbE1cCA=
+github.com/cloudquery/plugin-sdk/v4 v4.13.0 h1:ieTNPVPdzHAH6xQTOGz2sIS3WGtbfII6Rj4c9eBxQcs=
+github.com/cloudquery/plugin-sdk/v4 v4.13.0/go.mod h1:m7UY//dEzq2b/F6wDAqU2Vd9DLfZRrMjgn4qlnOrkPY=
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
 github.com/cncf/udpa/go v0.0.0-20201120205902-5459f2c99403/go.mod h1:WmhPx2Nbnhtbo57+VJT5O0JRkEi1Wbu0z5j0R8u5Hbk=
 github.com/cncf/udpa/go v0.0.0-20210930031921-04548b0d99d4/go.mod h1:6pvJx4me5XPnfI9Z40ddWsdw2W/uZgQLFXToKeRcDiI=

--- a/plugins/source/azure/go.mod
+++ b/plugins/source/azure/go.mod
@@ -100,7 +100,7 @@ require (
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/workloads/armworkloads v0.2.0
 	github.com/Azure/azure-sdk-for-go/sdk/storage/azqueue v0.1.0
 	github.com/apache/arrow/go/v14 v14.0.0-20230929201650-00efb06dc0de
-	github.com/cloudquery/plugin-sdk/v4 v4.12.5
+	github.com/cloudquery/plugin-sdk/v4 v4.13.0
 	github.com/cockroachdb/cockroachdb-parser v0.0.0-20230705064001-302c9ad52e1a
 	github.com/gorilla/mux v1.8.0
 	github.com/mitchellh/hashstructure/v2 v2.0.2
@@ -136,7 +136,7 @@ require (
 	github.com/chenzhuoyu/base64x v0.0.0-20230717121745-296ad89f973d // indirect
 	github.com/chenzhuoyu/iasm v0.9.0 // indirect
 	github.com/cloudquery/cloudquery-api-go v1.2.8 // indirect
-	github.com/cloudquery/plugin-pb-go v1.12.2 // indirect
+	github.com/cloudquery/plugin-pb-go v1.12.3 // indirect
 	github.com/cloudquery/plugin-sdk/v2 v2.7.0 // indirect
 	github.com/cockroachdb/apd/v3 v3.1.0 // indirect
 	github.com/cockroachdb/errors v1.9.0 // indirect

--- a/plugins/source/azure/go.sum
+++ b/plugins/source/azure/go.sum
@@ -320,12 +320,12 @@ github.com/cloudquery/arrow/go/v14 v14.0.0-20231014001145-dbcb1498009c h1:z0ZtXv
 github.com/cloudquery/arrow/go/v14 v14.0.0-20231014001145-dbcb1498009c/go.mod h1:EkHPhLB+98ANnPojOy2sUhM0rzYbPEmrtuA9v8aZp/c=
 github.com/cloudquery/cloudquery-api-go v1.2.8 h1:kzTuHxA/CwNFiCeg+rUZN+pe7lIi4w6FgbG2T+abGlI=
 github.com/cloudquery/cloudquery-api-go v1.2.8/go.mod h1:oyNUZZ6CKjPapxMbmE/qR2vdo9/G+tuCdF7uXT1LYuM=
-github.com/cloudquery/plugin-pb-go v1.12.2 h1:zDu+ClcuPLDcsyjiosyGpCADipPLhXNrc/sEC1WvWAU=
-github.com/cloudquery/plugin-pb-go v1.12.2/go.mod h1:CYorX3zCHF9ByoOgdBOuwLX/2vVCDH6/FoREOE3oH+w=
+github.com/cloudquery/plugin-pb-go v1.12.3 h1:rLK3/RR70/BX8tj2QzTnrjkxQhzfAT7SXEEEGuKr7Rk=
+github.com/cloudquery/plugin-pb-go v1.12.3/go.mod h1:CYorX3zCHF9ByoOgdBOuwLX/2vVCDH6/FoREOE3oH+w=
 github.com/cloudquery/plugin-sdk/v2 v2.7.0 h1:hRXsdEiaOxJtsn/wZMFQC9/jPfU1MeMK3KF+gPGqm7U=
 github.com/cloudquery/plugin-sdk/v2 v2.7.0/go.mod h1:pAX6ojIW99b/Vg4CkhnsGkRIzNaVEceYMR+Bdit73ug=
-github.com/cloudquery/plugin-sdk/v4 v4.12.5 h1:YLTIfYqnlaT5gz+Bv+CRrs9dX63e8mQNYNu3eteee+M=
-github.com/cloudquery/plugin-sdk/v4 v4.12.5/go.mod h1:WL9cNSAGEiEaUI5Go02hC5ZWUhei6TQJy/QEvbE1cCA=
+github.com/cloudquery/plugin-sdk/v4 v4.13.0 h1:ieTNPVPdzHAH6xQTOGz2sIS3WGtbfII6Rj4c9eBxQcs=
+github.com/cloudquery/plugin-sdk/v4 v4.13.0/go.mod h1:m7UY//dEzq2b/F6wDAqU2Vd9DLfZRrMjgn4qlnOrkPY=
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
 github.com/cncf/udpa/go v0.0.0-20201120205902-5459f2c99403/go.mod h1:WmhPx2Nbnhtbo57+VJT5O0JRkEi1Wbu0z5j0R8u5Hbk=
 github.com/cncf/udpa/go v0.0.0-20210930031921-04548b0d99d4/go.mod h1:6pvJx4me5XPnfI9Z40ddWsdw2W/uZgQLFXToKeRcDiI=

--- a/plugins/source/azuredevops/go.mod
+++ b/plugins/source/azuredevops/go.mod
@@ -4,7 +4,7 @@ go 1.21.1
 
 require (
 	github.com/apache/arrow/go/v14 v14.0.0-20230929201650-00efb06dc0de
-	github.com/cloudquery/plugin-sdk/v4 v4.12.5
+	github.com/cloudquery/plugin-sdk/v4 v4.13.0
 	github.com/google/uuid v1.3.1
 	github.com/microsoft/azure-devops-go-api/azuredevops/v6 v6.0.1
 	github.com/rs/zerolog v1.29.1
@@ -29,7 +29,7 @@ require (
 	github.com/chenzhuoyu/base64x v0.0.0-20230717121745-296ad89f973d // indirect
 	github.com/chenzhuoyu/iasm v0.9.0 // indirect
 	github.com/cloudquery/cloudquery-api-go v1.2.8 // indirect
-	github.com/cloudquery/plugin-pb-go v1.12.2 // indirect
+	github.com/cloudquery/plugin-pb-go v1.12.3 // indirect
 	github.com/cloudquery/plugin-sdk/v2 v2.7.0 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/deepmap/oapi-codegen v1.15.0 // indirect

--- a/plugins/source/azuredevops/go.sum
+++ b/plugins/source/azuredevops/go.sum
@@ -88,12 +88,12 @@ github.com/cloudquery/arrow/go/v14 v14.0.0-20231014001145-dbcb1498009c h1:z0ZtXv
 github.com/cloudquery/arrow/go/v14 v14.0.0-20231014001145-dbcb1498009c/go.mod h1:EkHPhLB+98ANnPojOy2sUhM0rzYbPEmrtuA9v8aZp/c=
 github.com/cloudquery/cloudquery-api-go v1.2.8 h1:kzTuHxA/CwNFiCeg+rUZN+pe7lIi4w6FgbG2T+abGlI=
 github.com/cloudquery/cloudquery-api-go v1.2.8/go.mod h1:oyNUZZ6CKjPapxMbmE/qR2vdo9/G+tuCdF7uXT1LYuM=
-github.com/cloudquery/plugin-pb-go v1.12.2 h1:zDu+ClcuPLDcsyjiosyGpCADipPLhXNrc/sEC1WvWAU=
-github.com/cloudquery/plugin-pb-go v1.12.2/go.mod h1:CYorX3zCHF9ByoOgdBOuwLX/2vVCDH6/FoREOE3oH+w=
+github.com/cloudquery/plugin-pb-go v1.12.3 h1:rLK3/RR70/BX8tj2QzTnrjkxQhzfAT7SXEEEGuKr7Rk=
+github.com/cloudquery/plugin-pb-go v1.12.3/go.mod h1:CYorX3zCHF9ByoOgdBOuwLX/2vVCDH6/FoREOE3oH+w=
 github.com/cloudquery/plugin-sdk/v2 v2.7.0 h1:hRXsdEiaOxJtsn/wZMFQC9/jPfU1MeMK3KF+gPGqm7U=
 github.com/cloudquery/plugin-sdk/v2 v2.7.0/go.mod h1:pAX6ojIW99b/Vg4CkhnsGkRIzNaVEceYMR+Bdit73ug=
-github.com/cloudquery/plugin-sdk/v4 v4.12.5 h1:YLTIfYqnlaT5gz+Bv+CRrs9dX63e8mQNYNu3eteee+M=
-github.com/cloudquery/plugin-sdk/v4 v4.12.5/go.mod h1:WL9cNSAGEiEaUI5Go02hC5ZWUhei6TQJy/QEvbE1cCA=
+github.com/cloudquery/plugin-sdk/v4 v4.13.0 h1:ieTNPVPdzHAH6xQTOGz2sIS3WGtbfII6Rj4c9eBxQcs=
+github.com/cloudquery/plugin-sdk/v4 v4.13.0/go.mod h1:m7UY//dEzq2b/F6wDAqU2Vd9DLfZRrMjgn4qlnOrkPY=
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
 github.com/cncf/udpa/go v0.0.0-20201120205902-5459f2c99403/go.mod h1:WmhPx2Nbnhtbo57+VJT5O0JRkEi1Wbu0z5j0R8u5Hbk=
 github.com/cncf/udpa/go v0.0.0-20210930031921-04548b0d99d4/go.mod h1:6pvJx4me5XPnfI9Z40ddWsdw2W/uZgQLFXToKeRcDiI=

--- a/plugins/source/cloudflare/go.mod
+++ b/plugins/source/cloudflare/go.mod
@@ -5,7 +5,7 @@ go 1.21.1
 require (
 	github.com/apache/arrow/go/v14 v14.0.0-20230929201650-00efb06dc0de
 	github.com/cloudflare/cloudflare-go v0.57.1
-	github.com/cloudquery/plugin-sdk/v4 v4.12.5
+	github.com/cloudquery/plugin-sdk/v4 v4.13.0
 	github.com/golang/mock v1.6.0
 	github.com/rs/zerolog v1.29.1
 	github.com/thoas/go-funk v0.9.3
@@ -30,7 +30,7 @@ require (
 	github.com/chenzhuoyu/base64x v0.0.0-20230717121745-296ad89f973d // indirect
 	github.com/chenzhuoyu/iasm v0.9.0 // indirect
 	github.com/cloudquery/cloudquery-api-go v1.2.8 // indirect
-	github.com/cloudquery/plugin-pb-go v1.12.2 // indirect
+	github.com/cloudquery/plugin-pb-go v1.12.3 // indirect
 	github.com/cloudquery/plugin-sdk/v2 v2.7.0 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/deepmap/oapi-codegen v1.15.0 // indirect

--- a/plugins/source/cloudflare/go.sum
+++ b/plugins/source/cloudflare/go.sum
@@ -90,12 +90,12 @@ github.com/cloudquery/arrow/go/v14 v14.0.0-20231014001145-dbcb1498009c h1:z0ZtXv
 github.com/cloudquery/arrow/go/v14 v14.0.0-20231014001145-dbcb1498009c/go.mod h1:EkHPhLB+98ANnPojOy2sUhM0rzYbPEmrtuA9v8aZp/c=
 github.com/cloudquery/cloudquery-api-go v1.2.8 h1:kzTuHxA/CwNFiCeg+rUZN+pe7lIi4w6FgbG2T+abGlI=
 github.com/cloudquery/cloudquery-api-go v1.2.8/go.mod h1:oyNUZZ6CKjPapxMbmE/qR2vdo9/G+tuCdF7uXT1LYuM=
-github.com/cloudquery/plugin-pb-go v1.12.2 h1:zDu+ClcuPLDcsyjiosyGpCADipPLhXNrc/sEC1WvWAU=
-github.com/cloudquery/plugin-pb-go v1.12.2/go.mod h1:CYorX3zCHF9ByoOgdBOuwLX/2vVCDH6/FoREOE3oH+w=
+github.com/cloudquery/plugin-pb-go v1.12.3 h1:rLK3/RR70/BX8tj2QzTnrjkxQhzfAT7SXEEEGuKr7Rk=
+github.com/cloudquery/plugin-pb-go v1.12.3/go.mod h1:CYorX3zCHF9ByoOgdBOuwLX/2vVCDH6/FoREOE3oH+w=
 github.com/cloudquery/plugin-sdk/v2 v2.7.0 h1:hRXsdEiaOxJtsn/wZMFQC9/jPfU1MeMK3KF+gPGqm7U=
 github.com/cloudquery/plugin-sdk/v2 v2.7.0/go.mod h1:pAX6ojIW99b/Vg4CkhnsGkRIzNaVEceYMR+Bdit73ug=
-github.com/cloudquery/plugin-sdk/v4 v4.12.5 h1:YLTIfYqnlaT5gz+Bv+CRrs9dX63e8mQNYNu3eteee+M=
-github.com/cloudquery/plugin-sdk/v4 v4.12.5/go.mod h1:WL9cNSAGEiEaUI5Go02hC5ZWUhei6TQJy/QEvbE1cCA=
+github.com/cloudquery/plugin-sdk/v4 v4.13.0 h1:ieTNPVPdzHAH6xQTOGz2sIS3WGtbfII6Rj4c9eBxQcs=
+github.com/cloudquery/plugin-sdk/v4 v4.13.0/go.mod h1:m7UY//dEzq2b/F6wDAqU2Vd9DLfZRrMjgn4qlnOrkPY=
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
 github.com/cncf/udpa/go v0.0.0-20201120205902-5459f2c99403/go.mod h1:WmhPx2Nbnhtbo57+VJT5O0JRkEi1Wbu0z5j0R8u5Hbk=
 github.com/cncf/udpa/go v0.0.0-20210930031921-04548b0d99d4/go.mod h1:6pvJx4me5XPnfI9Z40ddWsdw2W/uZgQLFXToKeRcDiI=

--- a/plugins/source/datadog/go.mod
+++ b/plugins/source/datadog/go.mod
@@ -5,7 +5,7 @@ go 1.21.1
 require (
 	github.com/DataDog/datadog-api-client-go/v2 v2.17.0
 	github.com/apache/arrow/go/v14 v14.0.0-20230929201650-00efb06dc0de
-	github.com/cloudquery/plugin-sdk/v4 v4.12.5
+	github.com/cloudquery/plugin-sdk/v4 v4.13.0
 	github.com/golang/mock v1.6.0
 	github.com/pkg/errors v0.9.1
 	github.com/rs/zerolog v1.29.1
@@ -34,7 +34,7 @@ require (
 	github.com/chenzhuoyu/base64x v0.0.0-20230717121745-296ad89f973d // indirect
 	github.com/chenzhuoyu/iasm v0.9.0 // indirect
 	github.com/cloudquery/cloudquery-api-go v1.2.8 // indirect
-	github.com/cloudquery/plugin-pb-go v1.12.2 // indirect
+	github.com/cloudquery/plugin-pb-go v1.12.3 // indirect
 	github.com/cloudquery/plugin-sdk/v2 v2.7.0 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/deepmap/oapi-codegen v1.15.0 // indirect

--- a/plugins/source/datadog/go.sum
+++ b/plugins/source/datadog/go.sum
@@ -92,12 +92,12 @@ github.com/cloudquery/arrow/go/v14 v14.0.0-20231014001145-dbcb1498009c h1:z0ZtXv
 github.com/cloudquery/arrow/go/v14 v14.0.0-20231014001145-dbcb1498009c/go.mod h1:EkHPhLB+98ANnPojOy2sUhM0rzYbPEmrtuA9v8aZp/c=
 github.com/cloudquery/cloudquery-api-go v1.2.8 h1:kzTuHxA/CwNFiCeg+rUZN+pe7lIi4w6FgbG2T+abGlI=
 github.com/cloudquery/cloudquery-api-go v1.2.8/go.mod h1:oyNUZZ6CKjPapxMbmE/qR2vdo9/G+tuCdF7uXT1LYuM=
-github.com/cloudquery/plugin-pb-go v1.12.2 h1:zDu+ClcuPLDcsyjiosyGpCADipPLhXNrc/sEC1WvWAU=
-github.com/cloudquery/plugin-pb-go v1.12.2/go.mod h1:CYorX3zCHF9ByoOgdBOuwLX/2vVCDH6/FoREOE3oH+w=
+github.com/cloudquery/plugin-pb-go v1.12.3 h1:rLK3/RR70/BX8tj2QzTnrjkxQhzfAT7SXEEEGuKr7Rk=
+github.com/cloudquery/plugin-pb-go v1.12.3/go.mod h1:CYorX3zCHF9ByoOgdBOuwLX/2vVCDH6/FoREOE3oH+w=
 github.com/cloudquery/plugin-sdk/v2 v2.7.0 h1:hRXsdEiaOxJtsn/wZMFQC9/jPfU1MeMK3KF+gPGqm7U=
 github.com/cloudquery/plugin-sdk/v2 v2.7.0/go.mod h1:pAX6ojIW99b/Vg4CkhnsGkRIzNaVEceYMR+Bdit73ug=
-github.com/cloudquery/plugin-sdk/v4 v4.12.5 h1:YLTIfYqnlaT5gz+Bv+CRrs9dX63e8mQNYNu3eteee+M=
-github.com/cloudquery/plugin-sdk/v4 v4.12.5/go.mod h1:WL9cNSAGEiEaUI5Go02hC5ZWUhei6TQJy/QEvbE1cCA=
+github.com/cloudquery/plugin-sdk/v4 v4.13.0 h1:ieTNPVPdzHAH6xQTOGz2sIS3WGtbfII6Rj4c9eBxQcs=
+github.com/cloudquery/plugin-sdk/v4 v4.13.0/go.mod h1:m7UY//dEzq2b/F6wDAqU2Vd9DLfZRrMjgn4qlnOrkPY=
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
 github.com/cncf/udpa/go v0.0.0-20201120205902-5459f2c99403/go.mod h1:WmhPx2Nbnhtbo57+VJT5O0JRkEi1Wbu0z5j0R8u5Hbk=
 github.com/cncf/udpa/go v0.0.0-20210930031921-04548b0d99d4/go.mod h1:6pvJx4me5XPnfI9Z40ddWsdw2W/uZgQLFXToKeRcDiI=

--- a/plugins/source/digitalocean/go.mod
+++ b/plugins/source/digitalocean/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/config v1.18.35
 	github.com/aws/aws-sdk-go-v2/service/s3 v1.38.4
 	github.com/aws/smithy-go v1.14.2
-	github.com/cloudquery/plugin-sdk/v4 v4.12.5
+	github.com/cloudquery/plugin-sdk/v4 v4.13.0
 	github.com/digitalocean/godo v1.99.0
 	github.com/golang/mock v1.6.0
 	github.com/pkg/errors v0.9.1
@@ -50,7 +50,7 @@ require (
 	github.com/chenzhuoyu/base64x v0.0.0-20230717121745-296ad89f973d // indirect
 	github.com/chenzhuoyu/iasm v0.9.0 // indirect
 	github.com/cloudquery/cloudquery-api-go v1.2.8 // indirect
-	github.com/cloudquery/plugin-pb-go v1.12.2 // indirect
+	github.com/cloudquery/plugin-pb-go v1.12.3 // indirect
 	github.com/cloudquery/plugin-sdk/v2 v2.7.0 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/deepmap/oapi-codegen v1.15.0 // indirect

--- a/plugins/source/digitalocean/go.sum
+++ b/plugins/source/digitalocean/go.sum
@@ -126,12 +126,12 @@ github.com/cloudquery/arrow/go/v14 v14.0.0-20231014001145-dbcb1498009c h1:z0ZtXv
 github.com/cloudquery/arrow/go/v14 v14.0.0-20231014001145-dbcb1498009c/go.mod h1:EkHPhLB+98ANnPojOy2sUhM0rzYbPEmrtuA9v8aZp/c=
 github.com/cloudquery/cloudquery-api-go v1.2.8 h1:kzTuHxA/CwNFiCeg+rUZN+pe7lIi4w6FgbG2T+abGlI=
 github.com/cloudquery/cloudquery-api-go v1.2.8/go.mod h1:oyNUZZ6CKjPapxMbmE/qR2vdo9/G+tuCdF7uXT1LYuM=
-github.com/cloudquery/plugin-pb-go v1.12.2 h1:zDu+ClcuPLDcsyjiosyGpCADipPLhXNrc/sEC1WvWAU=
-github.com/cloudquery/plugin-pb-go v1.12.2/go.mod h1:CYorX3zCHF9ByoOgdBOuwLX/2vVCDH6/FoREOE3oH+w=
+github.com/cloudquery/plugin-pb-go v1.12.3 h1:rLK3/RR70/BX8tj2QzTnrjkxQhzfAT7SXEEEGuKr7Rk=
+github.com/cloudquery/plugin-pb-go v1.12.3/go.mod h1:CYorX3zCHF9ByoOgdBOuwLX/2vVCDH6/FoREOE3oH+w=
 github.com/cloudquery/plugin-sdk/v2 v2.7.0 h1:hRXsdEiaOxJtsn/wZMFQC9/jPfU1MeMK3KF+gPGqm7U=
 github.com/cloudquery/plugin-sdk/v2 v2.7.0/go.mod h1:pAX6ojIW99b/Vg4CkhnsGkRIzNaVEceYMR+Bdit73ug=
-github.com/cloudquery/plugin-sdk/v4 v4.12.5 h1:YLTIfYqnlaT5gz+Bv+CRrs9dX63e8mQNYNu3eteee+M=
-github.com/cloudquery/plugin-sdk/v4 v4.12.5/go.mod h1:WL9cNSAGEiEaUI5Go02hC5ZWUhei6TQJy/QEvbE1cCA=
+github.com/cloudquery/plugin-sdk/v4 v4.13.0 h1:ieTNPVPdzHAH6xQTOGz2sIS3WGtbfII6Rj4c9eBxQcs=
+github.com/cloudquery/plugin-sdk/v4 v4.13.0/go.mod h1:m7UY//dEzq2b/F6wDAqU2Vd9DLfZRrMjgn4qlnOrkPY=
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
 github.com/cncf/udpa/go v0.0.0-20201120205902-5459f2c99403/go.mod h1:WmhPx2Nbnhtbo57+VJT5O0JRkEi1Wbu0z5j0R8u5Hbk=
 github.com/cncf/udpa/go v0.0.0-20210930031921-04548b0d99d4/go.mod h1:6pvJx4me5XPnfI9Z40ddWsdw2W/uZgQLFXToKeRcDiI=

--- a/plugins/source/facebookmarketing/go.mod
+++ b/plugins/source/facebookmarketing/go.mod
@@ -4,7 +4,7 @@ go 1.21.1
 
 require (
 	github.com/apache/arrow/go/v14 v14.0.0-20230929201650-00efb06dc0de
-	github.com/cloudquery/plugin-sdk/v4 v4.12.5
+	github.com/cloudquery/plugin-sdk/v4 v4.13.0
 	github.com/rs/zerolog v1.29.1
 	github.com/thoas/go-funk v0.9.3
 	golang.org/x/exp v0.0.0-20230905200255-921286631fa9
@@ -30,7 +30,7 @@ require (
 	github.com/chenzhuoyu/base64x v0.0.0-20230717121745-296ad89f973d // indirect
 	github.com/chenzhuoyu/iasm v0.9.0 // indirect
 	github.com/cloudquery/cloudquery-api-go v1.2.8 // indirect
-	github.com/cloudquery/plugin-pb-go v1.12.2 // indirect
+	github.com/cloudquery/plugin-pb-go v1.12.3 // indirect
 	github.com/cloudquery/plugin-sdk/v2 v2.7.0 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/deepmap/oapi-codegen v1.15.0 // indirect

--- a/plugins/source/facebookmarketing/go.sum
+++ b/plugins/source/facebookmarketing/go.sum
@@ -88,12 +88,12 @@ github.com/cloudquery/arrow/go/v14 v14.0.0-20231014001145-dbcb1498009c h1:z0ZtXv
 github.com/cloudquery/arrow/go/v14 v14.0.0-20231014001145-dbcb1498009c/go.mod h1:EkHPhLB+98ANnPojOy2sUhM0rzYbPEmrtuA9v8aZp/c=
 github.com/cloudquery/cloudquery-api-go v1.2.8 h1:kzTuHxA/CwNFiCeg+rUZN+pe7lIi4w6FgbG2T+abGlI=
 github.com/cloudquery/cloudquery-api-go v1.2.8/go.mod h1:oyNUZZ6CKjPapxMbmE/qR2vdo9/G+tuCdF7uXT1LYuM=
-github.com/cloudquery/plugin-pb-go v1.12.2 h1:zDu+ClcuPLDcsyjiosyGpCADipPLhXNrc/sEC1WvWAU=
-github.com/cloudquery/plugin-pb-go v1.12.2/go.mod h1:CYorX3zCHF9ByoOgdBOuwLX/2vVCDH6/FoREOE3oH+w=
+github.com/cloudquery/plugin-pb-go v1.12.3 h1:rLK3/RR70/BX8tj2QzTnrjkxQhzfAT7SXEEEGuKr7Rk=
+github.com/cloudquery/plugin-pb-go v1.12.3/go.mod h1:CYorX3zCHF9ByoOgdBOuwLX/2vVCDH6/FoREOE3oH+w=
 github.com/cloudquery/plugin-sdk/v2 v2.7.0 h1:hRXsdEiaOxJtsn/wZMFQC9/jPfU1MeMK3KF+gPGqm7U=
 github.com/cloudquery/plugin-sdk/v2 v2.7.0/go.mod h1:pAX6ojIW99b/Vg4CkhnsGkRIzNaVEceYMR+Bdit73ug=
-github.com/cloudquery/plugin-sdk/v4 v4.12.5 h1:YLTIfYqnlaT5gz+Bv+CRrs9dX63e8mQNYNu3eteee+M=
-github.com/cloudquery/plugin-sdk/v4 v4.12.5/go.mod h1:WL9cNSAGEiEaUI5Go02hC5ZWUhei6TQJy/QEvbE1cCA=
+github.com/cloudquery/plugin-sdk/v4 v4.13.0 h1:ieTNPVPdzHAH6xQTOGz2sIS3WGtbfII6Rj4c9eBxQcs=
+github.com/cloudquery/plugin-sdk/v4 v4.13.0/go.mod h1:m7UY//dEzq2b/F6wDAqU2Vd9DLfZRrMjgn4qlnOrkPY=
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
 github.com/cncf/udpa/go v0.0.0-20201120205902-5459f2c99403/go.mod h1:WmhPx2Nbnhtbo57+VJT5O0JRkEi1Wbu0z5j0R8u5Hbk=
 github.com/cncf/udpa/go v0.0.0-20210930031921-04548b0d99d4/go.mod h1:6pvJx4me5XPnfI9Z40ddWsdw2W/uZgQLFXToKeRcDiI=

--- a/plugins/source/fastly/go.mod
+++ b/plugins/source/fastly/go.mod
@@ -5,7 +5,7 @@ go 1.21.1
 require (
 	github.com/apache/arrow/go/v14 v14.0.0-20230929201650-00efb06dc0de
 	github.com/cloudquery/codegen v0.3.8
-	github.com/cloudquery/plugin-sdk/v4 v4.12.5
+	github.com/cloudquery/plugin-sdk/v4 v4.13.0
 	github.com/fastly/go-fastly/v7 v7.0.0
 	github.com/golang/mock v1.6.0
 	github.com/rs/zerolog v1.29.1
@@ -32,7 +32,7 @@ require (
 	github.com/chenzhuoyu/base64x v0.0.0-20230717121745-296ad89f973d // indirect
 	github.com/chenzhuoyu/iasm v0.9.0 // indirect
 	github.com/cloudquery/cloudquery-api-go v1.2.8 // indirect
-	github.com/cloudquery/plugin-pb-go v1.12.2 // indirect
+	github.com/cloudquery/plugin-pb-go v1.12.3 // indirect
 	github.com/cloudquery/plugin-sdk/v2 v2.7.0 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/deepmap/oapi-codegen v1.15.0 // indirect

--- a/plugins/source/fastly/go.sum
+++ b/plugins/source/fastly/go.sum
@@ -100,12 +100,12 @@ github.com/cloudquery/cloudquery-api-go v1.2.8 h1:kzTuHxA/CwNFiCeg+rUZN+pe7lIi4w
 github.com/cloudquery/cloudquery-api-go v1.2.8/go.mod h1:oyNUZZ6CKjPapxMbmE/qR2vdo9/G+tuCdF7uXT1LYuM=
 github.com/cloudquery/codegen v0.3.8 h1:SViYwHVhjTzTAHkAtTPxFJ+vxhZOB6BZAXk9DtczeBk=
 github.com/cloudquery/codegen v0.3.8/go.mod h1:ovC0nEJ5a1CO+sUWTsvkizVgZaO6yUBbACRmy0d+v5Y=
-github.com/cloudquery/plugin-pb-go v1.12.2 h1:zDu+ClcuPLDcsyjiosyGpCADipPLhXNrc/sEC1WvWAU=
-github.com/cloudquery/plugin-pb-go v1.12.2/go.mod h1:CYorX3zCHF9ByoOgdBOuwLX/2vVCDH6/FoREOE3oH+w=
+github.com/cloudquery/plugin-pb-go v1.12.3 h1:rLK3/RR70/BX8tj2QzTnrjkxQhzfAT7SXEEEGuKr7Rk=
+github.com/cloudquery/plugin-pb-go v1.12.3/go.mod h1:CYorX3zCHF9ByoOgdBOuwLX/2vVCDH6/FoREOE3oH+w=
 github.com/cloudquery/plugin-sdk/v2 v2.7.0 h1:hRXsdEiaOxJtsn/wZMFQC9/jPfU1MeMK3KF+gPGqm7U=
 github.com/cloudquery/plugin-sdk/v2 v2.7.0/go.mod h1:pAX6ojIW99b/Vg4CkhnsGkRIzNaVEceYMR+Bdit73ug=
-github.com/cloudquery/plugin-sdk/v4 v4.12.5 h1:YLTIfYqnlaT5gz+Bv+CRrs9dX63e8mQNYNu3eteee+M=
-github.com/cloudquery/plugin-sdk/v4 v4.12.5/go.mod h1:WL9cNSAGEiEaUI5Go02hC5ZWUhei6TQJy/QEvbE1cCA=
+github.com/cloudquery/plugin-sdk/v4 v4.13.0 h1:ieTNPVPdzHAH6xQTOGz2sIS3WGtbfII6Rj4c9eBxQcs=
+github.com/cloudquery/plugin-sdk/v4 v4.13.0/go.mod h1:m7UY//dEzq2b/F6wDAqU2Vd9DLfZRrMjgn4qlnOrkPY=
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
 github.com/cncf/udpa/go v0.0.0-20201120205902-5459f2c99403/go.mod h1:WmhPx2Nbnhtbo57+VJT5O0JRkEi1Wbu0z5j0R8u5Hbk=
 github.com/cncf/udpa/go v0.0.0-20210930031921-04548b0d99d4/go.mod h1:6pvJx4me5XPnfI9Z40ddWsdw2W/uZgQLFXToKeRcDiI=

--- a/plugins/source/firestore/go.mod
+++ b/plugins/source/firestore/go.mod
@@ -5,7 +5,7 @@ go 1.21.1
 require (
 	cloud.google.com/go/firestore v1.13.0
 	github.com/apache/arrow/go/v14 v14.0.0-20230929201650-00efb06dc0de
-	github.com/cloudquery/plugin-sdk/v4 v4.12.5
+	github.com/cloudquery/plugin-sdk/v4 v4.13.0
 	github.com/rs/zerolog v1.29.1
 	github.com/stretchr/testify v1.8.4
 	golang.org/x/sync v0.3.0
@@ -33,7 +33,7 @@ require (
 	github.com/chenzhuoyu/base64x v0.0.0-20230717121745-296ad89f973d // indirect
 	github.com/chenzhuoyu/iasm v0.9.0 // indirect
 	github.com/cloudquery/cloudquery-api-go v1.2.8 // indirect
-	github.com/cloudquery/plugin-pb-go v1.12.2 // indirect
+	github.com/cloudquery/plugin-pb-go v1.12.3 // indirect
 	github.com/cloudquery/plugin-sdk/v2 v2.7.0 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/deepmap/oapi-codegen v1.15.0 // indirect

--- a/plugins/source/firestore/go.sum
+++ b/plugins/source/firestore/go.sum
@@ -94,12 +94,12 @@ github.com/cloudquery/arrow/go/v14 v14.0.0-20231014001145-dbcb1498009c h1:z0ZtXv
 github.com/cloudquery/arrow/go/v14 v14.0.0-20231014001145-dbcb1498009c/go.mod h1:EkHPhLB+98ANnPojOy2sUhM0rzYbPEmrtuA9v8aZp/c=
 github.com/cloudquery/cloudquery-api-go v1.2.8 h1:kzTuHxA/CwNFiCeg+rUZN+pe7lIi4w6FgbG2T+abGlI=
 github.com/cloudquery/cloudquery-api-go v1.2.8/go.mod h1:oyNUZZ6CKjPapxMbmE/qR2vdo9/G+tuCdF7uXT1LYuM=
-github.com/cloudquery/plugin-pb-go v1.12.2 h1:zDu+ClcuPLDcsyjiosyGpCADipPLhXNrc/sEC1WvWAU=
-github.com/cloudquery/plugin-pb-go v1.12.2/go.mod h1:CYorX3zCHF9ByoOgdBOuwLX/2vVCDH6/FoREOE3oH+w=
+github.com/cloudquery/plugin-pb-go v1.12.3 h1:rLK3/RR70/BX8tj2QzTnrjkxQhzfAT7SXEEEGuKr7Rk=
+github.com/cloudquery/plugin-pb-go v1.12.3/go.mod h1:CYorX3zCHF9ByoOgdBOuwLX/2vVCDH6/FoREOE3oH+w=
 github.com/cloudquery/plugin-sdk/v2 v2.7.0 h1:hRXsdEiaOxJtsn/wZMFQC9/jPfU1MeMK3KF+gPGqm7U=
 github.com/cloudquery/plugin-sdk/v2 v2.7.0/go.mod h1:pAX6ojIW99b/Vg4CkhnsGkRIzNaVEceYMR+Bdit73ug=
-github.com/cloudquery/plugin-sdk/v4 v4.12.5 h1:YLTIfYqnlaT5gz+Bv+CRrs9dX63e8mQNYNu3eteee+M=
-github.com/cloudquery/plugin-sdk/v4 v4.12.5/go.mod h1:WL9cNSAGEiEaUI5Go02hC5ZWUhei6TQJy/QEvbE1cCA=
+github.com/cloudquery/plugin-sdk/v4 v4.13.0 h1:ieTNPVPdzHAH6xQTOGz2sIS3WGtbfII6Rj4c9eBxQcs=
+github.com/cloudquery/plugin-sdk/v4 v4.13.0/go.mod h1:m7UY//dEzq2b/F6wDAqU2Vd9DLfZRrMjgn4qlnOrkPY=
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
 github.com/cncf/udpa/go v0.0.0-20201120205902-5459f2c99403/go.mod h1:WmhPx2Nbnhtbo57+VJT5O0JRkEi1Wbu0z5j0R8u5Hbk=
 github.com/cncf/udpa/go v0.0.0-20210930031921-04548b0d99d4/go.mod h1:6pvJx4me5XPnfI9Z40ddWsdw2W/uZgQLFXToKeRcDiI=

--- a/plugins/source/gcp/go.mod
+++ b/plugins/source/gcp/go.mod
@@ -46,7 +46,7 @@ require (
 	cloud.google.com/go/workflows v1.12.0
 	github.com/apache/arrow/go/v14 v14.0.0-20230929201650-00efb06dc0de
 	github.com/cloudquery/codegen v0.3.8
-	github.com/cloudquery/plugin-sdk/v4 v4.12.5
+	github.com/cloudquery/plugin-sdk/v4 v4.13.0
 	github.com/cockroachdb/cockroachdb-parser v0.0.0-20230705064001-302c9ad52e1a
 	github.com/golang/mock v1.6.0
 	github.com/googleapis/gax-go/v2 v2.12.0
@@ -97,7 +97,7 @@ require (
 	github.com/chenzhuoyu/base64x v0.0.0-20230717121745-296ad89f973d // indirect
 	github.com/chenzhuoyu/iasm v0.9.0 // indirect
 	github.com/cloudquery/cloudquery-api-go v1.2.8 // indirect
-	github.com/cloudquery/plugin-pb-go v1.12.2 // indirect
+	github.com/cloudquery/plugin-pb-go v1.12.3 // indirect
 	github.com/cloudquery/plugin-sdk/v2 v2.7.0 // indirect
 	github.com/cncf/udpa/go v0.0.0-20220112060539-c52dc94e7fbe // indirect
 	github.com/cncf/xds/go v0.0.0-20230607035331-e9ce68804cb4 // indirect

--- a/plugins/source/gcp/go.sum
+++ b/plugins/source/gcp/go.sum
@@ -212,12 +212,12 @@ github.com/cloudquery/codegen v0.3.8 h1:SViYwHVhjTzTAHkAtTPxFJ+vxhZOB6BZAXk9Dtcz
 github.com/cloudquery/codegen v0.3.8/go.mod h1:ovC0nEJ5a1CO+sUWTsvkizVgZaO6yUBbACRmy0d+v5Y=
 github.com/cloudquery/jsonschema v0.0.0-20231012111802-b28735982a93 h1:Rgtj0YMsk5BGD76Y38xCAHEtfOguxntnJO/q+oCAry4=
 github.com/cloudquery/jsonschema v0.0.0-20231012111802-b28735982a93/go.mod h1:ffZ5Km5SWWRAIN6wbDXItl95euhFz2uON45H2qjYt+0=
-github.com/cloudquery/plugin-pb-go v1.12.2 h1:zDu+ClcuPLDcsyjiosyGpCADipPLhXNrc/sEC1WvWAU=
-github.com/cloudquery/plugin-pb-go v1.12.2/go.mod h1:CYorX3zCHF9ByoOgdBOuwLX/2vVCDH6/FoREOE3oH+w=
+github.com/cloudquery/plugin-pb-go v1.12.3 h1:rLK3/RR70/BX8tj2QzTnrjkxQhzfAT7SXEEEGuKr7Rk=
+github.com/cloudquery/plugin-pb-go v1.12.3/go.mod h1:CYorX3zCHF9ByoOgdBOuwLX/2vVCDH6/FoREOE3oH+w=
 github.com/cloudquery/plugin-sdk/v2 v2.7.0 h1:hRXsdEiaOxJtsn/wZMFQC9/jPfU1MeMK3KF+gPGqm7U=
 github.com/cloudquery/plugin-sdk/v2 v2.7.0/go.mod h1:pAX6ojIW99b/Vg4CkhnsGkRIzNaVEceYMR+Bdit73ug=
-github.com/cloudquery/plugin-sdk/v4 v4.12.5 h1:YLTIfYqnlaT5gz+Bv+CRrs9dX63e8mQNYNu3eteee+M=
-github.com/cloudquery/plugin-sdk/v4 v4.12.5/go.mod h1:WL9cNSAGEiEaUI5Go02hC5ZWUhei6TQJy/QEvbE1cCA=
+github.com/cloudquery/plugin-sdk/v4 v4.13.0 h1:ieTNPVPdzHAH6xQTOGz2sIS3WGtbfII6Rj4c9eBxQcs=
+github.com/cloudquery/plugin-sdk/v4 v4.13.0/go.mod h1:m7UY//dEzq2b/F6wDAqU2Vd9DLfZRrMjgn4qlnOrkPY=
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
 github.com/cncf/udpa/go v0.0.0-20201120205902-5459f2c99403/go.mod h1:WmhPx2Nbnhtbo57+VJT5O0JRkEi1Wbu0z5j0R8u5Hbk=
 github.com/cncf/udpa/go v0.0.0-20210930031921-04548b0d99d4/go.mod h1:6pvJx4me5XPnfI9Z40ddWsdw2W/uZgQLFXToKeRcDiI=

--- a/plugins/source/github/go.mod
+++ b/plugins/source/github/go.mod
@@ -5,7 +5,7 @@ go 1.21.1
 require (
 	github.com/apache/arrow/go/v14 v14.0.0-20230929201650-00efb06dc0de
 	github.com/beatlabs/github-auth v0.0.0-20230912161003-cdaa33aa0d65
-	github.com/cloudquery/plugin-sdk/v4 v4.12.5
+	github.com/cloudquery/plugin-sdk/v4 v4.13.0
 	github.com/gofri/go-github-ratelimit v1.0.3
 	github.com/golang/mock v1.6.0
 	github.com/google/go-github/v49 v49.0.0
@@ -33,7 +33,7 @@ require (
 	github.com/chenzhuoyu/base64x v0.0.0-20230717121745-296ad89f973d // indirect
 	github.com/chenzhuoyu/iasm v0.9.0 // indirect
 	github.com/cloudquery/cloudquery-api-go v1.2.8 // indirect
-	github.com/cloudquery/plugin-pb-go v1.12.2 // indirect
+	github.com/cloudquery/plugin-pb-go v1.12.3 // indirect
 	github.com/cloudquery/plugin-sdk/v2 v2.7.0 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/deepmap/oapi-codegen v1.15.0 // indirect

--- a/plugins/source/github/go.sum
+++ b/plugins/source/github/go.sum
@@ -90,12 +90,12 @@ github.com/cloudquery/arrow/go/v14 v14.0.0-20231014001145-dbcb1498009c h1:z0ZtXv
 github.com/cloudquery/arrow/go/v14 v14.0.0-20231014001145-dbcb1498009c/go.mod h1:EkHPhLB+98ANnPojOy2sUhM0rzYbPEmrtuA9v8aZp/c=
 github.com/cloudquery/cloudquery-api-go v1.2.8 h1:kzTuHxA/CwNFiCeg+rUZN+pe7lIi4w6FgbG2T+abGlI=
 github.com/cloudquery/cloudquery-api-go v1.2.8/go.mod h1:oyNUZZ6CKjPapxMbmE/qR2vdo9/G+tuCdF7uXT1LYuM=
-github.com/cloudquery/plugin-pb-go v1.12.2 h1:zDu+ClcuPLDcsyjiosyGpCADipPLhXNrc/sEC1WvWAU=
-github.com/cloudquery/plugin-pb-go v1.12.2/go.mod h1:CYorX3zCHF9ByoOgdBOuwLX/2vVCDH6/FoREOE3oH+w=
+github.com/cloudquery/plugin-pb-go v1.12.3 h1:rLK3/RR70/BX8tj2QzTnrjkxQhzfAT7SXEEEGuKr7Rk=
+github.com/cloudquery/plugin-pb-go v1.12.3/go.mod h1:CYorX3zCHF9ByoOgdBOuwLX/2vVCDH6/FoREOE3oH+w=
 github.com/cloudquery/plugin-sdk/v2 v2.7.0 h1:hRXsdEiaOxJtsn/wZMFQC9/jPfU1MeMK3KF+gPGqm7U=
 github.com/cloudquery/plugin-sdk/v2 v2.7.0/go.mod h1:pAX6ojIW99b/Vg4CkhnsGkRIzNaVEceYMR+Bdit73ug=
-github.com/cloudquery/plugin-sdk/v4 v4.12.5 h1:YLTIfYqnlaT5gz+Bv+CRrs9dX63e8mQNYNu3eteee+M=
-github.com/cloudquery/plugin-sdk/v4 v4.12.5/go.mod h1:WL9cNSAGEiEaUI5Go02hC5ZWUhei6TQJy/QEvbE1cCA=
+github.com/cloudquery/plugin-sdk/v4 v4.13.0 h1:ieTNPVPdzHAH6xQTOGz2sIS3WGtbfII6Rj4c9eBxQcs=
+github.com/cloudquery/plugin-sdk/v4 v4.13.0/go.mod h1:m7UY//dEzq2b/F6wDAqU2Vd9DLfZRrMjgn4qlnOrkPY=
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
 github.com/cncf/udpa/go v0.0.0-20201120205902-5459f2c99403/go.mod h1:WmhPx2Nbnhtbo57+VJT5O0JRkEi1Wbu0z5j0R8u5Hbk=
 github.com/cncf/udpa/go v0.0.0-20210930031921-04548b0d99d4/go.mod h1:6pvJx4me5XPnfI9Z40ddWsdw2W/uZgQLFXToKeRcDiI=

--- a/plugins/source/gitlab/go.mod
+++ b/plugins/source/gitlab/go.mod
@@ -4,7 +4,7 @@ go 1.21.1
 
 require (
 	github.com/apache/arrow/go/v14 v14.0.0-20230929201650-00efb06dc0de
-	github.com/cloudquery/plugin-sdk/v4 v4.12.5
+	github.com/cloudquery/plugin-sdk/v4 v4.13.0
 	github.com/julienschmidt/httprouter v1.3.0
 	github.com/rs/zerolog v1.29.1
 	github.com/xanzy/go-gitlab v0.83.0
@@ -30,7 +30,7 @@ require (
 	github.com/chenzhuoyu/base64x v0.0.0-20230717121745-296ad89f973d // indirect
 	github.com/chenzhuoyu/iasm v0.9.0 // indirect
 	github.com/cloudquery/cloudquery-api-go v1.2.8 // indirect
-	github.com/cloudquery/plugin-pb-go v1.12.2 // indirect
+	github.com/cloudquery/plugin-pb-go v1.12.3 // indirect
 	github.com/cloudquery/plugin-sdk/v2 v2.7.0 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/deepmap/oapi-codegen v1.15.0 // indirect

--- a/plugins/source/gitlab/go.sum
+++ b/plugins/source/gitlab/go.sum
@@ -88,12 +88,12 @@ github.com/cloudquery/arrow/go/v14 v14.0.0-20231014001145-dbcb1498009c h1:z0ZtXv
 github.com/cloudquery/arrow/go/v14 v14.0.0-20231014001145-dbcb1498009c/go.mod h1:EkHPhLB+98ANnPojOy2sUhM0rzYbPEmrtuA9v8aZp/c=
 github.com/cloudquery/cloudquery-api-go v1.2.8 h1:kzTuHxA/CwNFiCeg+rUZN+pe7lIi4w6FgbG2T+abGlI=
 github.com/cloudquery/cloudquery-api-go v1.2.8/go.mod h1:oyNUZZ6CKjPapxMbmE/qR2vdo9/G+tuCdF7uXT1LYuM=
-github.com/cloudquery/plugin-pb-go v1.12.2 h1:zDu+ClcuPLDcsyjiosyGpCADipPLhXNrc/sEC1WvWAU=
-github.com/cloudquery/plugin-pb-go v1.12.2/go.mod h1:CYorX3zCHF9ByoOgdBOuwLX/2vVCDH6/FoREOE3oH+w=
+github.com/cloudquery/plugin-pb-go v1.12.3 h1:rLK3/RR70/BX8tj2QzTnrjkxQhzfAT7SXEEEGuKr7Rk=
+github.com/cloudquery/plugin-pb-go v1.12.3/go.mod h1:CYorX3zCHF9ByoOgdBOuwLX/2vVCDH6/FoREOE3oH+w=
 github.com/cloudquery/plugin-sdk/v2 v2.7.0 h1:hRXsdEiaOxJtsn/wZMFQC9/jPfU1MeMK3KF+gPGqm7U=
 github.com/cloudquery/plugin-sdk/v2 v2.7.0/go.mod h1:pAX6ojIW99b/Vg4CkhnsGkRIzNaVEceYMR+Bdit73ug=
-github.com/cloudquery/plugin-sdk/v4 v4.12.5 h1:YLTIfYqnlaT5gz+Bv+CRrs9dX63e8mQNYNu3eteee+M=
-github.com/cloudquery/plugin-sdk/v4 v4.12.5/go.mod h1:WL9cNSAGEiEaUI5Go02hC5ZWUhei6TQJy/QEvbE1cCA=
+github.com/cloudquery/plugin-sdk/v4 v4.13.0 h1:ieTNPVPdzHAH6xQTOGz2sIS3WGtbfII6Rj4c9eBxQcs=
+github.com/cloudquery/plugin-sdk/v4 v4.13.0/go.mod h1:m7UY//dEzq2b/F6wDAqU2Vd9DLfZRrMjgn4qlnOrkPY=
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
 github.com/cncf/udpa/go v0.0.0-20201120205902-5459f2c99403/go.mod h1:WmhPx2Nbnhtbo57+VJT5O0JRkEi1Wbu0z5j0R8u5Hbk=
 github.com/cncf/udpa/go v0.0.0-20210930031921-04548b0d99d4/go.mod h1:6pvJx4me5XPnfI9Z40ddWsdw2W/uZgQLFXToKeRcDiI=

--- a/plugins/source/googleanalytics/go.mod
+++ b/plugins/source/googleanalytics/go.mod
@@ -5,7 +5,7 @@ go 1.21.1
 require (
 	github.com/apache/arrow/go/v14 v14.0.0-20230929201650-00efb06dc0de
 	github.com/cloudquery/codegen v0.3.8
-	github.com/cloudquery/plugin-sdk/v4 v4.12.5
+	github.com/cloudquery/plugin-sdk/v4 v4.13.0
 	github.com/invopop/jsonschema v0.11.0
 	github.com/rs/zerolog v1.29.1
 	github.com/stretchr/testify v1.8.4
@@ -41,7 +41,7 @@ require (
 	github.com/chenzhuoyu/base64x v0.0.0-20230717121745-296ad89f973d // indirect
 	github.com/chenzhuoyu/iasm v0.9.0 // indirect
 	github.com/cloudquery/cloudquery-api-go v1.2.8 // indirect
-	github.com/cloudquery/plugin-pb-go v1.12.2 // indirect
+	github.com/cloudquery/plugin-pb-go v1.12.3 // indirect
 	github.com/cloudquery/plugin-sdk/v2 v2.7.0 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/deepmap/oapi-codegen v1.15.0 // indirect

--- a/plugins/source/googleanalytics/go.sum
+++ b/plugins/source/googleanalytics/go.sum
@@ -96,12 +96,12 @@ github.com/cloudquery/codegen v0.3.8 h1:SViYwHVhjTzTAHkAtTPxFJ+vxhZOB6BZAXk9Dtcz
 github.com/cloudquery/codegen v0.3.8/go.mod h1:ovC0nEJ5a1CO+sUWTsvkizVgZaO6yUBbACRmy0d+v5Y=
 github.com/cloudquery/jsonschema v0.0.0-20231013155745-f32a9237eda0 h1:4L/chcVQqiOQXC9Y9/s51mbX5qWwaKa5sGGNXHkkD/A=
 github.com/cloudquery/jsonschema v0.0.0-20231013155745-f32a9237eda0/go.mod h1:ffZ5Km5SWWRAIN6wbDXItl95euhFz2uON45H2qjYt+0=
-github.com/cloudquery/plugin-pb-go v1.12.2 h1:zDu+ClcuPLDcsyjiosyGpCADipPLhXNrc/sEC1WvWAU=
-github.com/cloudquery/plugin-pb-go v1.12.2/go.mod h1:CYorX3zCHF9ByoOgdBOuwLX/2vVCDH6/FoREOE3oH+w=
+github.com/cloudquery/plugin-pb-go v1.12.3 h1:rLK3/RR70/BX8tj2QzTnrjkxQhzfAT7SXEEEGuKr7Rk=
+github.com/cloudquery/plugin-pb-go v1.12.3/go.mod h1:CYorX3zCHF9ByoOgdBOuwLX/2vVCDH6/FoREOE3oH+w=
 github.com/cloudquery/plugin-sdk/v2 v2.7.0 h1:hRXsdEiaOxJtsn/wZMFQC9/jPfU1MeMK3KF+gPGqm7U=
 github.com/cloudquery/plugin-sdk/v2 v2.7.0/go.mod h1:pAX6ojIW99b/Vg4CkhnsGkRIzNaVEceYMR+Bdit73ug=
-github.com/cloudquery/plugin-sdk/v4 v4.12.5 h1:YLTIfYqnlaT5gz+Bv+CRrs9dX63e8mQNYNu3eteee+M=
-github.com/cloudquery/plugin-sdk/v4 v4.12.5/go.mod h1:WL9cNSAGEiEaUI5Go02hC5ZWUhei6TQJy/QEvbE1cCA=
+github.com/cloudquery/plugin-sdk/v4 v4.13.0 h1:ieTNPVPdzHAH6xQTOGz2sIS3WGtbfII6Rj4c9eBxQcs=
+github.com/cloudquery/plugin-sdk/v4 v4.13.0/go.mod h1:m7UY//dEzq2b/F6wDAqU2Vd9DLfZRrMjgn4qlnOrkPY=
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
 github.com/cncf/udpa/go v0.0.0-20201120205902-5459f2c99403/go.mod h1:WmhPx2Nbnhtbo57+VJT5O0JRkEi1Wbu0z5j0R8u5Hbk=
 github.com/cncf/udpa/go v0.0.0-20210930031921-04548b0d99d4/go.mod h1:6pvJx4me5XPnfI9Z40ddWsdw2W/uZgQLFXToKeRcDiI=

--- a/plugins/source/hackernews/go.mod
+++ b/plugins/source/hackernews/go.mod
@@ -4,7 +4,7 @@ go 1.21.1
 
 require (
 	github.com/apache/arrow/go/v14 v14.0.0-20230929201650-00efb06dc0de
-	github.com/cloudquery/plugin-sdk/v4 v4.12.5
+	github.com/cloudquery/plugin-sdk/v4 v4.13.0
 	github.com/golang/mock v1.6.0
 	github.com/hermanschaaf/hackernews v1.0.1
 	github.com/rs/zerolog v1.29.1
@@ -33,7 +33,7 @@ require (
 	github.com/chenzhuoyu/base64x v0.0.0-20230717121745-296ad89f973d // indirect
 	github.com/chenzhuoyu/iasm v0.9.0 // indirect
 	github.com/cloudquery/cloudquery-api-go v1.2.8 // indirect
-	github.com/cloudquery/plugin-pb-go v1.12.2 // indirect
+	github.com/cloudquery/plugin-pb-go v1.12.3 // indirect
 	github.com/cloudquery/plugin-sdk/v2 v2.7.0 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/deepmap/oapi-codegen v1.15.0 // indirect

--- a/plugins/source/hackernews/go.sum
+++ b/plugins/source/hackernews/go.sum
@@ -88,12 +88,12 @@ github.com/cloudquery/arrow/go/v14 v14.0.0-20231014001145-dbcb1498009c h1:z0ZtXv
 github.com/cloudquery/arrow/go/v14 v14.0.0-20231014001145-dbcb1498009c/go.mod h1:EkHPhLB+98ANnPojOy2sUhM0rzYbPEmrtuA9v8aZp/c=
 github.com/cloudquery/cloudquery-api-go v1.2.8 h1:kzTuHxA/CwNFiCeg+rUZN+pe7lIi4w6FgbG2T+abGlI=
 github.com/cloudquery/cloudquery-api-go v1.2.8/go.mod h1:oyNUZZ6CKjPapxMbmE/qR2vdo9/G+tuCdF7uXT1LYuM=
-github.com/cloudquery/plugin-pb-go v1.12.2 h1:zDu+ClcuPLDcsyjiosyGpCADipPLhXNrc/sEC1WvWAU=
-github.com/cloudquery/plugin-pb-go v1.12.2/go.mod h1:CYorX3zCHF9ByoOgdBOuwLX/2vVCDH6/FoREOE3oH+w=
+github.com/cloudquery/plugin-pb-go v1.12.3 h1:rLK3/RR70/BX8tj2QzTnrjkxQhzfAT7SXEEEGuKr7Rk=
+github.com/cloudquery/plugin-pb-go v1.12.3/go.mod h1:CYorX3zCHF9ByoOgdBOuwLX/2vVCDH6/FoREOE3oH+w=
 github.com/cloudquery/plugin-sdk/v2 v2.7.0 h1:hRXsdEiaOxJtsn/wZMFQC9/jPfU1MeMK3KF+gPGqm7U=
 github.com/cloudquery/plugin-sdk/v2 v2.7.0/go.mod h1:pAX6ojIW99b/Vg4CkhnsGkRIzNaVEceYMR+Bdit73ug=
-github.com/cloudquery/plugin-sdk/v4 v4.12.5 h1:YLTIfYqnlaT5gz+Bv+CRrs9dX63e8mQNYNu3eteee+M=
-github.com/cloudquery/plugin-sdk/v4 v4.12.5/go.mod h1:WL9cNSAGEiEaUI5Go02hC5ZWUhei6TQJy/QEvbE1cCA=
+github.com/cloudquery/plugin-sdk/v4 v4.13.0 h1:ieTNPVPdzHAH6xQTOGz2sIS3WGtbfII6Rj4c9eBxQcs=
+github.com/cloudquery/plugin-sdk/v4 v4.13.0/go.mod h1:m7UY//dEzq2b/F6wDAqU2Vd9DLfZRrMjgn4qlnOrkPY=
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
 github.com/cncf/udpa/go v0.0.0-20201120205902-5459f2c99403/go.mod h1:WmhPx2Nbnhtbo57+VJT5O0JRkEi1Wbu0z5j0R8u5Hbk=
 github.com/cncf/udpa/go v0.0.0-20210930031921-04548b0d99d4/go.mod h1:6pvJx4me5XPnfI9Z40ddWsdw2W/uZgQLFXToKeRcDiI=

--- a/plugins/source/homebrew/go.mod
+++ b/plugins/source/homebrew/go.mod
@@ -3,7 +3,7 @@ module github.com/cloudquery/cloudquery/plugins/source/homebrew
 go 1.21.1
 
 require (
-	github.com/cloudquery/plugin-sdk/v4 v4.12.5
+	github.com/cloudquery/plugin-sdk/v4 v4.13.0
 	github.com/golang/mock v1.6.0
 	github.com/rs/zerolog v1.29.1
 )
@@ -28,7 +28,7 @@ require (
 	github.com/chenzhuoyu/base64x v0.0.0-20230717121745-296ad89f973d // indirect
 	github.com/chenzhuoyu/iasm v0.9.0 // indirect
 	github.com/cloudquery/cloudquery-api-go v1.2.8 // indirect
-	github.com/cloudquery/plugin-pb-go v1.12.2 // indirect
+	github.com/cloudquery/plugin-pb-go v1.12.3 // indirect
 	github.com/cloudquery/plugin-sdk/v2 v2.7.0 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/deepmap/oapi-codegen v1.15.0 // indirect

--- a/plugins/source/homebrew/go.sum
+++ b/plugins/source/homebrew/go.sum
@@ -88,12 +88,12 @@ github.com/cloudquery/arrow/go/v14 v14.0.0-20231014001145-dbcb1498009c h1:z0ZtXv
 github.com/cloudquery/arrow/go/v14 v14.0.0-20231014001145-dbcb1498009c/go.mod h1:EkHPhLB+98ANnPojOy2sUhM0rzYbPEmrtuA9v8aZp/c=
 github.com/cloudquery/cloudquery-api-go v1.2.8 h1:kzTuHxA/CwNFiCeg+rUZN+pe7lIi4w6FgbG2T+abGlI=
 github.com/cloudquery/cloudquery-api-go v1.2.8/go.mod h1:oyNUZZ6CKjPapxMbmE/qR2vdo9/G+tuCdF7uXT1LYuM=
-github.com/cloudquery/plugin-pb-go v1.12.2 h1:zDu+ClcuPLDcsyjiosyGpCADipPLhXNrc/sEC1WvWAU=
-github.com/cloudquery/plugin-pb-go v1.12.2/go.mod h1:CYorX3zCHF9ByoOgdBOuwLX/2vVCDH6/FoREOE3oH+w=
+github.com/cloudquery/plugin-pb-go v1.12.3 h1:rLK3/RR70/BX8tj2QzTnrjkxQhzfAT7SXEEEGuKr7Rk=
+github.com/cloudquery/plugin-pb-go v1.12.3/go.mod h1:CYorX3zCHF9ByoOgdBOuwLX/2vVCDH6/FoREOE3oH+w=
 github.com/cloudquery/plugin-sdk/v2 v2.7.0 h1:hRXsdEiaOxJtsn/wZMFQC9/jPfU1MeMK3KF+gPGqm7U=
 github.com/cloudquery/plugin-sdk/v2 v2.7.0/go.mod h1:pAX6ojIW99b/Vg4CkhnsGkRIzNaVEceYMR+Bdit73ug=
-github.com/cloudquery/plugin-sdk/v4 v4.12.5 h1:YLTIfYqnlaT5gz+Bv+CRrs9dX63e8mQNYNu3eteee+M=
-github.com/cloudquery/plugin-sdk/v4 v4.12.5/go.mod h1:WL9cNSAGEiEaUI5Go02hC5ZWUhei6TQJy/QEvbE1cCA=
+github.com/cloudquery/plugin-sdk/v4 v4.13.0 h1:ieTNPVPdzHAH6xQTOGz2sIS3WGtbfII6Rj4c9eBxQcs=
+github.com/cloudquery/plugin-sdk/v4 v4.13.0/go.mod h1:m7UY//dEzq2b/F6wDAqU2Vd9DLfZRrMjgn4qlnOrkPY=
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
 github.com/cncf/udpa/go v0.0.0-20201120205902-5459f2c99403/go.mod h1:WmhPx2Nbnhtbo57+VJT5O0JRkEi1Wbu0z5j0R8u5Hbk=
 github.com/cncf/udpa/go v0.0.0-20210930031921-04548b0d99d4/go.mod h1:6pvJx4me5XPnfI9Z40ddWsdw2W/uZgQLFXToKeRcDiI=

--- a/plugins/source/hubspot/go.mod
+++ b/plugins/source/hubspot/go.mod
@@ -5,7 +5,7 @@ go 1.21.1
 require (
 	github.com/apache/arrow/go/v14 v14.0.0-20230929201650-00efb06dc0de
 	github.com/clarkmcc/go-hubspot v0.0.0-20230906123538-bec7cb6c0126
-	github.com/cloudquery/plugin-sdk/v4 v4.12.5
+	github.com/cloudquery/plugin-sdk/v4 v4.13.0
 	github.com/rs/zerolog v1.29.1
 	golang.org/x/exp v0.0.0-20230905200255-921286631fa9
 	golang.org/x/time v0.3.0
@@ -30,7 +30,7 @@ require (
 	github.com/chenzhuoyu/base64x v0.0.0-20230717121745-296ad89f973d // indirect
 	github.com/chenzhuoyu/iasm v0.9.0 // indirect
 	github.com/cloudquery/cloudquery-api-go v1.2.8 // indirect
-	github.com/cloudquery/plugin-pb-go v1.12.2 // indirect
+	github.com/cloudquery/plugin-pb-go v1.12.3 // indirect
 	github.com/cloudquery/plugin-sdk/v2 v2.7.0 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/deepmap/oapi-codegen v1.15.0 // indirect

--- a/plugins/source/hubspot/go.sum
+++ b/plugins/source/hubspot/go.sum
@@ -90,12 +90,12 @@ github.com/cloudquery/arrow/go/v14 v14.0.0-20231014001145-dbcb1498009c h1:z0ZtXv
 github.com/cloudquery/arrow/go/v14 v14.0.0-20231014001145-dbcb1498009c/go.mod h1:EkHPhLB+98ANnPojOy2sUhM0rzYbPEmrtuA9v8aZp/c=
 github.com/cloudquery/cloudquery-api-go v1.2.8 h1:kzTuHxA/CwNFiCeg+rUZN+pe7lIi4w6FgbG2T+abGlI=
 github.com/cloudquery/cloudquery-api-go v1.2.8/go.mod h1:oyNUZZ6CKjPapxMbmE/qR2vdo9/G+tuCdF7uXT1LYuM=
-github.com/cloudquery/plugin-pb-go v1.12.2 h1:zDu+ClcuPLDcsyjiosyGpCADipPLhXNrc/sEC1WvWAU=
-github.com/cloudquery/plugin-pb-go v1.12.2/go.mod h1:CYorX3zCHF9ByoOgdBOuwLX/2vVCDH6/FoREOE3oH+w=
+github.com/cloudquery/plugin-pb-go v1.12.3 h1:rLK3/RR70/BX8tj2QzTnrjkxQhzfAT7SXEEEGuKr7Rk=
+github.com/cloudquery/plugin-pb-go v1.12.3/go.mod h1:CYorX3zCHF9ByoOgdBOuwLX/2vVCDH6/FoREOE3oH+w=
 github.com/cloudquery/plugin-sdk/v2 v2.7.0 h1:hRXsdEiaOxJtsn/wZMFQC9/jPfU1MeMK3KF+gPGqm7U=
 github.com/cloudquery/plugin-sdk/v2 v2.7.0/go.mod h1:pAX6ojIW99b/Vg4CkhnsGkRIzNaVEceYMR+Bdit73ug=
-github.com/cloudquery/plugin-sdk/v4 v4.12.5 h1:YLTIfYqnlaT5gz+Bv+CRrs9dX63e8mQNYNu3eteee+M=
-github.com/cloudquery/plugin-sdk/v4 v4.12.5/go.mod h1:WL9cNSAGEiEaUI5Go02hC5ZWUhei6TQJy/QEvbE1cCA=
+github.com/cloudquery/plugin-sdk/v4 v4.13.0 h1:ieTNPVPdzHAH6xQTOGz2sIS3WGtbfII6Rj4c9eBxQcs=
+github.com/cloudquery/plugin-sdk/v4 v4.13.0/go.mod h1:m7UY//dEzq2b/F6wDAqU2Vd9DLfZRrMjgn4qlnOrkPY=
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
 github.com/cncf/udpa/go v0.0.0-20201120205902-5459f2c99403/go.mod h1:WmhPx2Nbnhtbo57+VJT5O0JRkEi1Wbu0z5j0R8u5Hbk=
 github.com/cncf/udpa/go v0.0.0-20210930031921-04548b0d99d4/go.mod h1:6pvJx4me5XPnfI9Z40ddWsdw2W/uZgQLFXToKeRcDiI=

--- a/plugins/source/jira/go.mod
+++ b/plugins/source/jira/go.mod
@@ -4,7 +4,7 @@ go 1.21.1
 
 require (
 	github.com/andygrunwald/go-jira v1.16.0
-	github.com/cloudquery/plugin-sdk/v4 v4.12.5
+	github.com/cloudquery/plugin-sdk/v4 v4.13.0
 	github.com/rs/zerolog v1.30.0
 )
 
@@ -29,7 +29,7 @@ require (
 	github.com/chenzhuoyu/base64x v0.0.0-20230717121745-296ad89f973d // indirect
 	github.com/chenzhuoyu/iasm v0.9.0 // indirect
 	github.com/cloudquery/cloudquery-api-go v1.2.8 // indirect
-	github.com/cloudquery/plugin-pb-go v1.12.2 // indirect
+	github.com/cloudquery/plugin-pb-go v1.12.3 // indirect
 	github.com/cloudquery/plugin-sdk/v2 v2.7.0 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/deepmap/oapi-codegen v1.15.0 // indirect

--- a/plugins/source/jira/go.sum
+++ b/plugins/source/jira/go.sum
@@ -90,12 +90,12 @@ github.com/cloudquery/arrow/go/v14 v14.0.0-20231014001145-dbcb1498009c h1:z0ZtXv
 github.com/cloudquery/arrow/go/v14 v14.0.0-20231014001145-dbcb1498009c/go.mod h1:EkHPhLB+98ANnPojOy2sUhM0rzYbPEmrtuA9v8aZp/c=
 github.com/cloudquery/cloudquery-api-go v1.2.8 h1:kzTuHxA/CwNFiCeg+rUZN+pe7lIi4w6FgbG2T+abGlI=
 github.com/cloudquery/cloudquery-api-go v1.2.8/go.mod h1:oyNUZZ6CKjPapxMbmE/qR2vdo9/G+tuCdF7uXT1LYuM=
-github.com/cloudquery/plugin-pb-go v1.12.2 h1:zDu+ClcuPLDcsyjiosyGpCADipPLhXNrc/sEC1WvWAU=
-github.com/cloudquery/plugin-pb-go v1.12.2/go.mod h1:CYorX3zCHF9ByoOgdBOuwLX/2vVCDH6/FoREOE3oH+w=
+github.com/cloudquery/plugin-pb-go v1.12.3 h1:rLK3/RR70/BX8tj2QzTnrjkxQhzfAT7SXEEEGuKr7Rk=
+github.com/cloudquery/plugin-pb-go v1.12.3/go.mod h1:CYorX3zCHF9ByoOgdBOuwLX/2vVCDH6/FoREOE3oH+w=
 github.com/cloudquery/plugin-sdk/v2 v2.7.0 h1:hRXsdEiaOxJtsn/wZMFQC9/jPfU1MeMK3KF+gPGqm7U=
 github.com/cloudquery/plugin-sdk/v2 v2.7.0/go.mod h1:pAX6ojIW99b/Vg4CkhnsGkRIzNaVEceYMR+Bdit73ug=
-github.com/cloudquery/plugin-sdk/v4 v4.12.5 h1:YLTIfYqnlaT5gz+Bv+CRrs9dX63e8mQNYNu3eteee+M=
-github.com/cloudquery/plugin-sdk/v4 v4.12.5/go.mod h1:WL9cNSAGEiEaUI5Go02hC5ZWUhei6TQJy/QEvbE1cCA=
+github.com/cloudquery/plugin-sdk/v4 v4.13.0 h1:ieTNPVPdzHAH6xQTOGz2sIS3WGtbfII6Rj4c9eBxQcs=
+github.com/cloudquery/plugin-sdk/v4 v4.13.0/go.mod h1:m7UY//dEzq2b/F6wDAqU2Vd9DLfZRrMjgn4qlnOrkPY=
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
 github.com/cncf/udpa/go v0.0.0-20201120205902-5459f2c99403/go.mod h1:WmhPx2Nbnhtbo57+VJT5O0JRkEi1Wbu0z5j0R8u5Hbk=
 github.com/cncf/udpa/go v0.0.0-20210930031921-04548b0d99d4/go.mod h1:6pvJx4me5XPnfI9Z40ddWsdw2W/uZgQLFXToKeRcDiI=

--- a/plugins/source/k8s/go.mod
+++ b/plugins/source/k8s/go.mod
@@ -4,7 +4,7 @@ go 1.21.1
 
 require (
 	github.com/apache/arrow/go/v14 v14.0.0-20230929201650-00efb06dc0de
-	github.com/cloudquery/plugin-sdk/v4 v4.12.5
+	github.com/cloudquery/plugin-sdk/v4 v4.13.0
 	github.com/cockroachdb/cockroachdb-parser v0.0.0-20230705064001-302c9ad52e1a
 	github.com/golang/mock v1.6.0
 	github.com/google/gnostic v0.6.9
@@ -40,7 +40,7 @@ require (
 	github.com/chenzhuoyu/base64x v0.0.0-20230717121745-296ad89f973d // indirect
 	github.com/chenzhuoyu/iasm v0.9.0 // indirect
 	github.com/cloudquery/cloudquery-api-go v1.2.8 // indirect
-	github.com/cloudquery/plugin-pb-go v1.12.2 // indirect
+	github.com/cloudquery/plugin-pb-go v1.12.3 // indirect
 	github.com/cloudquery/plugin-sdk/v2 v2.7.0 // indirect
 	github.com/cockroachdb/apd/v3 v3.1.0 // indirect
 	github.com/cockroachdb/errors v1.9.0 // indirect

--- a/plugins/source/k8s/go.sum
+++ b/plugins/source/k8s/go.sum
@@ -118,12 +118,12 @@ github.com/cloudquery/arrow/go/v14 v14.0.0-20231014001145-dbcb1498009c h1:z0ZtXv
 github.com/cloudquery/arrow/go/v14 v14.0.0-20231014001145-dbcb1498009c/go.mod h1:EkHPhLB+98ANnPojOy2sUhM0rzYbPEmrtuA9v8aZp/c=
 github.com/cloudquery/cloudquery-api-go v1.2.8 h1:kzTuHxA/CwNFiCeg+rUZN+pe7lIi4w6FgbG2T+abGlI=
 github.com/cloudquery/cloudquery-api-go v1.2.8/go.mod h1:oyNUZZ6CKjPapxMbmE/qR2vdo9/G+tuCdF7uXT1LYuM=
-github.com/cloudquery/plugin-pb-go v1.12.2 h1:zDu+ClcuPLDcsyjiosyGpCADipPLhXNrc/sEC1WvWAU=
-github.com/cloudquery/plugin-pb-go v1.12.2/go.mod h1:CYorX3zCHF9ByoOgdBOuwLX/2vVCDH6/FoREOE3oH+w=
+github.com/cloudquery/plugin-pb-go v1.12.3 h1:rLK3/RR70/BX8tj2QzTnrjkxQhzfAT7SXEEEGuKr7Rk=
+github.com/cloudquery/plugin-pb-go v1.12.3/go.mod h1:CYorX3zCHF9ByoOgdBOuwLX/2vVCDH6/FoREOE3oH+w=
 github.com/cloudquery/plugin-sdk/v2 v2.7.0 h1:hRXsdEiaOxJtsn/wZMFQC9/jPfU1MeMK3KF+gPGqm7U=
 github.com/cloudquery/plugin-sdk/v2 v2.7.0/go.mod h1:pAX6ojIW99b/Vg4CkhnsGkRIzNaVEceYMR+Bdit73ug=
-github.com/cloudquery/plugin-sdk/v4 v4.12.5 h1:YLTIfYqnlaT5gz+Bv+CRrs9dX63e8mQNYNu3eteee+M=
-github.com/cloudquery/plugin-sdk/v4 v4.12.5/go.mod h1:WL9cNSAGEiEaUI5Go02hC5ZWUhei6TQJy/QEvbE1cCA=
+github.com/cloudquery/plugin-sdk/v4 v4.13.0 h1:ieTNPVPdzHAH6xQTOGz2sIS3WGtbfII6Rj4c9eBxQcs=
+github.com/cloudquery/plugin-sdk/v4 v4.13.0/go.mod h1:m7UY//dEzq2b/F6wDAqU2Vd9DLfZRrMjgn4qlnOrkPY=
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
 github.com/cncf/udpa/go v0.0.0-20201120205902-5459f2c99403/go.mod h1:WmhPx2Nbnhtbo57+VJT5O0JRkEi1Wbu0z5j0R8u5Hbk=
 github.com/cncf/udpa/go v0.0.0-20210930031921-04548b0d99d4/go.mod h1:6pvJx4me5XPnfI9Z40ddWsdw2W/uZgQLFXToKeRcDiI=

--- a/plugins/source/mysql/go.mod
+++ b/plugins/source/mysql/go.mod
@@ -4,7 +4,7 @@ go 1.21.1
 
 require (
 	github.com/apache/arrow/go/v14 v14.0.0-20230929201650-00efb06dc0de
-	github.com/cloudquery/plugin-sdk/v4 v4.12.5
+	github.com/cloudquery/plugin-sdk/v4 v4.13.0
 	github.com/go-sql-driver/mysql v1.7.0
 	github.com/rs/zerolog v1.29.1
 	github.com/stretchr/testify v1.8.4
@@ -29,7 +29,7 @@ require (
 	github.com/chenzhuoyu/base64x v0.0.0-20230717121745-296ad89f973d // indirect
 	github.com/chenzhuoyu/iasm v0.9.0 // indirect
 	github.com/cloudquery/cloudquery-api-go v1.2.8 // indirect
-	github.com/cloudquery/plugin-pb-go v1.12.2 // indirect
+	github.com/cloudquery/plugin-pb-go v1.12.3 // indirect
 	github.com/cloudquery/plugin-sdk/v2 v2.7.0 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/deepmap/oapi-codegen v1.15.0 // indirect

--- a/plugins/source/mysql/go.sum
+++ b/plugins/source/mysql/go.sum
@@ -84,12 +84,12 @@ github.com/cloudquery/arrow/go/v14 v14.0.0-20231014001145-dbcb1498009c h1:z0ZtXv
 github.com/cloudquery/arrow/go/v14 v14.0.0-20231014001145-dbcb1498009c/go.mod h1:EkHPhLB+98ANnPojOy2sUhM0rzYbPEmrtuA9v8aZp/c=
 github.com/cloudquery/cloudquery-api-go v1.2.8 h1:kzTuHxA/CwNFiCeg+rUZN+pe7lIi4w6FgbG2T+abGlI=
 github.com/cloudquery/cloudquery-api-go v1.2.8/go.mod h1:oyNUZZ6CKjPapxMbmE/qR2vdo9/G+tuCdF7uXT1LYuM=
-github.com/cloudquery/plugin-pb-go v1.12.2 h1:zDu+ClcuPLDcsyjiosyGpCADipPLhXNrc/sEC1WvWAU=
-github.com/cloudquery/plugin-pb-go v1.12.2/go.mod h1:CYorX3zCHF9ByoOgdBOuwLX/2vVCDH6/FoREOE3oH+w=
+github.com/cloudquery/plugin-pb-go v1.12.3 h1:rLK3/RR70/BX8tj2QzTnrjkxQhzfAT7SXEEEGuKr7Rk=
+github.com/cloudquery/plugin-pb-go v1.12.3/go.mod h1:CYorX3zCHF9ByoOgdBOuwLX/2vVCDH6/FoREOE3oH+w=
 github.com/cloudquery/plugin-sdk/v2 v2.7.0 h1:hRXsdEiaOxJtsn/wZMFQC9/jPfU1MeMK3KF+gPGqm7U=
 github.com/cloudquery/plugin-sdk/v2 v2.7.0/go.mod h1:pAX6ojIW99b/Vg4CkhnsGkRIzNaVEceYMR+Bdit73ug=
-github.com/cloudquery/plugin-sdk/v4 v4.12.5 h1:YLTIfYqnlaT5gz+Bv+CRrs9dX63e8mQNYNu3eteee+M=
-github.com/cloudquery/plugin-sdk/v4 v4.12.5/go.mod h1:WL9cNSAGEiEaUI5Go02hC5ZWUhei6TQJy/QEvbE1cCA=
+github.com/cloudquery/plugin-sdk/v4 v4.13.0 h1:ieTNPVPdzHAH6xQTOGz2sIS3WGtbfII6Rj4c9eBxQcs=
+github.com/cloudquery/plugin-sdk/v4 v4.13.0/go.mod h1:m7UY//dEzq2b/F6wDAqU2Vd9DLfZRrMjgn4qlnOrkPY=
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
 github.com/cncf/udpa/go v0.0.0-20201120205902-5459f2c99403/go.mod h1:WmhPx2Nbnhtbo57+VJT5O0JRkEi1Wbu0z5j0R8u5Hbk=
 github.com/cncf/udpa/go v0.0.0-20210930031921-04548b0d99d4/go.mod h1:6pvJx4me5XPnfI9Z40ddWsdw2W/uZgQLFXToKeRcDiI=

--- a/plugins/source/notion/go.mod
+++ b/plugins/source/notion/go.mod
@@ -3,7 +3,7 @@ module github.com/cloudquery/cloudquery/plugins/source/notion
 go 1.21.1
 
 require (
-	github.com/cloudquery/plugin-sdk/v4 v4.12.5
+	github.com/cloudquery/plugin-sdk/v4 v4.13.0
 	github.com/rs/zerolog v1.30.0
 )
 
@@ -27,7 +27,7 @@ require (
 	github.com/chenzhuoyu/base64x v0.0.0-20230717121745-296ad89f973d // indirect
 	github.com/chenzhuoyu/iasm v0.9.0 // indirect
 	github.com/cloudquery/cloudquery-api-go v1.2.8 // indirect
-	github.com/cloudquery/plugin-pb-go v1.12.2 // indirect
+	github.com/cloudquery/plugin-pb-go v1.12.3 // indirect
 	github.com/cloudquery/plugin-sdk/v2 v2.7.0 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/deepmap/oapi-codegen v1.15.0 // indirect

--- a/plugins/source/notion/go.sum
+++ b/plugins/source/notion/go.sum
@@ -88,12 +88,12 @@ github.com/cloudquery/arrow/go/v14 v14.0.0-20231014001145-dbcb1498009c h1:z0ZtXv
 github.com/cloudquery/arrow/go/v14 v14.0.0-20231014001145-dbcb1498009c/go.mod h1:EkHPhLB+98ANnPojOy2sUhM0rzYbPEmrtuA9v8aZp/c=
 github.com/cloudquery/cloudquery-api-go v1.2.8 h1:kzTuHxA/CwNFiCeg+rUZN+pe7lIi4w6FgbG2T+abGlI=
 github.com/cloudquery/cloudquery-api-go v1.2.8/go.mod h1:oyNUZZ6CKjPapxMbmE/qR2vdo9/G+tuCdF7uXT1LYuM=
-github.com/cloudquery/plugin-pb-go v1.12.2 h1:zDu+ClcuPLDcsyjiosyGpCADipPLhXNrc/sEC1WvWAU=
-github.com/cloudquery/plugin-pb-go v1.12.2/go.mod h1:CYorX3zCHF9ByoOgdBOuwLX/2vVCDH6/FoREOE3oH+w=
+github.com/cloudquery/plugin-pb-go v1.12.3 h1:rLK3/RR70/BX8tj2QzTnrjkxQhzfAT7SXEEEGuKr7Rk=
+github.com/cloudquery/plugin-pb-go v1.12.3/go.mod h1:CYorX3zCHF9ByoOgdBOuwLX/2vVCDH6/FoREOE3oH+w=
 github.com/cloudquery/plugin-sdk/v2 v2.7.0 h1:hRXsdEiaOxJtsn/wZMFQC9/jPfU1MeMK3KF+gPGqm7U=
 github.com/cloudquery/plugin-sdk/v2 v2.7.0/go.mod h1:pAX6ojIW99b/Vg4CkhnsGkRIzNaVEceYMR+Bdit73ug=
-github.com/cloudquery/plugin-sdk/v4 v4.12.5 h1:YLTIfYqnlaT5gz+Bv+CRrs9dX63e8mQNYNu3eteee+M=
-github.com/cloudquery/plugin-sdk/v4 v4.12.5/go.mod h1:WL9cNSAGEiEaUI5Go02hC5ZWUhei6TQJy/QEvbE1cCA=
+github.com/cloudquery/plugin-sdk/v4 v4.13.0 h1:ieTNPVPdzHAH6xQTOGz2sIS3WGtbfII6Rj4c9eBxQcs=
+github.com/cloudquery/plugin-sdk/v4 v4.13.0/go.mod h1:m7UY//dEzq2b/F6wDAqU2Vd9DLfZRrMjgn4qlnOrkPY=
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
 github.com/cncf/udpa/go v0.0.0-20201120205902-5459f2c99403/go.mod h1:WmhPx2Nbnhtbo57+VJT5O0JRkEi1Wbu0z5j0R8u5Hbk=
 github.com/cncf/udpa/go v0.0.0-20210930031921-04548b0d99d4/go.mod h1:6pvJx4me5XPnfI9Z40ddWsdw2W/uZgQLFXToKeRcDiI=

--- a/plugins/source/okta/go.mod
+++ b/plugins/source/okta/go.mod
@@ -4,7 +4,7 @@ go 1.21.1
 
 require (
 	github.com/apache/arrow/go/v14 v14.0.0-20230929201650-00efb06dc0de
-	github.com/cloudquery/plugin-sdk/v4 v4.12.5
+	github.com/cloudquery/plugin-sdk/v4 v4.13.0
 	github.com/gorilla/mux v1.8.0
 	github.com/okta/okta-sdk-golang/v3 v3.0.2
 	github.com/rs/zerolog v1.29.1
@@ -30,7 +30,7 @@ require (
 	github.com/chenzhuoyu/base64x v0.0.0-20230717121745-296ad89f973d // indirect
 	github.com/chenzhuoyu/iasm v0.9.0 // indirect
 	github.com/cloudquery/cloudquery-api-go v1.2.8 // indirect
-	github.com/cloudquery/plugin-pb-go v1.12.2 // indirect
+	github.com/cloudquery/plugin-pb-go v1.12.3 // indirect
 	github.com/cloudquery/plugin-sdk/v2 v2.7.0 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/deepmap/oapi-codegen v1.15.0 // indirect

--- a/plugins/source/okta/go.sum
+++ b/plugins/source/okta/go.sum
@@ -89,12 +89,12 @@ github.com/cloudquery/arrow/go/v14 v14.0.0-20231014001145-dbcb1498009c h1:z0ZtXv
 github.com/cloudquery/arrow/go/v14 v14.0.0-20231014001145-dbcb1498009c/go.mod h1:EkHPhLB+98ANnPojOy2sUhM0rzYbPEmrtuA9v8aZp/c=
 github.com/cloudquery/cloudquery-api-go v1.2.8 h1:kzTuHxA/CwNFiCeg+rUZN+pe7lIi4w6FgbG2T+abGlI=
 github.com/cloudquery/cloudquery-api-go v1.2.8/go.mod h1:oyNUZZ6CKjPapxMbmE/qR2vdo9/G+tuCdF7uXT1LYuM=
-github.com/cloudquery/plugin-pb-go v1.12.2 h1:zDu+ClcuPLDcsyjiosyGpCADipPLhXNrc/sEC1WvWAU=
-github.com/cloudquery/plugin-pb-go v1.12.2/go.mod h1:CYorX3zCHF9ByoOgdBOuwLX/2vVCDH6/FoREOE3oH+w=
+github.com/cloudquery/plugin-pb-go v1.12.3 h1:rLK3/RR70/BX8tj2QzTnrjkxQhzfAT7SXEEEGuKr7Rk=
+github.com/cloudquery/plugin-pb-go v1.12.3/go.mod h1:CYorX3zCHF9ByoOgdBOuwLX/2vVCDH6/FoREOE3oH+w=
 github.com/cloudquery/plugin-sdk/v2 v2.7.0 h1:hRXsdEiaOxJtsn/wZMFQC9/jPfU1MeMK3KF+gPGqm7U=
 github.com/cloudquery/plugin-sdk/v2 v2.7.0/go.mod h1:pAX6ojIW99b/Vg4CkhnsGkRIzNaVEceYMR+Bdit73ug=
-github.com/cloudquery/plugin-sdk/v4 v4.12.5 h1:YLTIfYqnlaT5gz+Bv+CRrs9dX63e8mQNYNu3eteee+M=
-github.com/cloudquery/plugin-sdk/v4 v4.12.5/go.mod h1:WL9cNSAGEiEaUI5Go02hC5ZWUhei6TQJy/QEvbE1cCA=
+github.com/cloudquery/plugin-sdk/v4 v4.13.0 h1:ieTNPVPdzHAH6xQTOGz2sIS3WGtbfII6Rj4c9eBxQcs=
+github.com/cloudquery/plugin-sdk/v4 v4.13.0/go.mod h1:m7UY//dEzq2b/F6wDAqU2Vd9DLfZRrMjgn4qlnOrkPY=
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
 github.com/cncf/udpa/go v0.0.0-20201120205902-5459f2c99403/go.mod h1:WmhPx2Nbnhtbo57+VJT5O0JRkEi1Wbu0z5j0R8u5Hbk=
 github.com/cncf/udpa/go v0.0.0-20210930031921-04548b0d99d4/go.mod h1:6pvJx4me5XPnfI9Z40ddWsdw2W/uZgQLFXToKeRcDiI=

--- a/plugins/source/oracle/go.mod
+++ b/plugins/source/oracle/go.mod
@@ -5,7 +5,7 @@ go 1.21.1
 require (
 	github.com/apache/arrow/go/v14 v14.0.0-20230929201650-00efb06dc0de
 	github.com/cloudquery/codegen v0.3.8
-	github.com/cloudquery/plugin-sdk/v4 v4.12.5
+	github.com/cloudquery/plugin-sdk/v4 v4.13.0
 	github.com/oracle/oci-go-sdk/v65 v65.28.3
 	github.com/rs/zerolog v1.29.1
 	github.com/stretchr/testify v1.8.4
@@ -35,7 +35,7 @@ require (
 	github.com/chenzhuoyu/base64x v0.0.0-20230717121745-296ad89f973d // indirect
 	github.com/chenzhuoyu/iasm v0.9.0 // indirect
 	github.com/cloudquery/cloudquery-api-go v1.2.8 // indirect
-	github.com/cloudquery/plugin-pb-go v1.12.2 // indirect
+	github.com/cloudquery/plugin-pb-go v1.12.3 // indirect
 	github.com/cloudquery/plugin-sdk/v2 v2.7.0 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/deepmap/oapi-codegen v1.15.0 // indirect

--- a/plugins/source/oracle/go.sum
+++ b/plugins/source/oracle/go.sum
@@ -92,12 +92,12 @@ github.com/cloudquery/codegen v0.3.8 h1:SViYwHVhjTzTAHkAtTPxFJ+vxhZOB6BZAXk9Dtcz
 github.com/cloudquery/codegen v0.3.8/go.mod h1:ovC0nEJ5a1CO+sUWTsvkizVgZaO6yUBbACRmy0d+v5Y=
 github.com/cloudquery/jsonschema v0.0.0-20231012111802-b28735982a93 h1:Rgtj0YMsk5BGD76Y38xCAHEtfOguxntnJO/q+oCAry4=
 github.com/cloudquery/jsonschema v0.0.0-20231012111802-b28735982a93/go.mod h1:ffZ5Km5SWWRAIN6wbDXItl95euhFz2uON45H2qjYt+0=
-github.com/cloudquery/plugin-pb-go v1.12.2 h1:zDu+ClcuPLDcsyjiosyGpCADipPLhXNrc/sEC1WvWAU=
-github.com/cloudquery/plugin-pb-go v1.12.2/go.mod h1:CYorX3zCHF9ByoOgdBOuwLX/2vVCDH6/FoREOE3oH+w=
+github.com/cloudquery/plugin-pb-go v1.12.3 h1:rLK3/RR70/BX8tj2QzTnrjkxQhzfAT7SXEEEGuKr7Rk=
+github.com/cloudquery/plugin-pb-go v1.12.3/go.mod h1:CYorX3zCHF9ByoOgdBOuwLX/2vVCDH6/FoREOE3oH+w=
 github.com/cloudquery/plugin-sdk/v2 v2.7.0 h1:hRXsdEiaOxJtsn/wZMFQC9/jPfU1MeMK3KF+gPGqm7U=
 github.com/cloudquery/plugin-sdk/v2 v2.7.0/go.mod h1:pAX6ojIW99b/Vg4CkhnsGkRIzNaVEceYMR+Bdit73ug=
-github.com/cloudquery/plugin-sdk/v4 v4.12.5 h1:YLTIfYqnlaT5gz+Bv+CRrs9dX63e8mQNYNu3eteee+M=
-github.com/cloudquery/plugin-sdk/v4 v4.12.5/go.mod h1:WL9cNSAGEiEaUI5Go02hC5ZWUhei6TQJy/QEvbE1cCA=
+github.com/cloudquery/plugin-sdk/v4 v4.13.0 h1:ieTNPVPdzHAH6xQTOGz2sIS3WGtbfII6Rj4c9eBxQcs=
+github.com/cloudquery/plugin-sdk/v4 v4.13.0/go.mod h1:m7UY//dEzq2b/F6wDAqU2Vd9DLfZRrMjgn4qlnOrkPY=
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
 github.com/cncf/udpa/go v0.0.0-20201120205902-5459f2c99403/go.mod h1:WmhPx2Nbnhtbo57+VJT5O0JRkEi1Wbu0z5j0R8u5Hbk=
 github.com/cncf/udpa/go v0.0.0-20210930031921-04548b0d99d4/go.mod h1:6pvJx4me5XPnfI9Z40ddWsdw2W/uZgQLFXToKeRcDiI=

--- a/plugins/source/oracledb/go.mod
+++ b/plugins/source/oracledb/go.mod
@@ -4,7 +4,7 @@ go 1.21.1
 
 require (
 	github.com/apache/arrow/go/v14 v14.0.0-20230929201650-00efb06dc0de
-	github.com/cloudquery/plugin-sdk/v4 v4.12.5
+	github.com/cloudquery/plugin-sdk/v4 v4.13.0
 	github.com/rs/zerolog v1.29.1
 	github.com/sijms/go-ora/v2 v2.7.9
 	github.com/stretchr/testify v1.8.4
@@ -29,7 +29,7 @@ require (
 	github.com/chenzhuoyu/base64x v0.0.0-20230717121745-296ad89f973d // indirect
 	github.com/chenzhuoyu/iasm v0.9.0 // indirect
 	github.com/cloudquery/cloudquery-api-go v1.2.8 // indirect
-	github.com/cloudquery/plugin-pb-go v1.12.2 // indirect
+	github.com/cloudquery/plugin-pb-go v1.12.3 // indirect
 	github.com/cloudquery/plugin-sdk/v2 v2.7.0 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/deepmap/oapi-codegen v1.15.0 // indirect

--- a/plugins/source/oracledb/go.sum
+++ b/plugins/source/oracledb/go.sum
@@ -84,12 +84,12 @@ github.com/cloudquery/arrow/go/v14 v14.0.0-20231014001145-dbcb1498009c h1:z0ZtXv
 github.com/cloudquery/arrow/go/v14 v14.0.0-20231014001145-dbcb1498009c/go.mod h1:EkHPhLB+98ANnPojOy2sUhM0rzYbPEmrtuA9v8aZp/c=
 github.com/cloudquery/cloudquery-api-go v1.2.8 h1:kzTuHxA/CwNFiCeg+rUZN+pe7lIi4w6FgbG2T+abGlI=
 github.com/cloudquery/cloudquery-api-go v1.2.8/go.mod h1:oyNUZZ6CKjPapxMbmE/qR2vdo9/G+tuCdF7uXT1LYuM=
-github.com/cloudquery/plugin-pb-go v1.12.2 h1:zDu+ClcuPLDcsyjiosyGpCADipPLhXNrc/sEC1WvWAU=
-github.com/cloudquery/plugin-pb-go v1.12.2/go.mod h1:CYorX3zCHF9ByoOgdBOuwLX/2vVCDH6/FoREOE3oH+w=
+github.com/cloudquery/plugin-pb-go v1.12.3 h1:rLK3/RR70/BX8tj2QzTnrjkxQhzfAT7SXEEEGuKr7Rk=
+github.com/cloudquery/plugin-pb-go v1.12.3/go.mod h1:CYorX3zCHF9ByoOgdBOuwLX/2vVCDH6/FoREOE3oH+w=
 github.com/cloudquery/plugin-sdk/v2 v2.7.0 h1:hRXsdEiaOxJtsn/wZMFQC9/jPfU1MeMK3KF+gPGqm7U=
 github.com/cloudquery/plugin-sdk/v2 v2.7.0/go.mod h1:pAX6ojIW99b/Vg4CkhnsGkRIzNaVEceYMR+Bdit73ug=
-github.com/cloudquery/plugin-sdk/v4 v4.12.5 h1:YLTIfYqnlaT5gz+Bv+CRrs9dX63e8mQNYNu3eteee+M=
-github.com/cloudquery/plugin-sdk/v4 v4.12.5/go.mod h1:WL9cNSAGEiEaUI5Go02hC5ZWUhei6TQJy/QEvbE1cCA=
+github.com/cloudquery/plugin-sdk/v4 v4.13.0 h1:ieTNPVPdzHAH6xQTOGz2sIS3WGtbfII6Rj4c9eBxQcs=
+github.com/cloudquery/plugin-sdk/v4 v4.13.0/go.mod h1:m7UY//dEzq2b/F6wDAqU2Vd9DLfZRrMjgn4qlnOrkPY=
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
 github.com/cncf/udpa/go v0.0.0-20201120205902-5459f2c99403/go.mod h1:WmhPx2Nbnhtbo57+VJT5O0JRkEi1Wbu0z5j0R8u5Hbk=
 github.com/cncf/udpa/go v0.0.0-20210930031921-04548b0d99d4/go.mod h1:6pvJx4me5XPnfI9Z40ddWsdw2W/uZgQLFXToKeRcDiI=

--- a/plugins/source/pagerduty/go.mod
+++ b/plugins/source/pagerduty/go.mod
@@ -5,7 +5,7 @@ go 1.21.1
 require (
 	github.com/PagerDuty/go-pagerduty v1.6.0
 	github.com/apache/arrow/go/v14 v14.0.0-20230929201650-00efb06dc0de
-	github.com/cloudquery/plugin-sdk/v4 v4.12.5
+	github.com/cloudquery/plugin-sdk/v4 v4.13.0
 	github.com/rs/zerolog v1.29.1
 	golang.org/x/time v0.3.0
 	gopkg.in/yaml.v3 v3.0.1
@@ -30,7 +30,7 @@ require (
 	github.com/chenzhuoyu/base64x v0.0.0-20230717121745-296ad89f973d // indirect
 	github.com/chenzhuoyu/iasm v0.9.0 // indirect
 	github.com/cloudquery/cloudquery-api-go v1.2.8 // indirect
-	github.com/cloudquery/plugin-pb-go v1.12.2 // indirect
+	github.com/cloudquery/plugin-pb-go v1.12.3 // indirect
 	github.com/cloudquery/plugin-sdk/v2 v2.7.0 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/deepmap/oapi-codegen v1.15.0 // indirect

--- a/plugins/source/pagerduty/go.sum
+++ b/plugins/source/pagerduty/go.sum
@@ -92,12 +92,12 @@ github.com/cloudquery/arrow/go/v14 v14.0.0-20231014001145-dbcb1498009c h1:z0ZtXv
 github.com/cloudquery/arrow/go/v14 v14.0.0-20231014001145-dbcb1498009c/go.mod h1:EkHPhLB+98ANnPojOy2sUhM0rzYbPEmrtuA9v8aZp/c=
 github.com/cloudquery/cloudquery-api-go v1.2.8 h1:kzTuHxA/CwNFiCeg+rUZN+pe7lIi4w6FgbG2T+abGlI=
 github.com/cloudquery/cloudquery-api-go v1.2.8/go.mod h1:oyNUZZ6CKjPapxMbmE/qR2vdo9/G+tuCdF7uXT1LYuM=
-github.com/cloudquery/plugin-pb-go v1.12.2 h1:zDu+ClcuPLDcsyjiosyGpCADipPLhXNrc/sEC1WvWAU=
-github.com/cloudquery/plugin-pb-go v1.12.2/go.mod h1:CYorX3zCHF9ByoOgdBOuwLX/2vVCDH6/FoREOE3oH+w=
+github.com/cloudquery/plugin-pb-go v1.12.3 h1:rLK3/RR70/BX8tj2QzTnrjkxQhzfAT7SXEEEGuKr7Rk=
+github.com/cloudquery/plugin-pb-go v1.12.3/go.mod h1:CYorX3zCHF9ByoOgdBOuwLX/2vVCDH6/FoREOE3oH+w=
 github.com/cloudquery/plugin-sdk/v2 v2.7.0 h1:hRXsdEiaOxJtsn/wZMFQC9/jPfU1MeMK3KF+gPGqm7U=
 github.com/cloudquery/plugin-sdk/v2 v2.7.0/go.mod h1:pAX6ojIW99b/Vg4CkhnsGkRIzNaVEceYMR+Bdit73ug=
-github.com/cloudquery/plugin-sdk/v4 v4.12.5 h1:YLTIfYqnlaT5gz+Bv+CRrs9dX63e8mQNYNu3eteee+M=
-github.com/cloudquery/plugin-sdk/v4 v4.12.5/go.mod h1:WL9cNSAGEiEaUI5Go02hC5ZWUhei6TQJy/QEvbE1cCA=
+github.com/cloudquery/plugin-sdk/v4 v4.13.0 h1:ieTNPVPdzHAH6xQTOGz2sIS3WGtbfII6Rj4c9eBxQcs=
+github.com/cloudquery/plugin-sdk/v4 v4.13.0/go.mod h1:m7UY//dEzq2b/F6wDAqU2Vd9DLfZRrMjgn4qlnOrkPY=
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
 github.com/cncf/udpa/go v0.0.0-20201120205902-5459f2c99403/go.mod h1:WmhPx2Nbnhtbo57+VJT5O0JRkEi1Wbu0z5j0R8u5Hbk=
 github.com/cncf/udpa/go v0.0.0-20210930031921-04548b0d99d4/go.mod h1:6pvJx4me5XPnfI9Z40ddWsdw2W/uZgQLFXToKeRcDiI=

--- a/plugins/source/postgresql/go.mod
+++ b/plugins/source/postgresql/go.mod
@@ -4,7 +4,7 @@ go 1.21.1
 
 require (
 	github.com/apache/arrow/go/v14 v14.0.0-20230929201650-00efb06dc0de
-	github.com/cloudquery/plugin-sdk/v4 v4.12.5
+	github.com/cloudquery/plugin-sdk/v4 v4.13.0
 	github.com/google/uuid v1.3.1
 	github.com/jackc/pglogrepl v0.0.0-20230826184802-9ed16cb201f6
 	github.com/jackc/pgx-zerolog v0.0.0-20230315001418-f978528409eb
@@ -32,7 +32,7 @@ require (
 	github.com/chenzhuoyu/base64x v0.0.0-20230717121745-296ad89f973d // indirect
 	github.com/chenzhuoyu/iasm v0.9.0 // indirect
 	github.com/cloudquery/cloudquery-api-go v1.2.8 // indirect
-	github.com/cloudquery/plugin-pb-go v1.12.2 // indirect
+	github.com/cloudquery/plugin-pb-go v1.12.3 // indirect
 	github.com/cloudquery/plugin-sdk/v2 v2.7.0 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/deepmap/oapi-codegen v1.15.0 // indirect

--- a/plugins/source/postgresql/go.sum
+++ b/plugins/source/postgresql/go.sum
@@ -84,12 +84,12 @@ github.com/cloudquery/arrow/go/v14 v14.0.0-20231014001145-dbcb1498009c h1:z0ZtXv
 github.com/cloudquery/arrow/go/v14 v14.0.0-20231014001145-dbcb1498009c/go.mod h1:EkHPhLB+98ANnPojOy2sUhM0rzYbPEmrtuA9v8aZp/c=
 github.com/cloudquery/cloudquery-api-go v1.2.8 h1:kzTuHxA/CwNFiCeg+rUZN+pe7lIi4w6FgbG2T+abGlI=
 github.com/cloudquery/cloudquery-api-go v1.2.8/go.mod h1:oyNUZZ6CKjPapxMbmE/qR2vdo9/G+tuCdF7uXT1LYuM=
-github.com/cloudquery/plugin-pb-go v1.12.2 h1:zDu+ClcuPLDcsyjiosyGpCADipPLhXNrc/sEC1WvWAU=
-github.com/cloudquery/plugin-pb-go v1.12.2/go.mod h1:CYorX3zCHF9ByoOgdBOuwLX/2vVCDH6/FoREOE3oH+w=
+github.com/cloudquery/plugin-pb-go v1.12.3 h1:rLK3/RR70/BX8tj2QzTnrjkxQhzfAT7SXEEEGuKr7Rk=
+github.com/cloudquery/plugin-pb-go v1.12.3/go.mod h1:CYorX3zCHF9ByoOgdBOuwLX/2vVCDH6/FoREOE3oH+w=
 github.com/cloudquery/plugin-sdk/v2 v2.7.0 h1:hRXsdEiaOxJtsn/wZMFQC9/jPfU1MeMK3KF+gPGqm7U=
 github.com/cloudquery/plugin-sdk/v2 v2.7.0/go.mod h1:pAX6ojIW99b/Vg4CkhnsGkRIzNaVEceYMR+Bdit73ug=
-github.com/cloudquery/plugin-sdk/v4 v4.12.5 h1:YLTIfYqnlaT5gz+Bv+CRrs9dX63e8mQNYNu3eteee+M=
-github.com/cloudquery/plugin-sdk/v4 v4.12.5/go.mod h1:WL9cNSAGEiEaUI5Go02hC5ZWUhei6TQJy/QEvbE1cCA=
+github.com/cloudquery/plugin-sdk/v4 v4.13.0 h1:ieTNPVPdzHAH6xQTOGz2sIS3WGtbfII6Rj4c9eBxQcs=
+github.com/cloudquery/plugin-sdk/v4 v4.13.0/go.mod h1:m7UY//dEzq2b/F6wDAqU2Vd9DLfZRrMjgn4qlnOrkPY=
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
 github.com/cncf/udpa/go v0.0.0-20201120205902-5459f2c99403/go.mod h1:WmhPx2Nbnhtbo57+VJT5O0JRkEi1Wbu0z5j0R8u5Hbk=
 github.com/cncf/udpa/go v0.0.0-20210930031921-04548b0d99d4/go.mod h1:6pvJx4me5XPnfI9Z40ddWsdw2W/uZgQLFXToKeRcDiI=

--- a/plugins/source/salesforce/go.mod
+++ b/plugins/source/salesforce/go.mod
@@ -4,7 +4,7 @@ go 1.21.1
 
 require (
 	github.com/apache/arrow/go/v14 v14.0.0-20230929201650-00efb06dc0de
-	github.com/cloudquery/plugin-sdk/v4 v4.12.5
+	github.com/cloudquery/plugin-sdk/v4 v4.13.0
 	github.com/gorilla/mux v1.8.0
 	github.com/rs/zerolog v1.29.1
 )
@@ -28,7 +28,7 @@ require (
 	github.com/chenzhuoyu/base64x v0.0.0-20230717121745-296ad89f973d // indirect
 	github.com/chenzhuoyu/iasm v0.9.0 // indirect
 	github.com/cloudquery/cloudquery-api-go v1.2.8 // indirect
-	github.com/cloudquery/plugin-pb-go v1.12.2 // indirect
+	github.com/cloudquery/plugin-pb-go v1.12.3 // indirect
 	github.com/cloudquery/plugin-sdk/v2 v2.7.0 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/deepmap/oapi-codegen v1.15.0 // indirect

--- a/plugins/source/salesforce/go.sum
+++ b/plugins/source/salesforce/go.sum
@@ -88,12 +88,12 @@ github.com/cloudquery/arrow/go/v14 v14.0.0-20231014001145-dbcb1498009c h1:z0ZtXv
 github.com/cloudquery/arrow/go/v14 v14.0.0-20231014001145-dbcb1498009c/go.mod h1:EkHPhLB+98ANnPojOy2sUhM0rzYbPEmrtuA9v8aZp/c=
 github.com/cloudquery/cloudquery-api-go v1.2.8 h1:kzTuHxA/CwNFiCeg+rUZN+pe7lIi4w6FgbG2T+abGlI=
 github.com/cloudquery/cloudquery-api-go v1.2.8/go.mod h1:oyNUZZ6CKjPapxMbmE/qR2vdo9/G+tuCdF7uXT1LYuM=
-github.com/cloudquery/plugin-pb-go v1.12.2 h1:zDu+ClcuPLDcsyjiosyGpCADipPLhXNrc/sEC1WvWAU=
-github.com/cloudquery/plugin-pb-go v1.12.2/go.mod h1:CYorX3zCHF9ByoOgdBOuwLX/2vVCDH6/FoREOE3oH+w=
+github.com/cloudquery/plugin-pb-go v1.12.3 h1:rLK3/RR70/BX8tj2QzTnrjkxQhzfAT7SXEEEGuKr7Rk=
+github.com/cloudquery/plugin-pb-go v1.12.3/go.mod h1:CYorX3zCHF9ByoOgdBOuwLX/2vVCDH6/FoREOE3oH+w=
 github.com/cloudquery/plugin-sdk/v2 v2.7.0 h1:hRXsdEiaOxJtsn/wZMFQC9/jPfU1MeMK3KF+gPGqm7U=
 github.com/cloudquery/plugin-sdk/v2 v2.7.0/go.mod h1:pAX6ojIW99b/Vg4CkhnsGkRIzNaVEceYMR+Bdit73ug=
-github.com/cloudquery/plugin-sdk/v4 v4.12.5 h1:YLTIfYqnlaT5gz+Bv+CRrs9dX63e8mQNYNu3eteee+M=
-github.com/cloudquery/plugin-sdk/v4 v4.12.5/go.mod h1:WL9cNSAGEiEaUI5Go02hC5ZWUhei6TQJy/QEvbE1cCA=
+github.com/cloudquery/plugin-sdk/v4 v4.13.0 h1:ieTNPVPdzHAH6xQTOGz2sIS3WGtbfII6Rj4c9eBxQcs=
+github.com/cloudquery/plugin-sdk/v4 v4.13.0/go.mod h1:m7UY//dEzq2b/F6wDAqU2Vd9DLfZRrMjgn4qlnOrkPY=
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
 github.com/cncf/udpa/go v0.0.0-20201120205902-5459f2c99403/go.mod h1:WmhPx2Nbnhtbo57+VJT5O0JRkEi1Wbu0z5j0R8u5Hbk=
 github.com/cncf/udpa/go v0.0.0-20210930031921-04548b0d99d4/go.mod h1:6pvJx4me5XPnfI9Z40ddWsdw2W/uZgQLFXToKeRcDiI=

--- a/plugins/source/shopify/go.mod
+++ b/plugins/source/shopify/go.mod
@@ -4,7 +4,7 @@ go 1.21.1
 
 require (
 	github.com/apache/arrow/go/v14 v14.0.0-20230929201650-00efb06dc0de
-	github.com/cloudquery/plugin-sdk/v4 v4.12.5
+	github.com/cloudquery/plugin-sdk/v4 v4.13.0
 	github.com/gorilla/mux v1.8.0
 	github.com/rs/zerolog v1.29.1
 	golang.org/x/net v0.17.0
@@ -31,7 +31,7 @@ require (
 	github.com/chenzhuoyu/base64x v0.0.0-20230717121745-296ad89f973d // indirect
 	github.com/chenzhuoyu/iasm v0.9.0 // indirect
 	github.com/cloudquery/cloudquery-api-go v1.2.8 // indirect
-	github.com/cloudquery/plugin-pb-go v1.12.2 // indirect
+	github.com/cloudquery/plugin-pb-go v1.12.3 // indirect
 	github.com/cloudquery/plugin-sdk/v2 v2.7.0 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/deepmap/oapi-codegen v1.15.0 // indirect

--- a/plugins/source/shopify/go.sum
+++ b/plugins/source/shopify/go.sum
@@ -88,12 +88,12 @@ github.com/cloudquery/arrow/go/v14 v14.0.0-20231014001145-dbcb1498009c h1:z0ZtXv
 github.com/cloudquery/arrow/go/v14 v14.0.0-20231014001145-dbcb1498009c/go.mod h1:EkHPhLB+98ANnPojOy2sUhM0rzYbPEmrtuA9v8aZp/c=
 github.com/cloudquery/cloudquery-api-go v1.2.8 h1:kzTuHxA/CwNFiCeg+rUZN+pe7lIi4w6FgbG2T+abGlI=
 github.com/cloudquery/cloudquery-api-go v1.2.8/go.mod h1:oyNUZZ6CKjPapxMbmE/qR2vdo9/G+tuCdF7uXT1LYuM=
-github.com/cloudquery/plugin-pb-go v1.12.2 h1:zDu+ClcuPLDcsyjiosyGpCADipPLhXNrc/sEC1WvWAU=
-github.com/cloudquery/plugin-pb-go v1.12.2/go.mod h1:CYorX3zCHF9ByoOgdBOuwLX/2vVCDH6/FoREOE3oH+w=
+github.com/cloudquery/plugin-pb-go v1.12.3 h1:rLK3/RR70/BX8tj2QzTnrjkxQhzfAT7SXEEEGuKr7Rk=
+github.com/cloudquery/plugin-pb-go v1.12.3/go.mod h1:CYorX3zCHF9ByoOgdBOuwLX/2vVCDH6/FoREOE3oH+w=
 github.com/cloudquery/plugin-sdk/v2 v2.7.0 h1:hRXsdEiaOxJtsn/wZMFQC9/jPfU1MeMK3KF+gPGqm7U=
 github.com/cloudquery/plugin-sdk/v2 v2.7.0/go.mod h1:pAX6ojIW99b/Vg4CkhnsGkRIzNaVEceYMR+Bdit73ug=
-github.com/cloudquery/plugin-sdk/v4 v4.12.5 h1:YLTIfYqnlaT5gz+Bv+CRrs9dX63e8mQNYNu3eteee+M=
-github.com/cloudquery/plugin-sdk/v4 v4.12.5/go.mod h1:WL9cNSAGEiEaUI5Go02hC5ZWUhei6TQJy/QEvbE1cCA=
+github.com/cloudquery/plugin-sdk/v4 v4.13.0 h1:ieTNPVPdzHAH6xQTOGz2sIS3WGtbfII6Rj4c9eBxQcs=
+github.com/cloudquery/plugin-sdk/v4 v4.13.0/go.mod h1:m7UY//dEzq2b/F6wDAqU2Vd9DLfZRrMjgn4qlnOrkPY=
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
 github.com/cncf/udpa/go v0.0.0-20201120205902-5459f2c99403/go.mod h1:WmhPx2Nbnhtbo57+VJT5O0JRkEi1Wbu0z5j0R8u5Hbk=
 github.com/cncf/udpa/go v0.0.0-20210930031921-04548b0d99d4/go.mod h1:6pvJx4me5XPnfI9Z40ddWsdw2W/uZgQLFXToKeRcDiI=

--- a/plugins/source/snyk/go.mod
+++ b/plugins/source/snyk/go.mod
@@ -4,7 +4,7 @@ go 1.21.1
 
 require (
 	github.com/apache/arrow/go/v14 v14.0.0-20230929201650-00efb06dc0de
-	github.com/cloudquery/plugin-sdk/v4 v4.12.5
+	github.com/cloudquery/plugin-sdk/v4 v4.13.0
 	github.com/google/uuid v1.3.1
 	github.com/julienschmidt/httprouter v1.3.0
 	github.com/pavel-snyk/snyk-sdk-go v0.4.1
@@ -36,7 +36,7 @@ require (
 	github.com/chenzhuoyu/base64x v0.0.0-20230717121745-296ad89f973d // indirect
 	github.com/chenzhuoyu/iasm v0.9.0 // indirect
 	github.com/cloudquery/cloudquery-api-go v1.2.8 // indirect
-	github.com/cloudquery/plugin-pb-go v1.12.2 // indirect
+	github.com/cloudquery/plugin-pb-go v1.12.3 // indirect
 	github.com/cloudquery/plugin-sdk/v2 v2.7.0 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/deepmap/oapi-codegen v1.15.0 // indirect

--- a/plugins/source/snyk/go.sum
+++ b/plugins/source/snyk/go.sum
@@ -88,12 +88,12 @@ github.com/cloudquery/arrow/go/v14 v14.0.0-20231014001145-dbcb1498009c h1:z0ZtXv
 github.com/cloudquery/arrow/go/v14 v14.0.0-20231014001145-dbcb1498009c/go.mod h1:EkHPhLB+98ANnPojOy2sUhM0rzYbPEmrtuA9v8aZp/c=
 github.com/cloudquery/cloudquery-api-go v1.2.8 h1:kzTuHxA/CwNFiCeg+rUZN+pe7lIi4w6FgbG2T+abGlI=
 github.com/cloudquery/cloudquery-api-go v1.2.8/go.mod h1:oyNUZZ6CKjPapxMbmE/qR2vdo9/G+tuCdF7uXT1LYuM=
-github.com/cloudquery/plugin-pb-go v1.12.2 h1:zDu+ClcuPLDcsyjiosyGpCADipPLhXNrc/sEC1WvWAU=
-github.com/cloudquery/plugin-pb-go v1.12.2/go.mod h1:CYorX3zCHF9ByoOgdBOuwLX/2vVCDH6/FoREOE3oH+w=
+github.com/cloudquery/plugin-pb-go v1.12.3 h1:rLK3/RR70/BX8tj2QzTnrjkxQhzfAT7SXEEEGuKr7Rk=
+github.com/cloudquery/plugin-pb-go v1.12.3/go.mod h1:CYorX3zCHF9ByoOgdBOuwLX/2vVCDH6/FoREOE3oH+w=
 github.com/cloudquery/plugin-sdk/v2 v2.7.0 h1:hRXsdEiaOxJtsn/wZMFQC9/jPfU1MeMK3KF+gPGqm7U=
 github.com/cloudquery/plugin-sdk/v2 v2.7.0/go.mod h1:pAX6ojIW99b/Vg4CkhnsGkRIzNaVEceYMR+Bdit73ug=
-github.com/cloudquery/plugin-sdk/v4 v4.12.5 h1:YLTIfYqnlaT5gz+Bv+CRrs9dX63e8mQNYNu3eteee+M=
-github.com/cloudquery/plugin-sdk/v4 v4.12.5/go.mod h1:WL9cNSAGEiEaUI5Go02hC5ZWUhei6TQJy/QEvbE1cCA=
+github.com/cloudquery/plugin-sdk/v4 v4.13.0 h1:ieTNPVPdzHAH6xQTOGz2sIS3WGtbfII6Rj4c9eBxQcs=
+github.com/cloudquery/plugin-sdk/v4 v4.13.0/go.mod h1:m7UY//dEzq2b/F6wDAqU2Vd9DLfZRrMjgn4qlnOrkPY=
 github.com/cloudquery/snyk-sdk-go v0.5.0 h1:aDA94/ix7ro4V1qh2mk3/XTaT2j37ETRkOaYUR2pHc8=
 github.com/cloudquery/snyk-sdk-go v0.5.0/go.mod h1:LRL1TRuuM925gnyGp54WtS9p8S4yJMd0oS4JpLg+n7Y=
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=

--- a/plugins/source/stripe/go.mod
+++ b/plugins/source/stripe/go.mod
@@ -4,7 +4,7 @@ go 1.21.1
 
 require (
 	github.com/apache/arrow/go/v14 v14.0.0-20230929201650-00efb06dc0de
-	github.com/cloudquery/plugin-sdk/v4 v4.12.5
+	github.com/cloudquery/plugin-sdk/v4 v4.13.0
 	github.com/gertd/go-pluralize v0.2.1
 	github.com/rs/zerolog v1.29.1
 	github.com/stripe/stripe-go/v74 v74.16.0
@@ -32,7 +32,7 @@ require (
 	github.com/chenzhuoyu/base64x v0.0.0-20230717121745-296ad89f973d // indirect
 	github.com/chenzhuoyu/iasm v0.9.0 // indirect
 	github.com/cloudquery/cloudquery-api-go v1.2.8 // indirect
-	github.com/cloudquery/plugin-pb-go v1.12.2 // indirect
+	github.com/cloudquery/plugin-pb-go v1.12.3 // indirect
 	github.com/cloudquery/plugin-sdk/v2 v2.7.0 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/deepmap/oapi-codegen v1.15.0 // indirect

--- a/plugins/source/stripe/go.sum
+++ b/plugins/source/stripe/go.sum
@@ -88,12 +88,12 @@ github.com/cloudquery/arrow/go/v14 v14.0.0-20231014001145-dbcb1498009c h1:z0ZtXv
 github.com/cloudquery/arrow/go/v14 v14.0.0-20231014001145-dbcb1498009c/go.mod h1:EkHPhLB+98ANnPojOy2sUhM0rzYbPEmrtuA9v8aZp/c=
 github.com/cloudquery/cloudquery-api-go v1.2.8 h1:kzTuHxA/CwNFiCeg+rUZN+pe7lIi4w6FgbG2T+abGlI=
 github.com/cloudquery/cloudquery-api-go v1.2.8/go.mod h1:oyNUZZ6CKjPapxMbmE/qR2vdo9/G+tuCdF7uXT1LYuM=
-github.com/cloudquery/plugin-pb-go v1.12.2 h1:zDu+ClcuPLDcsyjiosyGpCADipPLhXNrc/sEC1WvWAU=
-github.com/cloudquery/plugin-pb-go v1.12.2/go.mod h1:CYorX3zCHF9ByoOgdBOuwLX/2vVCDH6/FoREOE3oH+w=
+github.com/cloudquery/plugin-pb-go v1.12.3 h1:rLK3/RR70/BX8tj2QzTnrjkxQhzfAT7SXEEEGuKr7Rk=
+github.com/cloudquery/plugin-pb-go v1.12.3/go.mod h1:CYorX3zCHF9ByoOgdBOuwLX/2vVCDH6/FoREOE3oH+w=
 github.com/cloudquery/plugin-sdk/v2 v2.7.0 h1:hRXsdEiaOxJtsn/wZMFQC9/jPfU1MeMK3KF+gPGqm7U=
 github.com/cloudquery/plugin-sdk/v2 v2.7.0/go.mod h1:pAX6ojIW99b/Vg4CkhnsGkRIzNaVEceYMR+Bdit73ug=
-github.com/cloudquery/plugin-sdk/v4 v4.12.5 h1:YLTIfYqnlaT5gz+Bv+CRrs9dX63e8mQNYNu3eteee+M=
-github.com/cloudquery/plugin-sdk/v4 v4.12.5/go.mod h1:WL9cNSAGEiEaUI5Go02hC5ZWUhei6TQJy/QEvbE1cCA=
+github.com/cloudquery/plugin-sdk/v4 v4.13.0 h1:ieTNPVPdzHAH6xQTOGz2sIS3WGtbfII6Rj4c9eBxQcs=
+github.com/cloudquery/plugin-sdk/v4 v4.13.0/go.mod h1:m7UY//dEzq2b/F6wDAqU2Vd9DLfZRrMjgn4qlnOrkPY=
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
 github.com/cncf/udpa/go v0.0.0-20201120205902-5459f2c99403/go.mod h1:WmhPx2Nbnhtbo57+VJT5O0JRkEi1Wbu0z5j0R8u5Hbk=
 github.com/cncf/udpa/go v0.0.0-20210930031921-04548b0d99d4/go.mod h1:6pvJx4me5XPnfI9Z40ddWsdw2W/uZgQLFXToKeRcDiI=

--- a/plugins/source/terraform/go.mod
+++ b/plugins/source/terraform/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/feature/s3/manager v1.11.79
 	github.com/aws/aws-sdk-go-v2/service/s3 v1.38.4
 	github.com/aws/aws-sdk-go-v2/service/sts v1.21.4
-	github.com/cloudquery/plugin-sdk/v4 v4.12.5
+	github.com/cloudquery/plugin-sdk/v4 v4.13.0
 	github.com/rs/zerolog v1.29.1
 	github.com/stretchr/testify v1.8.4
 )
@@ -47,7 +47,7 @@ require (
 	github.com/chenzhuoyu/base64x v0.0.0-20230717121745-296ad89f973d // indirect
 	github.com/chenzhuoyu/iasm v0.9.0 // indirect
 	github.com/cloudquery/cloudquery-api-go v1.2.8 // indirect
-	github.com/cloudquery/plugin-pb-go v1.12.2 // indirect
+	github.com/cloudquery/plugin-pb-go v1.12.3 // indirect
 	github.com/cloudquery/plugin-sdk/v2 v2.7.0 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/deepmap/oapi-codegen v1.15.0 // indirect

--- a/plugins/source/terraform/go.sum
+++ b/plugins/source/terraform/go.sum
@@ -126,12 +126,12 @@ github.com/cloudquery/arrow/go/v14 v14.0.0-20231014001145-dbcb1498009c h1:z0ZtXv
 github.com/cloudquery/arrow/go/v14 v14.0.0-20231014001145-dbcb1498009c/go.mod h1:EkHPhLB+98ANnPojOy2sUhM0rzYbPEmrtuA9v8aZp/c=
 github.com/cloudquery/cloudquery-api-go v1.2.8 h1:kzTuHxA/CwNFiCeg+rUZN+pe7lIi4w6FgbG2T+abGlI=
 github.com/cloudquery/cloudquery-api-go v1.2.8/go.mod h1:oyNUZZ6CKjPapxMbmE/qR2vdo9/G+tuCdF7uXT1LYuM=
-github.com/cloudquery/plugin-pb-go v1.12.2 h1:zDu+ClcuPLDcsyjiosyGpCADipPLhXNrc/sEC1WvWAU=
-github.com/cloudquery/plugin-pb-go v1.12.2/go.mod h1:CYorX3zCHF9ByoOgdBOuwLX/2vVCDH6/FoREOE3oH+w=
+github.com/cloudquery/plugin-pb-go v1.12.3 h1:rLK3/RR70/BX8tj2QzTnrjkxQhzfAT7SXEEEGuKr7Rk=
+github.com/cloudquery/plugin-pb-go v1.12.3/go.mod h1:CYorX3zCHF9ByoOgdBOuwLX/2vVCDH6/FoREOE3oH+w=
 github.com/cloudquery/plugin-sdk/v2 v2.7.0 h1:hRXsdEiaOxJtsn/wZMFQC9/jPfU1MeMK3KF+gPGqm7U=
 github.com/cloudquery/plugin-sdk/v2 v2.7.0/go.mod h1:pAX6ojIW99b/Vg4CkhnsGkRIzNaVEceYMR+Bdit73ug=
-github.com/cloudquery/plugin-sdk/v4 v4.12.5 h1:YLTIfYqnlaT5gz+Bv+CRrs9dX63e8mQNYNu3eteee+M=
-github.com/cloudquery/plugin-sdk/v4 v4.12.5/go.mod h1:WL9cNSAGEiEaUI5Go02hC5ZWUhei6TQJy/QEvbE1cCA=
+github.com/cloudquery/plugin-sdk/v4 v4.13.0 h1:ieTNPVPdzHAH6xQTOGz2sIS3WGtbfII6Rj4c9eBxQcs=
+github.com/cloudquery/plugin-sdk/v4 v4.13.0/go.mod h1:m7UY//dEzq2b/F6wDAqU2Vd9DLfZRrMjgn4qlnOrkPY=
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
 github.com/cncf/udpa/go v0.0.0-20201120205902-5459f2c99403/go.mod h1:WmhPx2Nbnhtbo57+VJT5O0JRkEi1Wbu0z5j0R8u5Hbk=
 github.com/cncf/udpa/go v0.0.0-20210930031921-04548b0d99d4/go.mod h1:6pvJx4me5XPnfI9Z40ddWsdw2W/uZgQLFXToKeRcDiI=

--- a/plugins/source/test/go.mod
+++ b/plugins/source/test/go.mod
@@ -4,7 +4,7 @@ go 1.21.1
 
 require (
 	github.com/apache/arrow/go/v14 v14.0.0-20230929201650-00efb06dc0de
-	github.com/cloudquery/plugin-sdk/v4 v4.12.5
+	github.com/cloudquery/plugin-sdk/v4 v4.13.0
 	github.com/rs/zerolog v1.29.1
 )
 
@@ -27,7 +27,7 @@ require (
 	github.com/chenzhuoyu/base64x v0.0.0-20230717121745-296ad89f973d // indirect
 	github.com/chenzhuoyu/iasm v0.9.0 // indirect
 	github.com/cloudquery/cloudquery-api-go v1.2.8 // indirect
-	github.com/cloudquery/plugin-pb-go v1.12.2 // indirect
+	github.com/cloudquery/plugin-pb-go v1.12.3 // indirect
 	github.com/cloudquery/plugin-sdk/v2 v2.7.0 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/deepmap/oapi-codegen v1.15.0 // indirect

--- a/plugins/source/test/go.sum
+++ b/plugins/source/test/go.sum
@@ -88,12 +88,12 @@ github.com/cloudquery/arrow/go/v14 v14.0.0-20231014001145-dbcb1498009c h1:z0ZtXv
 github.com/cloudquery/arrow/go/v14 v14.0.0-20231014001145-dbcb1498009c/go.mod h1:EkHPhLB+98ANnPojOy2sUhM0rzYbPEmrtuA9v8aZp/c=
 github.com/cloudquery/cloudquery-api-go v1.2.8 h1:kzTuHxA/CwNFiCeg+rUZN+pe7lIi4w6FgbG2T+abGlI=
 github.com/cloudquery/cloudquery-api-go v1.2.8/go.mod h1:oyNUZZ6CKjPapxMbmE/qR2vdo9/G+tuCdF7uXT1LYuM=
-github.com/cloudquery/plugin-pb-go v1.12.2 h1:zDu+ClcuPLDcsyjiosyGpCADipPLhXNrc/sEC1WvWAU=
-github.com/cloudquery/plugin-pb-go v1.12.2/go.mod h1:CYorX3zCHF9ByoOgdBOuwLX/2vVCDH6/FoREOE3oH+w=
+github.com/cloudquery/plugin-pb-go v1.12.3 h1:rLK3/RR70/BX8tj2QzTnrjkxQhzfAT7SXEEEGuKr7Rk=
+github.com/cloudquery/plugin-pb-go v1.12.3/go.mod h1:CYorX3zCHF9ByoOgdBOuwLX/2vVCDH6/FoREOE3oH+w=
 github.com/cloudquery/plugin-sdk/v2 v2.7.0 h1:hRXsdEiaOxJtsn/wZMFQC9/jPfU1MeMK3KF+gPGqm7U=
 github.com/cloudquery/plugin-sdk/v2 v2.7.0/go.mod h1:pAX6ojIW99b/Vg4CkhnsGkRIzNaVEceYMR+Bdit73ug=
-github.com/cloudquery/plugin-sdk/v4 v4.12.5 h1:YLTIfYqnlaT5gz+Bv+CRrs9dX63e8mQNYNu3eteee+M=
-github.com/cloudquery/plugin-sdk/v4 v4.12.5/go.mod h1:WL9cNSAGEiEaUI5Go02hC5ZWUhei6TQJy/QEvbE1cCA=
+github.com/cloudquery/plugin-sdk/v4 v4.13.0 h1:ieTNPVPdzHAH6xQTOGz2sIS3WGtbfII6Rj4c9eBxQcs=
+github.com/cloudquery/plugin-sdk/v4 v4.13.0/go.mod h1:m7UY//dEzq2b/F6wDAqU2Vd9DLfZRrMjgn4qlnOrkPY=
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
 github.com/cncf/udpa/go v0.0.0-20201120205902-5459f2c99403/go.mod h1:WmhPx2Nbnhtbo57+VJT5O0JRkEi1Wbu0z5j0R8u5Hbk=
 github.com/cncf/udpa/go v0.0.0-20210930031921-04548b0d99d4/go.mod h1:6pvJx4me5XPnfI9Z40ddWsdw2W/uZgQLFXToKeRcDiI=

--- a/plugins/source/vault/go.mod
+++ b/plugins/source/vault/go.mod
@@ -5,7 +5,7 @@ go 1.21.1
 require (
 	github.com/apache/arrow/go/v14 v14.0.0-20230929201650-00efb06dc0de
 	github.com/cloudquery/codegen v0.3.8
-	github.com/cloudquery/plugin-sdk/v4 v4.12.5
+	github.com/cloudquery/plugin-sdk/v4 v4.13.0
 	github.com/golang/mock v1.4.4
 	github.com/hashicorp/vault/api v1.9.2
 	github.com/rs/zerolog v1.29.1
@@ -32,7 +32,7 @@ require (
 	github.com/chenzhuoyu/base64x v0.0.0-20230717121745-296ad89f973d // indirect
 	github.com/chenzhuoyu/iasm v0.9.0 // indirect
 	github.com/cloudquery/cloudquery-api-go v1.2.8 // indirect
-	github.com/cloudquery/plugin-pb-go v1.12.2 // indirect
+	github.com/cloudquery/plugin-pb-go v1.12.3 // indirect
 	github.com/cloudquery/plugin-sdk/v2 v2.7.0 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/deepmap/oapi-codegen v1.15.0 // indirect

--- a/plugins/source/vault/go.sum
+++ b/plugins/source/vault/go.sum
@@ -104,12 +104,12 @@ github.com/cloudquery/cloudquery-api-go v1.2.8 h1:kzTuHxA/CwNFiCeg+rUZN+pe7lIi4w
 github.com/cloudquery/cloudquery-api-go v1.2.8/go.mod h1:oyNUZZ6CKjPapxMbmE/qR2vdo9/G+tuCdF7uXT1LYuM=
 github.com/cloudquery/codegen v0.3.8 h1:SViYwHVhjTzTAHkAtTPxFJ+vxhZOB6BZAXk9DtczeBk=
 github.com/cloudquery/codegen v0.3.8/go.mod h1:ovC0nEJ5a1CO+sUWTsvkizVgZaO6yUBbACRmy0d+v5Y=
-github.com/cloudquery/plugin-pb-go v1.12.2 h1:zDu+ClcuPLDcsyjiosyGpCADipPLhXNrc/sEC1WvWAU=
-github.com/cloudquery/plugin-pb-go v1.12.2/go.mod h1:CYorX3zCHF9ByoOgdBOuwLX/2vVCDH6/FoREOE3oH+w=
+github.com/cloudquery/plugin-pb-go v1.12.3 h1:rLK3/RR70/BX8tj2QzTnrjkxQhzfAT7SXEEEGuKr7Rk=
+github.com/cloudquery/plugin-pb-go v1.12.3/go.mod h1:CYorX3zCHF9ByoOgdBOuwLX/2vVCDH6/FoREOE3oH+w=
 github.com/cloudquery/plugin-sdk/v2 v2.7.0 h1:hRXsdEiaOxJtsn/wZMFQC9/jPfU1MeMK3KF+gPGqm7U=
 github.com/cloudquery/plugin-sdk/v2 v2.7.0/go.mod h1:pAX6ojIW99b/Vg4CkhnsGkRIzNaVEceYMR+Bdit73ug=
-github.com/cloudquery/plugin-sdk/v4 v4.12.5 h1:YLTIfYqnlaT5gz+Bv+CRrs9dX63e8mQNYNu3eteee+M=
-github.com/cloudquery/plugin-sdk/v4 v4.12.5/go.mod h1:WL9cNSAGEiEaUI5Go02hC5ZWUhei6TQJy/QEvbE1cCA=
+github.com/cloudquery/plugin-sdk/v4 v4.13.0 h1:ieTNPVPdzHAH6xQTOGz2sIS3WGtbfII6Rj4c9eBxQcs=
+github.com/cloudquery/plugin-sdk/v4 v4.13.0/go.mod h1:m7UY//dEzq2b/F6wDAqU2Vd9DLfZRrMjgn4qlnOrkPY=
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
 github.com/cncf/udpa/go v0.0.0-20201120205902-5459f2c99403/go.mod h1:WmhPx2Nbnhtbo57+VJT5O0JRkEi1Wbu0z5j0R8u5Hbk=
 github.com/cncf/udpa/go v0.0.0-20210930031921-04548b0d99d4/go.mod h1:6pvJx4me5XPnfI9Z40ddWsdw2W/uZgQLFXToKeRcDiI=


### PR DESCRIPTION
Manual bump of plugin-pb-go and plugin-sdk