### PR TITLE
fix: Conditional static linking for linux/amd64 for DuckDB, SQLite and Snowflake

### DIFF
--- a/.github/workflows/dest_sqlite.yml
+++ b/.github/workflows/dest_sqlite.yml
@@ -55,10 +55,8 @@ jobs:
         CGO_ENABLED: 1
     steps:
       - name: Checkout
-        if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
         uses: actions/checkout@v4
       - uses: actions/cache@v3
-        if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
         with:
           path: |
             ~/.cache/go-build
@@ -67,20 +65,17 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-go-1.21.1-release-cache-plugins-destination-sqlite
       - name: Set up Go
-        if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
         uses: actions/setup-go@v4
         with:
           go-version-file: plugins/destination/sqlite/go.mod
           cache: false
       - name: Install GoReleaser
-        if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
         uses: goreleaser/goreleaser-action@v5
         with:
           distribution: goreleaser-pro
           version: latest
           install-only: true
       - name: Run GoReleaser Dry-Run
-        if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
         run: goreleaser release --snapshot --clean --skip=validate,publish,sign -f ./plugins/destination/sqlite/.goreleaser.yaml
         env:
           GORELEASER_KEY: ${{ secrets.GORELEASER_KEY }}

--- a/.github/workflows/dest_sqlite.yml
+++ b/.github/workflows/dest_sqlite.yml
@@ -55,8 +55,10 @@ jobs:
         CGO_ENABLED: 1
     steps:
       - name: Checkout
+        if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
         uses: actions/checkout@v4
       - uses: actions/cache@v3
+        if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
         with:
           path: |
             ~/.cache/go-build
@@ -65,17 +67,20 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-go-1.21.1-release-cache-plugins-destination-sqlite
       - name: Set up Go
+        if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
         uses: actions/setup-go@v4
         with:
           go-version-file: plugins/destination/sqlite/go.mod
           cache: false
       - name: Install GoReleaser
+        if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
         uses: goreleaser/goreleaser-action@v5
         with:
           distribution: goreleaser-pro
           version: latest
           install-only: true
       - name: Run GoReleaser Dry-Run
+        if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'
         run: goreleaser release --snapshot --clean --skip=validate,publish,sign -f ./plugins/destination/sqlite/.goreleaser.yaml
         env:
           GORELEASER_KEY: ${{ secrets.GORELEASER_KEY }}

--- a/plugins/destination/duckdb/.goreleaser.yaml
+++ b/plugins/destination/duckdb/.goreleaser.yaml
@@ -22,7 +22,7 @@ builds:
       - CC=/usr/bin/gencc.sh
       - CXX=/usr/bin/gencpp.sh
     ldflags:
-      - -s -w -X github.com/cloudquery/cloudquery/plugins/{{ .Var.component }}/resources/plugin.Version={{.Version}} -linkmode external -extldflags=-static
+      - -s -w -X github.com/cloudquery/cloudquery/plugins/{{ .Var.component }}/resources/plugin.Version={{.Version}}
     goos:
       # Windows disabled due to https://github.com/marcboeker/go-duckdb/issues/51
       # - windows
@@ -37,6 +37,11 @@ builds:
 # linux arm64 has some issues with cross-compile
       - goos: linux
         goarch: arm64
+    overrides:
+      - goos: linux
+        goarch: amd64
+        ldflags:
+          - -s -w -X github.com/cloudquery/cloudquery/plugins/{{ .Var.component }}/resources/plugin.Version={{.Version}} -linkmode external -extldflags=-static
 
 after:
   hooks:

--- a/plugins/destination/snowflake/.goreleaser.yaml
+++ b/plugins/destination/snowflake/.goreleaser.yaml
@@ -22,7 +22,7 @@ builds:
       - CC=/usr/bin/gencc.sh
       - CXX=/usr/bin/gencpp.sh
     ldflags:
-      - -s -w -X github.com/cloudquery/cloudquery/plugins/{{ .Var.component }}/resources/plugin.Version={{.Version}} -linkmode external -extldflags=-static
+      - -s -w -X github.com/cloudquery/cloudquery/plugins/{{ .Var.component }}/resources/plugin.Version={{.Version}}
     goos:
       - windows
       - linux
@@ -45,6 +45,10 @@ builds:
           - GO111MODULE=on
           - CC=/usr/bin/gencc.sh
           - CXX=/usr/bin/gencpp.sh
+      - goos: linux
+        goarch: amd64
+        ldflags:
+          - -s -w -X github.com/cloudquery/cloudquery/plugins/{{ .Var.component }}/resources/plugin.Version={{.Version}} -linkmode external -extldflags=-static
 after:
   hooks:
     - cmd: unzip -o {{ .Var.binary }}_darwin_arm64.zip

--- a/plugins/destination/sqlite/.goreleaser.yaml
+++ b/plugins/destination/sqlite/.goreleaser.yaml
@@ -36,6 +36,11 @@ builds:
 # linux arm64 has some issues with cross-compile
       - goos: linux
         goarch: arm64
+    overrides:
+      - goos: linux
+        goarch: amd64
+        ldflags:
+          - -s -w -X github.com/cloudquery/cloudquery/plugins/{{ .Var.component }}/resources/plugin.Version={{.Version}} -linkmode external -extldflags=-static
 
 after:
   hooks:

--- a/plugins/destination/sqlite/.goreleaser.yaml
+++ b/plugins/destination/sqlite/.goreleaser.yaml
@@ -22,7 +22,7 @@ builds:
       - CC=/usr/bin/gencc.sh
       - CXX=/usr/bin/gencpp.sh
     ldflags:
-      - -s -w -X github.com/cloudquery/cloudquery/plugins/{{ .Var.component }}/resources/plugin.Version={{.Version}} -linkmode external -extldflags=-static
+      - -s -w -X github.com/cloudquery/cloudquery/plugins/{{ .Var.component }}/resources/plugin.Version={{.Version}}
     goos:
       - windows
       - linux


### PR DESCRIPTION
In https://github.com/cloudquery/cloudquery/pull/14612 we added static linking to the DuckDB, SQLite and Snowflake plugins, but this broke Darwin buils. As it is only needed for Linux images I have added conditional overrides to the goreleaser yml config.