### PR TITLE
fix: Compile DuckDB, SQLite and Snowflake plugins for running under Alpine Linux 

### DIFF
--- a/plugins/destination/duckdb/.goreleaser.yaml
+++ b/plugins/destination/duckdb/.goreleaser.yaml
@@ -22,7 +22,7 @@ builds:
       - CC=/usr/bin/gencc.sh
       - CXX=/usr/bin/gencpp.sh
     ldflags:
-      - -s -w -X github.com/cloudquery/cloudquery/plugins/{{ .Var.component }}/resources/plugin.Version={{.Version}}
+      - -s -w -X github.com/cloudquery/cloudquery/plugins/{{ .Var.component }}/resources/plugin.Version={{.Version}} -linkmode external -extldflags=-static
     goos:
       # Windows disabled due to https://github.com/marcboeker/go-duckdb/issues/51
       # - windows

--- a/plugins/destination/duckdb/main.go
+++ b/plugins/destination/duckdb/main.go
@@ -24,6 +24,7 @@ func main() {
 			{OS: plugin.GoOSDarwin, Arch: plugin.GoArchAmd64},
 			{OS: plugin.GoOSDarwin, Arch: plugin.GoArchArm64},
 		}),
+		plugin.WithStaticLinking(),
 	)
 	server := serve.Plugin(p,
 		serve.WithPluginSentryDSN(sentryDSN),

--- a/plugins/destination/snowflake/.goreleaser.yaml
+++ b/plugins/destination/snowflake/.goreleaser.yaml
@@ -22,7 +22,7 @@ builds:
       - CC=/usr/bin/gencc.sh
       - CXX=/usr/bin/gencpp.sh
     ldflags:
-      - -s -w -X github.com/cloudquery/cloudquery/plugins/{{ .Var.component }}/resources/plugin.Version={{.Version}}
+      - -s -w -X github.com/cloudquery/cloudquery/plugins/{{ .Var.component }}/resources/plugin.Version={{.Version}} -linkmode external -extldflags=-static
     goos:
       - windows
       - linux

--- a/plugins/destination/snowflake/main.go
+++ b/plugins/destination/snowflake/main.go
@@ -26,6 +26,7 @@ func main() {
 			{OS: plugin.GoOSDarwin, Arch: plugin.GoArchAmd64},
 			{OS: plugin.GoOSDarwin, Arch: plugin.GoArchArm64},
 		}),
+		plugin.WithStaticLinking(),
 	)
 	if err := serve.Plugin(p, serve.WithPluginSentryDSN(sentryDSN), serve.WithDestinationV0V1Server()).Serve(context.Background()); err != nil {
 		fmt.Println(err)

--- a/plugins/destination/sqlite/.goreleaser.yaml
+++ b/plugins/destination/sqlite/.goreleaser.yaml
@@ -22,7 +22,7 @@ builds:
       - CC=/usr/bin/gencc.sh
       - CXX=/usr/bin/gencpp.sh
     ldflags:
-      - -s -w -X github.com/cloudquery/cloudquery/plugins/{{ .Var.component }}/resources/plugin.Version={{.Version}}
+      - -s -w -X github.com/cloudquery/cloudquery/plugins/{{ .Var.component }}/resources/plugin.Version={{.Version}} -linkmode external -extldflags=-static
     goos:
       - windows
       - linux

--- a/plugins/destination/sqlite/main.go
+++ b/plugins/destination/sqlite/main.go
@@ -25,7 +25,9 @@ func main() {
 			{OS: plugin.GoOSWindows, Arch: plugin.GoArchAmd64},
 			{OS: plugin.GoOSDarwin, Arch: plugin.GoArchAmd64},
 			{OS: plugin.GoOSDarwin, Arch: plugin.GoArchArm64},
-		}))
+		}),
+		plugin.WithStaticLinking(),
+	)
 	if err := serve.Plugin(p, serve.WithPluginSentryDSN(sentryDSN), serve.WithDestinationV0V1Server()).Serve(context.Background()); err != nil {
 		fmt.Println(err)
 		os.Exit(1)


### PR DESCRIPTION
We currently have three CGO_ENABLED plugins: DuckDB, SQLite and Snowflake. These don't correctly run under Alpine Linux due to missing libraries in the compiled executable. This adds statically linked C libraries to the executable for those plugins so they can run on those distros.

See https://github.com/cloudquery/cloudquery/issues/14465 for more info.