### PR TITLE
chore: Use large runners only for AWS, GCP, Azure CI workflows

### DIFF
--- a/.github/workflows/dest_azblob.yml
+++ b/.github/workflows/dest_azblob.yml
@@ -20,7 +20,7 @@ jobs:
   plugins-destination-azblob:
     timeout-minutes: 30
     name: "plugins/destination/azblob"
-    runs-on: large-ubuntu-monorepo
+    runs-on: ubuntu-latest
     defaults:
       run:
         working-directory: ./plugins/destination/azblob
@@ -52,7 +52,7 @@ jobs:
           AZURE_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
   validate-release:
     timeout-minutes: 30
-    runs-on: large-ubuntu-monorepo
+    runs-on: ubuntu-latest
     env:
       CGO_ENABLED: 0
     steps:

--- a/.github/workflows/dest_bigquery.yml
+++ b/.github/workflows/dest_bigquery.yml
@@ -20,7 +20,7 @@ jobs:
   plugins-destination-bigquery:
     timeout-minutes: 10
     name: "plugins/destination/bigquery"
-    runs-on: large-ubuntu-monorepo
+    runs-on: ubuntu-latest
     defaults:
       run:
         working-directory: ./plugins/destination/bigquery
@@ -63,7 +63,7 @@ jobs:
           BIGQUERY_DATASET_LOCATION: us-west1
   validate-release:
     timeout-minutes: 30
-    runs-on: large-ubuntu-monorepo
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout
         if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'

--- a/.github/workflows/dest_clickhouse.yml
+++ b/.github/workflows/dest_clickhouse.yml
@@ -19,7 +19,7 @@ on:
 jobs:
   plugins-destination-clickhouse:
     name: "plugins/destination/clickhouse"
-    runs-on: large-ubuntu-monorepo
+    runs-on: ubuntu-latest
     timeout-minutes: 30
     env:
       DB_USER:     cq
@@ -78,7 +78,7 @@ jobs:
       run:  make test
   validate-release:
     timeout-minutes: 30
-    runs-on: large-ubuntu-monorepo
+    runs-on: ubuntu-latest
     env:
       CGO_ENABLED: 0
     steps:

--- a/.github/workflows/dest_duckdb.yml
+++ b/.github/workflows/dest_duckdb.yml
@@ -20,7 +20,7 @@ jobs:
   plugins-destination-duckdb:
     timeout-minutes: 30
     name: "plugins/destination/duckdb"
-    runs-on: large-ubuntu-monorepo
+    runs-on: ubuntu-latest
     defaults:
       run:
         working-directory: ./plugins/destination/duckdb
@@ -48,7 +48,7 @@ jobs:
         run: make test
   validate-release:
     timeout-minutes: 30
-    runs-on: large-ubuntu-monorepo
+    runs-on: ubuntu-latest
     container:
       image: ghcr.io/cloudquery/golang-cross:v10.0.0
       env:

--- a/.github/workflows/dest_elasticsearch.yml
+++ b/.github/workflows/dest_elasticsearch.yml
@@ -20,7 +20,7 @@ jobs:
   plugins-destination-elasticsearch:
     timeout-minutes: 10
     name: "plugins/destination/elasticsearch"
-    runs-on: large-ubuntu-monorepo
+    runs-on: ubuntu-latest
     defaults:
       run:
         working-directory: ./plugins/destination/elasticsearch
@@ -62,7 +62,7 @@ jobs:
         run: make test
   validate-release:
     timeout-minutes: 30
-    runs-on: large-ubuntu-monorepo
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout
         if: startsWith(github.head_ref, 'release-please--branches--main--components') || github.event_name == 'push'

--- a/.github/workflows/dest_file.yml
+++ b/.github/workflows/dest_file.yml
@@ -22,7 +22,7 @@ jobs:
   plugins-destination-file:
     timeout-minutes: 30
     name: "plugins/destination/file"
-    runs-on: large-ubuntu-monorepo
+    runs-on: ubuntu-latest
     defaults:
       run:
         working-directory: ./plugins/destination/file
@@ -50,7 +50,7 @@ jobs:
         run: make test
   validate-release:
     timeout-minutes: 30
-    runs-on: large-ubuntu-monorepo
+    runs-on: ubuntu-latest
     env:
       CGO_ENABLED: 0
     steps:

--- a/.github/workflows/dest_firehose.yml
+++ b/.github/workflows/dest_firehose.yml
@@ -20,7 +20,7 @@ jobs:
   plugins-destination-firehose:
     timeout-minutes: 30
     name: "plugins/destination/firehose"
-    runs-on: large-ubuntu-monorepo
+    runs-on: ubuntu-latest
     defaults:
       run:
         working-directory: ./plugins/destination/firehose
@@ -57,7 +57,7 @@ jobs:
       #   run: make test
   validate-release:
     timeout-minutes: 30
-    runs-on: large-ubuntu-monorepo
+    runs-on: ubuntu-latest
     env:
       CGO_ENABLED: 0
     steps:

