### PR TITLE
fix: Set team context when logging in, and don't clear it when logging out

### DIFF
--- a/cli/cmd/login.go
+++ b/cli/cmd/login.go
@@ -10,6 +10,7 @@ import (
 	"os"
 	"os/signal"
 	"strconv"
+	"strings"
 	"syscall"
 	"time"
 
@@ -159,17 +160,22 @@ func runLogin(ctx context.Context, cmd *cobra.Command) (err error) {
 		return fmt.Errorf("failed to save refresh token: %w", err)
 	}
 
+	tc := auth.NewTokenClient()
+	token, err := tc.GetToken()
+	if err != nil {
+		return fmt.Errorf("failed to get auth token: %w", err)
+	}
+	cl, err := team.NewClient(apiURL, token)
+	if err != nil {
+		return fmt.Errorf("failed to create API client: %w", err)
+	}
+
+	currentTeam, err := config.GetValue("team")
+	if err != nil && !errors.Is(err, os.ErrNotExist) {
+		return fmt.Errorf("failed to get current team: %w", err)
+	}
 	if cmd.Flags().Changed("team") {
 		selectedTeam := cmd.Flag("team").Value.String()
-		tc := auth.NewTokenClient()
-		token, err := tc.GetToken()
-		if err != nil {
-			return fmt.Errorf("failed to get auth token: %w", err)
-		}
-		cl, err := team.NewClient(apiURL, token)
-		if err != nil {
-			return fmt.Errorf("failed to create API client: %w", err)
-		}
 		err = cl.ValidateTeam(ctx, selectedTeam)
 		if err != nil {
 			return fmt.Errorf("failed to set team: %w", err)
@@ -178,6 +184,25 @@ func runLogin(ctx context.Context, cmd *cobra.Command) (err error) {
 		if err != nil {
 			return fmt.Errorf("failed to set team: %w", err)
 		}
+	} else if currentTeam == "" {
+		// if current team is not set, try to set it from the API
+		teams, err := cl.ListAllTeams(ctx)
+		if err != nil {
+			return fmt.Errorf("failed to list teams: %w", err)
+		}
+		if len(teams) == 1 {
+			err = config.SetValue("team", teams[0])
+			if err != nil {
+				return fmt.Errorf("failed to set team: %w", err)
+			}
+			cmd.Printf("Your current team is set to %s.\n", teams[0])
+		} else {
+			cmd.Println("Your current team is not set.\n")
+			cmd.Println("Teams available to you: " + strings.Join(teams, ", ") + "\n")
+			cmd.Println("To set your current team, run `cloudquery switch <team>`\n")
+		}
+	} else {
+		cmd.Printf("Your current team is set to %s.\n", currentTeam)
 	}
 
 	cmd.Println("CLI successfully authenticated.")

--- a/cli/cmd/login.go
+++ b/cli/cmd/login.go
@@ -184,25 +184,27 @@ func runLogin(ctx context.Context, cmd *cobra.Command) (err error) {
 		if err != nil {
 			return fmt.Errorf("failed to set team: %w", err)
 		}
-	} else if currentTeam == "" {
-		// if current team is not set, try to set it from the API
-		teams, err := cl.ListAllTeams(ctx)
-		if err != nil {
-			return fmt.Errorf("failed to list teams: %w", err)
-		}
-		if len(teams) == 1 {
-			err = config.SetValue("team", teams[0])
-			if err != nil {
-				return fmt.Errorf("failed to set team: %w", err)
-			}
-			cmd.Printf("Your current team is set to %s.\n", teams[0])
-		} else {
-			cmd.Println("Your current team is not set.\n")
-			cmd.Println("Teams available to you: " + strings.Join(teams, ", ") + "\n")
-			cmd.Println("To set your current team, run `cloudquery switch <team>`\n")
-		}
 	} else {
-		cmd.Printf("Your current team is set to %s.\n", currentTeam)
+		if currentTeam == "" {
+			// if current team is not set, try to set it from the API
+			teams, err := cl.ListAllTeams(ctx)
+			if err != nil {
+				return fmt.Errorf("failed to list teams: %w", err)
+			}
+			if len(teams) == 1 {
+				err = config.SetValue("team", teams[0])
+				if err != nil {
+					return fmt.Errorf("failed to set team: %w", err)
+				}
+				cmd.Printf("Your current team is set to %s.\n", teams[0])
+			} else {
+				cmd.Printf("Your current team is not set.\n\n")
+				cmd.Printf("Teams available to you: " + strings.Join(teams, ", ") + "\n\n")
+				cmd.Printf("To set your current team, run `cloudquery switch <team>`\n\n")
+			}
+		} else {
+			cmd.Printf("Your current team is set to %s.\n", currentTeam)
+		}
 	}
 
 	cmd.Println("CLI successfully authenticated.")

--- a/cli/cmd/switch.go
+++ b/cli/cmd/switch.go
@@ -60,7 +60,7 @@ func runSwitch(cmd *cobra.Command, args []string) error {
 		}
 
 		if currentTeam == "" {
-			cmd.Println("Your current team is not set.\n")
+			cmd.Printf("Your current team is not set.\n\n")
 		} else {
 			cmd.Printf("Your current team is set to %v.\n\n", currentTeam)
 		}

--- a/cli/cmd/switch.go
+++ b/cli/cmd/switch.go
@@ -60,10 +60,7 @@ func runSwitch(cmd *cobra.Command, args []string) error {
 		}
 
 		if currentTeam == "" {
-			cmd.Println("Your team is not set.")
-			if len(allTeams) == 1 {
-				cmd.Println("As you are currently a member of only one team, this will be used as your default team.")
-			}
+			cmd.Println("Your current team is not set.\n")
 		} else {
 			cmd.Printf("Your current team is set to %v.\n\n", currentTeam)
 		}

--- a/cli/internal/auth/logout.go
+++ b/cli/internal/auth/logout.go
@@ -2,18 +2,14 @@ package auth
 
 import (
 	"fmt"
+
 	cqapiauth "github.com/cloudquery/cloudquery-api-go/auth"
-	"github.com/cloudquery/cloudquery-api-go/config"
 )
 
 func Logout() error {
 	err := cqapiauth.RemoveRefreshToken()
 	if err != nil {
 		return fmt.Errorf("failed to remove refresh token: %w", err)
-	}
-	err = config.UnsetValue("team")
-	if err != nil {
-		return fmt.Errorf("failed to reset team value: %w", err)
 	}
 	return nil
 }


### PR DESCRIPTION
This updates the login logic so that the team context is automatically set if a user is part of only one team. If the user is in multiple teams, a message is printed to indicate that `cloudquery switch <team>` will be needed.