### PR TITLE
fix: Change casting

### DIFF
--- a/plugins/source/aws/policies/queries/elb/elbv1_https_predefined_policy.sql
+++ b/plugins/source/aws/policies/queries/elb/elbv1_https_predefined_policy.sql
@@ -25,7 +25,7 @@ FROM flat_listeners fl
 )
 SELECT
   DISTINCT
-    :'execution_time' AS execution_time,
+    :'execution_time'::timestamp AS execution_time,
     :'framework' AS framework,
     :'check_id' AS check_id,
     'Classic Load Balancers with HTTPS/SSL listeners should use a predefined security policy that has strong configuration' AS title,

--- a/plugins/source/aws/policies/queries/elb/elbv1_https_predefined_policy.sql
+++ b/plugins/source/aws/policies/queries/elb/elbv1_https_predefined_policy.sql
@@ -25,7 +25,7 @@ FROM flat_listeners fl
 )
 SELECT
   DISTINCT
-    cast(:'execution_time' as timestamp with time zone) AS execution_time,
+    :'execution_time' AS execution_time,
     :'framework' AS framework,
     :'check_id' AS check_id,
     'Classic Load Balancers with HTTPS/SSL listeners should use a predefined security policy that has strong configuration' AS title,

--- a/website/tables/aws/aws_elbv1_load_balancer_policies.md
+++ b/website/tables/aws/aws_elbv1_load_balancer_policies.md
@@ -23,3 +23,64 @@ This table depends on [aws_elbv1_load_balancers](aws_elbv1_load_balancers).
 |policy_attribute_descriptions|`json`|
 |policy_name|`utf8`|
 |policy_type_name|`utf8`|
+
+## Example Queries
+
+These SQL queries are sampled from CloudQuery policies and are compatible with PostgreSQL.
+
+### Classic Load Balancers with HTTPS/SSL listeners should use a predefined security policy that has strong configuration
+
+```sql
+WITH
+  flat_listeners
+    AS (
+      SELECT
+        arn,
+        account_id,
+        li->'Listener'->>'Protocol' AS protocol,
+        li->'PolicyNames' AS policies_arr
+      FROM
+        aws_elbv1_load_balancers AS lb,
+        jsonb_array_elements(lb.listener_descriptions) AS li
+    ),
+  violations
+    AS (
+      SELECT
+        fl.arn,
+        fl.account_id,
+        CASE
+        WHEN fl.protocol IN ('HTTPS', 'SSL')
+        AND NOT
+            EXISTS(
+              SELECT
+                1
+              FROM
+                aws_elbv1_load_balancer_policies AS pol
+              WHERE
+                fl.policies_arr @> ('["' || pol.policy_name || '"]')::JSONB
+                AND pol.policy_attribute_descriptions->>'Reference-Security-Policy'
+                  = 'ELBSecurityPolicy-TLS-1-2-2017-01'
+            )
+        THEN 1
+        ELSE 0
+        END
+          AS flag
+      FROM
+        flat_listeners AS fl
+    )
+SELECT
+  DISTINCT
+  'Classic Load Balancers with HTTPS/SSL listeners should use a predefined security policy that has strong configuration'
+    AS title,
+  v.account_id,
+  v.arn AS resource_id,
+  CASE
+  WHEN max(flag) OVER (PARTITION BY arn) = 1 THEN 'fail'
+  ELSE 'pass'
+  END
+    AS status
+FROM
+  violations AS v;
+```
+
+

--- a/website/tables/aws/aws_elbv1_load_balancers.md
+++ b/website/tables/aws/aws_elbv1_load_balancers.md
@@ -135,6 +135,61 @@ FROM
   jsonb_array_elements(lb.listener_descriptions) AS li;
 ```
 
+### Classic Load Balancers with HTTPS/SSL listeners should use a predefined security policy that has strong configuration
+
+```sql
+WITH
+  flat_listeners
+    AS (
+      SELECT
+        arn,
+        account_id,
+        li->'Listener'->>'Protocol' AS protocol,
+        li->'PolicyNames' AS policies_arr
+      FROM
+        aws_elbv1_load_balancers AS lb,
+        jsonb_array_elements(lb.listener_descriptions) AS li
+    ),
+  violations
+    AS (
+      SELECT
+        fl.arn,
+        fl.account_id,
+        CASE
+        WHEN fl.protocol IN ('HTTPS', 'SSL')
+        AND NOT
+            EXISTS(
+              SELECT
+                1
+              FROM
+                aws_elbv1_load_balancer_policies AS pol
+              WHERE
+                fl.policies_arr @> ('["' || pol.policy_name || '"]')::JSONB
+                AND pol.policy_attribute_descriptions->>'Reference-Security-Policy'
+                  = 'ELBSecurityPolicy-TLS-1-2-2017-01'
+            )
+        THEN 1
+        ELSE 0
+        END
+          AS flag
+      FROM
+        flat_listeners AS fl
+    )
+SELECT
+  DISTINCT
+  'Classic Load Balancers with HTTPS/SSL listeners should use a predefined security policy that has strong configuration'
+    AS title,
+  v.account_id,
+  v.arn AS resource_id,
+  CASE
+  WHEN max(flag) OVER (PARTITION BY arn) = 1 THEN 'fail'
+  ELSE 'pass'
+  END
+    AS status
+FROM
+  violations AS v;
+```
+
 ### Find all Classic ELBs that are Internet Facing
 
 ```sql


### PR DESCRIPTION
`make gen-docs` outputs

```log
2023/10/26 13:53:13 Skipping query "Classic Load Balancers with HTTPS/SSL listeners should use a predefined security policy that has strong configuration" due to error: at or near ":": syntax error
```