### PR TITLE
fix: Update plugin-SDK to v4.16.0

### DIFF
--- a/plugins/destination/azblob/go.mod
+++ b/plugins/destination/azblob/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/Azure/azure-sdk-for-go/sdk/storage/azblob v1.0.0
 	github.com/apache/arrow/go/v14 v14.0.0-20230929201650-00efb06dc0de
 	github.com/cloudquery/filetypes/v4 v4.1.15
-	github.com/cloudquery/plugin-sdk/v4 v4.15.3
+	github.com/cloudquery/plugin-sdk/v4 v4.16.0
 	github.com/google/go-cmp v0.5.9
 	github.com/google/uuid v1.3.1
 	github.com/rs/zerolog v1.31.0

--- a/plugins/destination/azblob/go.sum
+++ b/plugins/destination/azblob/go.sum
@@ -108,8 +108,8 @@ github.com/cloudquery/plugin-pb-go v1.12.3 h1:rLK3/RR70/BX8tj2QzTnrjkxQhzfAT7SXE
 github.com/cloudquery/plugin-pb-go v1.12.3/go.mod h1:CYorX3zCHF9ByoOgdBOuwLX/2vVCDH6/FoREOE3oH+w=
 github.com/cloudquery/plugin-sdk/v2 v2.7.0 h1:hRXsdEiaOxJtsn/wZMFQC9/jPfU1MeMK3KF+gPGqm7U=
 github.com/cloudquery/plugin-sdk/v2 v2.7.0/go.mod h1:pAX6ojIW99b/Vg4CkhnsGkRIzNaVEceYMR+Bdit73ug=
-github.com/cloudquery/plugin-sdk/v4 v4.15.3 h1:krXOLZR/3xDAEMdfcZCVD2AbWO0SosnGrb0Lrk5AH/4=
-github.com/cloudquery/plugin-sdk/v4 v4.15.3/go.mod h1:ujSFEUAp8BmozOee0ljjsPHQfddXJCUTAzCD6sVKsu8=
+github.com/cloudquery/plugin-sdk/v4 v4.16.0 h1:AEYIEbZCCPxGFw/bPm5bOpyyPDSqM5DRFIUqfogyJfM=
+github.com/cloudquery/plugin-sdk/v4 v4.16.0/go.mod h1:ujSFEUAp8BmozOee0ljjsPHQfddXJCUTAzCD6sVKsu8=
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
 github.com/cncf/udpa/go v0.0.0-20201120205902-5459f2c99403/go.mod h1:WmhPx2Nbnhtbo57+VJT5O0JRkEi1Wbu0z5j0R8u5Hbk=
 github.com/cncf/udpa/go v0.0.0-20210930031921-04548b0d99d4/go.mod h1:6pvJx4me5XPnfI9Z40ddWsdw2W/uZgQLFXToKeRcDiI=

