### PR TITLE
chore: Exclude `hub.cloudquery.io` from broken links check

### DIFF
--- a/.github/workflows/broken_links_scheduled.yml
+++ b/.github/workflows/broken_links_scheduled.yml
@@ -53,6 +53,7 @@ jobs:
             --exclude mongodb.com \
             --exclude regex101.com \
             --exclude help.shopify.com/en/manual/apps/app-types/custom-apps \
+            --exclude hub.cloudquery.io \
             ${{ steps.vercel.outputs.url }} \
             | grep -v '───OK───' | grep -v '──SKIP──' | grep -v '0 broken'
       - name: Slack Notify


### PR DESCRIPTION
<!-- 🎉 Thank you for making CloudQuery awesome by submitting a PR 🎉 -->

#### Summary

`hub.cloudquery.io` now redirects to https://hub.cloudquery.io/plugins/source (the new Hub). I think we'd like to keep it that way instead of updating links to reference `https://hub.cloudquery.io/plugins/source` directly.
This adds an exclude to our broken links too as it fails on redirects

<!--
Use the following steps to ensure your PR is ready to be reviewed

- [ ] Read the [contribution guidelines](../blob/main/CONTRIBUTING.md) 🧑‍🎓
- [ ] Run `make lint` to ensure the proposed changes follow the coding style 🚨 (install golangci-lint [here](https://golangci-lint.run/usage/install/#local-installation))
- [ ] Run `make test` to ensure the proposed changes pass the tests 🧪
- [ ] If changing a source plugin run `make gen` to ensure docs are up to date 📝
- [ ] Ensure the status checks below are successful ✅
--->