--- a/.github/workflows/dest_gcs.yml
+++ b/.github/workflows/dest_gcs.yml
@@ -20,7 +20,7 @@ jobs:
   plugins-destination-gcs:
     timeout-minutes: 30
     name: "plugins/destination/gcs"
-    runs-on: large-ubuntu-monorepo
+    runs-on: ubuntu-latest
     defaults:
       run:
         working-directory: ./plugins/destination/gcs
@@ -56,7 +56,7 @@ jobs:
         run: make test
   validate-release:
     timeout-minutes: 30
-    runs-on: large-ubuntu-monorepo
+    runs-on: ubuntu-latest
     env:
       CGO_ENABLED: 0
     steps:

--- a/.github/workflows/dest_gremlin.yml
+++ b/.github/workflows/dest_gremlin.yml
@@ -20,7 +20,7 @@ jobs:
   plugins-destination-gremlin:
     timeout-minutes: 30
     name: "plugins/destination/gremlin"
-    runs-on: large-ubuntu-monorepo
+    runs-on: ubuntu-latest
     defaults:
       run:
         working-directory: ./plugins/destination/gremlin
@@ -53,7 +53,7 @@ jobs:
         run: make test
   validate-release:
     timeout-minutes: 30
-    runs-on: large-ubuntu-monorepo
+    runs-on: ubuntu-latest
     env:
       CGO_ENABLED: 0
     steps:

--- a/.github/workflows/dest_kafka.yml
+++ b/.github/workflows/dest_kafka.yml
@@ -20,7 +20,7 @@ jobs:
   plugins-destination-kafka:
     timeout-minutes: 30
     name: "plugins/destination/kafka"
-    runs-on: large-ubuntu-monorepo
+    runs-on: ubuntu-latest
     defaults:
       run:
         working-directory: ./plugins/destination/kafka
@@ -73,7 +73,7 @@ jobs:
         run: make test
   validate-release:
     timeout-minutes: 30
-    runs-on: large-ubuntu-monorepo
+    runs-on: ubuntu-latest
     env:
       CGO_ENABLED: 0
     steps:

--- a/.github/workflows/dest_meilisearch.yml
+++ b/.github/workflows/dest_meilisearch.yml
@@ -19,7 +19,7 @@ on:
 jobs:
   plugins-destination-meilisearch:
     name: "plugins/destination/meilisearch"
-    runs-on: large-ubuntu-monorepo
+    runs-on: ubuntu-latest
     timeout-minutes: 30
     env:
       MEILI_MASTER_KEY: test
@@ -70,7 +70,7 @@ jobs:
       run:  make test
   validate-release:
     timeout-minutes: 30
-    runs-on: large-ubuntu-monorepo
+    runs-on: ubuntu-latest
     env:
       CGO_ENABLED: 0
     steps:

--- a/.github/workflows/dest_mongodb.yml
+++ b/.github/workflows/dest_mongodb.yml
@@ -20,7 +20,7 @@ jobs:
   plugins-destination-mongodb:
     timeout-minutes: 30
     name: "plugins/destination/mongodb"
-    runs-on: large-ubuntu-monorepo
+    runs-on: ubuntu-latest
     defaults:
       run:
         working-directory: ./plugins/destination/mongodb
@@ -51,7 +51,7 @@ jobs:
         run: make test
   validate-release:
     timeout-minutes: 30
-    runs-on: large-ubuntu-monorepo
+    runs-on: ubuntu-latest
     env:
       CGO_ENABLED: 0
     steps:

--- a/.github/workflows/dest_mssql.yml
+++ b/.github/workflows/dest_mssql.yml
@@ -19,7 +19,7 @@ on:
 jobs:
   plugins-destination-mssql:
     name: "plugins/destination/mssql"
-    runs-on: large-ubuntu-monorepo
+    runs-on: ubuntu-latest
     timeout-minutes: 30
     env:
       DB_USER:     SA
@@ -77,7 +77,7 @@ jobs:
       run:  make test
   validate-release:
     timeout-minutes: 30
-    runs-on: large-ubuntu-monorepo
+    runs-on: ubuntu-latest
     env:
       CGO_ENABLED: 0
     steps:

--- a/.github/workflows/dest_mysql.yml
+++ b/.github/workflows/dest_mysql.yml
@@ -20,7 +20,7 @@ jobs:
   plugins-destination-mysql:
     timeout-minutes: 30
     name: "plugins/destination/mysql"
-    runs-on: large-ubuntu-monorepo
+    runs-on: ubuntu-latest
     defaults:
       run:
         working-directory: ./plugins/destination/mysql
@@ -54,7 +54,7 @@ jobs:
         run: make test
   validate-release:
     timeout-minutes: 30
-    runs-on: large-ubuntu-monorepo
+    runs-on: ubuntu-latest
     env:
       CGO_ENABLED: 0
     steps:

--- a/.github/workflows/dest_neo4j.yml
+++ b/.github/workflows/dest_neo4j.yml
@@ -20,7 +20,7 @@ jobs:
   plugins-destination-neo4j:
     timeout-minutes: 30
     name: "plugins/destination/neo4j"
