### PR TITLE
refactor: Simplify sync command options

### DIFF
--- a/cli/cmd/sync.go
+++ b/cli/cmd/sync.go
@@ -108,15 +108,13 @@ func sync(cmd *cobra.Command, args []string) error {
 	for _, source := range sources {
 		opts := []managedplugin.Option{
 			managedplugin.WithLogger(log.Logger),
+			managedplugin.WithOtelEndpoint(source.OtelEndpoint),
 		}
 		if cqDir != "" {
 			opts = append(opts, managedplugin.WithDirectory(cqDir))
 		}
 		if disableSentry {
 			opts = append(opts, managedplugin.WithNoSentry())
-		}
-		if source.OtelEndpoint != "" {
-			opts = append(opts, managedplugin.WithOtelEndpoint(source.OtelEndpoint))
 		}
 		if source.OtelEndpointInsecure {
 			opts = append(opts, managedplugin.WithOtelEndpointInsecure())


### PR DESCRIPTION
<!-- 🎉 Thank you for making CloudQuery awesome by submitting a PR 🎉 -->

#### Summary

Since the default for `OtelEndpoint` is an empty string we don't need the condition

<!--
Use the following steps to ensure your PR is ready to be reviewed

- [ ] Read the [contribution guidelines](../blob/main/CONTRIBUTING.md) 🧑‍🎓
- [ ] Run `make lint` to ensure the proposed changes follow the coding style 🚨 (install golangci-lint [here](https://golangci-lint.run/usage/install/#local-installation))
- [ ] Run `make test` to ensure the proposed changes pass the tests 🧪
- [ ] If changing a source plugin run `make gen` to ensure docs are up to date 📝
- [ ] Ensure the status checks below are successful ✅
--->
