### PR TITLE
chore(website): Add plugin documentation directories

### DIFF
--- a/plugins/source/mysql/docs/overview.md
+++ b/plugins/source/mysql/docs/overview.md
@@ -1,6 +1,6 @@
 ---
 name: MySQL
-stage: GA (Premium)
+stage: Preview (Premium)
 title: MySQL Source Plugin
 description: CloudQuery MySQL source plugin documentation
 ---

--- a/plugins/source/mysql/docs/overview.md
+++ b/plugins/source/mysql/docs/overview.md
@@ -1,0 +1,7 @@
+---
+name: MySQL
+stage: GA (Premium)
+title: MySQL Source Plugin
+description: CloudQuery MySQL source plugin documentation
+---
+

--- a/plugins/source/oracledb/docs/overview.md
+++ b/plugins/source/oracledb/docs/overview.md
@@ -1,6 +1,6 @@
 ---
 name: Oracle Database
-stage: GA (Premium)
+stage: Preview (Premium)
 title: Oracle Database Source Plugin
 description: CloudQuery Oracle Database source plugin documentation
 ---

--- a/plugins/source/oracledb/docs/overview.md
+++ b/plugins/source/oracledb/docs/overview.md
@@ -1,0 +1,7 @@
+---
+name: Oracle Database
+stage: GA (Premium)
+title: Oracle Database Source Plugin
+description: CloudQuery Oracle Database source plugin documentation
+---
+

--- a/plugins/source/postgresql/docs/overview.md
+++ b/plugins/source/postgresql/docs/overview.md
@@ -1,6 +1,6 @@
 ---
 name: PostgreSQL
-stage: GA (Premium)
+stage: Preview (Premium)
 title: PostgreSQL Source Plugin
 description: CloudQuery PostgreSQL source plugin documentation
 ---

--- a/plugins/source/postgresql/docs/overview.md
+++ b/plugins/source/postgresql/docs/overview.md
@@ -1,0 +1,6 @@
+---
+name: PostgreSQL
+stage: GA (Premium)
+title: PostgreSQL Source Plugin
+description: CloudQuery PostgreSQL source plugin documentation
+---

--- a/plugins/source/postgresql/docs/overview.md
+++ b/plugins/source/postgresql/docs/overview.md
@@ -4,3 +4,4 @@ stage: GA (Premium)
 title: PostgreSQL Source Plugin
 description: CloudQuery PostgreSQL source plugin documentation
 ---
+

--- a/website/components/pluginData.tsx
+++ b/website/components/pluginData.tsx
@@ -1268,3 +1268,4 @@ export function getPlugin(kind: string, id: string): Plugin {
   }
   return ALL_SOURCE_PLUGINS.find((p) => p.id === id);
 }
+


### PR DESCRIPTION
Adding plugin [documentation directories](https://github.com/cloudquery/cloudquery/blob/9fd925cf06a52c00b0189bf3d0c56f2d9afe0041/website/utils/plugins.js#L24) for plugins recently moved to `cloudquery-private`.