-    runs-on: large-ubuntu-monorepo
+    runs-on: ubuntu-latest
     defaults:
       run:
         working-directory: ./plugins/destination/neo4j
@@ -68,7 +68,7 @@ jobs:
         run: make test
   validate-release:
     timeout-minutes: 30
-    runs-on: large-ubuntu-monorepo
+    runs-on: ubuntu-latest
     env:
       CGO_ENABLED: 0
     steps:

--- a/.github/workflows/dest_postgresql.yml
+++ b/.github/workflows/dest_postgresql.yml
@@ -20,7 +20,7 @@ jobs:
   plugins-destination-postgresql:
     timeout-minutes: 30
     name: "plugins/destination/postgresql"
-    runs-on: large-ubuntu-monorepo
+    runs-on: ubuntu-latest
     defaults:
       run:
         working-directory: ./plugins/destination/postgresql
@@ -73,7 +73,7 @@ jobs:
         run: CQ_DEST_PG_TEST_CONN="postgresql://root@localhost:26257/postgres?sslmode=disable" make test
   validate-release:
     timeout-minutes: 30
-    runs-on: large-ubuntu-monorepo
+    runs-on: ubuntu-latest
     env:
       CGO_ENABLED: 0
     steps:

--- a/.github/workflows/dest_s3.yml
+++ b/.github/workflows/dest_s3.yml
@@ -22,7 +22,7 @@ jobs:
   plugins-destination-s3:
     timeout-minutes: 30
     name: "plugins/destination/s3"
-    runs-on: large-ubuntu-monorepo
+    runs-on: ubuntu-latest
     defaults:
       run:
         working-directory: ./plugins/destination/s3
@@ -58,7 +58,7 @@ jobs:
         run: make test
   validate-release:
     timeout-minutes: 30
-    runs-on: large-ubuntu-monorepo
+    runs-on: ubuntu-latest
     env:
       CGO_ENABLED: 0
     steps:

--- a/.github/workflows/dest_snowflake.yml
+++ b/.github/workflows/dest_snowflake.yml
@@ -20,7 +20,7 @@ jobs:
   plugins-destination-snowflake:
     timeout-minutes: 30
     name: "plugins/destination/snowflake"
-    runs-on: large-ubuntu-monorepo
+    runs-on: ubuntu-latest
     defaults:
       run:
         working-directory: ./plugins/destination/snowflake
@@ -50,7 +50,7 @@ jobs:
           SNOW_TEST_DSN: ${{ secrets.SNOW_TEST_DSN }}
   validate-release:
     timeout-minutes: 30
-    runs-on: large-ubuntu-monorepo
+    runs-on: ubuntu-latest
     container:
       image: ghcr.io/cloudquery/golang-cross:v10.0.0
       env:

--- a/.github/workflows/dest_sqlite.yml
+++ b/.github/workflows/dest_sqlite.yml
@@ -20,7 +20,7 @@ jobs:
   plugins-destination-sqlite:
     timeout-minutes: 30
     name: "plugins/destination/sqlite"
-    runs-on: large-ubuntu-monorepo
+    runs-on: ubuntu-latest
     defaults:
       run:
         working-directory: ./plugins/destination/sqlite
@@ -48,7 +48,7 @@ jobs:
         run: make test
   validate-release:
     timeout-minutes: 30
-    runs-on: large-ubuntu-monorepo
+    runs-on: ubuntu-latest
     container:
       image: ghcr.io/cloudquery/golang-cross:v10.0.0
       env:

--- a/.github/workflows/dest_test.yml
+++ b/.github/workflows/dest_test.yml
@@ -20,7 +20,7 @@ jobs:
   plugins-destination-test:
     timeout-minutes: 30
     name: "plugins/destination/test"
-    runs-on: large-ubuntu-monorepo
+    runs-on: ubuntu-latest
     defaults:
       run:
         working-directory: ./plugins/destination/test
@@ -48,7 +48,7 @@ jobs:
         run: make test
   validate-release:
     timeout-minutes: 30
-    runs-on: large-ubuntu-monorepo
+    runs-on: ubuntu-latest
     env:
       CGO_ENABLED: 0
     steps:

--- a/.github/workflows/scaffold.yml
+++ b/.github/workflows/scaffold.yml
@@ -20,7 +20,7 @@ jobs:
   scaffold:
     timeout-minutes: 30
     name: "scaffold"
-    runs-on: large-ubuntu-monorepo
+    runs-on: ubuntu-latest
     defaults:
       run:
         working-directory: ./scaffold
@@ -47,7 +47,7 @@ jobs:
         run: make test
   validate-release:
     timeout-minutes: 30
-    runs-on: large-ubuntu-monorepo
+    runs-on: ubuntu-latest
     env:
       CGO_ENABLED: 0
     steps:

--- a/.github/workflows/source_airtable.yml
+++ b/.github/workflows/source_airtable.yml
@@ -20,7 +20,7 @@ jobs:
   plugins-source-airtable:
     timeout-minutes: 30
     name: "plugins/source/airtable"
