### PR TITLE
chore: Add latest version to public paid plugins

### DIFF
--- a/website/pages/docs/developers/publishing-a-plugin-to-the-hub.md
+++ b/website/pages/docs/developers/publishing-a-plugin-to-the-hub.md
@@ -5,7 +5,7 @@ description: Learn how to publish a plugin to the Hub and have it listed in http
 
 # Publishing a Plugin to the Hub
 
-With the announcement of [CloudQuery Hub](/blog/announcing-cloudquery-new-hub), we are excited to see the community contribute plugins to the Hub. This guide will walk you through the process of publishing a plugin to the Hub.
+With the announcement of [CloudQuery Hub](blog/announcing-cloudquery-new-hub), we are excited to see the community contribute plugins to the Hub. This guide will walk you through the process of publishing a plugin to the Hub.
 
 :::callout
 Publishing to the CloudQuery Hub is only supported for Go plugins at the moment. We are working on adding support for other languages.

--- a/website/pages/docs/developers/publishing-a-plugin-to-the-hub.md
+++ b/website/pages/docs/developers/publishing-a-plugin-to-the-hub.md
@@ -5,7 +5,7 @@ description: Learn how to publish a plugin to the Hub and have it listed in http
 
 # Publishing a Plugin to the Hub
 
-With the announcement of [CloudQuery Hub](blog/announcing-cloudquery-new-hub), we are excited to see the community contribute plugins to the Hub. This guide will walk you through the process of publishing a plugin to the Hub.
+With the announcement of [CloudQuery Hub](/blog/announcing-cloudquery-new-hub), we are excited to see the community contribute plugins to the Hub. This guide will walk you through the process of publishing a plugin to the Hub.
 
 :::callout
 Publishing to the CloudQuery Hub is only supported for Go plugins at the moment. We are working on adding support for other languages.

--- a/website/pages/docs/plugins/sources/file/_configuration.md
+++ b/website/pages/docs/plugins/sources/file/_configuration.md
@@ -2,9 +2,9 @@
 kind: source
 spec:
   name: file
-  path: /path/to/downloaded/plugin # Buy from here: https://cloudquery.io/integrations/file
-  registry: local
-  version: "PREMIUM"
+  path: cloudquery/file
+  registry: cloudquery
+  version: "VERSION_SOURCE_FILE"
   tables: ["*"]
   destinations: ["DESTINATION_NAME"]
 

--- a/website/pages/docs/plugins/sources/file/overview.md
+++ b/website/pages/docs/plugins/sources/file/overview.md
@@ -6,7 +6,7 @@ description: CloudQuery File source plugin documentation
 ---
 # File Source Plugin
 
-:badge{text="Premium"}
+:badge
 
 This is a premium plugin that you can buy [here](/integrations/file).
 
