### PR TITLE
fix: Set plugin metadata

### DIFF
--- a/.github/workflows/publish_plugin_to_hub.yml
+++ b/.github/workflows/publish_plugin_to_hub.yml
@@ -109,7 +109,7 @@ jobs:
         working-directory: ${{ needs.prepare.outputs.plugin_dir }}
         run: |
           rsync -v --exclude='tables.md' ../../../website/pages/docs/plugins/${{ needs.prepare.outputs.plugin_kind_plural }}/${{ needs.prepare.outputs.plugin_name }}/*.md docsdir/
-          go run main.go package --docs-dir docsdir -m ${{ steps.release-notes.outputs.result }} ${{ needs.prepare.outputs.plugin_kind }} ${{ needs.prepare.outputs.plugin_version }} .
+          go run main.go package --docs-dir docsdir -m ${{ steps.release-notes.outputs.result }} ${{ needs.prepare.outputs.plugin_version }} .
 
       - name: Setup CloudQuery
         uses: cloudquery/setup-cloudquery@v3

--- a/.github/workflows/publish_plugin_to_hub_duckdb.yml
+++ b/.github/workflows/publish_plugin_to_hub_duckdb.yml
@@ -89,7 +89,7 @@ jobs:
         run: |
           mkdir -p stubdocs
           touch stubdocs/README.md
-          go run main.go package --docs-dir stubdocs -m ${{ steps.release-notes.outputs.result }} ${{ needs.prepare.outputs.plugin_kind }} ${{ needs.prepare.outputs.plugin_version }} .
+          go run main.go package --docs-dir stubdocs -m ${{ steps.release-notes.outputs.result }} ${{ needs.prepare.outputs.plugin_version }} .
       - name: Setup CloudQuery
         uses: cloudquery/setup-cloudquery@v3
         with:

--- a/.github/workflows/publish_plugin_to_hub_snowflake.yml
+++ b/.github/workflows/publish_plugin_to_hub_snowflake.yml
@@ -90,7 +90,7 @@ jobs:
         run: |
           mkdir -p stubdocs
           touch stubdocs/README.md
-          go run main.go package --docs-dir stubdocs -m ${{ steps.release-notes.outputs.result }} ${{ needs.prepare.outputs.plugin_kind }} ${{ needs.prepare.outputs.plugin_version }} .
+          go run main.go package --docs-dir stubdocs -m ${{ steps.release-notes.outputs.result }} ${{ needs.prepare.outputs.plugin_version }} .
       - name: Setup CloudQuery
         uses: cloudquery/setup-cloudquery@v3
         with:

--- a/.github/workflows/publish_plugin_to_hub_sqlite.yml
+++ b/.github/workflows/publish_plugin_to_hub_sqlite.yml
@@ -89,7 +89,7 @@ jobs:
         run: |
           mkdir -p stubdocs
           touch stubdocs/README.md
-          go run main.go package --docs-dir stubdocs -m ${{ steps.release-notes.outputs.result }} ${{ needs.prepare.outputs.plugin_kind }} ${{ needs.prepare.outputs.plugin_version }} .
+          go run main.go package --docs-dir stubdocs -m ${{ steps.release-notes.outputs.result }} ${{ needs.prepare.outputs.plugin_version }} .
       - name: Setup CloudQuery
         uses: cloudquery/setup-cloudquery@v3
         with:

--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -37,7 +37,7 @@
   "plugins/destination/bigquery+FILLER": "0.0.0",
   "plugins/source/pagerduty": "3.0.10",
   "plugins/source/pagerduty+FILLER": "0.0.0",
-  "plugins/destination/mongodb": "2.2.12",
+  "plugins/destination/mongodb": "2.2.13",
   "plugins/destination/mongodb+FILLER": "0.0.0",
   "plugins/source/gitlab": "4.1.10",
   "plugins/source/gitlab+FILLER": "0.0.0",

--- a/plugins/destination/azblob/main.go
+++ b/plugins/destination/azblob/main.go
@@ -15,7 +15,10 @@ const (
 )
 
 func main() {
-	p := plugin.NewPlugin("azblob", internalPlugin.Version, client.New)
+	p := plugin.NewPlugin(internalPlugin.Name, internalPlugin.Version, client.New,
+		plugin.WithKind(internalPlugin.Kind),
+		plugin.WithTeam(internalPlugin.Team),
+	)
 	if err := serve.Plugin(p, serve.WithPluginSentryDSN(sentryDSN), serve.WithDestinationV0V1Server()).Serve(context.Background()); err != nil {
 		log.Fatalf("failed to serve plugin: %v", err)
 	}

--- a/plugins/destination/azblob/resources/plugin/plugin.go
+++ b/plugins/destination/azblob/resources/plugin/plugin.go
@@ -1,6 +1,9 @@
 package plugin
 
+// Don't move this file to a different package, it's used by Go releaser to embed the version in the binary.
 var (
-	// Don't move this file to a different package, it's used by Go releaser to embed the version in the binary.
-	Version = "Development"
+	Name    = "azblob"
+	Kind    = "destination"
+	Team    = "cloudquery"
+	Version = "development"
 )

--- a/plugins/destination/bigquery/main.go
+++ b/plugins/destination/bigquery/main.go
@@ -15,7 +15,7 @@ const (
 )
 
 func main() {
-	p := plugin.NewPlugin("bigquery", internalPlugin.Version, client.New)
+	p := plugin.NewPlugin(internalPlugin.Name, internalPlugin.Version, client.New, plugin.WithKind(internalPlugin.Kind), plugin.WithTeam(internalPlugin.Team))
 	if err := serve.Plugin(p, serve.WithDestinationV0V1Server(), serve.WithPluginSentryDSN(sentryDSN)).Serve(context.Background()); err != nil {
 		log.Fatal(err)
 	}

--- a/plugins/destination/bigquery/resources/plugin/plugin.go
+++ b/plugins/destination/bigquery/resources/plugin/plugin.go
@@ -1,6 +1,9 @@
 package plugin
 
+// Don't move this file to a different package, it's used by Go releaser to embed the version in the binary.
 var (
-	// Don't move this file to a different package, it's used by Go releaser to embed the version in the binary.
-	Version = "Development"
+	Name    = "bigquery"
+	Kind    = "destination"
+	Team    = "cloudquery"
+	Version = "development"
 )

--- a/plugins/destination/clickhouse/main.go
+++ b/plugins/destination/clickhouse/main.go
@@ -16,10 +16,13 @@ const (
 )
 
 func main() {
-	p := plugin.NewPlugin("clickhouse",
+	p := plugin.NewPlugin(
+		internalPlugin.Name,
 		internalPlugin.Version,
 		client.New,
 		plugin.WithJSONSchema(spec.JSONSchema),
+		plugin.WithKind(internalPlugin.Kind),
+		plugin.WithTeam(internalPlugin.Team),
 	)
 	if err := serve.Plugin(p,
 		serve.WithPluginSentryDSN(sentryDSN),

--- a/plugins/destination/clickhouse/resources/plugin/plugin.go
+++ b/plugins/destination/clickhouse/resources/plugin/plugin.go
@@ -2,4 +2,9 @@ package plugin
 
 // Version is used by Go releaser to embed the version in the binary.
 // Should be left in this package.
-var Version = "Development"
+var (
+	Name    = "clickhouse"
+	Kind    = "destination"
+	Team    = "cloudquery"
+	Version = "development"
+)

--- a/plugins/destination/duckdb/main.go
+++ b/plugins/destination/duckdb/main.go
@@ -16,7 +16,7 @@ const (
 
 func main() {
 	p := plugin.NewPlugin(
-		"duckdb",
+		internalPlugin.Name,
 		internalPlugin.Version,
 		client.New,
 		plugin.WithBuildTargets([]plugin.BuildTarget{
@@ -25,6 +25,8 @@ func main() {
 			{OS: plugin.GoOSDarwin, Arch: plugin.GoArchArm64},
 		}),
 		plugin.WithStaticLinking(),
+		plugin.WithKind(internalPlugin.Kind),
+		plugin.WithTeam(internalPlugin.Team),
 	)
 	server := serve.Plugin(p,
 		serve.WithPluginSentryDSN(sentryDSN),

--- a/plugins/destination/duckdb/resources/plugin/plugin.go
+++ b/plugins/destination/duckdb/resources/plugin/plugin.go
@@ -1,6 +1,9 @@
 package plugin
 
+// Don't move this file to a different package, it's used by Go releaser to embed the version in the binary.
 var (
-	// Don't move this file to a different package, it's used by Go releaser to embed the version in the binary.
-	Version = "Development"
+	Name    = "duckdb"
+	Kind    = "destination"
+	Team    = "cloudquery"
+	Version = "development"
 )

--- a/plugins/destination/elasticsearch/main.go
+++ b/plugins/destination/elasticsearch/main.go
@@ -15,7 +15,10 @@ const (
 )
 
 func main() {
-	p := plugin.NewPlugin("elasticsearch", internalPlugin.Version, client.New)
+	p := plugin.NewPlugin(internalPlugin.Name, internalPlugin.Version, client.New,
+		plugin.WithKind(internalPlugin.Kind),
+		plugin.WithTeam(internalPlugin.Team),
+	)
 	if err := serve.Plugin(p, serve.WithPluginSentryDSN(sentryDSN), serve.WithDestinationV0V1Server()).Serve(context.Background()); err != nil {
 		log.Fatal(err)
 	}

--- a/plugins/destination/elasticsearch/resources/plugin/plugin.go
+++ b/plugins/destination/elasticsearch/resources/plugin/plugin.go
@@ -1,6 +1,9 @@
 package plugin
 
+// Don't move this file to a different package, it's used by Go releaser to embed the version in the binary.
 var (
-	// Don't move this file to a different package, it's used by Go releaser to embed the version in the binary.
-	Version = "Development"
+	Name    = "elasticsearch"
+	Kind    = "destination"
+	Team    = "cloudquery"
+	Version = "development"
 )

--- a/plugins/destination/file/main.go
+++ b/plugins/destination/file/main.go
@@ -15,7 +15,7 @@ const (
 )
 
 func main() {
-	p := plugin.NewPlugin("file", internalPlugin.Version, client.New)
+	p := plugin.NewPlugin(internalPlugin.Name, internalPlugin.Version, client.New, plugin.WithKind(internalPlugin.Kind), plugin.WithTeam(internalPlugin.Team))
 	if err := serve.Plugin(p, serve.WithPluginSentryDSN(sentryDSN), serve.WithDestinationV0V1Server()).Serve(context.Background()); err != nil {
 		log.Fatalf("failed to serve plugin: %v", err)
 	}

--- a/plugins/destination/file/resources/plugin/plugin.go
+++ b/plugins/destination/file/resources/plugin/plugin.go
@@ -1,6 +1,9 @@
 package plugin
 
+// Don't move this file to a different package, it's used by Go releaser to embed the version in the binary.
 var (
-	// Don't move this file to a different package, it's used by Go releaser to embed the version in the binary.
-	Version = "Development"
+	Name    = "file"
+	Kind    = "destination"
+	Team    = "cloudquery"
+	Version = "development"
 )

--- a/plugins/destination/firehose/main.go
+++ b/plugins/destination/firehose/main.go
@@ -15,7 +15,10 @@ const (
 )
 
 func main() {
-	p := plugin.NewPlugin("firehose", internalPlugin.Version, client.New)
+	p := plugin.NewPlugin(internalPlugin.Name, internalPlugin.Version, client.New,
+		plugin.WithKind(internalPlugin.Kind),
+		plugin.WithTeam(internalPlugin.Team),
+	)
 	if err := serve.Plugin(p,
 		serve.WithPluginSentryDSN(sentryDSN),
 		serve.WithDestinationV0V1Server(),

--- a/plugins/destination/firehose/resources/plugin/plugin.go
+++ b/plugins/destination/firehose/resources/plugin/plugin.go
@@ -1,4 +1,9 @@
 package plugin
 
 // Don't move this file to a different package, it's used by Go releaser to embed the version in the binary.
-var Version = "Development"
+var (
+	Name    = "firehose"
+	Kind    = "destination"
+	Team    = "cloudquery"
+	Version = "development"
+)

--- a/plugins/destination/gcs/main.go
+++ b/plugins/destination/gcs/main.go
@@ -15,7 +15,7 @@ const (
 )
 
 func main() {
-	p := plugin.NewPlugin("file", internalPlugin.Version, client.New)
+	p := plugin.NewPlugin(internalPlugin.Name, internalPlugin.Version, client.New, plugin.WithKind(internalPlugin.Kind), plugin.WithTeam(internalPlugin.Team))
 	if err := serve.Plugin(p, serve.WithPluginSentryDSN(sentryDSN), serve.WithDestinationV0V1Server()).Serve(context.Background()); err != nil {
 		log.Fatalf("failed to serve plugin: %v", err)
 	}

--- a/plugins/destination/gcs/resources/plugin/plugin.go
+++ b/plugins/destination/gcs/resources/plugin/plugin.go
@@ -1,6 +1,9 @@
 package plugin
 
+// Don't move this file to a different package, it's used by Go releaser to embed the version in the binary.
 var (
-	// Don't move this file to a different package, it's used by Go releaser to embed the version in the binary.
-	Version = "Development"
+	Name    = "gcs"
+	Kind    = "destination"
+	Team    = "cloudquery"
+	Version = "development"
 )

--- a/plugins/destination/gremlin/main.go
+++ b/plugins/destination/gremlin/main.go
@@ -15,7 +15,10 @@ const (
 )
 
 func main() {
-	p := plugin.NewPlugin("gremlin", internalPlugin.Version, client.New)
+	p := plugin.NewPlugin(internalPlugin.Name, internalPlugin.Version, client.New,
+		plugin.WithKind(internalPlugin.Kind),
+		plugin.WithTeam(internalPlugin.Team),
+	)
 	if err := serve.Plugin(p, serve.WithPluginSentryDSN(sentryDSN), serve.WithDestinationV0V1Server()).Serve(context.Background()); err != nil {
 		log.Fatalf("failed to serve plugin: %v", err)
 	}

--- a/plugins/destination/gremlin/resources/plugin/plugin.go
+++ b/plugins/destination/gremlin/resources/plugin/plugin.go
@@ -1,6 +1,9 @@
 package plugin
 
+// Don't move this file to a different package, it's used by Go releaser to embed the version in the binary.
 var (
-	// Don't move this file to a different package, it's used by Go releaser to embed the version in the binary.
-	Version = "Development"
+	Name    = "gremlin"
+	Kind    = "destination"
+	Team    = "cloudquery"
+	Version = "development"
 )

--- a/plugins/destination/kafka/main.go
+++ b/plugins/destination/kafka/main.go
@@ -15,7 +15,10 @@ const (
 )
 
 func main() {
-	p := plugin.NewPlugin("kafka", internalPlugin.Version, client.New)
+	p := plugin.NewPlugin(internalPlugin.Name, internalPlugin.Version, client.New,
+		plugin.WithKind(internalPlugin.Kind),
+		plugin.WithTeam(internalPlugin.Team),
+	)
 	if err := serve.Plugin(p, serve.WithPluginSentryDSN(sentryDSN), serve.WithDestinationV0V1Server()).Serve(context.Background()); err != nil {
 		log.Fatalf("failed to serve plugin: %v", err)
 	}

--- a/plugins/destination/kafka/resources/plugin/plugin.go
+++ b/plugins/destination/kafka/resources/plugin/plugin.go
@@ -1,6 +1,9 @@
 package plugin
 
+// Don't move this file to a different package, it's used by Go releaser to embed the version in the binary.
 var (
-	// Don't move this file to a different package, it's used by Go releaser to embed the version in the binary.
-	Version = "Development"
+	Name    = "kafka"
+	Kind    = "destination"
+	Team    = "cloudquery"
+	Version = "development"
 )

--- a/plugins/destination/meilisearch/main.go
+++ b/plugins/destination/meilisearch/main.go
@@ -15,7 +15,10 @@ const (
 )
 
 func main() {
-	p := plugin.NewPlugin("meilisearch", internalPlugin.Version, client.New)
+	p := plugin.NewPlugin(internalPlugin.Name, internalPlugin.Version, client.New,
+		plugin.WithKind(internalPlugin.Kind),
+		plugin.WithTeam(internalPlugin.Team),
+	)
 	if err := serve.Plugin(p,
 		serve.WithPluginSentryDSN(sentryDSN),
 		serve.WithDestinationV0V1Server(),

--- a/plugins/destination/meilisearch/resources/plugin/plugin.go
+++ b/plugins/destination/meilisearch/resources/plugin/plugin.go
@@ -2,4 +2,9 @@ package plugin
 
 // Version is used by Go releaser to embed the version in the binary.
 // Should be left in this package.
-var Version = "Development"
+var (
+	Name    = "meilisearch"
+	Kind    = "destination"
+	Team    = "cloudquery"
+	Version = "development"
+)

--- a/plugins/destination/mongodb/CHANGELOG.md
+++ b/plugins/destination/mongodb/CHANGELOG.md
@@ -1,5 +1,27 @@
 # Changelog
 
+## [2.2.13](https://github.com/cloudquery/cloudquery/compare/plugins-destination-mongodb-v2.2.12...plugins-destination-mongodb-v2.2.13) (2023-10-19)
+
+
+### Bug Fixes
+
+* **deps:** Update github.com/cloudquery/arrow/go/v14 digest to d401686 ([#14459](https://github.com/cloudquery/cloudquery/issues/14459)) ([7ce40f8](https://github.com/cloudquery/cloudquery/commit/7ce40f8dcb1e408c385e877e56b5bb78906b10d2))
+* **deps:** Update github.com/cloudquery/arrow/go/v14 digest to dbcb149 ([#14537](https://github.com/cloudquery/cloudquery/issues/14537)) ([68686f4](https://github.com/cloudquery/cloudquery/commit/68686f4e7636db02bddd961e3d75b60d5218ca85))
+* **deps:** Update module github.com/cloudquery/cloudquery-api-go to v1.2.6 ([#14475](https://github.com/cloudquery/cloudquery/issues/14475)) ([83fe7ca](https://github.com/cloudquery/cloudquery/commit/83fe7ca2f5fa83bd3219ddde8fe44fcf1d447480))
+* **deps:** Update module github.com/cloudquery/cloudquery-api-go to v1.2.8 ([#14503](https://github.com/cloudquery/cloudquery/issues/14503)) ([4056593](https://github.com/cloudquery/cloudquery/commit/40565937cfc12b33048980b55e91a9a60a62bd47))
+* **deps:** Update module github.com/cloudquery/cloudquery-api-go to v1.2.9 ([#14627](https://github.com/cloudquery/cloudquery/issues/14627)) ([c1d244c](https://github.com/cloudquery/cloudquery/commit/c1d244c95199141ac39a713a3f0577b2fb3bf736))
+* **deps:** Update module github.com/cloudquery/cloudquery-api-go to v1.3.0 ([#14635](https://github.com/cloudquery/cloudquery/issues/14635)) ([00b380c](https://github.com/cloudquery/cloudquery/commit/00b380c10be1642f737f871ba5588888ed5dd180))
+* **deps:** Update module github.com/cloudquery/cloudquery-api-go to v1.4.0 ([#14639](https://github.com/cloudquery/cloudquery/issues/14639)) ([f139c0e](https://github.com/cloudquery/cloudquery/commit/f139c0e9369ef92a3cd874003db40b48e229ab58))
+* **deps:** Update module github.com/cloudquery/plugin-sdk/v4 to v4.12.2 ([#14378](https://github.com/cloudquery/cloudquery/issues/14378)) ([a2e0c46](https://github.com/cloudquery/cloudquery/commit/a2e0c4615af4aa205fa082d3f196ea2dc5ce2445))
+* **deps:** Update module github.com/cloudquery/plugin-sdk/v4 to v4.12.3 ([#14436](https://github.com/cloudquery/cloudquery/issues/14436)) ([d529e2d](https://github.com/cloudquery/cloudquery/commit/d529e2d22da93a234492c4165e7eed1257c5767f))
+* **deps:** Update module github.com/cloudquery/plugin-sdk/v4 to v4.12.4 ([#14489](https://github.com/cloudquery/cloudquery/issues/14489)) ([9bb45dc](https://github.com/cloudquery/cloudquery/commit/9bb45dc2dacc2c7a6fbd47538b954f731741809b))
+* **deps:** Update module github.com/cloudquery/plugin-sdk/v4 to v4.12.5 ([#14516](https://github.com/cloudquery/cloudquery/issues/14516)) ([2d905bf](https://github.com/cloudquery/cloudquery/commit/2d905bf9ea81556282c8ca27dcc6334606a2e83b))
+* **deps:** Update module github.com/cloudquery/plugin-sdk/v4 to v4.14.0 ([#14577](https://github.com/cloudquery/cloudquery/issues/14577)) ([223c4c1](https://github.com/cloudquery/cloudquery/commit/223c4c1df6c432d7f1bf67a48114e417282bcd0f))
+* **deps:** Update module github.com/cloudquery/plugin-sdk/v4 to v4.15.0 ([#14622](https://github.com/cloudquery/cloudquery/issues/14622)) ([b497a6b](https://github.com/cloudquery/cloudquery/commit/b497a6bc5645854bd25d4083fd91ec549a7f274f))
+* **deps:** Update module github.com/cloudquery/plugin-sdk/v4 to v4.15.2 ([#14662](https://github.com/cloudquery/cloudquery/issues/14662)) ([e274fe4](https://github.com/cloudquery/cloudquery/commit/e274fe419f6cacdf62547cd7134f40916e5ddd96))
+* **deps:** Update module github.com/cloudquery/plugin-sdk/v4 to v4.15.3 ([#14679](https://github.com/cloudquery/cloudquery/issues/14679)) ([0513c19](https://github.com/cloudquery/cloudquery/commit/0513c193919f4555d41f22ba2ff66efaaf5fca67))
+* **deps:** Update module golang.org/x/net to v0.17.0 [SECURITY] ([#14500](https://github.com/cloudquery/cloudquery/issues/14500)) ([9e603d5](https://github.com/cloudquery/cloudquery/commit/9e603d50d28033ed5bf451e569abc7c25014dbfb))
+
 ## [2.2.12](https://github.com/cloudquery/cloudquery/compare/plugins-destination-mongodb-v2.2.11...plugins-destination-mongodb-v2.2.12) (2023-10-04)
 
 

--- a/plugins/destination/mongodb/main.go
+++ b/plugins/destination/mongodb/main.go
@@ -15,7 +15,10 @@ const (
 )
 
 func main() {
-	p := plugin.NewPlugin("mongodb", internalPlugin.Version, client.New)
+	p := plugin.NewPlugin(internalPlugin.Name, internalPlugin.Version, client.New,
+		plugin.WithKind(internalPlugin.Kind),
+		plugin.WithTeam(internalPlugin.Team),
+	)
 	if err := serve.Plugin(p, serve.WithPluginSentryDSN(sentryDSN), serve.WithDestinationV0V1Server()).Serve(context.Background()); err != nil {
 		log.Fatalf("failed to serve: %v", err)
 	}

--- a/plugins/destination/mongodb/resources/plugin/plugin.go
+++ b/plugins/destination/mongodb/resources/plugin/plugin.go
@@ -1,6 +1,9 @@
 package plugin
 
+// Don't move this file to a different package, it's used by Go releaser to embed the version in the binary.
 var (
-	// Don't move this file to a different package, it's used by Go releaser to embed the version in the binary.
-	Version = "Development"
+	Name    = "mongodb"
+	Kind    = "destination"
+	Team    = "cloudquery"
+	Version = "development"
 )

--- a/plugins/destination/mssql/resources/plugin/plugin.go
+++ b/plugins/destination/mssql/resources/plugin/plugin.go
@@ -1,5 +1,9 @@
 package plugin
 
 // Don't move this file to a different package, it's used by Go releaser to embed the version in the binary.
-
-var Version = "Development"
+var (
+	Name    = "mssql"
+	Kind    = "destination"
+	Team    = "cloudquery"
+	Version = "development"
+)

--- a/plugins/destination/mysql/main.go
+++ b/plugins/destination/mysql/main.go
@@ -17,9 +17,11 @@ const (
 func main() {
 	if err := serve.Plugin(
 		plugin.NewPlugin(
-			"mysql",
+			internalPlugin.Name,
 			internalPlugin.Version,
 			client.New,
+			plugin.WithKind(internalPlugin.Kind),
+			plugin.WithTeam(internalPlugin.Team),
 		),
 		serve.WithDestinationV0V1Server(),
 		serve.WithPluginSentryDSN(sentryDSN),

--- a/plugins/destination/mysql/resources/plugin/plugin.go
+++ b/plugins/destination/mysql/resources/plugin/plugin.go
@@ -1,6 +1,9 @@
 package plugin
 
+// Don't move this file to a different package, it's used by Go releaser to embed the version in the binary.
 var (
-	// Don't move this file to a different package, it's used by Go releaser to embed the version in the binary.
-	Version = "Development"
+	Name    = "mysql"
+	Kind    = "destination"
+	Team    = "cloudquery"
+	Version = "development"
 )

--- a/plugins/destination/neo4j/main.go
+++ b/plugins/destination/neo4j/main.go
@@ -15,7 +15,10 @@ const (
 )
 
 func main() {
-	p := plugin.NewPlugin("neo4j", internalPlugin.Version, client.New)
+	p := plugin.NewPlugin(internalPlugin.Name, internalPlugin.Version, client.New,
+		plugin.WithKind(internalPlugin.Kind),
+		plugin.WithTeam(internalPlugin.Team),
+	)
 	if err := serve.Plugin(p, serve.WithPluginSentryDSN(sentryDSN), serve.WithDestinationV0V1Server()).Serve(context.Background()); err != nil {
 		log.Fatalf("failed to serve plugin: %v", err)
 	}

--- a/plugins/destination/neo4j/resources/plugin/plugin.go
+++ b/plugins/destination/neo4j/resources/plugin/plugin.go
@@ -1,6 +1,9 @@
 package plugin
 
+// Don't move this file to a different package, it's used by Go releaser to embed the version in the binary.
 var (
-	// Don't move this file to a different package, it's used by Go releaser to embed the version in the binary.
-	Version = "Development"
+	Name    = "neo4j"
+	Kind    = "destination"
+	Team    = "cloudquery"
+	Version = "development"
 )

--- a/plugins/destination/postgresql/main.go
+++ b/plugins/destination/postgresql/main.go
@@ -15,7 +15,10 @@ const (
 )
 
 func main() {
-	p := pluginSDK.NewPlugin("postgresql", plugin.Version, client.New)
+	p := pluginSDK.NewPlugin(plugin.Name, plugin.Version, client.New,
+		pluginSDK.WithKind(plugin.Kind),
+		pluginSDK.WithTeam(plugin.Team),
+	)
 	server := serve.Plugin(p,
 		serve.WithPluginSentryDSN(sentryDSN),
 		serve.WithDestinationV0V1Server(),

--- a/plugins/destination/postgresql/resources/plugin/plugin.go
+++ b/plugins/destination/postgresql/resources/plugin/plugin.go
@@ -1,6 +1,9 @@
 package plugin
 
+// Don't move this file to a different package, it's used by Go releaser to embed the version in the binary.
 var (
-	// Don't move this file to a different package, it's used by Go releaser to embed the version in the binary.
-	Version = "Development"
+	Name    = "postgresql"
+	Kind    = "destination"
+	Team    = "cloudquery"
+	Version = "development"
 )

--- a/plugins/destination/s3/main.go
+++ b/plugins/destination/s3/main.go
@@ -15,7 +15,10 @@ const (
 )
 
 func main() {
-	p := plugin.NewPlugin("s3", internalPlugin.Version, client.New)
+	p := plugin.NewPlugin(internalPlugin.Name, internalPlugin.Version, client.New,
+		plugin.WithKind(internalPlugin.Kind),
+		plugin.WithTeam(internalPlugin.Team),
+	)
 	if err := serve.Plugin(p, serve.WithPluginSentryDSN(sentryDSN), serve.WithDestinationV0V1Server()).Serve(context.Background()); err != nil {
 		log.Fatalf("failed to serve plugin: %v", err)
 	}

--- a/plugins/destination/s3/resources/plugin/plugin.go
+++ b/plugins/destination/s3/resources/plugin/plugin.go
@@ -1,6 +1,9 @@
 package plugin
 
+// Don't move this file to a different package, it's used by Go releaser to embed the version in the binary.
 var (
-	// Don't move this file to a different package, it's used by Go releaser to embed the version in the binary.
-	Version = "Development"
+	Name    = "s3"
+	Kind    = "destination"
+	Team    = "cloudquery"
+	Version = "development"
 )

--- a/plugins/destination/snowflake/main.go
+++ b/plugins/destination/snowflake/main.go
@@ -17,7 +17,7 @@ const (
 
 func main() {
 	p := plugin.NewPlugin(
-		"snowflake",
+		internalPlugin.Name,
 		internalPlugin.Version,
 		client.New,
 		plugin.WithBuildTargets([]plugin.BuildTarget{
@@ -27,6 +27,8 @@ func main() {
 			{OS: plugin.GoOSDarwin, Arch: plugin.GoArchArm64},
 		}),
 		plugin.WithStaticLinking(),
+		plugin.WithKind(internalPlugin.Kind),
+		plugin.WithTeam(internalPlugin.Team),
 	)
 	if err := serve.Plugin(p, serve.WithPluginSentryDSN(sentryDSN), serve.WithDestinationV0V1Server()).Serve(context.Background()); err != nil {
 		fmt.Println(err)

--- a/plugins/destination/snowflake/resources/plugin/plugin.go
+++ b/plugins/destination/snowflake/resources/plugin/plugin.go
@@ -1,6 +1,9 @@
 package plugin
 
+// Don't move this file to a different package, it's used by Go releaser to embed the version in the binary.
 var (
-	// Don't move this file to a different package, it's used by Go releaser to embed the version in the binary.
-	Version = "Development"
+	Name    = "snowflake"
+	Kind    = "destination"
+	Team    = "cloudquery"
+	Version = "development"
 )

--- a/plugins/destination/sqlite/main.go
+++ b/plugins/destination/sqlite/main.go
@@ -17,7 +17,7 @@ const (
 
 func main() {
 	p := plugin.NewPlugin(
-		"sqlite",
+		internalPlugin.Name,
 		internalPlugin.Version,
 		client.New,
 		plugin.WithBuildTargets([]plugin.BuildTarget{
@@ -27,6 +27,8 @@ func main() {
 			{OS: plugin.GoOSDarwin, Arch: plugin.GoArchArm64},
 		}),
 		plugin.WithStaticLinking(),
+		plugin.WithKind(internalPlugin.Kind),
+		plugin.WithTeam(internalPlugin.Team),
 	)
 	if err := serve.Plugin(p, serve.WithPluginSentryDSN(sentryDSN), serve.WithDestinationV0V1Server()).Serve(context.Background()); err != nil {
 		fmt.Println(err)

--- a/plugins/destination/sqlite/resources/plugin/plugin.go
+++ b/plugins/destination/sqlite/resources/plugin/plugin.go
@@ -1,6 +1,9 @@
 package plugin
 
+// Don't move this file to a different package, it's used by Go releaser to embed the version in the binary.
 var (
-	// Don't move this file to a different package, it's used by Go releaser to embed the version in the binary.
-	Version = "Development"
+	Name    = "sqlite"
+	Kind    = "destination"
+	Team    = "cloudquery"
+	Version = "development"
 )

--- a/plugins/destination/test/main.go
+++ b/plugins/destination/test/main.go
@@ -11,7 +11,13 @@ import (
 )
 
 func main() {
-	p := plugin.NewPlugin("test", internalPlugin.Version, client.New)
+	p := plugin.NewPlugin(
+		internalPlugin.Name,
+		internalPlugin.Version,
+		client.New,
+		plugin.WithKind(internalPlugin.Kind),
+		plugin.WithTeam(internalPlugin.Team),
+	)
 	if err := serve.Plugin(p,
 		serve.WithDestinationV0V1Server(),
 	).Serve(context.Background()); err != nil {

--- a/plugins/destination/test/resources/plugin/plugin.go
+++ b/plugins/destination/test/resources/plugin/plugin.go
@@ -1,6 +1,9 @@
 package plugin
 
+// Don't move this file to a different package, it's used by Go releaser to embed the version in the binary.
 var (
-	// Don't move this file to a different package, it's used by Go releaser to embed the version in the binary.
-	Version = "Development"
+	Name    = "test"
+	Kind    = "destination"
+	Team    = "cloudquery"
+	Version = "development"
 )

--- a/plugins/source/alicloud/resources/plugin/plugin.go
+++ b/plugins/source/alicloud/resources/plugin/plugin.go
@@ -5,13 +5,18 @@ import (
 )
 
 var (
+	Name    = "alicloud"
+	Kind    = "source"
+	Team    = "cloudquery"
 	Version = "development"
 )
 
 func Plugin() *plugin.Plugin {
 	return plugin.NewPlugin(
-		"alicloud",
+		Name,
 		Version,
 		Configure,
+		plugin.WithKind(Kind),
+		plugin.WithTeam(Team),
 	)
 }

--- a/plugins/source/aws/resources/plugin/plugin.go
+++ b/plugins/source/aws/resources/plugin/plugin.go
@@ -11,7 +11,10 @@ import (
 )
 
 var (
-	Version = "Development"
+	Name    = "aws"
+	Kind    = "source"
+	Team    = "cloudquery"
+	Version = "development"
 )
 
 var awsExceptions = map[string]string{
@@ -111,9 +114,11 @@ func titleTransformer(table *schema.Table) {
 
 func AWS() *plugin.Plugin {
 	return plugin.NewPlugin(
-		"aws",
+		Name,
 		Version,
 		New,
 		plugin.WithJSONSchema(spec.JSONSchema),
+		plugin.WithKind(Kind),
+		plugin.WithTeam(Team),
 	)
 }

--- a/plugins/source/awspricing/resources/plugin/plugin.go
+++ b/plugins/source/awspricing/resources/plugin/plugin.go
@@ -5,13 +5,18 @@ import (
 )
 
 var (
+	Name    = "awspricing"
+	Kind    = "source"
+	Team    = "cloudquery"
 	Version = "development"
 )
 
 func Plugin() *plugin.Plugin {
 	return plugin.NewPlugin(
-		"awspricing",
+		Name,
 		Version,
 		Configure,
+		plugin.WithKind(Kind),
+		plugin.WithTeam(Team),
 	)
 }

--- a/plugins/source/azure/resources/plugin/plugin.go
+++ b/plugins/source/azure/resources/plugin/plugin.go
@@ -10,6 +10,9 @@ import (
 )
 
 var (
+	Name    = "azure"
+	Kind    = "source"
+	Team    = "cloudquery"
 	Version = "development"
 )
 
@@ -82,9 +85,11 @@ func titleTransformer(table *schema.Table) error {
 
 func Plugin() *plugin.Plugin {
 	return plugin.NewPlugin(
-		"azure",
+		Name,
 		Version,
 		NewClient,
 		plugin.WithJSONSchema(spec.JSONSchema),
+		plugin.WithKind(Kind),
+		plugin.WithTeam(Team),
 	)
 }

--- a/plugins/source/azuredevops/resources/plugin/plugin.go
+++ b/plugins/source/azuredevops/resources/plugin/plugin.go
@@ -5,13 +5,18 @@ import (
 )
 
 var (
+	Name    = "azuredevops"
+	Kind    = "source"
+	Team    = "cloudquery"
 	Version = "development"
 )
 
 func Plugin() *plugin.Plugin {
 	return plugin.NewPlugin(
-		"azuredevops",
+		Name,
 		Version,
 		Configure,
+		plugin.WithKind(Kind),
+		plugin.WithTeam(Team),
 	)
 }

--- a/plugins/source/cloudflare/resources/plugin/plugin.go
+++ b/plugins/source/cloudflare/resources/plugin/plugin.go
@@ -27,6 +27,9 @@ import (
 )
 
 var (
+	Name    = "cloudflare"
+	Kind    = "source"
+	Team    = "cloudquery"
 	Version = "development"
 )
 
@@ -81,9 +84,11 @@ func (c *Client) Sync(ctx context.Context, options plugin.SyncOptions, res chan<
 
 func Plugin() *plugin.Plugin {
 	return plugin.NewPlugin(
-		"cloudflare",
+		Name,
 		Version,
 		newClient,
+		plugin.WithKind(Kind),
+		plugin.WithTeam(Team),
 	)
 }
 

--- a/plugins/source/datadog/resources/plugin/plugin.go
+++ b/plugins/source/datadog/resources/plugin/plugin.go
@@ -14,7 +14,10 @@ import (
 )
 
 var (
-	Version = "Development"
+	Name    = "datadog"
+	Kind    = "source"
+	Team    = "cloudquery"
+	Version = "development"
 
 	customExceptions = map[string]string{
 		"slo":  "SLO",
@@ -76,8 +79,10 @@ func (c *Client) Sync(ctx context.Context, options plugin.SyncOptions, res chan<
 func Plugin() *plugin.Plugin {
 	// here you can append custom non-generated tables
 	return plugin.NewPlugin(
-		"datadog",
+		Name,
 		Version,
 		newClient,
+		plugin.WithKind(Kind),
+		plugin.WithTeam(Team),
 	)
 }

--- a/plugins/source/digitalocean/resources/plugin/plugin.go
+++ b/plugins/source/digitalocean/resources/plugin/plugin.go
@@ -5,13 +5,18 @@ import (
 )
 
 var (
+	Name    = "digitalocean"
+	Kind    = "source"
+	Team    = "cloudquery"
 	Version = "development"
 )
 
 func Plugin() *plugin.Plugin {
 	return plugin.NewPlugin(
-		"digitalocean",
+		Name,
 		Version,
 		Configure,
+		plugin.WithKind(Kind),
+		plugin.WithTeam(Team),
 	)
 }

--- a/plugins/source/facebookmarketing/resources/plugin/plugin.go
+++ b/plugins/source/facebookmarketing/resources/plugin/plugin.go
@@ -20,6 +20,9 @@ import (
 )
 
 var (
+	Name    = "facebookmarketing"
+	Kind    = "source"
+	Team    = "cloudquery"
 	Version = "development"
 )
 
@@ -108,9 +111,11 @@ func (c *Client) Sync(ctx context.Context, options plugin.SyncOptions, res chan<
 
 func Plugin() *plugin.Plugin {
 	return plugin.NewPlugin(
-		"facebookmarketing",
+		Name,
 		Version,
 		newClient,
+		plugin.WithKind(Kind),
+		plugin.WithTeam(Team),
 	)
 }
 

--- a/plugins/source/fastly/resources/plugin/plugin.go
+++ b/plugins/source/fastly/resources/plugin/plugin.go
@@ -14,6 +14,9 @@ import (
 )
 
 var (
+	Name    = "fastly"
+	Kind    = "source"
+	Team    = "cloudquery"
 	Version = "development"
 )
 
@@ -68,8 +71,10 @@ func (c *Client) Sync(ctx context.Context, options plugin.SyncOptions, res chan<
 
 func Plugin() *plugin.Plugin {
 	return plugin.NewPlugin(
-		"fastly",
+		Name,
 		Version,
 		newClient,
+		plugin.WithKind(Kind),
+		plugin.WithTeam(Team),
 	)
 }

--- a/plugins/source/firestore/resources/plugin/plugin.go
+++ b/plugins/source/firestore/resources/plugin/plugin.go
@@ -5,12 +5,19 @@ import (
 	"github.com/cloudquery/plugin-sdk/v4/plugin"
 )
 
-var version = "development"
+var (
+	Name    = "firestore"
+	Kind    = "source"
+	Team    = "cloudquery"
+	Version = "development"
+)
 
 func Plugin() *plugin.Plugin {
 	return plugin.NewPlugin(
-		"firestore",
-		version,
+		Name,
+		Version,
 		client.Configure,
+		plugin.WithKind(Kind),
+		plugin.WithTeam(Team),
 	)
 }

--- a/plugins/source/gcp/resources/plugin/plugin.go
+++ b/plugins/source/gcp/resources/plugin/plugin.go
@@ -12,6 +12,9 @@ import (
 )
 
 var (
+	Name    = "gcp"
+	Kind    = "source"
+	Team    = "cloudquery"
 	Version = "development"
 )
 
@@ -98,9 +101,11 @@ func titleTransformer(table *schema.Table) error {
 
 func Plugin() *plugin.Plugin {
 	return plugin.NewPlugin(
-		"gcp",
+		Name,
 		Version,
 		NewClient,
 		plugin.WithJSONSchema(spec.JSONSchema),
+		plugin.WithKind(Kind),
+		plugin.WithTeam(Team),
 	)
 }

--- a/plugins/source/github/resources/plugin/plugin.go
+++ b/plugins/source/github/resources/plugin/plugin.go
@@ -5,13 +5,18 @@ import (
 )
 
 var (
+	Name    = "github"
+	Kind    = "source"
+	Team    = "cloudquery"
 	Version = "development"
 )
 
 func Plugin() *plugin.Plugin {
 	return plugin.NewPlugin(
-		"github",
+		Name,
 		Version,
 		Configure,
+		plugin.WithKind(Kind),
+		plugin.WithTeam(Team),
 	)
 }

--- a/plugins/source/gitlab/resources/plugin/plugin.go
+++ b/plugins/source/gitlab/resources/plugin/plugin.go
@@ -19,7 +19,12 @@ import (
 	"github.com/rs/zerolog"
 )
 
-var Version = "Development"
+var (
+	Name    = "gitlab"
+	Kind    = "source"
+	Team    = "cloudquery"
+	Version = "development"
+)
 
 type Client struct {
 	plugin.UnimplementedDestination
@@ -79,9 +84,11 @@ func (c *Client) Sync(ctx context.Context, options plugin.SyncOptions, res chan<
 
 func Plugin() *plugin.Plugin {
 	return plugin.NewPlugin(
-		"gitlab",
+		Name,
 		Version,
 		newClient,
+		plugin.WithKind(Kind),
+		plugin.WithTeam(Team),
 	)
 }
 

--- a/plugins/source/googleanalytics/resources/plugin/plugin.go
+++ b/plugins/source/googleanalytics/resources/plugin/plugin.go
@@ -5,12 +5,19 @@ import (
 	"github.com/cloudquery/plugin-sdk/v4/plugin"
 )
 
-var Version = "Development"
+var (
+	Name    = "googleanalytics"
+	Kind    = "source"
+	Team    = "cloudquery"
+	Version = "development"
+)
 
 func Plugin() *plugin.Plugin {
 	return plugin.NewPlugin(
 		"googleanalytics",
 		Version,
 		client.Configure,
+		plugin.WithKind(Kind),
+		plugin.WithTeam(Team),
 	)
 }

--- a/plugins/source/hackernews/resources/plugin/plugin.go
+++ b/plugins/source/hackernews/resources/plugin/plugin.go
@@ -5,13 +5,18 @@ import (
 )
 
 var (
+	Name    = "hackernews"
+	Kind    = "source"
+	Team    = "cloudquery"
 	Version = "development"
 )
 
 func Plugin() *plugin.Plugin {
 	return plugin.NewPlugin(
-		"hackernews",
+		Name,
 		Version,
 		Configure,
+		plugin.WithKind(Kind),
+		plugin.WithTeam(Team),
 	)
 }

--- a/plugins/source/homebrew/resources/plugin/plugin.go
+++ b/plugins/source/homebrew/resources/plugin/plugin.go
@@ -5,13 +5,18 @@ import (
 )
 
 var (
+	Name    = "homebrew"
+	Kind    = "source"
+	Team    = "cloudquery"
 	Version = "development"
 )
 
 func Plugin() *plugin.Plugin {
 	return plugin.NewPlugin(
-		"homebrew",
+		Name,
 		Version,
 		Configure,
+		plugin.WithKind(Kind),
+		plugin.WithTeam(Team),
 	)
 }

--- a/plugins/source/hubspot/docs/tables/README.md
+++ b/plugins/source/hubspot/docs/tables/README.md
@@ -1,4 +1,4 @@
-# Source Plugin: cloudquery-hubspot
+# Source Plugin: hubspot
 
 ## Tables
 

--- a/plugins/source/hubspot/resources/plugin/plugin.go
+++ b/plugins/source/hubspot/resources/plugin/plugin.go
@@ -19,6 +19,9 @@ import (
 )
 
 var (
+	Name    = "hubspot"
+	Kind    = "source"
+	Team    = "cloudquery"
 	Version = "development"
 )
 
@@ -115,8 +118,10 @@ func getTables() schema.Tables {
 
 func Plugin() *plugin.Plugin {
 	return plugin.NewPlugin(
-		"cloudquery-hubspot",
+		Name,
 		Version,
 		newClient,
+		plugin.WithKind(Kind),
+		plugin.WithTeam(Team),
 	)
 }

--- a/plugins/source/jira/main.go
+++ b/plugins/source/jira/main.go
@@ -11,7 +11,10 @@ import (
 )
 
 func main() {
-	p := plugin.NewPlugin("jira", internalPlugin.Version, client.New)
+	p := plugin.NewPlugin(internalPlugin.Name, internalPlugin.Version, client.New,
+		plugin.WithTeam(internalPlugin.Team),
+		plugin.WithKind(internalPlugin.Kind),
+	)
 	if err := serve.Plugin(p).Serve(context.Background()); err != nil {
 		log.Fatal(err)
 	}

--- a/plugins/source/jira/resources/plugin/plugin.go
+++ b/plugins/source/jira/resources/plugin/plugin.go
@@ -1,6 +1,9 @@
 package plugin
 
+// Don't move this file to a different package, it's used by Go releaser to embed the version in the binary.
 var (
-	// Don't move this file to a different package, it's used by Go releaser to embed the version in the binary.
+	Name    = "jira"
+	Kind    = "source"
+	Team    = "cloudquery"
 	Version = "Development"
 )

--- a/plugins/source/k8s/resources/plugin/plugin.go
+++ b/plugins/source/k8s/resources/plugin/plugin.go
@@ -33,7 +33,12 @@ import (
 	"golang.org/x/exp/maps"
 )
 
-var Version = "Development"
+var var (
+	Name = "gcp"
+	Kind = "source"
+	Team = "cloudquery"
+	Version = "development"
+)
 
 var googleAdsExceptions = map[string]string{
 	"admissionregistration": "Admission Registration",

--- a/plugins/source/mysql/resources/plugin/plugin.go
+++ b/plugins/source/mysql/resources/plugin/plugin.go
@@ -5,12 +5,19 @@ import (
 	"github.com/cloudquery/plugin-sdk/v4/plugin"
 )
 
-var Version = "Development"
+var (
+	Name    = "mysql"
+	Kind    = "source"
+	Team    = "cloudquery"
+	Version = "development"
+)
 
 func Plugin() *plugin.Plugin {
 	return plugin.NewPlugin(
-		"mysql",
+		Name,
 		Version,
 		client.Configure,
+		plugin.WithKind(Kind),
+		plugin.WithTeam(Team),
 	)
 }

--- a/plugins/source/notion/Makefile
+++ b/plugins/source/notion/Makefile
@@ -21,7 +21,7 @@ gen-docs: build
 	cloudquery tables --format markdown --output-dir ../../../website/tables test/config.yml
 	sed 's_(\(.*\))_(../../../../../website/tables/notion/\1)_' ../../../website/tables/notion/README.md > ./docs/tables/README.md
 	sed -i.bak -e 's_(\(.*\).md)_(tables/\1)_' ../../../website/tables/notion/README.md
-	mkdir --parents ../../../website/pages/docs/plugins/sources/notion/
+	mkdir -p ../../../website/pages/docs/plugins/sources/notion/
 	mv ../../../website/tables/notion/README.md ../../../website/pages/docs/plugins/sources/notion/tables.md
 	sed -i.bak -e 's_(\(.*\).md)_(\1)_' ../../../website/tables/notion/*.md
 	rm -rf ../../../website/tables/notion/*.bak

--- a/plugins/source/notion/docs/tables/README.md
+++ b/plugins/source/notion/docs/tables/README.md
@@ -1,4 +1,4 @@
-# Source Plugin: cloudquery-notion
+# Source Plugin: notion
 
 ## Tables
 

--- a/plugins/source/notion/resources/plugin/plugin.go
+++ b/plugins/source/notion/resources/plugin/plugin.go
@@ -5,9 +5,18 @@ import (
 )
 
 var (
+	Name    = "notion"
+	Kind    = "source"
+	Team    = "cloudquery"
 	Version = "development"
 )
 
 func Plugin() *plugin.Plugin {
-	return plugin.NewPlugin("cloudquery-notion", Version, Configure)
+	return plugin.NewPlugin(
+		Name,
+		Version,
+		Configure,
+		plugin.WithKind(Kind),
+		plugin.WithTeam(Team),
+	)
 }

--- a/plugins/source/okta/resources/plugin/plugin.go
+++ b/plugins/source/okta/resources/plugin/plugin.go
@@ -5,13 +5,18 @@ import (
 )
 
 var (
+	Name    = "okta"
+	Kind    = "source"
+	Team    = "cloudquery"
 	Version = "development"
 )
 
 func Plugin() *plugin.Plugin {
 	return plugin.NewPlugin(
-		"okta",
+		Name,
 		Version,
 		Configure,
+		plugin.WithKind(Kind),
+		plugin.WithTeam(Team),
 	)
 }

--- a/plugins/source/oracle/resources/plugin/plugin.go
+++ b/plugins/source/oracle/resources/plugin/plugin.go
@@ -18,6 +18,9 @@ import (
 )
 
 var (
+	Name    = "oracle"
+	Kind    = "source"
+	Team    = "cloudquery"
 	Version = "development"
 )
 
@@ -120,9 +123,11 @@ func getTables() schema.Tables {
 
 func Plugin() *plugin.Plugin {
 	return plugin.NewPlugin(
-		"oracle",
+		Name,
 		Version,
 		Configure,
 		plugin.WithJSONSchema(spec.JSONSchema),
+		plugin.WithKind(Kind),
+		plugin.WithTeam(Team),
 	)
 }

--- a/plugins/source/oracledb/resources/plugin/plugin.go
+++ b/plugins/source/oracledb/resources/plugin/plugin.go
@@ -5,12 +5,19 @@ import (
 	"github.com/cloudquery/plugin-sdk/v4/plugin"
 )
 
-var Version = "Development"
+var (
+	Name    = "oracledb"
+	Kind    = "source"
+	Team    = "cloudquery"
+	Version = "development"
+)
 
 func Plugin() *plugin.Plugin {
 	return plugin.NewPlugin(
-		"oracledb",
+		Name,
 		Version,
 		client.Configure,
+		plugin.WithKind(Kind),
+		plugin.WithTeam(Team),
 	)
 }

--- a/plugins/source/pagerduty/resources/plugin/plugin.go
+++ b/plugins/source/pagerduty/resources/plugin/plugin.go
@@ -5,13 +5,18 @@ import (
 )
 
 var (
-	Version = "Development"
+	Name    = "pagerduty"
+	Kind    = "source"
+	Team    = "cloudquery"
+	Version = "development"
 )
 
 func Plugin() *plugin.Plugin {
 	return plugin.NewPlugin(
-		"pagerduty",
+		Name,
 		Version,
 		Configure,
+		plugin.WithKind(Kind),
+		plugin.WithTeam(Team),
 	)
 }

--- a/plugins/source/postgresql/resources/plugin/plugin.go
+++ b/plugins/source/postgresql/resources/plugin/plugin.go
@@ -5,12 +5,19 @@ import (
 	"github.com/cloudquery/plugin-sdk/v4/plugin"
 )
 
-var Version = "Development"
+var (
+	Name    = "postgresql"
+	Kind    = "source"
+	Team    = "cloudquery"
+	Version = "development"
+)
 
 func Plugin() *plugin.Plugin {
 	return plugin.NewPlugin(
-		"postgresql",
+		Name,
 		Version,
 		client.Configure,
+		plugin.WithKind(Kind),
+		plugin.WithTeam(Team),
 	)
 }

--- a/plugins/source/salesforce/resources/plugin/plugin.go
+++ b/plugins/source/salesforce/resources/plugin/plugin.go
@@ -5,13 +5,18 @@ import (
 )
 
 var (
+	Name    = "salesforce"
+	Kind    = "source"
+	Team    = "cloudquery"
 	Version = "development"
 )
 
 func Plugin() *plugin.Plugin {
 	return plugin.NewPlugin(
-		"salesforce",
+		Name,
 		Version,
 		Configure,
+		plugin.WithKind(Kind),
+		plugin.WithTeam(Team),
 	)
 }

--- a/plugins/source/shopify/resources/plugin/plugin.go
+++ b/plugins/source/shopify/resources/plugin/plugin.go
@@ -5,13 +5,18 @@ import (
 )
 
 var (
+	Name    = "shopify"
+	Kind    = "source"
+	Team    = "cloudquery"
 	Version = "development"
 )
 
 func Plugin() *plugin.Plugin {
 	return plugin.NewPlugin(
-		"shopify",
+		Name,
 		Version,
 		Configure,
+		plugin.WithKind(Kind),
+		plugin.WithTeam(Team),
 	)
 }

--- a/plugins/source/snyk/resources/plugin/plugin.go
+++ b/plugins/source/snyk/resources/plugin/plugin.go
@@ -4,12 +4,19 @@ import (
 	"github.com/cloudquery/plugin-sdk/v4/plugin"
 )
 
-var Version = "Development"
+var (
+	Name    = "snyk"
+	Kind    = "source"
+	Team    = "cloudquery"
+	Version = "development"
+)
 
 func Snyk() *plugin.Plugin {
 	return plugin.NewPlugin(
-		"snyk",
+		Name,
 		Version,
 		configure,
+		plugin.WithKind(Kind),
+		plugin.WithTeam(Team),
 	)
 }

--- a/plugins/source/stripe/resources/plugin/plugin.go
+++ b/plugins/source/stripe/resources/plugin/plugin.go
@@ -5,13 +5,18 @@ import (
 )
 
 var (
+	Name    = "stripe"
+	Kind    = "source"
+	Team    = "cloudquery"
 	Version = "development"
 )
 
 func Plugin() *plugin.Plugin {
 	return plugin.NewPlugin(
-		"stripe",
+		Name,
 		Version,
 		Configure,
+		plugin.WithKind(Kind),
+		plugin.WithTeam(Team),
 	)
 }

--- a/plugins/source/terraform/resources/plugin/plugin.go
+++ b/plugins/source/terraform/resources/plugin/plugin.go
@@ -4,12 +4,19 @@ import (
 	"github.com/cloudquery/plugin-sdk/v4/plugin"
 )
 
-var Version = "development"
+var (
+	Name    = "terraform"
+	Kind    = "source"
+	Team    = "cloudquery"
+	Version = "development"
+)
 
 func Terraform() *plugin.Plugin {
 	return plugin.NewPlugin(
-		"terraform",
+		Name,
 		Version,
 		configure,
+		plugin.WithKind(Kind),
+		plugin.WithTeam(Team),
 	)
 }

--- a/plugins/source/test/resources/plugin/plugin.go
+++ b/plugins/source/test/resources/plugin/plugin.go
@@ -5,13 +5,18 @@ import (
 )
 
 var (
+	Name    = "test"
+	Kind    = "source"
+	Team    = "cloudquery"
 	Version = "development"
 )
 
 func Plugin() *plugin.Plugin {
 	return plugin.NewPlugin(
-		"test",
+		Name,
 		Version,
 		Configure,
+		plugin.WithKind(Kind),
+		plugin.WithTeam(Team),
 	)
 }

--- a/plugins/source/vault/resources/plugin/plugin.go
+++ b/plugins/source/vault/resources/plugin/plugin.go
@@ -5,9 +5,12 @@ import (
 )
 
 var (
+	Name    = "vault"
+	Kind    = "source"
+	Team    = "cloudquery"
 	Version = "development"
 )
 
 func Plugin() *plugin.Plugin {
-	return plugin.NewPlugin("vault", Version, Configure)
+	return plugin.NewPlugin(Name, Version, Configure, plugin.WithKind(Kind), plugin.WithTeam(Team))
 }

--- a/website/pages/docs/plugins/sources/hubspot/tables.md
+++ b/website/pages/docs/plugins/sources/hubspot/tables.md
@@ -1,4 +1,4 @@
-# Source Plugin: cloudquery-hubspot
+# Source Plugin: hubspot
 
 ## Tables
 

--- a/website/pages/docs/plugins/sources/notion/tables.md
+++ b/website/pages/docs/plugins/sources/notion/tables.md
@@ -1,4 +1,4 @@
-# Source Plugin: cloudquery-notion
+# Source Plugin: notion
 
 ## Tables
 

--- a/website/versions/destination-meilisearch.json
+++ b/website/versions/destination-meilisearch.json
@@ -1,1 +1,1 @@
-{ "latest": "plugins-destination-meilisearch-v2.2.10" }
+{ "latest": "plugins-destination-meilisearch-v2.2.11" }

--- a/website/versions/destination-mongodb.json
+++ b/website/versions/destination-mongodb.json
@@ -1,1 +1,1 @@
-{ "latest": "plugins-destination-mongodb-v2.2.12" }
+{ "latest": "plugins-destination-mongodb-v2.2.13" }


### PR DESCRIPTION
This sets plugin metadata on all the CloudQuery-maintained plugins, following an update to plugin-sdk v4.16.0, which requires this metadata to be present for the `package` command to succeed.

Second attempt of [#14698](https://github.com/cloudquery/cloudquery/pull/14698)