-    runs-on: large-ubuntu-monorepo
+    runs-on: ubuntu-latest
     defaults:
       run:
         working-directory: ./plugins/source/airtable
@@ -44,7 +44,7 @@ jobs:
           npm run build
   validate-release:
     timeout-minutes: 10
-    runs-on: large-ubuntu-monorepo
+    runs-on: ubuntu-latest
     env:
       IMAGE_NAME_PREFIX: cloudquery
       REGISTRY: ghcr.io

--- a/.github/workflows/source_alicloud.yml
+++ b/.github/workflows/source_alicloud.yml
@@ -20,7 +20,7 @@ jobs:
   plugins-source-alicloud:
     timeout-minutes: 30
     name: "plugins/source/alicloud"
-    runs-on: large-ubuntu-monorepo
+    runs-on: ubuntu-latest
     defaults:
       run:
         working-directory: ./plugins/source/alicloud
@@ -59,7 +59,7 @@ jobs:
         run: make test
   validate-release:
     timeout-minutes: 30
-    runs-on: large-ubuntu-monorepo
+    runs-on: ubuntu-latest
     env:
       CGO_ENABLED: 0
     steps:

--- a/.github/workflows/source_awspricing.yml
+++ b/.github/workflows/source_awspricing.yml
@@ -20,7 +20,7 @@ jobs:
   plugins-source-awspricing:
     timeout-minutes: 30
     name: "plugins/source/awspricing"
-    runs-on: large-ubuntu-monorepo
+    runs-on: ubuntu-latest
     defaults:
       run:
         working-directory: ./plugins/source/awspricing
@@ -59,7 +59,7 @@ jobs:
         run: make test
   validate-release:
     timeout-minutes: 30
-    runs-on: large-ubuntu-monorepo
+    runs-on: ubuntu-latest
     env:
       CGO_ENABLED: 0
     steps:

--- a/.github/workflows/source_azuredevops.yml
+++ b/.github/workflows/source_azuredevops.yml
@@ -20,7 +20,7 @@ jobs:
   plugins-source-azuredevops:
     timeout-minutes: 30
     name: "plugins/source/azuredevops"
-    runs-on: large-ubuntu-monorepo
+    runs-on: ubuntu-latest
     defaults:
       run:
         working-directory: ./plugins/source/azuredevops
@@ -59,7 +59,7 @@ jobs:
         run: make test
   validate-release:
     timeout-minutes: 30
-    runs-on: large-ubuntu-monorepo
+    runs-on: ubuntu-latest
     env:
       CGO_ENABLED: 0
     steps:

--- a/.github/workflows/source_bitbucket.yml
+++ b/.github/workflows/source_bitbucket.yml
@@ -20,7 +20,7 @@ jobs:
   plugins-source-bitbucket:
     timeout-minutes: 30
     name: "plugins/source/bitbucket"
-    runs-on: large-ubuntu-monorepo
+    runs-on: ubuntu-latest
     defaults:
       run:
         working-directory: ./plugins/source/bitbucket
@@ -48,7 +48,7 @@ jobs:
           fail_on_failure: true
   validate-release:
     timeout-minutes: 10
-    runs-on: large-ubuntu-monorepo
+    runs-on: ubuntu-latest
     env:
       IMAGE_NAME_PREFIX: cloudquery
       REGISTRY: ghcr.io

--- a/.github/workflows/source_cloudflare.yml
+++ b/.github/workflows/source_cloudflare.yml
@@ -20,7 +20,7 @@ jobs:
   plugins-source-cloudflare:
     timeout-minutes: 30
     name: "plugins/source/cloudflare"
-    runs-on: large-ubuntu-monorepo
+    runs-on: ubuntu-latest
     defaults:
       run:
         working-directory: ./plugins/source/cloudflare
@@ -59,7 +59,7 @@ jobs:
         run: make test
   validate-release:
     timeout-minutes: 30
-    runs-on: large-ubuntu-monorepo
+    runs-on: ubuntu-latest
     env:
       CGO_ENABLED: 0
     steps:

--- a/.github/workflows/source_datadog.yml
+++ b/.github/workflows/source_datadog.yml
@@ -20,7 +20,7 @@ jobs:
   plugins-source-datadog:
     timeout-minutes: 45
     name: "plugins/source/datadog"
-    runs-on: large-ubuntu-monorepo
+    runs-on: ubuntu-latest
     defaults:
       run:
         working-directory: ./plugins/source/datadog
@@ -59,7 +59,7 @@ jobs:
         run: make test
   validate-release:
     timeout-minutes: 45
-    runs-on: large-ubuntu-monorepo
+    runs-on: ubuntu-latest
     env:
       CGO_ENABLED: 0
     steps:

--- a/.github/workflows/source_digitalocean.yml
+++ b/.github/workflows/source_digitalocean.yml
@@ -20,7 +20,7 @@ jobs:
   plugins-source-digitalocean:
     timeout-minutes: 30
     name: "plugins/source/digitalocean"
