### PR TITLE
chore: Remove markdown escaping

### DIFF
--- a/website/scripts/prebuild.tsx
+++ b/website/scripts/prebuild.tsx
@@ -109,9 +109,6 @@ function recreateDirectory(dir: string) {
     }
 }
 
-function escapeBracesForMDX(str: string) {
-    return  str.replaceAll("{", "&#123;").replaceAll("}", "&#125;");
-}
 
 // Copy the source authentication file if it exists
 function copySourceAuthenticationFile(source: Plugin) : boolean {
@@ -121,7 +118,7 @@ function copySourceAuthenticationFile(source: Plugin) : boolean {
     if (authFilePath) {
         const ext = path.extname(authFilePath);
         const outputFilePath = path.join(mdxSourceComponentDir, `${source.id}/_authentication${ext}`);
-        fs.writeFileSync(outputFilePath, escapeBracesForMDX(fs.readFileSync(authFilePath, "utf8")));
+        fs.copyFileSync(authFilePath, outputFilePath);
         return true;
     }
     return false;
@@ -139,7 +136,7 @@ function copySourceConfigurationFile(source: Plugin): boolean {
             fileContents = fileContents.replace(/DESTINATION_NAME/g, destination.id);
             const ext = path.extname(configFilePath);
             const outputFilePath = path.join(sourceConfigDir, `_configuration${ext}`);
-            fs.writeFileSync(outputFilePath, escapeBracesForMDX(fileContents));
+            fs.writeFileSync(outputFilePath, fileContents);
         })
         return true;
     }
@@ -154,7 +151,7 @@ function copyDestinationAuthenticationFile(destination: Plugin) : boolean {
     if (authFilePath) {
         const ext = path.extname(authFilePath);
         const outputFilePath = path.join(mdxDestinationComponentDir, `${destination.id}/_authentication${ext}`);
-        fs.writeFileSync(outputFilePath, escapeBracesForMDX(fs.readFileSync(authFilePath, "utf8")));
+        fs.copyFileSync(authFilePath, outputFilePath);
         return true;
     }
     return false;
@@ -167,7 +164,7 @@ function copyDestinationConfigurationFile(destination: Plugin) : boolean {
     if (configFilePath) {
         const ext = path.extname(configFilePath);
         const outputFilePath = path.join(mdxDestinationComponentDir, `${destination.id}/_configuration${ext}`);
-        fs.writeFileSync(outputFilePath, escapeBracesForMDX(fs.readFileSync(configFilePath, "utf8")));
+        fs.copyFileSync(configFilePath, outputFilePath);
         return true;
     }
     return false;


### PR DESCRIPTION
<!-- 🎉 Thank you for making CloudQuery awesome by submitting a PR 🎉 -->

#### Summary

Follow up to https://github.com/cloudquery/cloudquery/pull/14648. Found out we don't really need the escaping and also it broken some of the content 😅 

<!--
Use the following steps to ensure your PR is ready to be reviewed

- [ ] Read the [contribution guidelines](../blob/main/CONTRIBUTING.md) 🧑‍🎓
- [ ] Run `make lint` to ensure the proposed changes follow the coding style 🚨 (install golangci-lint [here](https://golangci-lint.run/usage/install/#local-installation))
- [ ] Run `make test` to ensure the proposed changes pass the tests 🧪
- [ ] If changing a source plugin run `make gen` to ensure docs are up to date 📝
- [ ] Ensure the status checks below are successful ✅
--->
