### PR TITLE
fix: Add missing options to tables command

### DIFF
--- a/cli/cmd/tables.go
+++ b/cli/cmd/tables.go
@@ -59,7 +59,12 @@ func tables(cmd *cobra.Command, args []string) error {
 	}
 	opts := []managedplugin.Option{
 		managedplugin.WithLogger(log.Logger),
-		managedplugin.WithDirectory(cqDir),
+	}
+	if cqDir != "" {
+		opts = append(opts, managedplugin.WithDirectory(cqDir))
+	}
+	if disableSentry {
+		opts = append(opts, managedplugin.WithNoSentry())
 	}
 	pluginConfigs := make([]managedplugin.Config, 0, len(specReader.Sources))
 	for _, sourceSpec := range specReader.Sources {


### PR DESCRIPTION
<!-- 🎉 Thank you for making CloudQuery awesome by submitting a PR 🎉 -->

#### Summary

Same as https://github.com/cloudquery/cloudquery/pull/15001 for the tables command

<!--
Use the following steps to ensure your PR is ready to be reviewed

- [ ] Read the [contribution guidelines](../blob/main/CONTRIBUTING.md) 🧑‍🎓
- [ ] Run `make lint` to ensure the proposed changes follow the coding style 🚨 (install golangci-lint [here](https://golangci-lint.run/usage/install/#local-installation))
- [ ] Run `make test` to ensure the proposed changes pass the tests 🧪
- [ ] If changing a source plugin run `make gen` to ensure docs are up to date 📝
- [ ] Ensure the status checks below are successful ✅
--->