-    runs-on: large-ubuntu-monorepo
+    runs-on: ubuntu-latest
     defaults:
       run:
         working-directory: ./plugins/source/digitalocean
@@ -59,7 +59,7 @@ jobs:
         run: make test
   validate-release:
     timeout-minutes: 30
-    runs-on: large-ubuntu-monorepo
+    runs-on: ubuntu-latest
     env:
       CGO_ENABLED: 0
     steps:

--- a/.github/workflows/source_facebookmarketing.yml
+++ b/.github/workflows/source_facebookmarketing.yml
@@ -20,7 +20,7 @@ jobs:
   plugins-source-facebookmarketing:
     timeout-minutes: 30
     name: "plugins/source/facebookmarketing"
-    runs-on: large-ubuntu-monorepo
+    runs-on: ubuntu-latest
     defaults:
       run:
         working-directory: ./plugins/source/facebookmarketing
@@ -59,7 +59,7 @@ jobs:
         run: make test
   validate-release:
     timeout-minutes: 30
-    runs-on: large-ubuntu-monorepo
+    runs-on: ubuntu-latest
     env:
       CGO_ENABLED: 0
     steps:

--- a/.github/workflows/source_fastly.yml
+++ b/.github/workflows/source_fastly.yml
@@ -20,7 +20,7 @@ jobs:
   plugins-source-fastly:
     timeout-minutes: 30
     name: "plugins/source/fastly"
-    runs-on: large-ubuntu-monorepo
+    runs-on: ubuntu-latest
     defaults:
       run:
         working-directory: ./plugins/source/fastly
@@ -59,7 +59,7 @@ jobs:
         run: make test
   validate-release:
     timeout-minutes: 30
-    runs-on: large-ubuntu-monorepo
+    runs-on: ubuntu-latest
     env:
       CGO_ENABLED: 0
     steps:

--- a/.github/workflows/source_firestore.yml
+++ b/.github/workflows/source_firestore.yml
@@ -21,7 +21,7 @@ jobs:
   plugins-source-firestore:
     timeout-minutes: 30
     name: "plugins/source/firestore"
-    runs-on: large-ubuntu-monorepo
+    runs-on: ubuntu-latest
     defaults:
       run:
         working-directory: ./plugins/source/firestore
@@ -58,7 +58,7 @@ jobs:
           FIRESTORE_EMULATOR_HOST: localhost:8080
   validate-release:
     timeout-minutes: 30
-    runs-on: large-ubuntu-monorepo
+    runs-on: ubuntu-latest
     env:
       CGO_ENABLED: 0
     steps:

--- a/.github/workflows/source_github.yml
+++ b/.github/workflows/source_github.yml
@@ -20,7 +20,7 @@ jobs:
   plugins-source-github:
     timeout-minutes: 30
     name: "plugins/source/github"
-    runs-on: large-ubuntu-monorepo
+    runs-on: ubuntu-latest
     defaults:
       run:
         working-directory: ./plugins/source/github
@@ -59,7 +59,7 @@ jobs:
         run: make test
   validate-release:
     timeout-minutes: 30
-    runs-on: large-ubuntu-monorepo
+    runs-on: ubuntu-latest
     env:
       CGO_ENABLED: 0
     steps:

--- a/.github/workflows/source_gitlab.yml
+++ b/.github/workflows/source_gitlab.yml
@@ -20,7 +20,7 @@ jobs:
   plugins-source-github:
     timeout-minutes: 30
     name: "plugins/source/gitlab"
-    runs-on: large-ubuntu-monorepo
+    runs-on: ubuntu-latest
     defaults:
       run:
         working-directory: ./plugins/source/gitlab
@@ -59,7 +59,7 @@ jobs:
         run: make test
   validate-release:
     timeout-minutes: 30
-    runs-on: large-ubuntu-monorepo
+    runs-on: ubuntu-latest
     env:
       CGO_ENABLED: 0
     steps:

--- a/.github/workflows/source_googleanalytics.yml
+++ b/.github/workflows/source_googleanalytics.yml
@@ -20,7 +20,7 @@ jobs:
   plugins-source-googleanalytics:
     timeout-minutes: 30
     name: "plugins/source/googleanalytics"
-    runs-on: large-ubuntu-monorepo
+    runs-on: ubuntu-latest
     defaults:
       run:
         working-directory: ./plugins/source/googleanalytics
@@ -54,7 +54,7 @@ jobs:
         run: make test
   validate-release:
     timeout-minutes: 30
-    runs-on: large-ubuntu-monorepo
+    runs-on: ubuntu-latest
     env:
       CGO_ENABLED: 0
     steps:

--- a/.github/workflows/source_hackernews.yml
+++ b/.github/workflows/source_hackernews.yml
@@ -20,7 +20,7 @@ jobs:
   plugins-source-hackernews:
     timeout-minutes: 30
     name: "plugins/source/hackernews"
-    runs-on: large-ubuntu-monorepo
+    runs-on: ubuntu-latest
     defaults:
       run:
         working-directory: ./plugins/source/hackernews
