### PR TITLE
fix: Add missing options to install command

### DIFF
--- a/cli/cmd/install.go
+++ b/cli/cmd/install.go
@@ -49,9 +49,15 @@ func installPlugin(cmd *cobra.Command, args []string) error {
 	}
 	sources := specReader.Sources
 	destinations := specReader.Destinations
-	opts := []managedplugin.Option{managedplugin.WithNoExec()}
+	opts := []managedplugin.Option{
+		managedplugin.WithNoExec(),
+		managedplugin.WithLogger(log.Logger),
+	}
 	if cqDir != "" {
 		opts = append(opts, managedplugin.WithDirectory(cqDir))
+	}
+	if disableSentry {
+		opts = append(opts, managedplugin.WithNoSentry())
 	}
 
 	sourcePluginConfigs := make([]managedplugin.Config, 0, len(sources))


### PR DESCRIPTION
<!-- 🎉 Thank you for making CloudQuery awesome by submitting a PR 🎉 -->

#### Summary

Extracted from https://github.com/cloudquery/cloudquery/pull/15000

Added some missing options to the `install` command.
We could probably also do `managedplugin.WithDirectory(cqDir)` directly without the condition as `cqDir` has a default so the only way it can be an empty string is when someone does `--cq-dir ""` (I tested that and it sets `cqDir` to an empty string).
Not doing the `cqDir` fix as that could be considered a breaking change fix (doing `--cq-dir ""` with the current code will use the default `.cq`)

<!--
Use the following steps to ensure your PR is ready to be reviewed

- [ ] Read the [contribution guidelines](../blob/main/CONTRIBUTING.md) 🧑‍🎓
- [ ] Run `make lint` to ensure the proposed changes follow the coding style 🚨 (install golangci-lint [here](https://golangci-lint.run/usage/install/#local-installation))
- [ ] Run `make test` to ensure the proposed changes pass the tests 🧪
- [ ] If changing a source plugin run `make gen` to ensure docs are up to date 📝
- [ ] Ensure the status checks below are successful ✅
--->
