### PR TITLE
chore: Fix docs publishing cross-compile image

### DIFF
--- a/.github/workflows/publish_plugin_to_hub_duckdb.yml
+++ b/.github/workflows/publish_plugin_to_hub_duckdb.yml
@@ -90,7 +90,9 @@ jobs:
       - name: Run package command
         working-directory: ${{ needs.prepare.outputs.plugin_dir }}
         run: |
-          rsync -v --exclude='tables.md' ../../../website/pages/docs/plugins/${{ needs.prepare.outputs.plugin_kind_plural }}/${{ needs.prepare.outputs.plugin_name }}/*.md docsdir/
+          mkdir -p docsdir
+          cp ../../../website/pages/docs/plugins/${{ needs.prepare.outputs.plugin_kind_plural }}/${{ needs.prepare.outputs.plugin_name }}/*.md docsdir/
+          rm -rf docsdir/tables.md
           go run main.go package --docs-dir docsdir -m ${{ steps.release-notes.outputs.result }} ${{ needs.prepare.outputs.plugin_version }} .
       - name: Setup CloudQuery
         uses: cloudquery/setup-cloudquery@v3

--- a/.github/workflows/publish_plugin_to_hub_snowflake.yml
+++ b/.github/workflows/publish_plugin_to_hub_snowflake.yml
@@ -91,7 +91,9 @@ jobs:
       - name: Run package command
         working-directory: ${{ needs.prepare.outputs.plugin_dir }}
         run: |
-          rsync -v --exclude='tables.md' ../../../website/pages/docs/plugins/${{ needs.prepare.outputs.plugin_kind_plural }}/${{ needs.prepare.outputs.plugin_name }}/*.md docsdir/
+          mkdir -p docsdir
+          cp ../../../website/pages/docs/plugins/${{ needs.prepare.outputs.plugin_kind_plural }}/${{ needs.prepare.outputs.plugin_name }}/*.md docsdir/
+          rm -rf docsdir/tables.md
           go run main.go package --docs-dir docsdir -m ${{ steps.release-notes.outputs.result }} ${{ needs.prepare.outputs.plugin_version }} .
       - name: Setup CloudQuery
         uses: cloudquery/setup-cloudquery@v3

--- a/.github/workflows/publish_plugin_to_hub_sqlite.yml
+++ b/.github/workflows/publish_plugin_to_hub_sqlite.yml
@@ -90,7 +90,9 @@ jobs:
       - name: Run package command
         working-directory: ${{ needs.prepare.outputs.plugin_dir }}
         run: |
-          rsync -v --exclude='tables.md' ../../../website/pages/docs/plugins/${{ needs.prepare.outputs.plugin_kind_plural }}/${{ needs.prepare.outputs.plugin_name }}/*.md docsdir/
+          mkdir -p docsdir
+          cp ../../../website/pages/docs/plugins/${{ needs.prepare.outputs.plugin_kind_plural }}/${{ needs.prepare.outputs.plugin_name }}/*.md docsdir/
+          rm -rf docsdir/tables.md
           go run main.go package --docs-dir docsdir -m ${{ steps.release-notes.outputs.result }} ${{ needs.prepare.outputs.plugin_version }} .
       - name: Setup CloudQuery
         uses: cloudquery/setup-cloudquery@v3


### PR DESCRIPTION
<!-- 🎉 Thank you for making CloudQuery awesome by submitting a PR 🎉 -->

#### Summary

Seems like `rsync` [doesn't work as expected](https://github.com/cloudquery/cloudquery/actions/runs/6719832688/job/18262200668#step:9:11) on the cross compile image so trying a different approach

<!--
Use the following steps to ensure your PR is ready to be reviewed

- [ ] Read the [contribution guidelines](../blob/main/CONTRIBUTING.md) 🧑‍🎓
- [ ] Run `make lint` to ensure the proposed changes follow the coding style 🚨 (install golangci-lint [here](https://golangci-lint.run/usage/install/#local-installation))
- [ ] Run `make test` to ensure the proposed changes pass the tests 🧪
- [ ] If changing a source plugin run `make gen` to ensure docs are up to date 📝
- [ ] Ensure the status checks below are successful ✅
--->