--- a/plugins/destination/bigquery/go.mod
+++ b/plugins/destination/bigquery/go.mod
@@ -5,7 +5,7 @@ go 1.21.1
 require (
 	cloud.google.com/go/bigquery v1.55.0
 	github.com/apache/arrow/go/v14 v14.0.0-20230929201650-00efb06dc0de
-	github.com/cloudquery/plugin-sdk/v4 v4.15.3
+	github.com/cloudquery/plugin-sdk/v4 v4.16.0
 	github.com/goccy/go-json v0.10.2
 	github.com/rs/zerolog v1.29.1
 	golang.org/x/sync v0.3.0

--- a/plugins/destination/bigquery/go.sum
+++ b/plugins/destination/bigquery/go.sum
@@ -114,8 +114,8 @@ github.com/cloudquery/plugin-pb-go v1.12.3 h1:rLK3/RR70/BX8tj2QzTnrjkxQhzfAT7SXE
 github.com/cloudquery/plugin-pb-go v1.12.3/go.mod h1:CYorX3zCHF9ByoOgdBOuwLX/2vVCDH6/FoREOE3oH+w=
 github.com/cloudquery/plugin-sdk/v2 v2.7.0 h1:hRXsdEiaOxJtsn/wZMFQC9/jPfU1MeMK3KF+gPGqm7U=
 github.com/cloudquery/plugin-sdk/v2 v2.7.0/go.mod h1:pAX6ojIW99b/Vg4CkhnsGkRIzNaVEceYMR+Bdit73ug=
-github.com/cloudquery/plugin-sdk/v4 v4.15.3 h1:krXOLZR/3xDAEMdfcZCVD2AbWO0SosnGrb0Lrk5AH/4=
-github.com/cloudquery/plugin-sdk/v4 v4.15.3/go.mod h1:ujSFEUAp8BmozOee0ljjsPHQfddXJCUTAzCD6sVKsu8=
+github.com/cloudquery/plugin-sdk/v4 v4.16.0 h1:AEYIEbZCCPxGFw/bPm5bOpyyPDSqM5DRFIUqfogyJfM=
+github.com/cloudquery/plugin-sdk/v4 v4.16.0/go.mod h1:ujSFEUAp8BmozOee0ljjsPHQfddXJCUTAzCD6sVKsu8=
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
 github.com/cncf/udpa/go v0.0.0-20201120205902-5459f2c99403/go.mod h1:WmhPx2Nbnhtbo57+VJT5O0JRkEi1Wbu0z5j0R8u5Hbk=
 github.com/cncf/udpa/go v0.0.0-20210930031921-04548b0d99d4/go.mod h1:6pvJx4me5XPnfI9Z40ddWsdw2W/uZgQLFXToKeRcDiI=

--- a/plugins/destination/clickhouse/go.mod
+++ b/plugins/destination/clickhouse/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/ClickHouse/clickhouse-go/v2 v2.10.1
 	github.com/apache/arrow/go/v14 v14.0.0-20230929201650-00efb06dc0de
 	github.com/cloudquery/codegen v0.3.9
-	github.com/cloudquery/plugin-sdk/v4 v4.15.3
+	github.com/cloudquery/plugin-sdk/v4 v4.16.0
 	github.com/goccy/go-json v0.10.2
 	github.com/google/uuid v1.3.1
 	github.com/rs/zerolog v1.29.1

--- a/plugins/destination/clickhouse/go.sum
+++ b/plugins/destination/clickhouse/go.sum
@@ -100,8 +100,8 @@ github.com/cloudquery/plugin-pb-go v1.12.3 h1:rLK3/RR70/BX8tj2QzTnrjkxQhzfAT7SXE
 github.com/cloudquery/plugin-pb-go v1.12.3/go.mod h1:CYorX3zCHF9ByoOgdBOuwLX/2vVCDH6/FoREOE3oH+w=
 github.com/cloudquery/plugin-sdk/v2 v2.7.0 h1:hRXsdEiaOxJtsn/wZMFQC9/jPfU1MeMK3KF+gPGqm7U=
 github.com/cloudquery/plugin-sdk/v2 v2.7.0/go.mod h1:pAX6ojIW99b/Vg4CkhnsGkRIzNaVEceYMR+Bdit73ug=
-github.com/cloudquery/plugin-sdk/v4 v4.15.3 h1:krXOLZR/3xDAEMdfcZCVD2AbWO0SosnGrb0Lrk5AH/4=
-github.com/cloudquery/plugin-sdk/v4 v4.15.3/go.mod h1:ujSFEUAp8BmozOee0ljjsPHQfddXJCUTAzCD6sVKsu8=
+github.com/cloudquery/plugin-sdk/v4 v4.16.0 h1:AEYIEbZCCPxGFw/bPm5bOpyyPDSqM5DRFIUqfogyJfM=
+github.com/cloudquery/plugin-sdk/v4 v4.16.0/go.mod h1:ujSFEUAp8BmozOee0ljjsPHQfddXJCUTAzCD6sVKsu8=
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
 github.com/cncf/udpa/go v0.0.0-20201120205902-5459f2c99403/go.mod h1:WmhPx2Nbnhtbo57+VJT5O0JRkEi1Wbu0z5j0R8u5Hbk=
 github.com/cncf/udpa/go v0.0.0-20210930031921-04548b0d99d4/go.mod h1:6pvJx4me5XPnfI9Z40ddWsdw2W/uZgQLFXToKeRcDiI=

--- a/plugins/destination/duckdb/go.mod
+++ b/plugins/destination/duckdb/go.mod
@@ -5,7 +5,7 @@ go 1.21.1
 require (
 	github.com/apache/arrow/go/v14 v14.0.0-20230929201650-00efb06dc0de
 	github.com/cenkalti/backoff/v4 v4.2.1
-	github.com/cloudquery/plugin-sdk/v4 v4.15.3
+	github.com/cloudquery/plugin-sdk/v4 v4.16.0
 	github.com/google/uuid v1.3.1
 	github.com/marcboeker/go-duckdb v1.5.1
 	github.com/rs/zerolog v1.29.1

--- a/plugins/destination/duckdb/go.sum
+++ b/plugins/destination/duckdb/go.sum
@@ -92,8 +92,8 @@ github.com/cloudquery/plugin-pb-go v1.12.3 h1:rLK3/RR70/BX8tj2QzTnrjkxQhzfAT7SXE
 github.com/cloudquery/plugin-pb-go v1.12.3/go.mod h1:CYorX3zCHF9ByoOgdBOuwLX/2vVCDH6/FoREOE3oH+w=
 github.com/cloudquery/plugin-sdk/v2 v2.7.0 h1:hRXsdEiaOxJtsn/wZMFQC9/jPfU1MeMK3KF+gPGqm7U=
 github.com/cloudquery/plugin-sdk/v2 v2.7.0/go.mod h1:pAX6ojIW99b/Vg4CkhnsGkRIzNaVEceYMR+Bdit73ug=
-github.com/cloudquery/plugin-sdk/v4 v4.15.3 h1:krXOLZR/3xDAEMdfcZCVD2AbWO0SosnGrb0Lrk5AH/4=
-github.com/cloudquery/plugin-sdk/v4 v4.15.3/go.mod h1:ujSFEUAp8BmozOee0ljjsPHQfddXJCUTAzCD6sVKsu8=
+github.com/cloudquery/plugin-sdk/v4 v4.16.0 h1:AEYIEbZCCPxGFw/bPm5bOpyyPDSqM5DRFIUqfogyJfM=
+github.com/cloudquery/plugin-sdk/v4 v4.16.0/go.mod h1:ujSFEUAp8BmozOee0ljjsPHQfddXJCUTAzCD6sVKsu8=
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
 github.com/cncf/udpa/go v0.0.0-20201120205902-5459f2c99403/go.mod h1:WmhPx2Nbnhtbo57+VJT5O0JRkEi1Wbu0z5j0R8u5Hbk=
 github.com/cncf/udpa/go v0.0.0-20210930031921-04548b0d99d4/go.mod h1:6pvJx4me5XPnfI9Z40ddWsdw2W/uZgQLFXToKeRcDiI=

--- a/plugins/destination/elasticsearch/go.mod
+++ b/plugins/destination/elasticsearch/go.mod
@@ -5,7 +5,7 @@ go 1.21.1
 require (
 	github.com/apache/arrow/go/v14 v14.0.0-20230929201650-00efb06dc0de
 	github.com/cenkalti/backoff/v4 v4.2.1
-	github.com/cloudquery/plugin-sdk/v4 v4.15.3
+	github.com/cloudquery/plugin-sdk/v4 v4.16.0
 	github.com/elastic/go-elasticsearch/v8 v8.6.0
 	github.com/goccy/go-json v0.10.2
 	github.com/rs/zerolog v1.29.1

--- a/plugins/destination/elasticsearch/go.sum
+++ b/plugins/destination/elasticsearch/go.sum
@@ -88,8 +88,8 @@ github.com/cloudquery/plugin-pb-go v1.12.3 h1:rLK3/RR70/BX8tj2QzTnrjkxQhzfAT7SXE
 github.com/cloudquery/plugin-pb-go v1.12.3/go.mod h1:CYorX3zCHF9ByoOgdBOuwLX/2vVCDH6/FoREOE3oH+w=
 github.com/cloudquery/plugin-sdk/v2 v2.7.0 h1:hRXsdEiaOxJtsn/wZMFQC9/jPfU1MeMK3KF+gPGqm7U=
 github.com/cloudquery/plugin-sdk/v2 v2.7.0/go.mod h1:pAX6ojIW99b/Vg4CkhnsGkRIzNaVEceYMR+Bdit73ug=
-github.com/cloudquery/plugin-sdk/v4 v4.15.3 h1:krXOLZR/3xDAEMdfcZCVD2AbWO0SosnGrb0Lrk5AH/4=
-github.com/cloudquery/plugin-sdk/v4 v4.15.3/go.mod h1:ujSFEUAp8BmozOee0ljjsPHQfddXJCUTAzCD6sVKsu8=
+github.com/cloudquery/plugin-sdk/v4 v4.16.0 h1:AEYIEbZCCPxGFw/bPm5bOpyyPDSqM5DRFIUqfogyJfM=
+github.com/cloudquery/plugin-sdk/v4 v4.16.0/go.mod h1:ujSFEUAp8BmozOee0ljjsPHQfddXJCUTAzCD6sVKsu8=
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
 github.com/cncf/udpa/go v0.0.0-20201120205902-5459f2c99403/go.mod h1:WmhPx2Nbnhtbo57+VJT5O0JRkEi1Wbu0z5j0R8u5Hbk=
 github.com/cncf/udpa/go v0.0.0-20210930031921-04548b0d99d4/go.mod h1:6pvJx4me5XPnfI9Z40ddWsdw2W/uZgQLFXToKeRcDiI=

--- a/plugins/destination/file/go.mod
+++ b/plugins/destination/file/go.mod
@@ -5,7 +5,7 @@ go 1.21.1
 require (
 	github.com/apache/arrow/go/v14 v14.0.0-20230929201650-00efb06dc0de
 	github.com/cloudquery/filetypes/v4 v4.1.15
-	github.com/cloudquery/plugin-sdk/v4 v4.15.3
+	github.com/cloudquery/plugin-sdk/v4 v4.16.0
 	github.com/google/go-cmp v0.5.9
 	github.com/google/uuid v1.3.1
 	github.com/rs/zerolog v1.31.0

--- a/plugins/destination/file/go.sum
+++ b/plugins/destination/file/go.sum
@@ -98,8 +98,8 @@ github.com/cloudquery/plugin-pb-go v1.12.3 h1:rLK3/RR70/BX8tj2QzTnrjkxQhzfAT7SXE
 github.com/cloudquery/plugin-pb-go v1.12.3/go.mod h1:CYorX3zCHF9ByoOgdBOuwLX/2vVCDH6/FoREOE3oH+w=
 github.com/cloudquery/plugin-sdk/v2 v2.7.0 h1:hRXsdEiaOxJtsn/wZMFQC9/jPfU1MeMK3KF+gPGqm7U=
 github.com/cloudquery/plugin-sdk/v2 v2.7.0/go.mod h1:pAX6ojIW99b/Vg4CkhnsGkRIzNaVEceYMR+Bdit73ug=
-github.com/cloudquery/plugin-sdk/v4 v4.15.3 h1:krXOLZR/3xDAEMdfcZCVD2AbWO0SosnGrb0Lrk5AH/4=
-github.com/cloudquery/plugin-sdk/v4 v4.15.3/go.mod h1:ujSFEUAp8BmozOee0ljjsPHQfddXJCUTAzCD6sVKsu8=
+github.com/cloudquery/plugin-sdk/v4 v4.16.0 h1:AEYIEbZCCPxGFw/bPm5bOpyyPDSqM5DRFIUqfogyJfM=
+github.com/cloudquery/plugin-sdk/v4 v4.16.0/go.mod h1:ujSFEUAp8BmozOee0ljjsPHQfddXJCUTAzCD6sVKsu8=
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
 github.com/cncf/udpa/go v0.0.0-20201120205902-5459f2c99403/go.mod h1:WmhPx2Nbnhtbo57+VJT5O0JRkEi1Wbu0z5j0R8u5Hbk=
 github.com/cncf/udpa/go v0.0.0-20210930031921-04548b0d99d4/go.mod h1:6pvJx4me5XPnfI9Z40ddWsdw2W/uZgQLFXToKeRcDiI=

--- a/plugins/destination/firehose/go.mod
+++ b/plugins/destination/firehose/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/aws/aws-sdk-go-v2 v1.21.1
 	github.com/aws/aws-sdk-go-v2/config v1.18.44
 	github.com/aws/aws-sdk-go-v2/service/firehose v1.19.1
-	github.com/cloudquery/plugin-sdk/v4 v4.15.3
+	github.com/cloudquery/plugin-sdk/v4 v4.16.0
 	github.com/goccy/go-json v0.10.2
 	github.com/rs/zerolog v1.29.1
 	github.com/stretchr/testify v1.8.4

--- a/plugins/destination/firehose/go.sum
+++ b/plugins/destination/firehose/go.sum
@@ -114,8 +114,8 @@ github.com/cloudquery/plugin-pb-go v1.12.3 h1:rLK3/RR70/BX8tj2QzTnrjkxQhzfAT7SXE
 github.com/cloudquery/plugin-pb-go v1.12.3/go.mod h1:CYorX3zCHF9ByoOgdBOuwLX/2vVCDH6/FoREOE3oH+w=
 github.com/cloudquery/plugin-sdk/v2 v2.7.0 h1:hRXsdEiaOxJtsn/wZMFQC9/jPfU1MeMK3KF+gPGqm7U=
 github.com/cloudquery/plugin-sdk/v2 v2.7.0/go.mod h1:pAX6ojIW99b/Vg4CkhnsGkRIzNaVEceYMR+Bdit73ug=
-github.com/cloudquery/plugin-sdk/v4 v4.15.3 h1:krXOLZR/3xDAEMdfcZCVD2AbWO0SosnGrb0Lrk5AH/4=
-github.com/cloudquery/plugin-sdk/v4 v4.15.3/go.mod h1:ujSFEUAp8BmozOee0ljjsPHQfddXJCUTAzCD6sVKsu8=
+github.com/cloudquery/plugin-sdk/v4 v4.16.0 h1:AEYIEbZCCPxGFw/bPm5bOpyyPDSqM5DRFIUqfogyJfM=
+github.com/cloudquery/plugin-sdk/v4 v4.16.0/go.mod h1:ujSFEUAp8BmozOee0ljjsPHQfddXJCUTAzCD6sVKsu8=
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
 github.com/cncf/udpa/go v0.0.0-20201120205902-5459f2c99403/go.mod h1:WmhPx2Nbnhtbo57+VJT5O0JRkEi1Wbu0z5j0R8u5Hbk=
 github.com/cncf/udpa/go v0.0.0-20210930031921-04548b0d99d4/go.mod h1:6pvJx4me5XPnfI9Z40ddWsdw2W/uZgQLFXToKeRcDiI=

--- a/plugins/destination/gcs/go.mod
+++ b/plugins/destination/gcs/go.mod
@@ -6,7 +6,7 @@ require (
 	cloud.google.com/go/storage v1.30.1
 	github.com/apache/arrow/go/v14 v14.0.0-20230929201650-00efb06dc0de
 	github.com/cloudquery/filetypes/v4 v4.1.15
-	github.com/cloudquery/plugin-sdk/v4 v4.15.3
+	github.com/cloudquery/plugin-sdk/v4 v4.16.0
 	github.com/google/uuid v1.3.1
 	github.com/rs/zerolog v1.31.0
 	github.com/stretchr/testify v1.8.4

--- a/plugins/destination/gcs/go.sum
+++ b/plugins/destination/gcs/go.sum
@@ -108,8 +108,8 @@ github.com/cloudquery/plugin-pb-go v1.12.3 h1:rLK3/RR70/BX8tj2QzTnrjkxQhzfAT7SXE
 github.com/cloudquery/plugin-pb-go v1.12.3/go.mod h1:CYorX3zCHF9ByoOgdBOuwLX/2vVCDH6/FoREOE3oH+w=
 github.com/cloudquery/plugin-sdk/v2 v2.7.0 h1:hRXsdEiaOxJtsn/wZMFQC9/jPfU1MeMK3KF+gPGqm7U=
 github.com/cloudquery/plugin-sdk/v2 v2.7.0/go.mod h1:pAX6ojIW99b/Vg4CkhnsGkRIzNaVEceYMR+Bdit73ug=
-github.com/cloudquery/plugin-sdk/v4 v4.15.3 h1:krXOLZR/3xDAEMdfcZCVD2AbWO0SosnGrb0Lrk5AH/4=
-github.com/cloudquery/plugin-sdk/v4 v4.15.3/go.mod h1:ujSFEUAp8BmozOee0ljjsPHQfddXJCUTAzCD6sVKsu8=
+github.com/cloudquery/plugin-sdk/v4 v4.16.0 h1:AEYIEbZCCPxGFw/bPm5bOpyyPDSqM5DRFIUqfogyJfM=
+github.com/cloudquery/plugin-sdk/v4 v4.16.0/go.mod h1:ujSFEUAp8BmozOee0ljjsPHQfddXJCUTAzCD6sVKsu8=
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
 github.com/cncf/udpa/go v0.0.0-20201120205902-5459f2c99403/go.mod h1:WmhPx2Nbnhtbo57+VJT5O0JRkEi1Wbu0z5j0R8u5Hbk=
 github.com/cncf/udpa/go v0.0.0-20210930031921-04548b0d99d4/go.mod h1:6pvJx4me5XPnfI9Z40ddWsdw2W/uZgQLFXToKeRcDiI=

--- a/plugins/destination/gremlin/go.mod
+++ b/plugins/destination/gremlin/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/aws/aws-sdk-go-v2 v1.21.1
 	github.com/aws/aws-sdk-go-v2/config v1.18.44
 	github.com/cenkalti/backoff/v4 v4.2.1
-	github.com/cloudquery/plugin-sdk/v4 v4.15.3
+	github.com/cloudquery/plugin-sdk/v4 v4.16.0
 	github.com/rs/zerolog v1.29.1
 	github.com/stretchr/testify v1.8.4
 )

--- a/plugins/destination/gremlin/go.sum
+++ b/plugins/destination/gremlin/go.sum
@@ -115,8 +115,8 @@ github.com/cloudquery/plugin-pb-go v1.12.3 h1:rLK3/RR70/BX8tj2QzTnrjkxQhzfAT7SXE
 github.com/cloudquery/plugin-pb-go v1.12.3/go.mod h1:CYorX3zCHF9ByoOgdBOuwLX/2vVCDH6/FoREOE3oH+w=
 github.com/cloudquery/plugin-sdk/v2 v2.7.0 h1:hRXsdEiaOxJtsn/wZMFQC9/jPfU1MeMK3KF+gPGqm7U=
 github.com/cloudquery/plugin-sdk/v2 v2.7.0/go.mod h1:pAX6ojIW99b/Vg4CkhnsGkRIzNaVEceYMR+Bdit73ug=
-github.com/cloudquery/plugin-sdk/v4 v4.15.3 h1:krXOLZR/3xDAEMdfcZCVD2AbWO0SosnGrb0Lrk5AH/4=
-github.com/cloudquery/plugin-sdk/v4 v4.15.3/go.mod h1:ujSFEUAp8BmozOee0ljjsPHQfddXJCUTAzCD6sVKsu8=
+github.com/cloudquery/plugin-sdk/v4 v4.16.0 h1:AEYIEbZCCPxGFw/bPm5bOpyyPDSqM5DRFIUqfogyJfM=
+github.com/cloudquery/plugin-sdk/v4 v4.16.0/go.mod h1:ujSFEUAp8BmozOee0ljjsPHQfddXJCUTAzCD6sVKsu8=
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
 github.com/cncf/udpa/go v0.0.0-20201120205902-5459f2c99403/go.mod h1:WmhPx2Nbnhtbo57+VJT5O0JRkEi1Wbu0z5j0R8u5Hbk=
 github.com/cncf/udpa/go v0.0.0-20210930031921-04548b0d99d4/go.mod h1:6pvJx4me5XPnfI9Z40ddWsdw2W/uZgQLFXToKeRcDiI=

--- a/plugins/destination/kafka/go.mod
+++ b/plugins/destination/kafka/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/Shopify/sarama v1.37.2
 	github.com/apache/arrow/go/v14 v14.0.0-20230929201650-00efb06dc0de
 	github.com/cloudquery/filetypes/v4 v4.1.15
-	github.com/cloudquery/plugin-sdk/v4 v4.15.3
+	github.com/cloudquery/plugin-sdk/v4 v4.16.0
 	github.com/rs/zerolog v1.31.0
 )
 

--- a/plugins/destination/kafka/go.sum
+++ b/plugins/destination/kafka/go.sum
@@ -98,8 +98,8 @@ github.com/cloudquery/plugin-pb-go v1.12.3 h1:rLK3/RR70/BX8tj2QzTnrjkxQhzfAT7SXE
 github.com/cloudquery/plugin-pb-go v1.12.3/go.mod h1:CYorX3zCHF9ByoOgdBOuwLX/2vVCDH6/FoREOE3oH+w=
 github.com/cloudquery/plugin-sdk/v2 v2.7.0 h1:hRXsdEiaOxJtsn/wZMFQC9/jPfU1MeMK3KF+gPGqm7U=
 github.com/cloudquery/plugin-sdk/v2 v2.7.0/go.mod h1:pAX6ojIW99b/Vg4CkhnsGkRIzNaVEceYMR+Bdit73ug=
-github.com/cloudquery/plugin-sdk/v4 v4.15.3 h1:krXOLZR/3xDAEMdfcZCVD2AbWO0SosnGrb0Lrk5AH/4=
-github.com/cloudquery/plugin-sdk/v4 v4.15.3/go.mod h1:ujSFEUAp8BmozOee0ljjsPHQfddXJCUTAzCD6sVKsu8=
+github.com/cloudquery/plugin-sdk/v4 v4.16.0 h1:AEYIEbZCCPxGFw/bPm5bOpyyPDSqM5DRFIUqfogyJfM=
+github.com/cloudquery/plugin-sdk/v4 v4.16.0/go.mod h1:ujSFEUAp8BmozOee0ljjsPHQfddXJCUTAzCD6sVKsu8=
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
 github.com/cncf/udpa/go v0.0.0-20201120205902-5459f2c99403/go.mod h1:WmhPx2Nbnhtbo57+VJT5O0JRkEi1Wbu0z5j0R8u5Hbk=
 github.com/cncf/udpa/go v0.0.0-20210930031921-04548b0d99d4/go.mod h1:6pvJx4me5XPnfI9Z40ddWsdw2W/uZgQLFXToKeRcDiI=

--- a/plugins/destination/meilisearch/go.mod
+++ b/plugins/destination/meilisearch/go.mod
@@ -4,7 +4,7 @@ go 1.21.1
 
 require (
 	github.com/apache/arrow/go/v14 v14.0.0-20230929201650-00efb06dc0de
-	github.com/cloudquery/plugin-sdk/v4 v4.15.3
+	github.com/cloudquery/plugin-sdk/v4 v4.16.0
 	github.com/goccy/go-json v0.10.2
 	github.com/google/uuid v1.3.1
 	github.com/meilisearch/meilisearch-go v0.24.0

--- a/plugins/destination/meilisearch/go.sum
+++ b/plugins/destination/meilisearch/go.sum
@@ -93,8 +93,8 @@ github.com/cloudquery/plugin-pb-go v1.12.3 h1:rLK3/RR70/BX8tj2QzTnrjkxQhzfAT7SXE
 github.com/cloudquery/plugin-pb-go v1.12.3/go.mod h1:CYorX3zCHF9ByoOgdBOuwLX/2vVCDH6/FoREOE3oH+w=
 github.com/cloudquery/plugin-sdk/v2 v2.7.0 h1:hRXsdEiaOxJtsn/wZMFQC9/jPfU1MeMK3KF+gPGqm7U=
 github.com/cloudquery/plugin-sdk/v2 v2.7.0/go.mod h1:pAX6ojIW99b/Vg4CkhnsGkRIzNaVEceYMR+Bdit73ug=
-github.com/cloudquery/plugin-sdk/v4 v4.15.3 h1:krXOLZR/3xDAEMdfcZCVD2AbWO0SosnGrb0Lrk5AH/4=
-github.com/cloudquery/plugin-sdk/v4 v4.15.3/go.mod h1:ujSFEUAp8BmozOee0ljjsPHQfddXJCUTAzCD6sVKsu8=
+github.com/cloudquery/plugin-sdk/v4 v4.16.0 h1:AEYIEbZCCPxGFw/bPm5bOpyyPDSqM5DRFIUqfogyJfM=
+github.com/cloudquery/plugin-sdk/v4 v4.16.0/go.mod h1:ujSFEUAp8BmozOee0ljjsPHQfddXJCUTAzCD6sVKsu8=
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
 github.com/cncf/udpa/go v0.0.0-20201120205902-5459f2c99403/go.mod h1:WmhPx2Nbnhtbo57+VJT5O0JRkEi1Wbu0z5j0R8u5Hbk=
 github.com/cncf/udpa/go v0.0.0-20210930031921-04548b0d99d4/go.mod h1:6pvJx4me5XPnfI9Z40ddWsdw2W/uZgQLFXToKeRcDiI=

--- a/plugins/destination/mongodb/go.mod
+++ b/plugins/destination/mongodb/go.mod
@@ -4,7 +4,7 @@ go 1.21.1
 
 require (
 	github.com/apache/arrow/go/v14 v14.0.0-20230929201650-00efb06dc0de
-	github.com/cloudquery/plugin-sdk/v4 v4.15.3
+	github.com/cloudquery/plugin-sdk/v4 v4.16.0
 	github.com/goccy/go-json v0.10.2
 	github.com/rs/zerolog v1.29.1
 	go.mongodb.org/mongo-driver v1.12.1

--- a/plugins/destination/mongodb/go.sum
+++ b/plugins/destination/mongodb/go.sum
@@ -88,8 +88,8 @@ github.com/cloudquery/plugin-pb-go v1.12.3 h1:rLK3/RR70/BX8tj2QzTnrjkxQhzfAT7SXE
 github.com/cloudquery/plugin-pb-go v1.12.3/go.mod h1:CYorX3zCHF9ByoOgdBOuwLX/2vVCDH6/FoREOE3oH+w=
 github.com/cloudquery/plugin-sdk/v2 v2.7.0 h1:hRXsdEiaOxJtsn/wZMFQC9/jPfU1MeMK3KF+gPGqm7U=
 github.com/cloudquery/plugin-sdk/v2 v2.7.0/go.mod h1:pAX6ojIW99b/Vg4CkhnsGkRIzNaVEceYMR+Bdit73ug=
-github.com/cloudquery/plugin-sdk/v4 v4.15.3 h1:krXOLZR/3xDAEMdfcZCVD2AbWO0SosnGrb0Lrk5AH/4=
-github.com/cloudquery/plugin-sdk/v4 v4.15.3/go.mod h1:ujSFEUAp8BmozOee0ljjsPHQfddXJCUTAzCD6sVKsu8=
+github.com/cloudquery/plugin-sdk/v4 v4.16.0 h1:AEYIEbZCCPxGFw/bPm5bOpyyPDSqM5DRFIUqfogyJfM=
+github.com/cloudquery/plugin-sdk/v4 v4.16.0/go.mod h1:ujSFEUAp8BmozOee0ljjsPHQfddXJCUTAzCD6sVKsu8=
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
 github.com/cncf/udpa/go v0.0.0-20201120205902-5459f2c99403/go.mod h1:WmhPx2Nbnhtbo57+VJT5O0JRkEi1Wbu0z5j0R8u5Hbk=
 github.com/cncf/udpa/go v0.0.0-20210930031921-04548b0d99d4/go.mod h1:6pvJx4me5XPnfI9Z40ddWsdw2W/uZgQLFXToKeRcDiI=

--- a/plugins/destination/mssql/go.mod
+++ b/plugins/destination/mssql/go.mod
@@ -4,7 +4,7 @@ go 1.21.1
 
 require (
 	github.com/apache/arrow/go/v14 v14.0.0-20230929201650-00efb06dc0de
-	github.com/cloudquery/plugin-sdk/v4 v4.15.3
+	github.com/cloudquery/plugin-sdk/v4 v4.16.0
 	github.com/goccy/go-json v0.10.2
 	github.com/google/uuid v1.3.1
 	github.com/microsoft/go-mssqldb v1.5.0

--- a/plugins/destination/mssql/go.sum
+++ b/plugins/destination/mssql/go.sum
@@ -100,8 +100,8 @@ github.com/cloudquery/plugin-pb-go v1.12.3 h1:rLK3/RR70/BX8tj2QzTnrjkxQhzfAT7SXE
 github.com/cloudquery/plugin-pb-go v1.12.3/go.mod h1:CYorX3zCHF9ByoOgdBOuwLX/2vVCDH6/FoREOE3oH+w=
 github.com/cloudquery/plugin-sdk/v2 v2.7.0 h1:hRXsdEiaOxJtsn/wZMFQC9/jPfU1MeMK3KF+gPGqm7U=
 github.com/cloudquery/plugin-sdk/v2 v2.7.0/go.mod h1:pAX6ojIW99b/Vg4CkhnsGkRIzNaVEceYMR+Bdit73ug=
-github.com/cloudquery/plugin-sdk/v4 v4.15.3 h1:krXOLZR/3xDAEMdfcZCVD2AbWO0SosnGrb0Lrk5AH/4=
-github.com/cloudquery/plugin-sdk/v4 v4.15.3/go.mod h1:ujSFEUAp8BmozOee0ljjsPHQfddXJCUTAzCD6sVKsu8=
+github.com/cloudquery/plugin-sdk/v4 v4.16.0 h1:AEYIEbZCCPxGFw/bPm5bOpyyPDSqM5DRFIUqfogyJfM=
+github.com/cloudquery/plugin-sdk/v4 v4.16.0/go.mod h1:ujSFEUAp8BmozOee0ljjsPHQfddXJCUTAzCD6sVKsu8=
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
 github.com/cncf/udpa/go v0.0.0-20201120205902-5459f2c99403/go.mod h1:WmhPx2Nbnhtbo57+VJT5O0JRkEi1Wbu0z5j0R8u5Hbk=
 github.com/cncf/udpa/go v0.0.0-20210930031921-04548b0d99d4/go.mod h1:6pvJx4me5XPnfI9Z40ddWsdw2W/uZgQLFXToKeRcDiI=

--- a/plugins/destination/mysql/go.mod
+++ b/plugins/destination/mysql/go.mod
@@ -4,7 +4,7 @@ go 1.21.1
 
 require (
 	github.com/apache/arrow/go/v14 v14.0.0-20230929201650-00efb06dc0de
-	github.com/cloudquery/plugin-sdk/v4 v4.15.3
+	github.com/cloudquery/plugin-sdk/v4 v4.16.0
 	github.com/go-sql-driver/mysql v1.7.1
 	github.com/google/uuid v1.3.1
 	github.com/rs/zerolog v1.29.1

--- a/plugins/destination/mysql/go.sum
+++ b/plugins/destination/mysql/go.sum
@@ -88,8 +88,8 @@ github.com/cloudquery/plugin-pb-go v1.12.3 h1:rLK3/RR70/BX8tj2QzTnrjkxQhzfAT7SXE
 github.com/cloudquery/plugin-pb-go v1.12.3/go.mod h1:CYorX3zCHF9ByoOgdBOuwLX/2vVCDH6/FoREOE3oH+w=
 github.com/cloudquery/plugin-sdk/v2 v2.7.0 h1:hRXsdEiaOxJtsn/wZMFQC9/jPfU1MeMK3KF+gPGqm7U=
 github.com/cloudquery/plugin-sdk/v2 v2.7.0/go.mod h1:pAX6ojIW99b/Vg4CkhnsGkRIzNaVEceYMR+Bdit73ug=
-github.com/cloudquery/plugin-sdk/v4 v4.15.3 h1:krXOLZR/3xDAEMdfcZCVD2AbWO0SosnGrb0Lrk5AH/4=
-github.com/cloudquery/plugin-sdk/v4 v4.15.3/go.mod h1:ujSFEUAp8BmozOee0ljjsPHQfddXJCUTAzCD6sVKsu8=
+github.com/cloudquery/plugin-sdk/v4 v4.16.0 h1:AEYIEbZCCPxGFw/bPm5bOpyyPDSqM5DRFIUqfogyJfM=
+github.com/cloudquery/plugin-sdk/v4 v4.16.0/go.mod h1:ujSFEUAp8BmozOee0ljjsPHQfddXJCUTAzCD6sVKsu8=
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
 github.com/cncf/udpa/go v0.0.0-20201120205902-5459f2c99403/go.mod h1:WmhPx2Nbnhtbo57+VJT5O0JRkEi1Wbu0z5j0R8u5Hbk=
 github.com/cncf/udpa/go v0.0.0-20210930031921-04548b0d99d4/go.mod h1:6pvJx4me5XPnfI9Z40ddWsdw2W/uZgQLFXToKeRcDiI=

--- a/plugins/destination/neo4j/go.mod
+++ b/plugins/destination/neo4j/go.mod
@@ -4,7 +4,7 @@ go 1.21.1
 
 require (
 	github.com/apache/arrow/go/v14 v14.0.0-20230929201650-00efb06dc0de
-	github.com/cloudquery/plugin-sdk/v4 v4.15.3
+	github.com/cloudquery/plugin-sdk/v4 v4.16.0
 	github.com/neo4j/neo4j-go-driver/v5 v5.6.0
 	github.com/rs/zerolog v1.29.1
 	github.com/stretchr/testify v1.8.4

--- a/plugins/destination/neo4j/go.sum
+++ b/plugins/destination/neo4j/go.sum
@@ -88,8 +88,8 @@ github.com/cloudquery/plugin-pb-go v1.12.3 h1:rLK3/RR70/BX8tj2QzTnrjkxQhzfAT7SXE
 github.com/cloudquery/plugin-pb-go v1.12.3/go.mod h1:CYorX3zCHF9ByoOgdBOuwLX/2vVCDH6/FoREOE3oH+w=
 github.com/cloudquery/plugin-sdk/v2 v2.7.0 h1:hRXsdEiaOxJtsn/wZMFQC9/jPfU1MeMK3KF+gPGqm7U=
 github.com/cloudquery/plugin-sdk/v2 v2.7.0/go.mod h1:pAX6ojIW99b/Vg4CkhnsGkRIzNaVEceYMR+Bdit73ug=
-github.com/cloudquery/plugin-sdk/v4 v4.15.3 h1:krXOLZR/3xDAEMdfcZCVD2AbWO0SosnGrb0Lrk5AH/4=
-github.com/cloudquery/plugin-sdk/v4 v4.15.3/go.mod h1:ujSFEUAp8BmozOee0ljjsPHQfddXJCUTAzCD6sVKsu8=
+github.com/cloudquery/plugin-sdk/v4 v4.16.0 h1:AEYIEbZCCPxGFw/bPm5bOpyyPDSqM5DRFIUqfogyJfM=
+github.com/cloudquery/plugin-sdk/v4 v4.16.0/go.mod h1:ujSFEUAp8BmozOee0ljjsPHQfddXJCUTAzCD6sVKsu8=
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
 github.com/cncf/udpa/go v0.0.0-20201120205902-5459f2c99403/go.mod h1:WmhPx2Nbnhtbo57+VJT5O0JRkEi1Wbu0z5j0R8u5Hbk=
 github.com/cncf/udpa/go v0.0.0-20210930031921-04548b0d99d4/go.mod h1:6pvJx4me5XPnfI9Z40ddWsdw2W/uZgQLFXToKeRcDiI=

--- a/plugins/destination/postgresql/go.mod
+++ b/plugins/destination/postgresql/go.mod
@@ -4,7 +4,7 @@ go 1.21.1
 
 require (
 	github.com/apache/arrow/go/v14 v14.0.0-20230929201650-00efb06dc0de
-	github.com/cloudquery/plugin-sdk/v4 v4.15.3
+	github.com/cloudquery/plugin-sdk/v4 v4.16.0
 	github.com/google/go-cmp v0.5.9
 	github.com/jackc/pgx-zerolog v0.0.0-20230315001418-f978528409eb
 	github.com/jackc/pgx/v5 v5.3.1

--- a/plugins/destination/postgresql/go.sum
+++ b/plugins/destination/postgresql/go.sum
@@ -92,8 +92,8 @@ github.com/cloudquery/plugin-pb-go v1.12.3 h1:rLK3/RR70/BX8tj2QzTnrjkxQhzfAT7SXE
 github.com/cloudquery/plugin-pb-go v1.12.3/go.mod h1:CYorX3zCHF9ByoOgdBOuwLX/2vVCDH6/FoREOE3oH+w=
 github.com/cloudquery/plugin-sdk/v2 v2.7.0 h1:hRXsdEiaOxJtsn/wZMFQC9/jPfU1MeMK3KF+gPGqm7U=
 github.com/cloudquery/plugin-sdk/v2 v2.7.0/go.mod h1:pAX6ojIW99b/Vg4CkhnsGkRIzNaVEceYMR+Bdit73ug=
-github.com/cloudquery/plugin-sdk/v4 v4.15.3 h1:krXOLZR/3xDAEMdfcZCVD2AbWO0SosnGrb0Lrk5AH/4=
-github.com/cloudquery/plugin-sdk/v4 v4.15.3/go.mod h1:ujSFEUAp8BmozOee0ljjsPHQfddXJCUTAzCD6sVKsu8=
+github.com/cloudquery/plugin-sdk/v4 v4.16.0 h1:AEYIEbZCCPxGFw/bPm5bOpyyPDSqM5DRFIUqfogyJfM=
+github.com/cloudquery/plugin-sdk/v4 v4.16.0/go.mod h1:ujSFEUAp8BmozOee0ljjsPHQfddXJCUTAzCD6sVKsu8=
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
 github.com/cncf/udpa/go v0.0.0-20201120205902-5459f2c99403/go.mod h1:WmhPx2Nbnhtbo57+VJT5O0JRkEi1Wbu0z5j0R8u5Hbk=
 github.com/cncf/udpa/go v0.0.0-20210930031921-04548b0d99d4/go.mod h1:6pvJx4me5XPnfI9Z40ddWsdw2W/uZgQLFXToKeRcDiI=

--- a/plugins/destination/s3/go.mod
+++ b/plugins/destination/s3/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/feature/s3/manager v1.11.87
 	github.com/aws/aws-sdk-go-v2/service/s3 v1.40.0
 	github.com/cloudquery/filetypes/v4 v4.1.15
-	github.com/cloudquery/plugin-sdk/v4 v4.15.3
+	github.com/cloudquery/plugin-sdk/v4 v4.16.0
 	github.com/google/go-cmp v0.5.9
 	github.com/google/uuid v1.3.1
 	github.com/rs/zerolog v1.31.0

--- a/plugins/destination/s3/go.sum
+++ b/plugins/destination/s3/go.sum
@@ -136,8 +136,8 @@ github.com/cloudquery/plugin-pb-go v1.12.3 h1:rLK3/RR70/BX8tj2QzTnrjkxQhzfAT7SXE
 github.com/cloudquery/plugin-pb-go v1.12.3/go.mod h1:CYorX3zCHF9ByoOgdBOuwLX/2vVCDH6/FoREOE3oH+w=
 github.com/cloudquery/plugin-sdk/v2 v2.7.0 h1:hRXsdEiaOxJtsn/wZMFQC9/jPfU1MeMK3KF+gPGqm7U=
 github.com/cloudquery/plugin-sdk/v2 v2.7.0/go.mod h1:pAX6ojIW99b/Vg4CkhnsGkRIzNaVEceYMR+Bdit73ug=
-github.com/cloudquery/plugin-sdk/v4 v4.15.3 h1:krXOLZR/3xDAEMdfcZCVD2AbWO0SosnGrb0Lrk5AH/4=
-github.com/cloudquery/plugin-sdk/v4 v4.15.3/go.mod h1:ujSFEUAp8BmozOee0ljjsPHQfddXJCUTAzCD6sVKsu8=
+github.com/cloudquery/plugin-sdk/v4 v4.16.0 h1:AEYIEbZCCPxGFw/bPm5bOpyyPDSqM5DRFIUqfogyJfM=
+github.com/cloudquery/plugin-sdk/v4 v4.16.0/go.mod h1:ujSFEUAp8BmozOee0ljjsPHQfddXJCUTAzCD6sVKsu8=
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
 github.com/cncf/udpa/go v0.0.0-20201120205902-5459f2c99403/go.mod h1:WmhPx2Nbnhtbo57+VJT5O0JRkEi1Wbu0z5j0R8u5Hbk=
 github.com/cncf/udpa/go v0.0.0-20210930031921-04548b0d99d4/go.mod h1:6pvJx4me5XPnfI9Z40ddWsdw2W/uZgQLFXToKeRcDiI=

--- a/plugins/destination/snowflake/go.mod
+++ b/plugins/destination/snowflake/go.mod
@@ -4,7 +4,7 @@ go 1.21.1
 
 require (
 	github.com/apache/arrow/go/v14 v14.0.0-20230929201650-00efb06dc0de
-	github.com/cloudquery/plugin-sdk/v4 v4.15.3
+	github.com/cloudquery/plugin-sdk/v4 v4.16.0
 	github.com/goccy/go-json v0.10.2
 	github.com/rs/zerolog v1.29.1
 	github.com/snowflakedb/gosnowflake v1.6.19

--- a/plugins/destination/snowflake/go.sum
+++ b/plugins/destination/snowflake/go.sum
@@ -146,8 +146,8 @@ github.com/cloudquery/plugin-pb-go v1.12.3 h1:rLK3/RR70/BX8tj2QzTnrjkxQhzfAT7SXE
 github.com/cloudquery/plugin-pb-go v1.12.3/go.mod h1:CYorX3zCHF9ByoOgdBOuwLX/2vVCDH6/FoREOE3oH+w=
 github.com/cloudquery/plugin-sdk/v2 v2.7.0 h1:hRXsdEiaOxJtsn/wZMFQC9/jPfU1MeMK3KF+gPGqm7U=
 github.com/cloudquery/plugin-sdk/v2 v2.7.0/go.mod h1:pAX6ojIW99b/Vg4CkhnsGkRIzNaVEceYMR+Bdit73ug=
-github.com/cloudquery/plugin-sdk/v4 v4.15.3 h1:krXOLZR/3xDAEMdfcZCVD2AbWO0SosnGrb0Lrk5AH/4=
-github.com/cloudquery/plugin-sdk/v4 v4.15.3/go.mod h1:ujSFEUAp8BmozOee0ljjsPHQfddXJCUTAzCD6sVKsu8=
+github.com/cloudquery/plugin-sdk/v4 v4.16.0 h1:AEYIEbZCCPxGFw/bPm5bOpyyPDSqM5DRFIUqfogyJfM=
+github.com/cloudquery/plugin-sdk/v4 v4.16.0/go.mod h1:ujSFEUAp8BmozOee0ljjsPHQfddXJCUTAzCD6sVKsu8=
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
 github.com/cncf/udpa/go v0.0.0-20201120205902-5459f2c99403/go.mod h1:WmhPx2Nbnhtbo57+VJT5O0JRkEi1Wbu0z5j0R8u5Hbk=
 github.com/cncf/udpa/go v0.0.0-20210930031921-04548b0d99d4/go.mod h1:6pvJx4me5XPnfI9Z40ddWsdw2W/uZgQLFXToKeRcDiI=

--- a/plugins/destination/sqlite/go.mod
+++ b/plugins/destination/sqlite/go.mod
@@ -4,7 +4,7 @@ go 1.21.1
 
 require (
 	github.com/apache/arrow/go/v14 v14.0.0-20230929201650-00efb06dc0de
-	github.com/cloudquery/plugin-sdk/v4 v4.15.3
+	github.com/cloudquery/plugin-sdk/v4 v4.16.0
 	github.com/mattn/go-sqlite3 v1.14.16
 	github.com/rs/zerolog v1.29.1
 )

--- a/plugins/destination/sqlite/go.sum
+++ b/plugins/destination/sqlite/go.sum
@@ -88,8 +88,8 @@ github.com/cloudquery/plugin-pb-go v1.12.3 h1:rLK3/RR70/BX8tj2QzTnrjkxQhzfAT7SXE
 github.com/cloudquery/plugin-pb-go v1.12.3/go.mod h1:CYorX3zCHF9ByoOgdBOuwLX/2vVCDH6/FoREOE3oH+w=
 github.com/cloudquery/plugin-sdk/v2 v2.7.0 h1:hRXsdEiaOxJtsn/wZMFQC9/jPfU1MeMK3KF+gPGqm7U=
 github.com/cloudquery/plugin-sdk/v2 v2.7.0/go.mod h1:pAX6ojIW99b/Vg4CkhnsGkRIzNaVEceYMR+Bdit73ug=
-github.com/cloudquery/plugin-sdk/v4 v4.15.3 h1:krXOLZR/3xDAEMdfcZCVD2AbWO0SosnGrb0Lrk5AH/4=
-github.com/cloudquery/plugin-sdk/v4 v4.15.3/go.mod h1:ujSFEUAp8BmozOee0ljjsPHQfddXJCUTAzCD6sVKsu8=
+github.com/cloudquery/plugin-sdk/v4 v4.16.0 h1:AEYIEbZCCPxGFw/bPm5bOpyyPDSqM5DRFIUqfogyJfM=
+github.com/cloudquery/plugin-sdk/v4 v4.16.0/go.mod h1:ujSFEUAp8BmozOee0ljjsPHQfddXJCUTAzCD6sVKsu8=
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
 github.com/cncf/udpa/go v0.0.0-20201120205902-5459f2c99403/go.mod h1:WmhPx2Nbnhtbo57+VJT5O0JRkEi1Wbu0z5j0R8u5Hbk=
 github.com/cncf/udpa/go v0.0.0-20210930031921-04548b0d99d4/go.mod h1:6pvJx4me5XPnfI9Z40ddWsdw2W/uZgQLFXToKeRcDiI=

--- a/plugins/destination/test/go.mod
+++ b/plugins/destination/test/go.mod
@@ -4,7 +4,7 @@ go 1.21.1
 
 require (
 	github.com/apache/arrow/go/v14 v14.0.0-20230929201650-00efb06dc0de
-	github.com/cloudquery/plugin-sdk/v4 v4.15.3
+	github.com/cloudquery/plugin-sdk/v4 v4.16.0
 	github.com/rs/zerolog v1.29.1
 )
 

--- a/plugins/destination/test/go.sum
+++ b/plugins/destination/test/go.sum
@@ -88,8 +88,8 @@ github.com/cloudquery/plugin-pb-go v1.12.3 h1:rLK3/RR70/BX8tj2QzTnrjkxQhzfAT7SXE
 github.com/cloudquery/plugin-pb-go v1.12.3/go.mod h1:CYorX3zCHF9ByoOgdBOuwLX/2vVCDH6/FoREOE3oH+w=
 github.com/cloudquery/plugin-sdk/v2 v2.7.0 h1:hRXsdEiaOxJtsn/wZMFQC9/jPfU1MeMK3KF+gPGqm7U=
 github.com/cloudquery/plugin-sdk/v2 v2.7.0/go.mod h1:pAX6ojIW99b/Vg4CkhnsGkRIzNaVEceYMR+Bdit73ug=
-github.com/cloudquery/plugin-sdk/v4 v4.15.3 h1:krXOLZR/3xDAEMdfcZCVD2AbWO0SosnGrb0Lrk5AH/4=
-github.com/cloudquery/plugin-sdk/v4 v4.15.3/go.mod h1:ujSFEUAp8BmozOee0ljjsPHQfddXJCUTAzCD6sVKsu8=
+github.com/cloudquery/plugin-sdk/v4 v4.16.0 h1:AEYIEbZCCPxGFw/bPm5bOpyyPDSqM5DRFIUqfogyJfM=
+github.com/cloudquery/plugin-sdk/v4 v4.16.0/go.mod h1:ujSFEUAp8BmozOee0ljjsPHQfddXJCUTAzCD6sVKsu8=
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
 github.com/cncf/udpa/go v0.0.0-20201120205902-5459f2c99403/go.mod h1:WmhPx2Nbnhtbo57+VJT5O0JRkEi1Wbu0z5j0R8u5Hbk=
 github.com/cncf/udpa/go v0.0.0-20210930031921-04548b0d99d4/go.mod h1:6pvJx4me5XPnfI9Z40ddWsdw2W/uZgQLFXToKeRcDiI=

--- a/plugins/source/alicloud/go.mod
+++ b/plugins/source/alicloud/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/aliyun/aliyun-oss-go-sdk v2.2.7+incompatible
 	github.com/apache/arrow/go/v14 v14.0.0-20230929201650-00efb06dc0de
 	github.com/cloudquery/codegen v0.3.9
-	github.com/cloudquery/plugin-sdk/v4 v4.15.3
+	github.com/cloudquery/plugin-sdk/v4 v4.16.0
 	github.com/golang/mock v1.5.0
 	github.com/pkg/errors v0.9.1
 	github.com/rs/zerolog v1.29.1

--- a/plugins/source/alicloud/go.sum
+++ b/plugins/source/alicloud/go.sum
@@ -108,8 +108,8 @@ github.com/cloudquery/plugin-pb-go v1.12.3 h1:rLK3/RR70/BX8tj2QzTnrjkxQhzfAT7SXE
 github.com/cloudquery/plugin-pb-go v1.12.3/go.mod h1:CYorX3zCHF9ByoOgdBOuwLX/2vVCDH6/FoREOE3oH+w=
 github.com/cloudquery/plugin-sdk/v2 v2.7.0 h1:hRXsdEiaOxJtsn/wZMFQC9/jPfU1MeMK3KF+gPGqm7U=
 github.com/cloudquery/plugin-sdk/v2 v2.7.0/go.mod h1:pAX6ojIW99b/Vg4CkhnsGkRIzNaVEceYMR+Bdit73ug=
-github.com/cloudquery/plugin-sdk/v4 v4.15.3 h1:krXOLZR/3xDAEMdfcZCVD2AbWO0SosnGrb0Lrk5AH/4=
-github.com/cloudquery/plugin-sdk/v4 v4.15.3/go.mod h1:ujSFEUAp8BmozOee0ljjsPHQfddXJCUTAzCD6sVKsu8=
+github.com/cloudquery/plugin-sdk/v4 v4.16.0 h1:AEYIEbZCCPxGFw/bPm5bOpyyPDSqM5DRFIUqfogyJfM=
+github.com/cloudquery/plugin-sdk/v4 v4.16.0/go.mod h1:ujSFEUAp8BmozOee0ljjsPHQfddXJCUTAzCD6sVKsu8=
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
 github.com/cncf/udpa/go v0.0.0-20201120205902-5459f2c99403/go.mod h1:WmhPx2Nbnhtbo57+VJT5O0JRkEi1Wbu0z5j0R8u5Hbk=
 github.com/cncf/udpa/go v0.0.0-20210930031921-04548b0d99d4/go.mod h1:6pvJx4me5XPnfI9Z40ddWsdw2W/uZgQLFXToKeRcDiI=

--- a/plugins/source/aws/go.mod
+++ b/plugins/source/aws/go.mod
@@ -131,7 +131,7 @@ require (
 	github.com/aws/smithy-go v1.14.1
 	github.com/basgys/goxml2json v1.1.0
 	github.com/cloudquery/codegen v0.3.9
-	github.com/cloudquery/plugin-sdk/v4 v4.15.3
+	github.com/cloudquery/plugin-sdk/v4 v4.16.0
 	github.com/cockroachdb/cockroachdb-parser v0.0.0-20230705064001-302c9ad52e1a
 	github.com/gertd/go-pluralize v0.2.1
 	github.com/ghodss/yaml v1.0.0

--- a/plugins/source/aws/go.sum
+++ b/plugins/source/aws/go.sum
@@ -416,8 +416,8 @@ github.com/cloudquery/plugin-pb-go v1.12.3 h1:rLK3/RR70/BX8tj2QzTnrjkxQhzfAT7SXE
 github.com/cloudquery/plugin-pb-go v1.12.3/go.mod h1:CYorX3zCHF9ByoOgdBOuwLX/2vVCDH6/FoREOE3oH+w=
 github.com/cloudquery/plugin-sdk/v2 v2.7.0 h1:hRXsdEiaOxJtsn/wZMFQC9/jPfU1MeMK3KF+gPGqm7U=
 github.com/cloudquery/plugin-sdk/v2 v2.7.0/go.mod h1:pAX6ojIW99b/Vg4CkhnsGkRIzNaVEceYMR+Bdit73ug=
-github.com/cloudquery/plugin-sdk/v4 v4.15.3 h1:krXOLZR/3xDAEMdfcZCVD2AbWO0SosnGrb0Lrk5AH/4=
-github.com/cloudquery/plugin-sdk/v4 v4.15.3/go.mod h1:ujSFEUAp8BmozOee0ljjsPHQfddXJCUTAzCD6sVKsu8=
+github.com/cloudquery/plugin-sdk/v4 v4.16.0 h1:AEYIEbZCCPxGFw/bPm5bOpyyPDSqM5DRFIUqfogyJfM=
+github.com/cloudquery/plugin-sdk/v4 v4.16.0/go.mod h1:ujSFEUAp8BmozOee0ljjsPHQfddXJCUTAzCD6sVKsu8=
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
 github.com/cncf/udpa/go v0.0.0-20201120205902-5459f2c99403/go.mod h1:WmhPx2Nbnhtbo57+VJT5O0JRkEi1Wbu0z5j0R8u5Hbk=
 github.com/cncf/udpa/go v0.0.0-20210930031921-04548b0d99d4/go.mod h1:6pvJx4me5XPnfI9Z40ddWsdw2W/uZgQLFXToKeRcDiI=

--- a/plugins/source/awspricing/go.mod
+++ b/plugins/source/awspricing/go.mod
@@ -3,7 +3,7 @@ module github.com/cloudquery/cloudquery/plugins/source/awspricing
 go 1.21.1
 
 require (
-	github.com/cloudquery/plugin-sdk/v4 v4.15.3
+	github.com/cloudquery/plugin-sdk/v4 v4.16.0
 	github.com/rs/zerolog v1.29.1
 )
 

--- a/plugins/source/awspricing/go.sum
+++ b/plugins/source/awspricing/go.sum
@@ -92,8 +92,8 @@ github.com/cloudquery/plugin-pb-go v1.12.3 h1:rLK3/RR70/BX8tj2QzTnrjkxQhzfAT7SXE
 github.com/cloudquery/plugin-pb-go v1.12.3/go.mod h1:CYorX3zCHF9ByoOgdBOuwLX/2vVCDH6/FoREOE3oH+w=
 github.com/cloudquery/plugin-sdk/v2 v2.7.0 h1:hRXsdEiaOxJtsn/wZMFQC9/jPfU1MeMK3KF+gPGqm7U=
 github.com/cloudquery/plugin-sdk/v2 v2.7.0/go.mod h1:pAX6ojIW99b/Vg4CkhnsGkRIzNaVEceYMR+Bdit73ug=
-github.com/cloudquery/plugin-sdk/v4 v4.15.3 h1:krXOLZR/3xDAEMdfcZCVD2AbWO0SosnGrb0Lrk5AH/4=
-github.com/cloudquery/plugin-sdk/v4 v4.15.3/go.mod h1:ujSFEUAp8BmozOee0ljjsPHQfddXJCUTAzCD6sVKsu8=
+github.com/cloudquery/plugin-sdk/v4 v4.16.0 h1:AEYIEbZCCPxGFw/bPm5bOpyyPDSqM5DRFIUqfogyJfM=
+github.com/cloudquery/plugin-sdk/v4 v4.16.0/go.mod h1:ujSFEUAp8BmozOee0ljjsPHQfddXJCUTAzCD6sVKsu8=
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
 github.com/cncf/udpa/go v0.0.0-20201120205902-5459f2c99403/go.mod h1:WmhPx2Nbnhtbo57+VJT5O0JRkEi1Wbu0z5j0R8u5Hbk=
 github.com/cncf/udpa/go v0.0.0-20210930031921-04548b0d99d4/go.mod h1:6pvJx4me5XPnfI9Z40ddWsdw2W/uZgQLFXToKeRcDiI=

--- a/plugins/source/azure/go.mod
+++ b/plugins/source/azure/go.mod
@@ -101,7 +101,7 @@ require (
 	github.com/Azure/azure-sdk-for-go/sdk/storage/azqueue v0.1.0
 	github.com/apache/arrow/go/v14 v14.0.0-20230929201650-00efb06dc0de
 	github.com/cloudquery/codegen v0.3.9
-	github.com/cloudquery/plugin-sdk/v4 v4.15.3
+	github.com/cloudquery/plugin-sdk/v4 v4.16.0
 	github.com/cockroachdb/cockroachdb-parser v0.0.0-20230705064001-302c9ad52e1a
 	github.com/gorilla/mux v1.8.0
 	github.com/invopop/jsonschema v0.11.0

--- a/plugins/source/azure/go.sum
+++ b/plugins/source/azure/go.sum
@@ -328,8 +328,8 @@ github.com/cloudquery/plugin-pb-go v1.12.3 h1:rLK3/RR70/BX8tj2QzTnrjkxQhzfAT7SXE
 github.com/cloudquery/plugin-pb-go v1.12.3/go.mod h1:CYorX3zCHF9ByoOgdBOuwLX/2vVCDH6/FoREOE3oH+w=
 github.com/cloudquery/plugin-sdk/v2 v2.7.0 h1:hRXsdEiaOxJtsn/wZMFQC9/jPfU1MeMK3KF+gPGqm7U=
 github.com/cloudquery/plugin-sdk/v2 v2.7.0/go.mod h1:pAX6ojIW99b/Vg4CkhnsGkRIzNaVEceYMR+Bdit73ug=
-github.com/cloudquery/plugin-sdk/v4 v4.15.3 h1:krXOLZR/3xDAEMdfcZCVD2AbWO0SosnGrb0Lrk5AH/4=
-github.com/cloudquery/plugin-sdk/v4 v4.15.3/go.mod h1:ujSFEUAp8BmozOee0ljjsPHQfddXJCUTAzCD6sVKsu8=
+github.com/cloudquery/plugin-sdk/v4 v4.16.0 h1:AEYIEbZCCPxGFw/bPm5bOpyyPDSqM5DRFIUqfogyJfM=
+github.com/cloudquery/plugin-sdk/v4 v4.16.0/go.mod h1:ujSFEUAp8BmozOee0ljjsPHQfddXJCUTAzCD6sVKsu8=
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
 github.com/cncf/udpa/go v0.0.0-20201120205902-5459f2c99403/go.mod h1:WmhPx2Nbnhtbo57+VJT5O0JRkEi1Wbu0z5j0R8u5Hbk=
 github.com/cncf/udpa/go v0.0.0-20210930031921-04548b0d99d4/go.mod h1:6pvJx4me5XPnfI9Z40ddWsdw2W/uZgQLFXToKeRcDiI=

--- a/plugins/source/azuredevops/go.mod
+++ b/plugins/source/azuredevops/go.mod
@@ -4,7 +4,7 @@ go 1.21.1
 
 require (
 	github.com/apache/arrow/go/v14 v14.0.0-20230929201650-00efb06dc0de
-	github.com/cloudquery/plugin-sdk/v4 v4.15.3
+	github.com/cloudquery/plugin-sdk/v4 v4.16.0
 	github.com/google/uuid v1.3.1
 	github.com/microsoft/azure-devops-go-api/azuredevops/v6 v6.0.1
 	github.com/rs/zerolog v1.29.1

--- a/plugins/source/azuredevops/go.sum
+++ b/plugins/source/azuredevops/go.sum
@@ -92,8 +92,8 @@ github.com/cloudquery/plugin-pb-go v1.12.3 h1:rLK3/RR70/BX8tj2QzTnrjkxQhzfAT7SXE
 github.com/cloudquery/plugin-pb-go v1.12.3/go.mod h1:CYorX3zCHF9ByoOgdBOuwLX/2vVCDH6/FoREOE3oH+w=
 github.com/cloudquery/plugin-sdk/v2 v2.7.0 h1:hRXsdEiaOxJtsn/wZMFQC9/jPfU1MeMK3KF+gPGqm7U=
 github.com/cloudquery/plugin-sdk/v2 v2.7.0/go.mod h1:pAX6ojIW99b/Vg4CkhnsGkRIzNaVEceYMR+Bdit73ug=
-github.com/cloudquery/plugin-sdk/v4 v4.15.3 h1:krXOLZR/3xDAEMdfcZCVD2AbWO0SosnGrb0Lrk5AH/4=
-github.com/cloudquery/plugin-sdk/v4 v4.15.3/go.mod h1:ujSFEUAp8BmozOee0ljjsPHQfddXJCUTAzCD6sVKsu8=
+github.com/cloudquery/plugin-sdk/v4 v4.16.0 h1:AEYIEbZCCPxGFw/bPm5bOpyyPDSqM5DRFIUqfogyJfM=
+github.com/cloudquery/plugin-sdk/v4 v4.16.0/go.mod h1:ujSFEUAp8BmozOee0ljjsPHQfddXJCUTAzCD6sVKsu8=
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
 github.com/cncf/udpa/go v0.0.0-20201120205902-5459f2c99403/go.mod h1:WmhPx2Nbnhtbo57+VJT5O0JRkEi1Wbu0z5j0R8u5Hbk=
 github.com/cncf/udpa/go v0.0.0-20210930031921-04548b0d99d4/go.mod h1:6pvJx4me5XPnfI9Z40ddWsdw2W/uZgQLFXToKeRcDiI=

--- a/plugins/source/cloudflare/go.mod
+++ b/plugins/source/cloudflare/go.mod
@@ -5,7 +5,7 @@ go 1.21.1
 require (
 	github.com/apache/arrow/go/v14 v14.0.0-20230929201650-00efb06dc0de
 	github.com/cloudflare/cloudflare-go v0.57.1
-	github.com/cloudquery/plugin-sdk/v4 v4.15.3
+	github.com/cloudquery/plugin-sdk/v4 v4.16.0
 	github.com/golang/mock v1.6.0
 	github.com/rs/zerolog v1.29.1
 	github.com/thoas/go-funk v0.9.3

--- a/plugins/source/cloudflare/go.sum
+++ b/plugins/source/cloudflare/go.sum
@@ -94,8 +94,8 @@ github.com/cloudquery/plugin-pb-go v1.12.3 h1:rLK3/RR70/BX8tj2QzTnrjkxQhzfAT7SXE
 github.com/cloudquery/plugin-pb-go v1.12.3/go.mod h1:CYorX3zCHF9ByoOgdBOuwLX/2vVCDH6/FoREOE3oH+w=
 github.com/cloudquery/plugin-sdk/v2 v2.7.0 h1:hRXsdEiaOxJtsn/wZMFQC9/jPfU1MeMK3KF+gPGqm7U=
 github.com/cloudquery/plugin-sdk/v2 v2.7.0/go.mod h1:pAX6ojIW99b/Vg4CkhnsGkRIzNaVEceYMR+Bdit73ug=
-github.com/cloudquery/plugin-sdk/v4 v4.15.3 h1:krXOLZR/3xDAEMdfcZCVD2AbWO0SosnGrb0Lrk5AH/4=
-github.com/cloudquery/plugin-sdk/v4 v4.15.3/go.mod h1:ujSFEUAp8BmozOee0ljjsPHQfddXJCUTAzCD6sVKsu8=
+github.com/cloudquery/plugin-sdk/v4 v4.16.0 h1:AEYIEbZCCPxGFw/bPm5bOpyyPDSqM5DRFIUqfogyJfM=
+github.com/cloudquery/plugin-sdk/v4 v4.16.0/go.mod h1:ujSFEUAp8BmozOee0ljjsPHQfddXJCUTAzCD6sVKsu8=
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
 github.com/cncf/udpa/go v0.0.0-20201120205902-5459f2c99403/go.mod h1:WmhPx2Nbnhtbo57+VJT5O0JRkEi1Wbu0z5j0R8u5Hbk=
 github.com/cncf/udpa/go v0.0.0-20210930031921-04548b0d99d4/go.mod h1:6pvJx4me5XPnfI9Z40ddWsdw2W/uZgQLFXToKeRcDiI=

--- a/plugins/source/datadog/go.mod
+++ b/plugins/source/datadog/go.mod
@@ -5,7 +5,7 @@ go 1.21.1
 require (
 	github.com/DataDog/datadog-api-client-go/v2 v2.17.0
 	github.com/apache/arrow/go/v14 v14.0.0-20230929201650-00efb06dc0de
-	github.com/cloudquery/plugin-sdk/v4 v4.15.3
+	github.com/cloudquery/plugin-sdk/v4 v4.16.0
 	github.com/golang/mock v1.6.0
 	github.com/pkg/errors v0.9.1
 	github.com/rs/zerolog v1.29.1

--- a/plugins/source/datadog/go.sum
+++ b/plugins/source/datadog/go.sum
@@ -96,8 +96,8 @@ github.com/cloudquery/plugin-pb-go v1.12.3 h1:rLK3/RR70/BX8tj2QzTnrjkxQhzfAT7SXE
 github.com/cloudquery/plugin-pb-go v1.12.3/go.mod h1:CYorX3zCHF9ByoOgdBOuwLX/2vVCDH6/FoREOE3oH+w=
 github.com/cloudquery/plugin-sdk/v2 v2.7.0 h1:hRXsdEiaOxJtsn/wZMFQC9/jPfU1MeMK3KF+gPGqm7U=
 github.com/cloudquery/plugin-sdk/v2 v2.7.0/go.mod h1:pAX6ojIW99b/Vg4CkhnsGkRIzNaVEceYMR+Bdit73ug=
-github.com/cloudquery/plugin-sdk/v4 v4.15.3 h1:krXOLZR/3xDAEMdfcZCVD2AbWO0SosnGrb0Lrk5AH/4=
-github.com/cloudquery/plugin-sdk/v4 v4.15.3/go.mod h1:ujSFEUAp8BmozOee0ljjsPHQfddXJCUTAzCD6sVKsu8=
+github.com/cloudquery/plugin-sdk/v4 v4.16.0 h1:AEYIEbZCCPxGFw/bPm5bOpyyPDSqM5DRFIUqfogyJfM=
+github.com/cloudquery/plugin-sdk/v4 v4.16.0/go.mod h1:ujSFEUAp8BmozOee0ljjsPHQfddXJCUTAzCD6sVKsu8=
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
 github.com/cncf/udpa/go v0.0.0-20201120205902-5459f2c99403/go.mod h1:WmhPx2Nbnhtbo57+VJT5O0JRkEi1Wbu0z5j0R8u5Hbk=
 github.com/cncf/udpa/go v0.0.0-20210930031921-04548b0d99d4/go.mod h1:6pvJx4me5XPnfI9Z40ddWsdw2W/uZgQLFXToKeRcDiI=

--- a/plugins/source/digitalocean/go.mod
+++ b/plugins/source/digitalocean/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/config v1.18.35
 	github.com/aws/aws-sdk-go-v2/service/s3 v1.38.4
 	github.com/aws/smithy-go v1.14.2
-	github.com/cloudquery/plugin-sdk/v4 v4.15.3
+	github.com/cloudquery/plugin-sdk/v4 v4.16.0
 	github.com/digitalocean/godo v1.99.0
 	github.com/golang/mock v1.6.0
 	github.com/pkg/errors v0.9.1

--- a/plugins/source/digitalocean/go.sum
+++ b/plugins/source/digitalocean/go.sum
@@ -130,8 +130,8 @@ github.com/cloudquery/plugin-pb-go v1.12.3 h1:rLK3/RR70/BX8tj2QzTnrjkxQhzfAT7SXE
 github.com/cloudquery/plugin-pb-go v1.12.3/go.mod h1:CYorX3zCHF9ByoOgdBOuwLX/2vVCDH6/FoREOE3oH+w=
 github.com/cloudquery/plugin-sdk/v2 v2.7.0 h1:hRXsdEiaOxJtsn/wZMFQC9/jPfU1MeMK3KF+gPGqm7U=
 github.com/cloudquery/plugin-sdk/v2 v2.7.0/go.mod h1:pAX6ojIW99b/Vg4CkhnsGkRIzNaVEceYMR+Bdit73ug=
-github.com/cloudquery/plugin-sdk/v4 v4.15.3 h1:krXOLZR/3xDAEMdfcZCVD2AbWO0SosnGrb0Lrk5AH/4=
-github.com/cloudquery/plugin-sdk/v4 v4.15.3/go.mod h1:ujSFEUAp8BmozOee0ljjsPHQfddXJCUTAzCD6sVKsu8=
+github.com/cloudquery/plugin-sdk/v4 v4.16.0 h1:AEYIEbZCCPxGFw/bPm5bOpyyPDSqM5DRFIUqfogyJfM=
+github.com/cloudquery/plugin-sdk/v4 v4.16.0/go.mod h1:ujSFEUAp8BmozOee0ljjsPHQfddXJCUTAzCD6sVKsu8=
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
 github.com/cncf/udpa/go v0.0.0-20201120205902-5459f2c99403/go.mod h1:WmhPx2Nbnhtbo57+VJT5O0JRkEi1Wbu0z5j0R8u5Hbk=
 github.com/cncf/udpa/go v0.0.0-20210930031921-04548b0d99d4/go.mod h1:6pvJx4me5XPnfI9Z40ddWsdw2W/uZgQLFXToKeRcDiI=

--- a/plugins/source/facebookmarketing/go.mod
+++ b/plugins/source/facebookmarketing/go.mod
@@ -4,7 +4,7 @@ go 1.21.1
 
 require (
 	github.com/apache/arrow/go/v14 v14.0.0-20230929201650-00efb06dc0de
-	github.com/cloudquery/plugin-sdk/v4 v4.15.3
+	github.com/cloudquery/plugin-sdk/v4 v4.16.0
 	github.com/rs/zerolog v1.29.1
 	github.com/thoas/go-funk v0.9.3
 	golang.org/x/exp v0.0.0-20230905200255-921286631fa9

--- a/plugins/source/facebookmarketing/go.sum
+++ b/plugins/source/facebookmarketing/go.sum
@@ -92,8 +92,8 @@ github.com/cloudquery/plugin-pb-go v1.12.3 h1:rLK3/RR70/BX8tj2QzTnrjkxQhzfAT7SXE
 github.com/cloudquery/plugin-pb-go v1.12.3/go.mod h1:CYorX3zCHF9ByoOgdBOuwLX/2vVCDH6/FoREOE3oH+w=
 github.com/cloudquery/plugin-sdk/v2 v2.7.0 h1:hRXsdEiaOxJtsn/wZMFQC9/jPfU1MeMK3KF+gPGqm7U=
 github.com/cloudquery/plugin-sdk/v2 v2.7.0/go.mod h1:pAX6ojIW99b/Vg4CkhnsGkRIzNaVEceYMR+Bdit73ug=
-github.com/cloudquery/plugin-sdk/v4 v4.15.3 h1:krXOLZR/3xDAEMdfcZCVD2AbWO0SosnGrb0Lrk5AH/4=
-github.com/cloudquery/plugin-sdk/v4 v4.15.3/go.mod h1:ujSFEUAp8BmozOee0ljjsPHQfddXJCUTAzCD6sVKsu8=
+github.com/cloudquery/plugin-sdk/v4 v4.16.0 h1:AEYIEbZCCPxGFw/bPm5bOpyyPDSqM5DRFIUqfogyJfM=
+github.com/cloudquery/plugin-sdk/v4 v4.16.0/go.mod h1:ujSFEUAp8BmozOee0ljjsPHQfddXJCUTAzCD6sVKsu8=
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
 github.com/cncf/udpa/go v0.0.0-20201120205902-5459f2c99403/go.mod h1:WmhPx2Nbnhtbo57+VJT5O0JRkEi1Wbu0z5j0R8u5Hbk=
 github.com/cncf/udpa/go v0.0.0-20210930031921-04548b0d99d4/go.mod h1:6pvJx4me5XPnfI9Z40ddWsdw2W/uZgQLFXToKeRcDiI=

--- a/plugins/source/fastly/go.mod
+++ b/plugins/source/fastly/go.mod
@@ -5,7 +5,7 @@ go 1.21.1
 require (
 	github.com/apache/arrow/go/v14 v14.0.0-20230929201650-00efb06dc0de
 	github.com/cloudquery/codegen v0.3.9
-	github.com/cloudquery/plugin-sdk/v4 v4.15.3
+	github.com/cloudquery/plugin-sdk/v4 v4.16.0
 	github.com/fastly/go-fastly/v7 v7.0.0
 	github.com/golang/mock v1.6.0
 	github.com/rs/zerolog v1.29.1

--- a/plugins/source/fastly/go.sum
+++ b/plugins/source/fastly/go.sum
@@ -104,8 +104,8 @@ github.com/cloudquery/plugin-pb-go v1.12.3 h1:rLK3/RR70/BX8tj2QzTnrjkxQhzfAT7SXE
 github.com/cloudquery/plugin-pb-go v1.12.3/go.mod h1:CYorX3zCHF9ByoOgdBOuwLX/2vVCDH6/FoREOE3oH+w=
 github.com/cloudquery/plugin-sdk/v2 v2.7.0 h1:hRXsdEiaOxJtsn/wZMFQC9/jPfU1MeMK3KF+gPGqm7U=
 github.com/cloudquery/plugin-sdk/v2 v2.7.0/go.mod h1:pAX6ojIW99b/Vg4CkhnsGkRIzNaVEceYMR+Bdit73ug=
-github.com/cloudquery/plugin-sdk/v4 v4.15.3 h1:krXOLZR/3xDAEMdfcZCVD2AbWO0SosnGrb0Lrk5AH/4=
-github.com/cloudquery/plugin-sdk/v4 v4.15.3/go.mod h1:ujSFEUAp8BmozOee0ljjsPHQfddXJCUTAzCD6sVKsu8=
+github.com/cloudquery/plugin-sdk/v4 v4.16.0 h1:AEYIEbZCCPxGFw/bPm5bOpyyPDSqM5DRFIUqfogyJfM=
+github.com/cloudquery/plugin-sdk/v4 v4.16.0/go.mod h1:ujSFEUAp8BmozOee0ljjsPHQfddXJCUTAzCD6sVKsu8=
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
 github.com/cncf/udpa/go v0.0.0-20201120205902-5459f2c99403/go.mod h1:WmhPx2Nbnhtbo57+VJT5O0JRkEi1Wbu0z5j0R8u5Hbk=
 github.com/cncf/udpa/go v0.0.0-20210930031921-04548b0d99d4/go.mod h1:6pvJx4me5XPnfI9Z40ddWsdw2W/uZgQLFXToKeRcDiI=

--- a/plugins/source/firestore/go.mod
+++ b/plugins/source/firestore/go.mod
@@ -5,7 +5,7 @@ go 1.21.1
 require (
 	cloud.google.com/go/firestore v1.13.0
 	github.com/apache/arrow/go/v14 v14.0.0-20230929201650-00efb06dc0de
-	github.com/cloudquery/plugin-sdk/v4 v4.15.3
+	github.com/cloudquery/plugin-sdk/v4 v4.16.0
 	github.com/rs/zerolog v1.29.1
 	github.com/stretchr/testify v1.8.4
 	golang.org/x/sync v0.3.0

--- a/plugins/source/firestore/go.sum
+++ b/plugins/source/firestore/go.sum
@@ -98,8 +98,8 @@ github.com/cloudquery/plugin-pb-go v1.12.3 h1:rLK3/RR70/BX8tj2QzTnrjkxQhzfAT7SXE
 github.com/cloudquery/plugin-pb-go v1.12.3/go.mod h1:CYorX3zCHF9ByoOgdBOuwLX/2vVCDH6/FoREOE3oH+w=
 github.com/cloudquery/plugin-sdk/v2 v2.7.0 h1:hRXsdEiaOxJtsn/wZMFQC9/jPfU1MeMK3KF+gPGqm7U=
 github.com/cloudquery/plugin-sdk/v2 v2.7.0/go.mod h1:pAX6ojIW99b/Vg4CkhnsGkRIzNaVEceYMR+Bdit73ug=
-github.com/cloudquery/plugin-sdk/v4 v4.15.3 h1:krXOLZR/3xDAEMdfcZCVD2AbWO0SosnGrb0Lrk5AH/4=
-github.com/cloudquery/plugin-sdk/v4 v4.15.3/go.mod h1:ujSFEUAp8BmozOee0ljjsPHQfddXJCUTAzCD6sVKsu8=
+github.com/cloudquery/plugin-sdk/v4 v4.16.0 h1:AEYIEbZCCPxGFw/bPm5bOpyyPDSqM5DRFIUqfogyJfM=
+github.com/cloudquery/plugin-sdk/v4 v4.16.0/go.mod h1:ujSFEUAp8BmozOee0ljjsPHQfddXJCUTAzCD6sVKsu8=
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
 github.com/cncf/udpa/go v0.0.0-20201120205902-5459f2c99403/go.mod h1:WmhPx2Nbnhtbo57+VJT5O0JRkEi1Wbu0z5j0R8u5Hbk=
 github.com/cncf/udpa/go v0.0.0-20210930031921-04548b0d99d4/go.mod h1:6pvJx4me5XPnfI9Z40ddWsdw2W/uZgQLFXToKeRcDiI=

--- a/plugins/source/gcp/go.mod
+++ b/plugins/source/gcp/go.mod
@@ -46,7 +46,7 @@ require (
 	cloud.google.com/go/workflows v1.12.0
 	github.com/apache/arrow/go/v14 v14.0.0-20230929201650-00efb06dc0de
 	github.com/cloudquery/codegen v0.3.9
-	github.com/cloudquery/plugin-sdk/v4 v4.15.3
+	github.com/cloudquery/plugin-sdk/v4 v4.16.0
 	github.com/cockroachdb/cockroachdb-parser v0.0.0-20230705064001-302c9ad52e1a
 	github.com/golang/mock v1.6.0
 	github.com/googleapis/gax-go/v2 v2.12.0

--- a/plugins/source/gcp/go.sum
+++ b/plugins/source/gcp/go.sum
@@ -216,8 +216,8 @@ github.com/cloudquery/plugin-pb-go v1.12.3 h1:rLK3/RR70/BX8tj2QzTnrjkxQhzfAT7SXE
 github.com/cloudquery/plugin-pb-go v1.12.3/go.mod h1:CYorX3zCHF9ByoOgdBOuwLX/2vVCDH6/FoREOE3oH+w=
 github.com/cloudquery/plugin-sdk/v2 v2.7.0 h1:hRXsdEiaOxJtsn/wZMFQC9/jPfU1MeMK3KF+gPGqm7U=
 github.com/cloudquery/plugin-sdk/v2 v2.7.0/go.mod h1:pAX6ojIW99b/Vg4CkhnsGkRIzNaVEceYMR+Bdit73ug=
-github.com/cloudquery/plugin-sdk/v4 v4.15.3 h1:krXOLZR/3xDAEMdfcZCVD2AbWO0SosnGrb0Lrk5AH/4=
-github.com/cloudquery/plugin-sdk/v4 v4.15.3/go.mod h1:ujSFEUAp8BmozOee0ljjsPHQfddXJCUTAzCD6sVKsu8=
+github.com/cloudquery/plugin-sdk/v4 v4.16.0 h1:AEYIEbZCCPxGFw/bPm5bOpyyPDSqM5DRFIUqfogyJfM=
+github.com/cloudquery/plugin-sdk/v4 v4.16.0/go.mod h1:ujSFEUAp8BmozOee0ljjsPHQfddXJCUTAzCD6sVKsu8=
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
 github.com/cncf/udpa/go v0.0.0-20201120205902-5459f2c99403/go.mod h1:WmhPx2Nbnhtbo57+VJT5O0JRkEi1Wbu0z5j0R8u5Hbk=
 github.com/cncf/udpa/go v0.0.0-20210930031921-04548b0d99d4/go.mod h1:6pvJx4me5XPnfI9Z40ddWsdw2W/uZgQLFXToKeRcDiI=

--- a/plugins/source/github/go.mod
+++ b/plugins/source/github/go.mod
@@ -5,7 +5,7 @@ go 1.21.1
 require (
 	github.com/apache/arrow/go/v14 v14.0.0-20230929201650-00efb06dc0de
 	github.com/beatlabs/github-auth v0.0.0-20230912161003-cdaa33aa0d65
-	github.com/cloudquery/plugin-sdk/v4 v4.15.3
+	github.com/cloudquery/plugin-sdk/v4 v4.16.0
 	github.com/gofri/go-github-ratelimit v1.0.3
 	github.com/golang/mock v1.6.0
 	github.com/google/go-github/v49 v49.0.0

--- a/plugins/source/github/go.sum
+++ b/plugins/source/github/go.sum
@@ -94,8 +94,8 @@ github.com/cloudquery/plugin-pb-go v1.12.3 h1:rLK3/RR70/BX8tj2QzTnrjkxQhzfAT7SXE
 github.com/cloudquery/plugin-pb-go v1.12.3/go.mod h1:CYorX3zCHF9ByoOgdBOuwLX/2vVCDH6/FoREOE3oH+w=
 github.com/cloudquery/plugin-sdk/v2 v2.7.0 h1:hRXsdEiaOxJtsn/wZMFQC9/jPfU1MeMK3KF+gPGqm7U=
 github.com/cloudquery/plugin-sdk/v2 v2.7.0/go.mod h1:pAX6ojIW99b/Vg4CkhnsGkRIzNaVEceYMR+Bdit73ug=
-github.com/cloudquery/plugin-sdk/v4 v4.15.3 h1:krXOLZR/3xDAEMdfcZCVD2AbWO0SosnGrb0Lrk5AH/4=
-github.com/cloudquery/plugin-sdk/v4 v4.15.3/go.mod h1:ujSFEUAp8BmozOee0ljjsPHQfddXJCUTAzCD6sVKsu8=
+github.com/cloudquery/plugin-sdk/v4 v4.16.0 h1:AEYIEbZCCPxGFw/bPm5bOpyyPDSqM5DRFIUqfogyJfM=
+github.com/cloudquery/plugin-sdk/v4 v4.16.0/go.mod h1:ujSFEUAp8BmozOee0ljjsPHQfddXJCUTAzCD6sVKsu8=
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
 github.com/cncf/udpa/go v0.0.0-20201120205902-5459f2c99403/go.mod h1:WmhPx2Nbnhtbo57+VJT5O0JRkEi1Wbu0z5j0R8u5Hbk=
 github.com/cncf/udpa/go v0.0.0-20210930031921-04548b0d99d4/go.mod h1:6pvJx4me5XPnfI9Z40ddWsdw2W/uZgQLFXToKeRcDiI=

--- a/plugins/source/gitlab/go.mod
+++ b/plugins/source/gitlab/go.mod
@@ -4,7 +4,7 @@ go 1.21.1
 
 require (
 	github.com/apache/arrow/go/v14 v14.0.0-20230929201650-00efb06dc0de
-	github.com/cloudquery/plugin-sdk/v4 v4.15.3
+	github.com/cloudquery/plugin-sdk/v4 v4.16.0
 	github.com/julienschmidt/httprouter v1.3.0
 	github.com/rs/zerolog v1.29.1
 	github.com/xanzy/go-gitlab v0.83.0

--- a/plugins/source/gitlab/go.sum
+++ b/plugins/source/gitlab/go.sum
@@ -92,8 +92,8 @@ github.com/cloudquery/plugin-pb-go v1.12.3 h1:rLK3/RR70/BX8tj2QzTnrjkxQhzfAT7SXE
 github.com/cloudquery/plugin-pb-go v1.12.3/go.mod h1:CYorX3zCHF9ByoOgdBOuwLX/2vVCDH6/FoREOE3oH+w=
 github.com/cloudquery/plugin-sdk/v2 v2.7.0 h1:hRXsdEiaOxJtsn/wZMFQC9/jPfU1MeMK3KF+gPGqm7U=
 github.com/cloudquery/plugin-sdk/v2 v2.7.0/go.mod h1:pAX6ojIW99b/Vg4CkhnsGkRIzNaVEceYMR+Bdit73ug=
-github.com/cloudquery/plugin-sdk/v4 v4.15.3 h1:krXOLZR/3xDAEMdfcZCVD2AbWO0SosnGrb0Lrk5AH/4=
-github.com/cloudquery/plugin-sdk/v4 v4.15.3/go.mod h1:ujSFEUAp8BmozOee0ljjsPHQfddXJCUTAzCD6sVKsu8=
+github.com/cloudquery/plugin-sdk/v4 v4.16.0 h1:AEYIEbZCCPxGFw/bPm5bOpyyPDSqM5DRFIUqfogyJfM=
+github.com/cloudquery/plugin-sdk/v4 v4.16.0/go.mod h1:ujSFEUAp8BmozOee0ljjsPHQfddXJCUTAzCD6sVKsu8=
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
 github.com/cncf/udpa/go v0.0.0-20201120205902-5459f2c99403/go.mod h1:WmhPx2Nbnhtbo57+VJT5O0JRkEi1Wbu0z5j0R8u5Hbk=
 github.com/cncf/udpa/go v0.0.0-20210930031921-04548b0d99d4/go.mod h1:6pvJx4me5XPnfI9Z40ddWsdw2W/uZgQLFXToKeRcDiI=

--- a/plugins/source/googleanalytics/go.mod
+++ b/plugins/source/googleanalytics/go.mod
@@ -5,7 +5,7 @@ go 1.21.1
 require (
 	github.com/apache/arrow/go/v14 v14.0.0-20230929201650-00efb06dc0de
 	github.com/cloudquery/codegen v0.3.9
-	github.com/cloudquery/plugin-sdk/v4 v4.15.3
+	github.com/cloudquery/plugin-sdk/v4 v4.16.0
 	github.com/invopop/jsonschema v0.11.0
 	github.com/rs/zerolog v1.29.1
 	github.com/stretchr/testify v1.8.4

--- a/plugins/source/googleanalytics/go.sum
+++ b/plugins/source/googleanalytics/go.sum
@@ -100,8 +100,8 @@ github.com/cloudquery/plugin-pb-go v1.12.3 h1:rLK3/RR70/BX8tj2QzTnrjkxQhzfAT7SXE
 github.com/cloudquery/plugin-pb-go v1.12.3/go.mod h1:CYorX3zCHF9ByoOgdBOuwLX/2vVCDH6/FoREOE3oH+w=
 github.com/cloudquery/plugin-sdk/v2 v2.7.0 h1:hRXsdEiaOxJtsn/wZMFQC9/jPfU1MeMK3KF+gPGqm7U=
 github.com/cloudquery/plugin-sdk/v2 v2.7.0/go.mod h1:pAX6ojIW99b/Vg4CkhnsGkRIzNaVEceYMR+Bdit73ug=
-github.com/cloudquery/plugin-sdk/v4 v4.15.3 h1:krXOLZR/3xDAEMdfcZCVD2AbWO0SosnGrb0Lrk5AH/4=
-github.com/cloudquery/plugin-sdk/v4 v4.15.3/go.mod h1:ujSFEUAp8BmozOee0ljjsPHQfddXJCUTAzCD6sVKsu8=
+github.com/cloudquery/plugin-sdk/v4 v4.16.0 h1:AEYIEbZCCPxGFw/bPm5bOpyyPDSqM5DRFIUqfogyJfM=
+github.com/cloudquery/plugin-sdk/v4 v4.16.0/go.mod h1:ujSFEUAp8BmozOee0ljjsPHQfddXJCUTAzCD6sVKsu8=
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
 github.com/cncf/udpa/go v0.0.0-20201120205902-5459f2c99403/go.mod h1:WmhPx2Nbnhtbo57+VJT5O0JRkEi1Wbu0z5j0R8u5Hbk=
 github.com/cncf/udpa/go v0.0.0-20210930031921-04548b0d99d4/go.mod h1:6pvJx4me5XPnfI9Z40ddWsdw2W/uZgQLFXToKeRcDiI=

--- a/plugins/source/hackernews/go.mod
+++ b/plugins/source/hackernews/go.mod
@@ -4,7 +4,7 @@ go 1.21.1
 
 require (
 	github.com/apache/arrow/go/v14 v14.0.0-20230929201650-00efb06dc0de
-	github.com/cloudquery/plugin-sdk/v4 v4.15.3
+	github.com/cloudquery/plugin-sdk/v4 v4.16.0
 	github.com/golang/mock v1.6.0
 	github.com/hermanschaaf/hackernews v1.0.1
 	github.com/rs/zerolog v1.29.1

--- a/plugins/source/hackernews/go.sum
+++ b/plugins/source/hackernews/go.sum
@@ -92,8 +92,8 @@ github.com/cloudquery/plugin-pb-go v1.12.3 h1:rLK3/RR70/BX8tj2QzTnrjkxQhzfAT7SXE
 github.com/cloudquery/plugin-pb-go v1.12.3/go.mod h1:CYorX3zCHF9ByoOgdBOuwLX/2vVCDH6/FoREOE3oH+w=
 github.com/cloudquery/plugin-sdk/v2 v2.7.0 h1:hRXsdEiaOxJtsn/wZMFQC9/jPfU1MeMK3KF+gPGqm7U=
 github.com/cloudquery/plugin-sdk/v2 v2.7.0/go.mod h1:pAX6ojIW99b/Vg4CkhnsGkRIzNaVEceYMR+Bdit73ug=
-github.com/cloudquery/plugin-sdk/v4 v4.15.3 h1:krXOLZR/3xDAEMdfcZCVD2AbWO0SosnGrb0Lrk5AH/4=
-github.com/cloudquery/plugin-sdk/v4 v4.15.3/go.mod h1:ujSFEUAp8BmozOee0ljjsPHQfddXJCUTAzCD6sVKsu8=
+github.com/cloudquery/plugin-sdk/v4 v4.16.0 h1:AEYIEbZCCPxGFw/bPm5bOpyyPDSqM5DRFIUqfogyJfM=
+github.com/cloudquery/plugin-sdk/v4 v4.16.0/go.mod h1:ujSFEUAp8BmozOee0ljjsPHQfddXJCUTAzCD6sVKsu8=
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
 github.com/cncf/udpa/go v0.0.0-20201120205902-5459f2c99403/go.mod h1:WmhPx2Nbnhtbo57+VJT5O0JRkEi1Wbu0z5j0R8u5Hbk=
 github.com/cncf/udpa/go v0.0.0-20210930031921-04548b0d99d4/go.mod h1:6pvJx4me5XPnfI9Z40ddWsdw2W/uZgQLFXToKeRcDiI=

--- a/plugins/source/homebrew/go.mod
+++ b/plugins/source/homebrew/go.mod
@@ -3,7 +3,7 @@ module github.com/cloudquery/cloudquery/plugins/source/homebrew
 go 1.21.1
 
 require (
-	github.com/cloudquery/plugin-sdk/v4 v4.15.3
+	github.com/cloudquery/plugin-sdk/v4 v4.16.0
 	github.com/golang/mock v1.6.0
 	github.com/rs/zerolog v1.29.1
 )

--- a/plugins/source/homebrew/go.sum
+++ b/plugins/source/homebrew/go.sum
@@ -92,8 +92,8 @@ github.com/cloudquery/plugin-pb-go v1.12.3 h1:rLK3/RR70/BX8tj2QzTnrjkxQhzfAT7SXE
 github.com/cloudquery/plugin-pb-go v1.12.3/go.mod h1:CYorX3zCHF9ByoOgdBOuwLX/2vVCDH6/FoREOE3oH+w=
 github.com/cloudquery/plugin-sdk/v2 v2.7.0 h1:hRXsdEiaOxJtsn/wZMFQC9/jPfU1MeMK3KF+gPGqm7U=
 github.com/cloudquery/plugin-sdk/v2 v2.7.0/go.mod h1:pAX6ojIW99b/Vg4CkhnsGkRIzNaVEceYMR+Bdit73ug=
-github.com/cloudquery/plugin-sdk/v4 v4.15.3 h1:krXOLZR/3xDAEMdfcZCVD2AbWO0SosnGrb0Lrk5AH/4=
-github.com/cloudquery/plugin-sdk/v4 v4.15.3/go.mod h1:ujSFEUAp8BmozOee0ljjsPHQfddXJCUTAzCD6sVKsu8=
+github.com/cloudquery/plugin-sdk/v4 v4.16.0 h1:AEYIEbZCCPxGFw/bPm5bOpyyPDSqM5DRFIUqfogyJfM=
+github.com/cloudquery/plugin-sdk/v4 v4.16.0/go.mod h1:ujSFEUAp8BmozOee0ljjsPHQfddXJCUTAzCD6sVKsu8=
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
 github.com/cncf/udpa/go v0.0.0-20201120205902-5459f2c99403/go.mod h1:WmhPx2Nbnhtbo57+VJT5O0JRkEi1Wbu0z5j0R8u5Hbk=
 github.com/cncf/udpa/go v0.0.0-20210930031921-04548b0d99d4/go.mod h1:6pvJx4me5XPnfI9Z40ddWsdw2W/uZgQLFXToKeRcDiI=

--- a/plugins/source/hubspot/go.mod
+++ b/plugins/source/hubspot/go.mod
@@ -5,7 +5,7 @@ go 1.21.1
 require (
 	github.com/apache/arrow/go/v14 v14.0.0-20230929201650-00efb06dc0de
 	github.com/clarkmcc/go-hubspot v0.0.0-20230906123538-bec7cb6c0126
-	github.com/cloudquery/plugin-sdk/v4 v4.15.3
+	github.com/cloudquery/plugin-sdk/v4 v4.16.0
 	github.com/rs/zerolog v1.29.1
 	golang.org/x/exp v0.0.0-20230905200255-921286631fa9
 	golang.org/x/time v0.3.0

--- a/plugins/source/hubspot/go.sum
+++ b/plugins/source/hubspot/go.sum
@@ -94,8 +94,8 @@ github.com/cloudquery/plugin-pb-go v1.12.3 h1:rLK3/RR70/BX8tj2QzTnrjkxQhzfAT7SXE
 github.com/cloudquery/plugin-pb-go v1.12.3/go.mod h1:CYorX3zCHF9ByoOgdBOuwLX/2vVCDH6/FoREOE3oH+w=
 github.com/cloudquery/plugin-sdk/v2 v2.7.0 h1:hRXsdEiaOxJtsn/wZMFQC9/jPfU1MeMK3KF+gPGqm7U=
 github.com/cloudquery/plugin-sdk/v2 v2.7.0/go.mod h1:pAX6ojIW99b/Vg4CkhnsGkRIzNaVEceYMR+Bdit73ug=
-github.com/cloudquery/plugin-sdk/v4 v4.15.3 h1:krXOLZR/3xDAEMdfcZCVD2AbWO0SosnGrb0Lrk5AH/4=
-github.com/cloudquery/plugin-sdk/v4 v4.15.3/go.mod h1:ujSFEUAp8BmozOee0ljjsPHQfddXJCUTAzCD6sVKsu8=
+github.com/cloudquery/plugin-sdk/v4 v4.16.0 h1:AEYIEbZCCPxGFw/bPm5bOpyyPDSqM5DRFIUqfogyJfM=
+github.com/cloudquery/plugin-sdk/v4 v4.16.0/go.mod h1:ujSFEUAp8BmozOee0ljjsPHQfddXJCUTAzCD6sVKsu8=
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
 github.com/cncf/udpa/go v0.0.0-20201120205902-5459f2c99403/go.mod h1:WmhPx2Nbnhtbo57+VJT5O0JRkEi1Wbu0z5j0R8u5Hbk=
 github.com/cncf/udpa/go v0.0.0-20210930031921-04548b0d99d4/go.mod h1:6pvJx4me5XPnfI9Z40ddWsdw2W/uZgQLFXToKeRcDiI=

--- a/plugins/source/jira/go.mod
+++ b/plugins/source/jira/go.mod
@@ -4,7 +4,7 @@ go 1.21.1
 
 require (
 	github.com/andygrunwald/go-jira v1.16.0
-	github.com/cloudquery/plugin-sdk/v4 v4.15.3
+	github.com/cloudquery/plugin-sdk/v4 v4.16.0
 	github.com/rs/zerolog v1.30.0
 )
 

--- a/plugins/source/jira/go.sum
+++ b/plugins/source/jira/go.sum
@@ -94,8 +94,8 @@ github.com/cloudquery/plugin-pb-go v1.12.3 h1:rLK3/RR70/BX8tj2QzTnrjkxQhzfAT7SXE
 github.com/cloudquery/plugin-pb-go v1.12.3/go.mod h1:CYorX3zCHF9ByoOgdBOuwLX/2vVCDH6/FoREOE3oH+w=
 github.com/cloudquery/plugin-sdk/v2 v2.7.0 h1:hRXsdEiaOxJtsn/wZMFQC9/jPfU1MeMK3KF+gPGqm7U=
 github.com/cloudquery/plugin-sdk/v2 v2.7.0/go.mod h1:pAX6ojIW99b/Vg4CkhnsGkRIzNaVEceYMR+Bdit73ug=
-github.com/cloudquery/plugin-sdk/v4 v4.15.3 h1:krXOLZR/3xDAEMdfcZCVD2AbWO0SosnGrb0Lrk5AH/4=
-github.com/cloudquery/plugin-sdk/v4 v4.15.3/go.mod h1:ujSFEUAp8BmozOee0ljjsPHQfddXJCUTAzCD6sVKsu8=
+github.com/cloudquery/plugin-sdk/v4 v4.16.0 h1:AEYIEbZCCPxGFw/bPm5bOpyyPDSqM5DRFIUqfogyJfM=
+github.com/cloudquery/plugin-sdk/v4 v4.16.0/go.mod h1:ujSFEUAp8BmozOee0ljjsPHQfddXJCUTAzCD6sVKsu8=
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
 github.com/cncf/udpa/go v0.0.0-20201120205902-5459f2c99403/go.mod h1:WmhPx2Nbnhtbo57+VJT5O0JRkEi1Wbu0z5j0R8u5Hbk=
 github.com/cncf/udpa/go v0.0.0-20210930031921-04548b0d99d4/go.mod h1:6pvJx4me5XPnfI9Z40ddWsdw2W/uZgQLFXToKeRcDiI=

--- a/plugins/source/k8s/go.mod
+++ b/plugins/source/k8s/go.mod
@@ -5,7 +5,7 @@ go 1.21.1
 require (
 	github.com/apache/arrow/go/v14 v14.0.0-20230929201650-00efb06dc0de
 	github.com/cloudquery/codegen v0.3.9
-	github.com/cloudquery/plugin-sdk/v4 v4.15.3
+	github.com/cloudquery/plugin-sdk/v4 v4.16.0
 	github.com/cockroachdb/cockroachdb-parser v0.0.0-20230705064001-302c9ad52e1a
 	github.com/golang/mock v1.6.0
 	github.com/google/gnostic v0.6.9

--- a/plugins/source/k8s/go.sum
+++ b/plugins/source/k8s/go.sum
@@ -126,8 +126,8 @@ github.com/cloudquery/plugin-pb-go v1.12.3 h1:rLK3/RR70/BX8tj2QzTnrjkxQhzfAT7SXE
 github.com/cloudquery/plugin-pb-go v1.12.3/go.mod h1:CYorX3zCHF9ByoOgdBOuwLX/2vVCDH6/FoREOE3oH+w=
 github.com/cloudquery/plugin-sdk/v2 v2.7.0 h1:hRXsdEiaOxJtsn/wZMFQC9/jPfU1MeMK3KF+gPGqm7U=
 github.com/cloudquery/plugin-sdk/v2 v2.7.0/go.mod h1:pAX6ojIW99b/Vg4CkhnsGkRIzNaVEceYMR+Bdit73ug=
-github.com/cloudquery/plugin-sdk/v4 v4.15.3 h1:krXOLZR/3xDAEMdfcZCVD2AbWO0SosnGrb0Lrk5AH/4=
-github.com/cloudquery/plugin-sdk/v4 v4.15.3/go.mod h1:ujSFEUAp8BmozOee0ljjsPHQfddXJCUTAzCD6sVKsu8=
+github.com/cloudquery/plugin-sdk/v4 v4.16.0 h1:AEYIEbZCCPxGFw/bPm5bOpyyPDSqM5DRFIUqfogyJfM=
+github.com/cloudquery/plugin-sdk/v4 v4.16.0/go.mod h1:ujSFEUAp8BmozOee0ljjsPHQfddXJCUTAzCD6sVKsu8=
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
 github.com/cncf/udpa/go v0.0.0-20201120205902-5459f2c99403/go.mod h1:WmhPx2Nbnhtbo57+VJT5O0JRkEi1Wbu0z5j0R8u5Hbk=
 github.com/cncf/udpa/go v0.0.0-20210930031921-04548b0d99d4/go.mod h1:6pvJx4me5XPnfI9Z40ddWsdw2W/uZgQLFXToKeRcDiI=

--- a/plugins/source/mysql/go.mod
+++ b/plugins/source/mysql/go.mod
@@ -4,7 +4,7 @@ go 1.21.1
 
 require (
 	github.com/apache/arrow/go/v14 v14.0.0-20230929201650-00efb06dc0de
-	github.com/cloudquery/plugin-sdk/v4 v4.15.3
+	github.com/cloudquery/plugin-sdk/v4 v4.16.0
 	github.com/go-sql-driver/mysql v1.7.0
 	github.com/rs/zerolog v1.29.1
 	github.com/stretchr/testify v1.8.4

--- a/plugins/source/mysql/go.sum
+++ b/plugins/source/mysql/go.sum
@@ -88,8 +88,8 @@ github.com/cloudquery/plugin-pb-go v1.12.3 h1:rLK3/RR70/BX8tj2QzTnrjkxQhzfAT7SXE
 github.com/cloudquery/plugin-pb-go v1.12.3/go.mod h1:CYorX3zCHF9ByoOgdBOuwLX/2vVCDH6/FoREOE3oH+w=
 github.com/cloudquery/plugin-sdk/v2 v2.7.0 h1:hRXsdEiaOxJtsn/wZMFQC9/jPfU1MeMK3KF+gPGqm7U=
 github.com/cloudquery/plugin-sdk/v2 v2.7.0/go.mod h1:pAX6ojIW99b/Vg4CkhnsGkRIzNaVEceYMR+Bdit73ug=
-github.com/cloudquery/plugin-sdk/v4 v4.15.3 h1:krXOLZR/3xDAEMdfcZCVD2AbWO0SosnGrb0Lrk5AH/4=
-github.com/cloudquery/plugin-sdk/v4 v4.15.3/go.mod h1:ujSFEUAp8BmozOee0ljjsPHQfddXJCUTAzCD6sVKsu8=
+github.com/cloudquery/plugin-sdk/v4 v4.16.0 h1:AEYIEbZCCPxGFw/bPm5bOpyyPDSqM5DRFIUqfogyJfM=
+github.com/cloudquery/plugin-sdk/v4 v4.16.0/go.mod h1:ujSFEUAp8BmozOee0ljjsPHQfddXJCUTAzCD6sVKsu8=
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
 github.com/cncf/udpa/go v0.0.0-20201120205902-5459f2c99403/go.mod h1:WmhPx2Nbnhtbo57+VJT5O0JRkEi1Wbu0z5j0R8u5Hbk=
 github.com/cncf/udpa/go v0.0.0-20210930031921-04548b0d99d4/go.mod h1:6pvJx4me5XPnfI9Z40ddWsdw2W/uZgQLFXToKeRcDiI=

--- a/plugins/source/notion/go.mod
+++ b/plugins/source/notion/go.mod
@@ -3,7 +3,7 @@ module github.com/cloudquery/cloudquery/plugins/source/notion
 go 1.21.1
 
 require (
-	github.com/cloudquery/plugin-sdk/v4 v4.15.3
+	github.com/cloudquery/plugin-sdk/v4 v4.16.0
 	github.com/rs/zerolog v1.30.0
 )
 

--- a/plugins/source/notion/go.sum
+++ b/plugins/source/notion/go.sum
@@ -92,8 +92,8 @@ github.com/cloudquery/plugin-pb-go v1.12.3 h1:rLK3/RR70/BX8tj2QzTnrjkxQhzfAT7SXE
 github.com/cloudquery/plugin-pb-go v1.12.3/go.mod h1:CYorX3zCHF9ByoOgdBOuwLX/2vVCDH6/FoREOE3oH+w=
 github.com/cloudquery/plugin-sdk/v2 v2.7.0 h1:hRXsdEiaOxJtsn/wZMFQC9/jPfU1MeMK3KF+gPGqm7U=
 github.com/cloudquery/plugin-sdk/v2 v2.7.0/go.mod h1:pAX6ojIW99b/Vg4CkhnsGkRIzNaVEceYMR+Bdit73ug=
-github.com/cloudquery/plugin-sdk/v4 v4.15.3 h1:krXOLZR/3xDAEMdfcZCVD2AbWO0SosnGrb0Lrk5AH/4=
-github.com/cloudquery/plugin-sdk/v4 v4.15.3/go.mod h1:ujSFEUAp8BmozOee0ljjsPHQfddXJCUTAzCD6sVKsu8=
+github.com/cloudquery/plugin-sdk/v4 v4.16.0 h1:AEYIEbZCCPxGFw/bPm5bOpyyPDSqM5DRFIUqfogyJfM=
+github.com/cloudquery/plugin-sdk/v4 v4.16.0/go.mod h1:ujSFEUAp8BmozOee0ljjsPHQfddXJCUTAzCD6sVKsu8=
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
 github.com/cncf/udpa/go v0.0.0-20201120205902-5459f2c99403/go.mod h1:WmhPx2Nbnhtbo57+VJT5O0JRkEi1Wbu0z5j0R8u5Hbk=
 github.com/cncf/udpa/go v0.0.0-20210930031921-04548b0d99d4/go.mod h1:6pvJx4me5XPnfI9Z40ddWsdw2W/uZgQLFXToKeRcDiI=

--- a/plugins/source/okta/go.mod
+++ b/plugins/source/okta/go.mod
@@ -4,7 +4,7 @@ go 1.21.1
 
 require (
 	github.com/apache/arrow/go/v14 v14.0.0-20230929201650-00efb06dc0de
-	github.com/cloudquery/plugin-sdk/v4 v4.15.3
+	github.com/cloudquery/plugin-sdk/v4 v4.16.0
 	github.com/gorilla/mux v1.8.0
 	github.com/okta/okta-sdk-golang/v3 v3.0.2
 	github.com/rs/zerolog v1.29.1

--- a/plugins/source/okta/go.sum
+++ b/plugins/source/okta/go.sum
@@ -93,8 +93,8 @@ github.com/cloudquery/plugin-pb-go v1.12.3 h1:rLK3/RR70/BX8tj2QzTnrjkxQhzfAT7SXE
 github.com/cloudquery/plugin-pb-go v1.12.3/go.mod h1:CYorX3zCHF9ByoOgdBOuwLX/2vVCDH6/FoREOE3oH+w=
 github.com/cloudquery/plugin-sdk/v2 v2.7.0 h1:hRXsdEiaOxJtsn/wZMFQC9/jPfU1MeMK3KF+gPGqm7U=
 github.com/cloudquery/plugin-sdk/v2 v2.7.0/go.mod h1:pAX6ojIW99b/Vg4CkhnsGkRIzNaVEceYMR+Bdit73ug=
-github.com/cloudquery/plugin-sdk/v4 v4.15.3 h1:krXOLZR/3xDAEMdfcZCVD2AbWO0SosnGrb0Lrk5AH/4=
-github.com/cloudquery/plugin-sdk/v4 v4.15.3/go.mod h1:ujSFEUAp8BmozOee0ljjsPHQfddXJCUTAzCD6sVKsu8=
+github.com/cloudquery/plugin-sdk/v4 v4.16.0 h1:AEYIEbZCCPxGFw/bPm5bOpyyPDSqM5DRFIUqfogyJfM=
+github.com/cloudquery/plugin-sdk/v4 v4.16.0/go.mod h1:ujSFEUAp8BmozOee0ljjsPHQfddXJCUTAzCD6sVKsu8=
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
 github.com/cncf/udpa/go v0.0.0-20201120205902-5459f2c99403/go.mod h1:WmhPx2Nbnhtbo57+VJT5O0JRkEi1Wbu0z5j0R8u5Hbk=
 github.com/cncf/udpa/go v0.0.0-20210930031921-04548b0d99d4/go.mod h1:6pvJx4me5XPnfI9Z40ddWsdw2W/uZgQLFXToKeRcDiI=

--- a/plugins/source/oracle/go.mod
+++ b/plugins/source/oracle/go.mod
@@ -5,7 +5,7 @@ go 1.21.1
 require (
 	github.com/apache/arrow/go/v14 v14.0.0-20230929201650-00efb06dc0de
 	github.com/cloudquery/codegen v0.3.9
-	github.com/cloudquery/plugin-sdk/v4 v4.15.3
+	github.com/cloudquery/plugin-sdk/v4 v4.16.0
 	github.com/oracle/oci-go-sdk/v65 v65.28.3
 	github.com/rs/zerolog v1.29.1
 	github.com/stretchr/testify v1.8.4

--- a/plugins/source/oracle/go.sum
+++ b/plugins/source/oracle/go.sum
@@ -96,8 +96,8 @@ github.com/cloudquery/plugin-pb-go v1.12.3 h1:rLK3/RR70/BX8tj2QzTnrjkxQhzfAT7SXE
 github.com/cloudquery/plugin-pb-go v1.12.3/go.mod h1:CYorX3zCHF9ByoOgdBOuwLX/2vVCDH6/FoREOE3oH+w=
 github.com/cloudquery/plugin-sdk/v2 v2.7.0 h1:hRXsdEiaOxJtsn/wZMFQC9/jPfU1MeMK3KF+gPGqm7U=
 github.com/cloudquery/plugin-sdk/v2 v2.7.0/go.mod h1:pAX6ojIW99b/Vg4CkhnsGkRIzNaVEceYMR+Bdit73ug=
-github.com/cloudquery/plugin-sdk/v4 v4.15.3 h1:krXOLZR/3xDAEMdfcZCVD2AbWO0SosnGrb0Lrk5AH/4=
-github.com/cloudquery/plugin-sdk/v4 v4.15.3/go.mod h1:ujSFEUAp8BmozOee0ljjsPHQfddXJCUTAzCD6sVKsu8=
+github.com/cloudquery/plugin-sdk/v4 v4.16.0 h1:AEYIEbZCCPxGFw/bPm5bOpyyPDSqM5DRFIUqfogyJfM=
+github.com/cloudquery/plugin-sdk/v4 v4.16.0/go.mod h1:ujSFEUAp8BmozOee0ljjsPHQfddXJCUTAzCD6sVKsu8=
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
 github.com/cncf/udpa/go v0.0.0-20201120205902-5459f2c99403/go.mod h1:WmhPx2Nbnhtbo57+VJT5O0JRkEi1Wbu0z5j0R8u5Hbk=
 github.com/cncf/udpa/go v0.0.0-20210930031921-04548b0d99d4/go.mod h1:6pvJx4me5XPnfI9Z40ddWsdw2W/uZgQLFXToKeRcDiI=

--- a/plugins/source/oracledb/go.mod
+++ b/plugins/source/oracledb/go.mod
@@ -4,7 +4,7 @@ go 1.21.1
 
 require (
 	github.com/apache/arrow/go/v14 v14.0.0-20230929201650-00efb06dc0de
-	github.com/cloudquery/plugin-sdk/v4 v4.15.3
+	github.com/cloudquery/plugin-sdk/v4 v4.16.0
 	github.com/rs/zerolog v1.29.1
 	github.com/sijms/go-ora/v2 v2.7.9
 	github.com/stretchr/testify v1.8.4

--- a/plugins/source/oracledb/go.sum
+++ b/plugins/source/oracledb/go.sum
@@ -88,8 +88,8 @@ github.com/cloudquery/plugin-pb-go v1.12.3 h1:rLK3/RR70/BX8tj2QzTnrjkxQhzfAT7SXE
 github.com/cloudquery/plugin-pb-go v1.12.3/go.mod h1:CYorX3zCHF9ByoOgdBOuwLX/2vVCDH6/FoREOE3oH+w=
 github.com/cloudquery/plugin-sdk/v2 v2.7.0 h1:hRXsdEiaOxJtsn/wZMFQC9/jPfU1MeMK3KF+gPGqm7U=
 github.com/cloudquery/plugin-sdk/v2 v2.7.0/go.mod h1:pAX6ojIW99b/Vg4CkhnsGkRIzNaVEceYMR+Bdit73ug=
-github.com/cloudquery/plugin-sdk/v4 v4.15.3 h1:krXOLZR/3xDAEMdfcZCVD2AbWO0SosnGrb0Lrk5AH/4=
-github.com/cloudquery/plugin-sdk/v4 v4.15.3/go.mod h1:ujSFEUAp8BmozOee0ljjsPHQfddXJCUTAzCD6sVKsu8=
+github.com/cloudquery/plugin-sdk/v4 v4.16.0 h1:AEYIEbZCCPxGFw/bPm5bOpyyPDSqM5DRFIUqfogyJfM=
+github.com/cloudquery/plugin-sdk/v4 v4.16.0/go.mod h1:ujSFEUAp8BmozOee0ljjsPHQfddXJCUTAzCD6sVKsu8=
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
 github.com/cncf/udpa/go v0.0.0-20201120205902-5459f2c99403/go.mod h1:WmhPx2Nbnhtbo57+VJT5O0JRkEi1Wbu0z5j0R8u5Hbk=
 github.com/cncf/udpa/go v0.0.0-20210930031921-04548b0d99d4/go.mod h1:6pvJx4me5XPnfI9Z40ddWsdw2W/uZgQLFXToKeRcDiI=

--- a/plugins/source/pagerduty/go.mod
+++ b/plugins/source/pagerduty/go.mod
@@ -5,7 +5,7 @@ go 1.21.1
 require (
 	github.com/PagerDuty/go-pagerduty v1.6.0
 	github.com/apache/arrow/go/v14 v14.0.0-20230929201650-00efb06dc0de
-	github.com/cloudquery/plugin-sdk/v4 v4.15.3
+	github.com/cloudquery/plugin-sdk/v4 v4.16.0
 	github.com/rs/zerolog v1.29.1
 	golang.org/x/time v0.3.0
 	gopkg.in/yaml.v3 v3.0.1

--- a/plugins/source/pagerduty/go.sum
+++ b/plugins/source/pagerduty/go.sum
@@ -96,8 +96,8 @@ github.com/cloudquery/plugin-pb-go v1.12.3 h1:rLK3/RR70/BX8tj2QzTnrjkxQhzfAT7SXE
 github.com/cloudquery/plugin-pb-go v1.12.3/go.mod h1:CYorX3zCHF9ByoOgdBOuwLX/2vVCDH6/FoREOE3oH+w=
 github.com/cloudquery/plugin-sdk/v2 v2.7.0 h1:hRXsdEiaOxJtsn/wZMFQC9/jPfU1MeMK3KF+gPGqm7U=
 github.com/cloudquery/plugin-sdk/v2 v2.7.0/go.mod h1:pAX6ojIW99b/Vg4CkhnsGkRIzNaVEceYMR+Bdit73ug=
-github.com/cloudquery/plugin-sdk/v4 v4.15.3 h1:krXOLZR/3xDAEMdfcZCVD2AbWO0SosnGrb0Lrk5AH/4=
-github.com/cloudquery/plugin-sdk/v4 v4.15.3/go.mod h1:ujSFEUAp8BmozOee0ljjsPHQfddXJCUTAzCD6sVKsu8=
+github.com/cloudquery/plugin-sdk/v4 v4.16.0 h1:AEYIEbZCCPxGFw/bPm5bOpyyPDSqM5DRFIUqfogyJfM=
+github.com/cloudquery/plugin-sdk/v4 v4.16.0/go.mod h1:ujSFEUAp8BmozOee0ljjsPHQfddXJCUTAzCD6sVKsu8=
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
 github.com/cncf/udpa/go v0.0.0-20201120205902-5459f2c99403/go.mod h1:WmhPx2Nbnhtbo57+VJT5O0JRkEi1Wbu0z5j0R8u5Hbk=
 github.com/cncf/udpa/go v0.0.0-20210930031921-04548b0d99d4/go.mod h1:6pvJx4me5XPnfI9Z40ddWsdw2W/uZgQLFXToKeRcDiI=

--- a/plugins/source/postgresql/go.mod
+++ b/plugins/source/postgresql/go.mod
@@ -4,7 +4,7 @@ go 1.21.1
 
 require (
 	github.com/apache/arrow/go/v14 v14.0.0-20230929201650-00efb06dc0de
-	github.com/cloudquery/plugin-sdk/v4 v4.15.3
+	github.com/cloudquery/plugin-sdk/v4 v4.16.0
 	github.com/google/uuid v1.3.1
 	github.com/jackc/pglogrepl v0.0.0-20230826184802-9ed16cb201f6
 	github.com/jackc/pgx-zerolog v0.0.0-20230315001418-f978528409eb

--- a/plugins/source/postgresql/go.sum
+++ b/plugins/source/postgresql/go.sum
@@ -88,8 +88,8 @@ github.com/cloudquery/plugin-pb-go v1.12.3 h1:rLK3/RR70/BX8tj2QzTnrjkxQhzfAT7SXE
 github.com/cloudquery/plugin-pb-go v1.12.3/go.mod h1:CYorX3zCHF9ByoOgdBOuwLX/2vVCDH6/FoREOE3oH+w=
 github.com/cloudquery/plugin-sdk/v2 v2.7.0 h1:hRXsdEiaOxJtsn/wZMFQC9/jPfU1MeMK3KF+gPGqm7U=
 github.com/cloudquery/plugin-sdk/v2 v2.7.0/go.mod h1:pAX6ojIW99b/Vg4CkhnsGkRIzNaVEceYMR+Bdit73ug=
-github.com/cloudquery/plugin-sdk/v4 v4.15.3 h1:krXOLZR/3xDAEMdfcZCVD2AbWO0SosnGrb0Lrk5AH/4=
-github.com/cloudquery/plugin-sdk/v4 v4.15.3/go.mod h1:ujSFEUAp8BmozOee0ljjsPHQfddXJCUTAzCD6sVKsu8=
+github.com/cloudquery/plugin-sdk/v4 v4.16.0 h1:AEYIEbZCCPxGFw/bPm5bOpyyPDSqM5DRFIUqfogyJfM=
+github.com/cloudquery/plugin-sdk/v4 v4.16.0/go.mod h1:ujSFEUAp8BmozOee0ljjsPHQfddXJCUTAzCD6sVKsu8=
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
 github.com/cncf/udpa/go v0.0.0-20201120205902-5459f2c99403/go.mod h1:WmhPx2Nbnhtbo57+VJT5O0JRkEi1Wbu0z5j0R8u5Hbk=
 github.com/cncf/udpa/go v0.0.0-20210930031921-04548b0d99d4/go.mod h1:6pvJx4me5XPnfI9Z40ddWsdw2W/uZgQLFXToKeRcDiI=

--- a/plugins/source/salesforce/go.mod
+++ b/plugins/source/salesforce/go.mod
@@ -4,7 +4,7 @@ go 1.21.1
 
 require (
 	github.com/apache/arrow/go/v14 v14.0.0-20230929201650-00efb06dc0de
-	github.com/cloudquery/plugin-sdk/v4 v4.15.3
+	github.com/cloudquery/plugin-sdk/v4 v4.16.0
 	github.com/gorilla/mux v1.8.0
 	github.com/rs/zerolog v1.29.1
 )

--- a/plugins/source/salesforce/go.sum
+++ b/plugins/source/salesforce/go.sum
@@ -92,8 +92,8 @@ github.com/cloudquery/plugin-pb-go v1.12.3 h1:rLK3/RR70/BX8tj2QzTnrjkxQhzfAT7SXE
 github.com/cloudquery/plugin-pb-go v1.12.3/go.mod h1:CYorX3zCHF9ByoOgdBOuwLX/2vVCDH6/FoREOE3oH+w=
 github.com/cloudquery/plugin-sdk/v2 v2.7.0 h1:hRXsdEiaOxJtsn/wZMFQC9/jPfU1MeMK3KF+gPGqm7U=
 github.com/cloudquery/plugin-sdk/v2 v2.7.0/go.mod h1:pAX6ojIW99b/Vg4CkhnsGkRIzNaVEceYMR+Bdit73ug=
-github.com/cloudquery/plugin-sdk/v4 v4.15.3 h1:krXOLZR/3xDAEMdfcZCVD2AbWO0SosnGrb0Lrk5AH/4=
-github.com/cloudquery/plugin-sdk/v4 v4.15.3/go.mod h1:ujSFEUAp8BmozOee0ljjsPHQfddXJCUTAzCD6sVKsu8=
+github.com/cloudquery/plugin-sdk/v4 v4.16.0 h1:AEYIEbZCCPxGFw/bPm5bOpyyPDSqM5DRFIUqfogyJfM=
+github.com/cloudquery/plugin-sdk/v4 v4.16.0/go.mod h1:ujSFEUAp8BmozOee0ljjsPHQfddXJCUTAzCD6sVKsu8=
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
 github.com/cncf/udpa/go v0.0.0-20201120205902-5459f2c99403/go.mod h1:WmhPx2Nbnhtbo57+VJT5O0JRkEi1Wbu0z5j0R8u5Hbk=
 github.com/cncf/udpa/go v0.0.0-20210930031921-04548b0d99d4/go.mod h1:6pvJx4me5XPnfI9Z40ddWsdw2W/uZgQLFXToKeRcDiI=

--- a/plugins/source/shopify/go.mod
+++ b/plugins/source/shopify/go.mod
@@ -4,7 +4,7 @@ go 1.21.1
 
 require (
 	github.com/apache/arrow/go/v14 v14.0.0-20230929201650-00efb06dc0de
-	github.com/cloudquery/plugin-sdk/v4 v4.15.3
+	github.com/cloudquery/plugin-sdk/v4 v4.16.0
 	github.com/gorilla/mux v1.8.0
 	github.com/rs/zerolog v1.29.1
 	golang.org/x/net v0.17.0

--- a/plugins/source/shopify/go.sum
+++ b/plugins/source/shopify/go.sum
@@ -92,8 +92,8 @@ github.com/cloudquery/plugin-pb-go v1.12.3 h1:rLK3/RR70/BX8tj2QzTnrjkxQhzfAT7SXE
 github.com/cloudquery/plugin-pb-go v1.12.3/go.mod h1:CYorX3zCHF9ByoOgdBOuwLX/2vVCDH6/FoREOE3oH+w=
 github.com/cloudquery/plugin-sdk/v2 v2.7.0 h1:hRXsdEiaOxJtsn/wZMFQC9/jPfU1MeMK3KF+gPGqm7U=
 github.com/cloudquery/plugin-sdk/v2 v2.7.0/go.mod h1:pAX6ojIW99b/Vg4CkhnsGkRIzNaVEceYMR+Bdit73ug=
-github.com/cloudquery/plugin-sdk/v4 v4.15.3 h1:krXOLZR/3xDAEMdfcZCVD2AbWO0SosnGrb0Lrk5AH/4=
-github.com/cloudquery/plugin-sdk/v4 v4.15.3/go.mod h1:ujSFEUAp8BmozOee0ljjsPHQfddXJCUTAzCD6sVKsu8=
+github.com/cloudquery/plugin-sdk/v4 v4.16.0 h1:AEYIEbZCCPxGFw/bPm5bOpyyPDSqM5DRFIUqfogyJfM=
+github.com/cloudquery/plugin-sdk/v4 v4.16.0/go.mod h1:ujSFEUAp8BmozOee0ljjsPHQfddXJCUTAzCD6sVKsu8=
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
 github.com/cncf/udpa/go v0.0.0-20201120205902-5459f2c99403/go.mod h1:WmhPx2Nbnhtbo57+VJT5O0JRkEi1Wbu0z5j0R8u5Hbk=
 github.com/cncf/udpa/go v0.0.0-20210930031921-04548b0d99d4/go.mod h1:6pvJx4me5XPnfI9Z40ddWsdw2W/uZgQLFXToKeRcDiI=

--- a/plugins/source/snyk/go.mod
+++ b/plugins/source/snyk/go.mod
@@ -4,7 +4,7 @@ go 1.21.1
 
 require (
 	github.com/apache/arrow/go/v14 v14.0.0-20230929201650-00efb06dc0de
-	github.com/cloudquery/plugin-sdk/v4 v4.15.3
+	github.com/cloudquery/plugin-sdk/v4 v4.16.0
 	github.com/google/uuid v1.3.1
 	github.com/julienschmidt/httprouter v1.3.0
 	github.com/pavel-snyk/snyk-sdk-go v0.4.1

--- a/plugins/source/snyk/go.sum
+++ b/plugins/source/snyk/go.sum
@@ -92,8 +92,8 @@ github.com/cloudquery/plugin-pb-go v1.12.3 h1:rLK3/RR70/BX8tj2QzTnrjkxQhzfAT7SXE
 github.com/cloudquery/plugin-pb-go v1.12.3/go.mod h1:CYorX3zCHF9ByoOgdBOuwLX/2vVCDH6/FoREOE3oH+w=
 github.com/cloudquery/plugin-sdk/v2 v2.7.0 h1:hRXsdEiaOxJtsn/wZMFQC9/jPfU1MeMK3KF+gPGqm7U=
 github.com/cloudquery/plugin-sdk/v2 v2.7.0/go.mod h1:pAX6ojIW99b/Vg4CkhnsGkRIzNaVEceYMR+Bdit73ug=
-github.com/cloudquery/plugin-sdk/v4 v4.15.3 h1:krXOLZR/3xDAEMdfcZCVD2AbWO0SosnGrb0Lrk5AH/4=
-github.com/cloudquery/plugin-sdk/v4 v4.15.3/go.mod h1:ujSFEUAp8BmozOee0ljjsPHQfddXJCUTAzCD6sVKsu8=
+github.com/cloudquery/plugin-sdk/v4 v4.16.0 h1:AEYIEbZCCPxGFw/bPm5bOpyyPDSqM5DRFIUqfogyJfM=
+github.com/cloudquery/plugin-sdk/v4 v4.16.0/go.mod h1:ujSFEUAp8BmozOee0ljjsPHQfddXJCUTAzCD6sVKsu8=
 github.com/cloudquery/snyk-sdk-go v0.5.0 h1:aDA94/ix7ro4V1qh2mk3/XTaT2j37ETRkOaYUR2pHc8=
 github.com/cloudquery/snyk-sdk-go v0.5.0/go.mod h1:LRL1TRuuM925gnyGp54WtS9p8S4yJMd0oS4JpLg+n7Y=
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=

--- a/plugins/source/stripe/go.mod
+++ b/plugins/source/stripe/go.mod
@@ -4,7 +4,7 @@ go 1.21.1
 
 require (
 	github.com/apache/arrow/go/v14 v14.0.0-20230929201650-00efb06dc0de
-	github.com/cloudquery/plugin-sdk/v4 v4.15.3
+	github.com/cloudquery/plugin-sdk/v4 v4.16.0
 	github.com/gertd/go-pluralize v0.2.1
 	github.com/rs/zerolog v1.29.1
 	github.com/stripe/stripe-go/v74 v74.16.0

--- a/plugins/source/stripe/go.sum
+++ b/plugins/source/stripe/go.sum
@@ -92,8 +92,8 @@ github.com/cloudquery/plugin-pb-go v1.12.3 h1:rLK3/RR70/BX8tj2QzTnrjkxQhzfAT7SXE
 github.com/cloudquery/plugin-pb-go v1.12.3/go.mod h1:CYorX3zCHF9ByoOgdBOuwLX/2vVCDH6/FoREOE3oH+w=
 github.com/cloudquery/plugin-sdk/v2 v2.7.0 h1:hRXsdEiaOxJtsn/wZMFQC9/jPfU1MeMK3KF+gPGqm7U=
 github.com/cloudquery/plugin-sdk/v2 v2.7.0/go.mod h1:pAX6ojIW99b/Vg4CkhnsGkRIzNaVEceYMR+Bdit73ug=
-github.com/cloudquery/plugin-sdk/v4 v4.15.3 h1:krXOLZR/3xDAEMdfcZCVD2AbWO0SosnGrb0Lrk5AH/4=
-github.com/cloudquery/plugin-sdk/v4 v4.15.3/go.mod h1:ujSFEUAp8BmozOee0ljjsPHQfddXJCUTAzCD6sVKsu8=
+github.com/cloudquery/plugin-sdk/v4 v4.16.0 h1:AEYIEbZCCPxGFw/bPm5bOpyyPDSqM5DRFIUqfogyJfM=
+github.com/cloudquery/plugin-sdk/v4 v4.16.0/go.mod h1:ujSFEUAp8BmozOee0ljjsPHQfddXJCUTAzCD6sVKsu8=
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
 github.com/cncf/udpa/go v0.0.0-20201120205902-5459f2c99403/go.mod h1:WmhPx2Nbnhtbo57+VJT5O0JRkEi1Wbu0z5j0R8u5Hbk=
 github.com/cncf/udpa/go v0.0.0-20210930031921-04548b0d99d4/go.mod h1:6pvJx4me5XPnfI9Z40ddWsdw2W/uZgQLFXToKeRcDiI=

--- a/plugins/source/terraform/go.mod
+++ b/plugins/source/terraform/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/feature/s3/manager v1.11.79
 	github.com/aws/aws-sdk-go-v2/service/s3 v1.38.4
 	github.com/aws/aws-sdk-go-v2/service/sts v1.21.4
-	github.com/cloudquery/plugin-sdk/v4 v4.15.3
+	github.com/cloudquery/plugin-sdk/v4 v4.16.0
 	github.com/rs/zerolog v1.29.1
 	github.com/stretchr/testify v1.8.4
 )

--- a/plugins/source/terraform/go.sum
+++ b/plugins/source/terraform/go.sum
@@ -130,8 +130,8 @@ github.com/cloudquery/plugin-pb-go v1.12.3 h1:rLK3/RR70/BX8tj2QzTnrjkxQhzfAT7SXE
 github.com/cloudquery/plugin-pb-go v1.12.3/go.mod h1:CYorX3zCHF9ByoOgdBOuwLX/2vVCDH6/FoREOE3oH+w=
 github.com/cloudquery/plugin-sdk/v2 v2.7.0 h1:hRXsdEiaOxJtsn/wZMFQC9/jPfU1MeMK3KF+gPGqm7U=
 github.com/cloudquery/plugin-sdk/v2 v2.7.0/go.mod h1:pAX6ojIW99b/Vg4CkhnsGkRIzNaVEceYMR+Bdit73ug=
-github.com/cloudquery/plugin-sdk/v4 v4.15.3 h1:krXOLZR/3xDAEMdfcZCVD2AbWO0SosnGrb0Lrk5AH/4=
-github.com/cloudquery/plugin-sdk/v4 v4.15.3/go.mod h1:ujSFEUAp8BmozOee0ljjsPHQfddXJCUTAzCD6sVKsu8=
+github.com/cloudquery/plugin-sdk/v4 v4.16.0 h1:AEYIEbZCCPxGFw/bPm5bOpyyPDSqM5DRFIUqfogyJfM=
+github.com/cloudquery/plugin-sdk/v4 v4.16.0/go.mod h1:ujSFEUAp8BmozOee0ljjsPHQfddXJCUTAzCD6sVKsu8=
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
 github.com/cncf/udpa/go v0.0.0-20201120205902-5459f2c99403/go.mod h1:WmhPx2Nbnhtbo57+VJT5O0JRkEi1Wbu0z5j0R8u5Hbk=
 github.com/cncf/udpa/go v0.0.0-20210930031921-04548b0d99d4/go.mod h1:6pvJx4me5XPnfI9Z40ddWsdw2W/uZgQLFXToKeRcDiI=

--- a/plugins/source/test/go.mod
+++ b/plugins/source/test/go.mod
@@ -4,7 +4,7 @@ go 1.21.1
 
 require (
 	github.com/apache/arrow/go/v14 v14.0.0-20230929201650-00efb06dc0de
-	github.com/cloudquery/plugin-sdk/v4 v4.15.3
+	github.com/cloudquery/plugin-sdk/v4 v4.16.0
 	github.com/rs/zerolog v1.29.1
 )
 

--- a/plugins/source/test/go.sum
+++ b/plugins/source/test/go.sum
@@ -92,8 +92,8 @@ github.com/cloudquery/plugin-pb-go v1.12.3 h1:rLK3/RR70/BX8tj2QzTnrjkxQhzfAT7SXE
 github.com/cloudquery/plugin-pb-go v1.12.3/go.mod h1:CYorX3zCHF9ByoOgdBOuwLX/2vVCDH6/FoREOE3oH+w=
 github.com/cloudquery/plugin-sdk/v2 v2.7.0 h1:hRXsdEiaOxJtsn/wZMFQC9/jPfU1MeMK3KF+gPGqm7U=
 github.com/cloudquery/plugin-sdk/v2 v2.7.0/go.mod h1:pAX6ojIW99b/Vg4CkhnsGkRIzNaVEceYMR+Bdit73ug=
-github.com/cloudquery/plugin-sdk/v4 v4.15.3 h1:krXOLZR/3xDAEMdfcZCVD2AbWO0SosnGrb0Lrk5AH/4=
-github.com/cloudquery/plugin-sdk/v4 v4.15.3/go.mod h1:ujSFEUAp8BmozOee0ljjsPHQfddXJCUTAzCD6sVKsu8=
+github.com/cloudquery/plugin-sdk/v4 v4.16.0 h1:AEYIEbZCCPxGFw/bPm5bOpyyPDSqM5DRFIUqfogyJfM=
+github.com/cloudquery/plugin-sdk/v4 v4.16.0/go.mod h1:ujSFEUAp8BmozOee0ljjsPHQfddXJCUTAzCD6sVKsu8=
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
 github.com/cncf/udpa/go v0.0.0-20201120205902-5459f2c99403/go.mod h1:WmhPx2Nbnhtbo57+VJT5O0JRkEi1Wbu0z5j0R8u5Hbk=
 github.com/cncf/udpa/go v0.0.0-20210930031921-04548b0d99d4/go.mod h1:6pvJx4me5XPnfI9Z40ddWsdw2W/uZgQLFXToKeRcDiI=

--- a/plugins/source/vault/go.mod
+++ b/plugins/source/vault/go.mod
@@ -5,7 +5,7 @@ go 1.21.1
 require (
 	github.com/apache/arrow/go/v14 v14.0.0-20230929201650-00efb06dc0de
 	github.com/cloudquery/codegen v0.3.9
-	github.com/cloudquery/plugin-sdk/v4 v4.15.3
+	github.com/cloudquery/plugin-sdk/v4 v4.16.0
 	github.com/golang/mock v1.4.4
 	github.com/hashicorp/vault/api v1.9.2
 	github.com/rs/zerolog v1.29.1

--- a/plugins/source/vault/go.sum
+++ b/plugins/source/vault/go.sum
@@ -108,8 +108,8 @@ github.com/cloudquery/plugin-pb-go v1.12.3 h1:rLK3/RR70/BX8tj2QzTnrjkxQhzfAT7SXE
 github.com/cloudquery/plugin-pb-go v1.12.3/go.mod h1:CYorX3zCHF9ByoOgdBOuwLX/2vVCDH6/FoREOE3oH+w=
 github.com/cloudquery/plugin-sdk/v2 v2.7.0 h1:hRXsdEiaOxJtsn/wZMFQC9/jPfU1MeMK3KF+gPGqm7U=
 github.com/cloudquery/plugin-sdk/v2 v2.7.0/go.mod h1:pAX6ojIW99b/Vg4CkhnsGkRIzNaVEceYMR+Bdit73ug=
-github.com/cloudquery/plugin-sdk/v4 v4.15.3 h1:krXOLZR/3xDAEMdfcZCVD2AbWO0SosnGrb0Lrk5AH/4=
-github.com/cloudquery/plugin-sdk/v4 v4.15.3/go.mod h1:ujSFEUAp8BmozOee0ljjsPHQfddXJCUTAzCD6sVKsu8=
+github.com/cloudquery/plugin-sdk/v4 v4.16.0 h1:AEYIEbZCCPxGFw/bPm5bOpyyPDSqM5DRFIUqfogyJfM=
+github.com/cloudquery/plugin-sdk/v4 v4.16.0/go.mod h1:ujSFEUAp8BmozOee0ljjsPHQfddXJCUTAzCD6sVKsu8=
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
 github.com/cncf/udpa/go v0.0.0-20201120205902-5459f2c99403/go.mod h1:WmhPx2Nbnhtbo57+VJT5O0JRkEi1Wbu0z5j0R8u5Hbk=
 github.com/cncf/udpa/go v0.0.0-20210930031921-04548b0d99d4/go.mod h1:6pvJx4me5XPnfI9Z40ddWsdw2W/uZgQLFXToKeRcDiI=


### PR DESCRIPTION
This version changes the `package` command to require metadata about the team publishing the plugin. It also introduces a plugin `info` command to print this information. Other than that, there are no functional changes for plugins in this upgrade.