### PR TITLE
fix!: Change `aws_ec2_images` table `creation_date` & `deprecation_time` columns type to `timestamp`

### DIFF
--- a/plugins/source/aws/resources/services/ec2/images.go
+++ b/plugins/source/aws/resources/services/ec2/images.go
@@ -2,7 +2,7 @@ package ec2
 
 import (
 	"context"
-	reflect "reflect"
+	"reflect"
 
 	"github.com/apache/arrow/go/v14/arrow"
 	"github.com/aws/aws-sdk-go-v2/aws"

--- a/plugins/source/aws/resources/services/ec2/images.go
+++ b/plugins/source/aws/resources/services/ec2/images.go
@@ -2,6 +2,7 @@ package ec2
 
 import (
 	"context"
+	reflect "reflect"
 
 	"github.com/apache/arrow/go/v14/arrow"
 	"github.com/aws/aws-sdk-go-v2/aws"
@@ -22,7 +23,15 @@ func Images() *schema.Table {
 		Description: `https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_Image.html`,
 		Resolver:    fetchEc2Images,
 		Multiplex:   client.ServiceAccountRegionMultiplexer(tableName, "ec2"),
-		Transform:   transformers.TransformWithStruct(&types.Image{}),
+		Transform: transformers.TransformWithStruct(&types.Image{},
+			transformers.WithTypeTransformer(func(field reflect.StructField) (arrow.DataType, error) {
+				switch field.Name {
+				case "CreationDate", "DeprecationTime": // based on docs these are timestamps
+					return arrow.FixedWidthTypes.Timestamp_us, nil
+				default:
+					return transformers.DefaultTypeTransformer(field)
+				}
+			})),
 		Columns: []schema.Column{
 			client.DefaultAccountIDColumn(true),
 			client.DefaultRegionColumn(true),

--- a/plugins/source/aws/resources/services/ec2/images.go
+++ b/plugins/source/aws/resources/services/ec2/images.go
@@ -24,14 +24,17 @@ func Images() *schema.Table {
 		Resolver:    fetchEc2Images,
 		Multiplex:   client.ServiceAccountRegionMultiplexer(tableName, "ec2"),
 		Transform: transformers.TransformWithStruct(&types.Image{},
-			transformers.WithTypeTransformer(func(field reflect.StructField) (arrow.DataType, error) {
-				switch field.Name {
-				case "CreationDate", "DeprecationTime": // based on docs these are timestamps
-					return arrow.FixedWidthTypes.Timestamp_us, nil
-				default:
-					return transformers.DefaultTypeTransformer(field)
-				}
-			})),
+			transformers.WithTypeTransformer(
+				func(field reflect.StructField) (arrow.DataType, error) {
+					switch field.Name {
+					case "CreationDate", "DeprecationTime": // based on docs these are timestamps
+						return arrow.FixedWidthTypes.Timestamp_us, nil
+					default:
+						return transformers.DefaultTypeTransformer(field)
+					}
+				},
+			),
+		),
 		Columns: []schema.Column{
 			client.DefaultAccountIDColumn(true),
 			client.DefaultRegionColumn(true),

--- a/plugins/source/aws/resources/services/ec2/images_mock_test.go
+++ b/plugins/source/aws/resources/services/ec2/images_mock_test.go
@@ -21,7 +21,7 @@ func buildEc2ImagesMock(t *testing.T, ctrl *gomock.Controller) client.Services {
 	g := types.Image{}
 	require.NoError(t, faker.FakeObject(&g))
 
-	creationDate := "1994-11-05T08:15:30-05:00"
+	creationDate := "2019-05-10T13:17:12.000Z" // from docs
 	g.OwnerId = aws.String("testAccount")
 	g.CreationDate = &creationDate
 	deprecationTime := "2050-11-05T08:15:30-05:00"

--- a/website/tables/aws/aws_ec2_images.md
+++ b/website/tables/aws/aws_ec2_images.md
@@ -25,8 +25,8 @@ The following tables depend on aws_ec2_images:
 |architecture|`utf8`|
 |block_device_mappings|`json`|
 |boot_mode|`utf8`|
-|creation_date|`utf8`|
-|deprecation_time|`utf8`|
+|creation_date|`timestamp[us, tz=UTC]`|
+|deprecation_time|`timestamp[us, tz=UTC]`|
 |description|`utf8`|
 |ena_support|`bool`|
 |hypervisor|`utf8`|


### PR DESCRIPTION
Part of https://github.com/cloudquery/cloudquery/issues/12648