### PR TITLE
chore: Removes the xdg (direct) dependency

### DIFF
--- a/cli/cmd/switch_test.go
+++ b/cli/cmd/switch_test.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"bytes"
 	"github.com/cloudquery/cloudquery-api-go/auth"
+	"github.com/cloudquery/cloudquery-api-go/config"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -10,7 +11,6 @@ import (
 	"path"
 	"testing"
 
-	"github.com/adrg/xdg"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -38,13 +38,13 @@ func TestSwitch(t *testing.T) {
 		os.RemoveAll(configDir)
 	})
 
-	t.Setenv("XDG_CONFIG_HOME", configDir)
-	xdg.Reload()
+	err := config.SetConfigHome(configDir)
+	require.NoError(t, err)
 
 	// calling switch before a team is set should not result in an error
 	cmd := NewCmdRoot()
 	cmd.SetArgs([]string{"switch"})
-	err := cmd.Execute()
+	err = cmd.Execute()
 	require.NoError(t, err)
 
 	// now set the team

--- a/cli/go.mod
+++ b/cli/go.mod
@@ -3,7 +3,6 @@ module github.com/cloudquery/cloudquery/cli
 go 1.21.1
 
 require (
-	github.com/adrg/xdg v0.4.0
 	github.com/apache/arrow/go/v14 v14.0.0-20230929201650-00efb06dc0de
 	github.com/bradleyjkemp/cupaloy/v2 v2.8.0
 	github.com/cenkalti/backoff/v4 v4.2.1
@@ -33,6 +32,7 @@ require (
 	github.com/Joker/jade v1.1.3 // indirect
 	github.com/Microsoft/go-winio v0.6.1 // indirect
 	github.com/Shopify/goreferrer v0.0.0-20220729165902-8cddb4f5de06 // indirect
+	github.com/adrg/xdg v0.4.0 // indirect
 	github.com/andybalholm/brotli v1.0.5 // indirect
 	github.com/apapsch/go-jsonmerge/v2 v2.0.0 // indirect
 	github.com/avast/retry-go/v4 v4.5.0 // indirect

--- a/cli/go.sum
+++ b/cli/go.sum
@@ -183,8 +183,6 @@ github.com/mattn/go-isatty v0.0.19/go.mod h1:W+V8PltTTMOvKvAeJH7IuucS94S2C6jfK/D
 github.com/mattn/go-runewidth v0.0.14/go.mod h1:Jdepj2loyihRzMpdS35Xk/zdY8IAYHsh153qUoGf23w=
 github.com/mattn/go-runewidth v0.0.15 h1:UNAjwbU9l54TA3KzvqLGxwWjHmMgBUVhBiTjelZgg3U=
 github.com/mattn/go-runewidth v0.0.15/go.mod h1:Jdepj2loyihRzMpdS35Xk/zdY8IAYHsh153qUoGf23w=
-github.com/microcosm-cc/bluemonday v1.0.25 h1:4NEwSfiJ+Wva0VxN5B8OwMicaJvD8r9tlJWm9rtloEg=
-github.com/microcosm-cc/bluemonday v1.0.25/go.mod h1:ZIOjCQp1OrzBBPIJmfX4qDYFuhU02nx4bn030ixfHLE=
 github.com/microcosm-cc/bluemonday v1.0.26 h1:xbqSvqzQMeEHCqMi64VAs4d8uy6Mequs3rQ0k/Khz58=
 github.com/microcosm-cc/bluemonday v1.0.26/go.mod h1:JyzOCs9gkyQyjs+6h10UEVSe02CGwkhd72Xdqh78TWs=
 github.com/mitchellh/colorstring v0.0.0-20190213212951-d06e56a500db h1:62I3jR2EmQ4l5rM/4FEfDWcRD+abF5XlKShorW5LRoQ=


### PR DESCRIPTION
The xdg logic for configuraiton management is now available through the `cloudquery-api-go` dependency and is no longer needed as a direct dependency in the CLI.