@@ -59,7 +59,7 @@ jobs:
         run: make test
   validate-release:
     timeout-minutes: 30
-    runs-on: large-ubuntu-monorepo
+    runs-on: ubuntu-latest
     env:
       CGO_ENABLED: 0
     steps:

--- a/.github/workflows/source_homebrew.yml
+++ b/.github/workflows/source_homebrew.yml
@@ -20,7 +20,7 @@ jobs:
   plugins-source-homebrew:
     timeout-minutes: 30
     name: "plugins/source/homebrew"
-    runs-on: large-ubuntu-monorepo
+    runs-on: ubuntu-latest
     defaults:
       run:
         working-directory: ./plugins/source/homebrew
@@ -59,7 +59,7 @@ jobs:
         run: make test
   validate-release:
     timeout-minutes: 30
-    runs-on: large-ubuntu-monorepo
+    runs-on: ubuntu-latest
     env:
       CGO_ENABLED: 0
     steps:

--- a/.github/workflows/source_hubspot.yml
+++ b/.github/workflows/source_hubspot.yml
@@ -20,7 +20,7 @@ jobs:
   plugins-source-hubspot:
     timeout-minutes: 30
     name: "plugins/source/hubspot"
-    runs-on: large-ubuntu-monorepo
+    runs-on: ubuntu-latest
     defaults:
       run:
         working-directory: ./plugins/source/hubspot
@@ -59,7 +59,7 @@ jobs:
         run: make test
   validate-release:
     timeout-minutes: 30
-    runs-on: large-ubuntu-monorepo
+    runs-on: ubuntu-latest
     env:
       CGO_ENABLED: 0
     steps:

--- a/.github/workflows/source_jira.yml
+++ b/.github/workflows/source_jira.yml
@@ -20,7 +20,7 @@ jobs:
   plugins-source-jira:
     timeout-minutes: 30
     name: "plugins/source/jira"
-    runs-on: large-ubuntu-monorepo
+    runs-on: ubuntu-latest
     defaults:
       run:
         working-directory: ./plugins/source/jira
@@ -60,7 +60,7 @@ jobs:
         run: make test
   validate-release:
     timeout-minutes: 30
-    runs-on: large-ubuntu-monorepo
+    runs-on: ubuntu-latest
     env:
       CGO_ENABLED: 0
     steps:

--- a/.github/workflows/source_k8s.yml
+++ b/.github/workflows/source_k8s.yml
@@ -20,7 +20,7 @@ jobs:
   plugins-source-k8s:
     timeout-minutes: 30
     name: "plugins/source/k8s"
-    runs-on: large-ubuntu-monorepo
+    runs-on: ubuntu-latest
     defaults:
       run:
         working-directory: ./plugins/source/k8s
@@ -60,7 +60,7 @@ jobs:
         run: make test
   validate-release:
     timeout-minutes: 30
-    runs-on: large-ubuntu-monorepo
+    runs-on: ubuntu-latest
     env:
       CGO_ENABLED: 0
     steps:
@@ -96,7 +96,7 @@ jobs:
           GORELEASER_KEY: ${{ secrets.GORELEASER_KEY }}
   test-policies:
     timeout-minutes: 30
-    runs-on: large-ubuntu-monorepo
+    runs-on: ubuntu-latest
     defaults:
       run:
         working-directory: ./plugins/source/k8s

--- a/.github/workflows/source_mysql.yml
+++ b/.github/workflows/source_mysql.yml
@@ -20,7 +20,7 @@ jobs:
   plugins-source-mysql:
     timeout-minutes: 30
     name: "plugins/source/mysql"
-    runs-on: large-ubuntu-monorepo
+    runs-on: ubuntu-latest
     defaults:
       run:
         working-directory: ./plugins/source/mysql
@@ -54,7 +54,7 @@ jobs:
         run: make test
   validate-release:
     timeout-minutes: 30
-    runs-on: large-ubuntu-monorepo
+    runs-on: ubuntu-latest
     env:
       CGO_ENABLED: 0
     steps:

--- a/.github/workflows/source_notion.yml
+++ b/.github/workflows/source_notion.yml
@@ -20,7 +20,7 @@ jobs:
   plugins-source-notion:
     timeout-minutes: 30
     name: "plugins/source/notion"
-    runs-on: large-ubuntu-monorepo
+    runs-on: ubuntu-latest
     defaults:
       run:
         working-directory: ./plugins/source/notion
@@ -59,7 +59,7 @@ jobs:
         run: make test
   validate-release:
     timeout-minutes: 30
-    runs-on: large-ubuntu-monorepo
+    runs-on: ubuntu-latest
     env:
       CGO_ENABLED: 0
     steps:

--- a/.github/workflows/source_okta.yml
+++ b/.github/workflows/source_okta.yml
@@ -20,7 +20,7 @@ jobs:
   plugins-source-okta:
     timeout-minutes: 30
     name: "plugins/source/okta"
-    runs-on: large-ubuntu-monorepo
+    runs-on: ubuntu-latest
     defaults:
       run:
         working-directory: ./plugins/source/okta
