### PR TITLE
fix: Improve error message if version is specified incorrectly

### DIFF
--- a/cli/internal/specs/v0/destination.go
+++ b/cli/internal/specs/v0/destination.go
@@ -75,7 +75,7 @@ func (d *Destination) Validate() error {
 		return fmt.Errorf(msg)
 	}
 
-	if d.Registry == RegistryGithub {
+	if d.Registry == RegistryGithub || d.Registry == RegistryCloudQuery {
 		if d.Version == "" {
 			return fmt.Errorf("version is required")
 		}

--- a/cli/internal/specs/v0/source.go
+++ b/cli/internal/specs/v0/source.go
@@ -4,9 +4,8 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	"strings"
-
 	"slices"
+	"strings"
 
 	"github.com/thoas/go-funk"
 )
@@ -170,7 +169,7 @@ func (s *Source) Validate() error {
 		return fmt.Errorf("tables configuration is required. Hint: set the tables you want to sync by adding `tables: [...]` or use `cloudquery tables` to list available tables")
 	}
 
-	if s.Registry == RegistryGithub {
+	if s.Registry == RegistryGithub || s.Registry == RegistryCloudQuery {
 		if s.Version == "" {
 			return fmt.Errorf("version is required")
 		}


### PR DESCRIPTION
This makes the error message clearer when you forget to add `v` for a CloudQuery registry plugin.