### PR TITLE
fix: Add missing metadata

### DIFF
--- a/plugins/destination/mssql/main.go
+++ b/plugins/destination/mssql/main.go
@@ -15,7 +15,7 @@ const (
 )
 
 func main() {
-	p := plugin.NewPlugin("mssql", internalPlugin.Version, client.New)
+	p := plugin.NewPlugin("mssql", internalPlugin.Version, client.New, plugin.WithKind(internalPlugin.Kind), plugin.WithTeam(internalPlugin.Kind))
 	if err := serve.Plugin(p,
 		serve.WithPluginSentryDSN(sentryDSN),
 		serve.WithDestinationV0V1Server(),


### PR DESCRIPTION
<!-- 🎉 Thank you for making CloudQuery awesome by submitting a PR 🎉 -->

#### Summary

MSSQL publishing to the Hub fails since it's missing metadata https://github.com/cloudquery/cloudquery/actions/runs/6615875816/job/17968986032

(noticed since it was a spike on failed downloads in our monitoring).

Did a search and couldn't find other plugins that are missing it

<!--
Use the following steps to ensure your PR is ready to be reviewed

- [ ] Read the [contribution guidelines](../blob/main/CONTRIBUTING.md) 🧑‍🎓
- [ ] Run `make lint` to ensure the proposed changes follow the coding style 🚨 (install golangci-lint [here](https://golangci-lint.run/usage/install/#local-installation))
- [ ] Run `make test` to ensure the proposed changes pass the tests 🧪
- [ ] If changing a source plugin run `make gen` to ensure docs are up to date 📝
- [ ] Ensure the status checks below are successful ✅
--->
