### PR TITLE
fix: Github source plugin hanging on missing permissions

### DIFF
--- a/plugins/source/github/go.mod
+++ b/plugins/source/github/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/apache/arrow/go/v14 v14.0.0-20230929201650-00efb06dc0de
 	github.com/beatlabs/github-auth v0.0.0-20230912161003-cdaa33aa0d65
 	github.com/cloudquery/plugin-sdk/v4 v4.12.5
-	github.com/gofri/go-github-ratelimit v1.0.3
+	github.com/gofri/go-github-ratelimit v1.0.4
 	github.com/golang/mock v1.6.0
 	github.com/google/go-github/v49 v49.0.0
 	github.com/rs/zerolog v1.29.1

--- a/plugins/source/github/go.sum
+++ b/plugins/source/github/go.sum
@@ -156,8 +156,8 @@ github.com/gobwas/glob v0.2.3/go.mod h1:d3Ez4x06l9bZtSvzIay5+Yzi0fmZzPgnTbPcKjJA
 github.com/goccy/go-json v0.10.2 h1:CrxCmQqYDkv1z7lO7Wbh2HN93uovUHgrECaO5ZrCXAU=
 github.com/goccy/go-json v0.10.2/go.mod h1:6MelG93GURQebXPDq3khkgXZkazVtN9CRI+MGFi0w8I=
 github.com/godbus/dbus/v5 v5.0.4/go.mod h1:xhWf0FNVPg57R7Z0UbKHbJfkEywrmjJnf7w5xrFpKfA=
-github.com/gofri/go-github-ratelimit v1.0.3 h1:Ocs2jaYokZDzgvqaajX+g04dqFyVqL0JQzoO7d2wmlk=
-github.com/gofri/go-github-ratelimit v1.0.3/go.mod h1:OnCi5gV+hAG/LMR7llGhU7yHt44se9sYgKPnafoL7RY=
+github.com/gofri/go-github-ratelimit v1.0.4 h1:pOwtjHldpsDACBgBiyfa3exXbbu8hlQ9tgFPimnCZzM=
+github.com/gofri/go-github-ratelimit v1.0.4/go.mod h1:OnCi5gV+hAG/LMR7llGhU7yHt44se9sYgKPnafoL7RY=
 github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b/go.mod h1:SBH7ygxi8pfUlaOkMMuAQtPIUF8ecWP5IEl/CR7VP2Q=
 github.com/golang/glog v1.0.0/go.mod h1:EWib/APOK0SL3dFbYqvxE3UYd8E6s1ouQ7iEp/0LWV4=
 github.com/golang/glog v1.1.0 h1:/d3pCKDPWNnvIWe0vVUpNP32qc8U3PDVxySP/y360qE=


### PR DESCRIPTION
#### Summary

Bump `github.com/gofri/go-github-ratelimit` to v1.0.4 in the Github source plugin.

v1.0.3 treats `403 Forbidden` errors from the Github API due to missing permissions as breaching the rate limit, this causes the Cloudquery to wait until the rate limit reset (potentially up to an hour!) before trying again, at which point it will keep repeating this until the token is granted the correct permissions or the job is terminated.

v1.0.4 improves the rate limit detection behaviour so that it doesn't detect missing permission errors as being rate limited https://github.com/gofri/go-github-ratelimit/pull/13