@@ -59,7 +59,7 @@ jobs:
         run: make test
   validate-release:
     timeout-minutes: 30
-    runs-on: large-ubuntu-monorepo
+    runs-on: ubuntu-latest
     env:
       CGO_ENABLED: 0
     steps:

--- a/.github/workflows/source_oracle.yml
+++ b/.github/workflows/source_oracle.yml
@@ -20,7 +20,7 @@ jobs:
   plugins-source-oracle:
     timeout-minutes: 30
     name: "plugins/source/oracle"
-    runs-on: large-ubuntu-monorepo
+    runs-on: ubuntu-latest
     defaults:
       run:
         working-directory: ./plugins/source/oracle
@@ -59,7 +59,7 @@ jobs:
         run: make test
   validate-release:
     timeout-minutes: 30
-    runs-on: large-ubuntu-monorepo
+    runs-on: ubuntu-latest
     env:
       CGO_ENABLED: 0
     steps:

--- a/.github/workflows/source_oracledb.yml
+++ b/.github/workflows/source_oracledb.yml
@@ -20,7 +20,7 @@ jobs:
   plugins-source-oracledb:
     timeout-minutes: 30
     name: "plugins/source/oracledb"
-    runs-on: large-ubuntu-monorepo
+    runs-on: ubuntu-latest
     defaults:
       run:
         working-directory: ./plugins/source/oracledb
@@ -64,7 +64,7 @@ jobs:
         run: make test
   validate-release:
     timeout-minutes: 30
-    runs-on: large-ubuntu-monorepo
+    runs-on: ubuntu-latest
     env:
       CGO_ENABLED: 0
     steps:

--- a/.github/workflows/source_pagerduty.yml
+++ b/.github/workflows/source_pagerduty.yml
@@ -20,7 +20,7 @@ jobs:
   plugins-source-pagerduty:
     timeout-minutes: 30
     name: "plugins/source/pagerduty"
-    runs-on: large-ubuntu-monorepo
+    runs-on: ubuntu-latest
     defaults:
       run:
         working-directory: ./plugins/source/pagerduty
@@ -59,7 +59,7 @@ jobs:
         run: make test
   validate-release:
     timeout-minutes: 30
-    runs-on: large-ubuntu-monorepo
+    runs-on: ubuntu-latest
     env:
       CGO_ENABLED: 0
     steps:

--- a/.github/workflows/source_postgresql.yml
+++ b/.github/workflows/source_postgresql.yml
@@ -20,7 +20,7 @@ jobs:
   plugins-source-postgresql:
     timeout-minutes: 30
     name: "plugins/source/postgresql"
-    runs-on: large-ubuntu-monorepo
+    runs-on: ubuntu-latest
     defaults:
       run:
         working-directory: ./plugins/source/postgresql
@@ -54,7 +54,7 @@ jobs:
         run: make test
   validate-release:
     timeout-minutes: 30
-    runs-on: large-ubuntu-monorepo
+    runs-on: ubuntu-latest
     env:
       CGO_ENABLED: 0
     steps:

--- a/.github/workflows/source_salesforce.yml
+++ b/.github/workflows/source_salesforce.yml
@@ -20,7 +20,7 @@ jobs:
   plugins-source-salesforce:
     timeout-minutes: 30
     name: "plugins/source/salesforce"
-    runs-on: large-ubuntu-monorepo
+    runs-on: ubuntu-latest
     defaults:
       run:
         working-directory: ./plugins/source/salesforce
@@ -59,7 +59,7 @@ jobs:
         run: make test
   validate-release:
     timeout-minutes: 30
-    runs-on: large-ubuntu-monorepo
+    runs-on: ubuntu-latest
     env:
       CGO_ENABLED: 0
     steps:

--- a/.github/workflows/source_shopify.yml
+++ b/.github/workflows/source_shopify.yml
@@ -20,7 +20,7 @@ jobs:
   plugins-source-shopify:
     timeout-minutes: 30
     name: "plugins/source/shopify"
-    runs-on: large-ubuntu-monorepo
+    runs-on: ubuntu-latest
     defaults:
       run:
         working-directory: ./plugins/source/shopify
@@ -59,7 +59,7 @@ jobs:
         run: make test
   validate-release:
     timeout-minutes: 30
-    runs-on: large-ubuntu-monorepo
+    runs-on: ubuntu-latest
     env:
       CGO_ENABLED: 0
     steps:

--- a/.github/workflows/source_snyk.yml
+++ b/.github/workflows/source_snyk.yml
@@ -20,7 +20,7 @@ jobs:
   plugins-source-snyk:
     timeout-minutes: 30
     name: "plugins/source/snyk"
-    runs-on: large-ubuntu-monorepo
+    runs-on: ubuntu-latest
     defaults:
       run:
         working-directory: ./plugins/source/snyk
@@ -59,7 +59,7 @@ jobs:
         run: make test
   validate-release:
     timeout-minutes: 30
