### PR TITLE
feat: Add tags column to typeform plugin

### DIFF
--- a/.github/workflows/source_typeform.yml
+++ b/.github/workflows/source_typeform.yml
@@ -31,7 +31,9 @@ jobs:
         with:
           python-version: '3.x'
       - name: Install dependencies
-        run: pip install -r requirements.txt
+        run: |
+          pip install --upgrade pip
+          pip install -r requirements.txt
       - name: Check formatting
         run: make fmt-check
       - name: Setup CloudQuery

--- a/.github/workflows/source_typeform.yml
+++ b/.github/workflows/source_typeform.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
-          python-version: '3.x'
+          python-version: '3.11'
       - name: Install dependencies
         run: |
           pip install --upgrade pip

--- a/plugins/source/typeform/plugin/tables/form_responses.py
+++ b/plugins/source/typeform/plugin/tables/form_responses.py
@@ -27,6 +27,7 @@ class FormResponses(Table):
                 Column("hidden", JSONType()),
                 Column("calculated", JSONType()),
                 Column("variables", JSONType()),
+                Column("tags", JSONType()),
             ],
         )
 

--- a/plugins/source/typeform/tests/tables/test_forms.py
+++ b/plugins/source/typeform/tests/tables/test_forms.py
@@ -28,6 +28,9 @@ def test_forms(mock_typeform_client):
                 "display": "https://cloudquery.typeform.com/to/XYZ",
                 "responses": "https://api.typeform.com/forms/XYZ/responses",
             },
+            "tags": [
+                "tag1", "tag2"
+            ]
         },
         {
             "id": "form2",

--- a/plugins/source/typeform/tests/tables/test_forms.py
+++ b/plugins/source/typeform/tests/tables/test_forms.py
@@ -28,9 +28,7 @@ def test_forms(mock_typeform_client):
                 "display": "https://cloudquery.typeform.com/to/XYZ",
                 "responses": "https://api.typeform.com/forms/XYZ/responses",
             },
-            "tags": [
-                "tag1", "tag2"
-            ]
+            "tags": ["tag1", "tag2"],
         },
         {
             "id": "form2",

--- a/website/tables/typeform/typeform_form_responses.md
+++ b/website/tables/typeform/typeform_form_responses.md
@@ -23,3 +23,4 @@ This table depends on [typeform_forms](typeform_forms).
 |hidden|`json`|
 |calculated|`json`|
 |variables|`json`|
+|tags|`json`|

--- a/website/tables/typeform/typeform_forms.md
+++ b/website/tables/typeform/typeform_forms.md
@@ -22,4 +22,3 @@ The following tables depend on typeform_forms:
 |theme|`json`|
 |title|`utf8`|
 |_links|`json`|
-|tags|`json`|

--- a/website/tables/typeform/typeform_forms.md
+++ b/website/tables/typeform/typeform_forms.md
@@ -22,3 +22,4 @@ The following tables depend on typeform_forms:
 |theme|`json`|
 |title|`utf8`|
 |_links|`json`|
+|tags|`json`|


### PR DESCRIPTION
This adds the `tags` column to `typeform_form_responses` table.

Tags are useful for further data analysis of the responses.