@@ -39,9 +39,10 @@ To learn more about visualizing AWS Cost and Usage Reports, visit [our dashboard
 kind: source
 spec:
   name: file
-  version: "PREMIUM"
+  path: cloudquery/file
+  registry: cloudquery
+  version: "VERSION_SOURCE_FILE"
   destinations: [postgresql]
-  path: /path/to/downloaded/plugin
   tables: ["*"]
   spec:
     files_dir: "/path/to/cost_and_usage_reports" # Update this value to the local directory with your AWS Cost and Usage Reports

--- a/website/pages/docs/plugins/sources/heroku/_configuration.md
+++ b/website/pages/docs/plugins/sources/heroku/_configuration.md
@@ -2,9 +2,9 @@
 kind: source
 spec: # Common source spec section
   name: heroku
-  path: /path/to/downloaded/plugin # Buy from here: https://cloudquery.io/integrations/heroku
-  registry: local
-  version: "PREMIUM"
+  path: cloudquery/heroku
+  registry: cloudquery
+  version: "VERSION_SOURCE_HEROKU"
   tables: ["*"]
   destinations: ["DESTINATION_NAME"]
 

--- a/website/pages/docs/plugins/sources/heroku/overview.md
+++ b/website/pages/docs/plugins/sources/heroku/overview.md
@@ -6,7 +6,7 @@ description: CloudQuery Heroku source plugin documentation
 ---
 # Heroku Source Plugin
 
-:badge{text="Premium"}
+:badge
 
 This is a premium plugin that you can buy [here](/integrations/heroku).
 

--- a/website/pages/docs/plugins/sources/slack/_configuration.md
+++ b/website/pages/docs/plugins/sources/slack/_configuration.md
@@ -3,9 +3,9 @@ kind: source
 # Common source-plugin configuration
 spec:
   name: slack
-  path: /path/to/downloaded/plugin # Buy from here: https://cloudquery.io/integrations/slack
-  registry: local
-  version: "PREMIUM"
+  path: cloudquery/slack
+  registry: cloudquery
+  version: "VERSION_SOURCE_SLACK"
   tables: ["*"]
   destinations: ["DESTINATION_NAME"]
 

--- a/website/pages/docs/plugins/sources/slack/overview.md
+++ b/website/pages/docs/plugins/sources/slack/overview.md
@@ -6,7 +6,7 @@ description: CloudQuery Slack source plugin documentation
 ---
 # Slack Source Plugin
 
-:badge{text="Premium"}
+:badge
 
 This is a premium plugin that you can buy [here](/integrations/slack).
 

--- a/website/pages/docs/plugins/sources/tailscale/_configuration.md
+++ b/website/pages/docs/plugins/sources/tailscale/_configuration.md
@@ -3,9 +3,9 @@ kind: source
 # Common source-plugin configuration
 spec:
   name: tailscale
-  path: /path/to/downloaded/plugin # Buy from here: https://cloudquery.io/integrations/tailscale
-  registry: local
-  version: "PREMIUM"
+  path: cloudquery/tailscale
+  registry: cloudquery
+  version: "VERSION_SOURCE_TAILSCALE"
   tables: ["*"]
   destinations: ["DESTINATION_NAME"]
 

--- a/website/pages/docs/plugins/sources/tailscale/overview.md
+++ b/website/pages/docs/plugins/sources/tailscale/overview.md
@@ -6,7 +6,7 @@ description: CloudQuery Tailscale source plugin documentation
 ---
 # Tailscale Source Plugin
 
-:badge{text="Premium"}
+:badge
 
 This is a premium plugin that you can buy [here](/integrations/tailscale).
 


### PR DESCRIPTION
<!-- 🎉 Thank you for making CloudQuery awesome by submitting a PR 🎉 -->

#### Summary

Part of cloudquery/cloudquery-issues#768 (internal issue). Adds the latest versions for the paid public plugins, see https://hub.cloudquery.io/plugins/source?tiers=paid.

I also removed the buy links from the configuration comments as I think the CLI should guide users to login when using these plugins.

Once this PR is merged we can publish new versions of the plugins with the new docs.

**Not in this PR** - latest versions in https://www.cloudquery.io/docs/plugins/sources/overview as it requires a bigger change to get the versions in the React component here https://github.com/cloudquery/cloudquery/blob/0971c8a49c6415eb9330f4d078f5ab7a37bd78ae/website/components/PluginsTable.tsx#L32

<!--
Use the following steps to ensure your PR is ready to be reviewed

- [ ] Read the [contribution guidelines](../blob/main/CONTRIBUTING.md) 🧑‍🎓
- [ ] Run `make lint` to ensure the proposed changes follow the coding style 🚨 (install golangci-lint [here](https://golangci-lint.run/usage/install/#local-installation))
- [ ] Run `make test` to ensure the proposed changes pass the tests 🧪
- [ ] If changing a source plugin run `make gen` to ensure docs are up to date 📝
- [ ] Ensure the status checks below are successful ✅
--->