-    runs-on: large-ubuntu-monorepo
+    runs-on: ubuntu-latest
     env:
       CGO_ENABLED: 0
     steps:

--- a/.github/workflows/source_square.yml
+++ b/.github/workflows/source_square.yml
@@ -20,7 +20,7 @@ jobs:
   plugins-source-square:
     timeout-minutes: 30
     name: "plugins/source/square"
-    runs-on: large-ubuntu-monorepo
+    runs-on: ubuntu-latest
     defaults:
       run:
         working-directory: ./plugins/source/square
@@ -41,7 +41,7 @@ jobs:
 
   validate-release:
     timeout-minutes: 10
-    runs-on: large-ubuntu-monorepo
+    runs-on: ubuntu-latest
     env:
       IMAGE_NAME_PREFIX: cloudquery
       REGISTRY: ghcr.io

--- a/.github/workflows/source_stripe.yml
+++ b/.github/workflows/source_stripe.yml
@@ -20,7 +20,7 @@ jobs:
   plugins-source-stripe:
     timeout-minutes: 30
     name: "plugins/source/stripe"
-    runs-on: large-ubuntu-monorepo
+    runs-on: ubuntu-latest
     defaults:
       run:
         working-directory: ./plugins/source/stripe
@@ -59,7 +59,7 @@ jobs:
         run: make test
   validate-release:
     timeout-minutes: 30
-    runs-on: large-ubuntu-monorepo
+    runs-on: ubuntu-latest
     env:
       CGO_ENABLED: 0
     steps:

--- a/.github/workflows/source_terraform.yml
+++ b/.github/workflows/source_terraform.yml
@@ -20,7 +20,7 @@ jobs:
   plugins-source-terraform:
     timeout-minutes: 30
     name: "plugins/source/terraform"
-    runs-on: large-ubuntu-monorepo
+    runs-on: ubuntu-latest
     defaults:
       run:
         working-directory: ./plugins/source/terraform
@@ -59,7 +59,7 @@ jobs:
         run: make test
   validate-release:
     timeout-minutes: 30
-    runs-on: large-ubuntu-monorepo
+    runs-on: ubuntu-latest
     env:
       CGO_ENABLED: 0
     steps:

--- a/.github/workflows/source_test.yml
+++ b/.github/workflows/source_test.yml
@@ -20,7 +20,7 @@ jobs:
   plugins-source-test:
     timeout-minutes: 30
     name: "plugins/source/test"
-    runs-on: large-ubuntu-monorepo
+    runs-on: ubuntu-latest
     defaults:
       run:
         working-directory: ./plugins/source/test
@@ -59,7 +59,7 @@ jobs:
         run: make test
   validate-release:
     timeout-minutes: 30
-    runs-on: large-ubuntu-monorepo
+    runs-on: ubuntu-latest
     env:
       CGO_ENABLED: 0
     steps:

--- a/.github/workflows/source_typeform.yml
+++ b/.github/workflows/source_typeform.yml
@@ -20,7 +20,7 @@ jobs:
   plugins-source-typeform:
     timeout-minutes: 30
     name: "plugins/source/typeform"
-    runs-on: large-ubuntu-monorepo
+    runs-on: ubuntu-latest
     defaults:
       run:
         working-directory: ./plugins/source/typeform
@@ -52,7 +52,7 @@ jobs:
 
   validate-release:
     timeout-minutes: 10
-    runs-on: large-ubuntu-monorepo
+    runs-on: ubuntu-latest
     env:
       IMAGE_NAME_PREFIX: cloudquery
       REGISTRY: ghcr.io

--- a/.github/workflows/source_vault.yml
+++ b/.github/workflows/source_vault.yml
@@ -20,7 +20,7 @@ jobs:
   plugins-source-vault:
     timeout-minutes: 30
     name: "plugins/source/vault"
-    runs-on: large-ubuntu-monorepo
+    runs-on: ubuntu-latest
     defaults:
       run:
         working-directory: ./plugins/source/vault
@@ -55,7 +55,7 @@ jobs:
         run: make test
   validate-release:
     timeout-minutes: 30
-    runs-on: large-ubuntu-monorepo
+    runs-on: ubuntu-latest
     env:
       CGO_ENABLED: 0
     steps:


### PR DESCRIPTION
<!-- 🎉 Thank you for making CloudQuery awesome by submitting a PR 🎉 -->

#### Summary

Same as https://github.com/cloudquery/cloudquery/pull/15069 not from a fork so workflows that require secrets can pass

<!--
Use the following steps to ensure your PR is ready to be reviewed

- [ ] Read the [contribution guidelines](../blob/main/CONTRIBUTING.md) 🧑‍🎓
- [ ] Run `make lint` to ensure the proposed changes follow the coding style 🚨 (install golangci-lint [here](https://golangci-lint.run/usage/install/#local-installation))
- [ ] Run `make test` to ensure the proposed changes pass the tests 🧪
- [ ] If changing a source plugin run `make gen` to ensure docs are up to date 📝
- [ ] Ensure the status checks below are successful ✅
--->
