### PR TITLE
feat: Add `addon download` command

### DIFF
--- a/cli/cmd/addon_download.go
+++ b/cli/cmd/addon_download.go
@@ -99,17 +99,15 @@ func runAddonDownload(ctx context.Context, cmd *cobra.Command, args []string) er
 func getAddonMetadata(ctx context.Context, c *cloudquery_api.ClientWithResponses, teamName, addonType, addonName, version string) (*cloudquery_api.Addon, *cloudquery_api.AddonVersion, error) {
 	addonResp, err := c.GetAddonWithResponse(ctx, teamName, cloudquery_api.AddonType(addonType), addonName)
 	if err != nil {
-		if addonResp == nil {
-			return nil, nil, fmt.Errorf("failed to get addon: %w", err)
-		}
+		return nil, nil, fmt.Errorf("failed to get addon: %w", err)
+	} else if addonResp.StatusCode() != http.StatusOK {
 		return nil, nil, fmt.Errorf("failed to get addon: %w", errorFromHTTPResponse(addonResp.HTTPResponse, addonResp))
 	}
 
 	addonVersionResp, err := c.GetAddonVersionWithResponse(ctx, teamName, cloudquery_api.AddonType(addonType), addonName, version)
 	if err != nil {
-		if addonVersionResp == nil {
-			return nil, nil, fmt.Errorf("failed to get addon version: %w", err)
-		}
+		return nil, nil, fmt.Errorf("failed to get addon version: %w", err)
+	} else if addonVersionResp.StatusCode() != http.StatusOK {
 		return nil, nil, fmt.Errorf("failed to get addon version: %w", errorFromHTTPResponse(addonVersionResp.HTTPResponse, addonVersionResp))
 	}
 	return addonResp.JSON200, addonVersionResp.JSON200, nil

--- a/cli/cmd/addon_download.go
+++ b/cli/cmd/addon_download.go
@@ -93,11 +93,7 @@ func runAddonDownload(ctx context.Context, cmd *cobra.Command, args []string) er
 		return fmt.Errorf("failed to get addon metadata: %w", err)
 	}
 
-	if err := downloadAddon(ctx, c, addon.TeamName, addon.AddonType, addon.Name, addonVersion.Name, addon.AddonFormat, addonVersion.Checksum, target); err != nil {
-		return err
-	}
-
-	return nil
+	return downloadAddon(ctx, c, addon.TeamName, addon.AddonType, addon.Name, addonVersion.Name, addon.AddonFormat, addonVersion.Checksum, target)
 }
 
 func getAddonMetadata(ctx context.Context, c *cloudquery_api.ClientWithResponses, teamName, addonType, addonName, version string) (*cloudquery_api.Addon, *cloudquery_api.AddonVersion, error) {

--- a/cli/cmd/addon_download.go
+++ b/cli/cmd/addon_download.go
@@ -1,0 +1,180 @@
+package cmd
+
+import (
+	"context"
+	"crypto/sha256"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"os/signal"
+	"path/filepath"
+	"strings"
+	"syscall"
+
+	cloudquery_api "github.com/cloudquery/cloudquery-api-go"
+	"github.com/cloudquery/cloudquery-api-go/auth"
+	"github.com/spf13/cobra"
+)
+
+const (
+	addonDownloadShort = "Download addon from CloudQuery Hub."
+	addonDownloadLong  = `Download addon from CloudQuery Hub.
+
+This downloads an addon from CloudQuery Hub to local disk.
+`
+	addonDownloadExample = `
+# Download an addon to local disk
+cloudquery addon download addon-team/addon-type/addon-name@v1.0.0`
+)
+
+func newCmdAddonDownload() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:     "download addon-team/addon-type/addon-name@v1.0.0 [-t directory]",
+		Short:   addonDownloadShort,
+		Long:    addonDownloadLong,
+		Example: addonDownloadExample,
+		Args:    cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			// Set up a channel to listen for OS signals for graceful shutdown.
+			ctx, cancel := context.WithCancel(cmd.Context())
+
+			sigChan := make(chan os.Signal, 1)
+			signal.Notify(sigChan, syscall.SIGTERM)
+
+			go func() {
+				<-sigChan
+				cancel()
+			}()
+
+			return runAddonDownload(ctx, cmd, args)
+		},
+	}
+	cmd.Flags().StringP("target", "t", ".", `Download to specified directory. Use - for stdout`)
+
+	return cmd
+}
+
+func runAddonDownload(ctx context.Context, cmd *cobra.Command, args []string) error {
+	tc := auth.NewTokenClient()
+	token, err := tc.GetToken()
+	if err != nil {
+		return fmt.Errorf("failed to get auth token: %w", err)
+	}
+
+	addonParts := strings.Split(args[0], "/")
+	if len(addonParts) != 3 {
+		return fmt.Errorf("invalid addon ref: %s", args[0])
+	}
+	addonVer := strings.Split(addonParts[2], "@")
+	if len(addonVer) != 2 {
+		return fmt.Errorf("invalid addon ref %q: no version specified", args[0])
+	}
+	if !strings.HasPrefix(addonVer[1], "v") {
+		return fmt.Errorf("invalid addon ref %q: version must start with 'v'", args[0])
+	}
+
+	c, err := cloudquery_api.NewClientWithResponses(getEnvOrDefault(envAPIURL, defaultAPIURL),
+		cloudquery_api.WithRequestEditorFn(func(ctx context.Context, req *http.Request) error {
+			req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", token))
+			return nil
+		}))
+	if err != nil {
+		return fmt.Errorf("failed to create hub client: %w", err)
+	}
+
+	target, err := cmd.Flags().GetString("target")
+	if err != nil {
+		return err
+	}
+
+	addon, addonVersion, err := getAddonMetadata(ctx, c, addonParts[0], addonParts[1], addonVer[0], addonVer[1])
+	if err != nil {
+		return fmt.Errorf("failed to get addon metadata: %w", err)
+	}
+
+	if err := downloadAddon(ctx, c, addon.TeamName, addon.AddonType, addon.Name, addonVersion.Name, addon.AddonFormat, addonVersion.Checksum, target); err != nil {
+		return fmt.Errorf("download failed: %w", err)
+	}
+
+	return nil
+}
+
+func getAddonMetadata(ctx context.Context, c *cloudquery_api.ClientWithResponses, teamName, addonType, addonName, version string) (*cloudquery_api.Addon, *cloudquery_api.AddonVersion, error) {
+	addonResp, err := c.GetAddonWithResponse(ctx, teamName, cloudquery_api.AddonType(addonType), addonName)
+	if err != nil {
+		if addonResp == nil {
+			return nil, nil, fmt.Errorf("failed to get addon: %w", err)
+		}
+		return nil, nil, fmt.Errorf("failed to get addon: %w", errorFromHTTPResponse(addonResp.HTTPResponse, addonResp))
+	}
+
+	addonVersionResp, err := c.GetAddonVersionWithResponse(ctx, teamName, cloudquery_api.AddonType(addonType), addonName, version)
+	if err != nil {
+		if addonVersionResp == nil {
+			return nil, nil, fmt.Errorf("failed to get addon version: %w", err)
+		}
+		return nil, nil, fmt.Errorf("failed to get addon version: %w", errorFromHTTPResponse(addonVersionResp.HTTPResponse, addonVersionResp))
+	}
+	return addonResp.JSON200, addonVersionResp.JSON200, nil
+}
+
+func downloadAddon(ctx context.Context, c *cloudquery_api.ClientWithResponses, teamName string, addonType cloudquery_api.AddonType, addonName, version string, format cloudquery_api.AddonFormat, checksum, targetDir string) (retErr error) {
+	res, err := c.DownloadAddonAsset(ctx, teamName, addonType, addonName, version)
+	if err != nil {
+		return err
+	}
+	if res.StatusCode > 399 {
+		resp, err := cloudquery_api.ParseDownloadAddonAssetResponse(res)
+		if err != nil {
+			return fmt.Errorf("failed to parse %d response: %w", res.StatusCode, err)
+		}
+		return fmt.Errorf("failed to download addon: %w", errorFromHTTPResponse(resp.HTTPResponse, resp))
+	}
+
+	var (
+		fileWriter io.WriteCloser
+		size       int64
+	)
+
+	switch targetDir {
+	case "-":
+		fileWriter = os.Stdout
+	default:
+		filename := strings.Join([]string{teamName, string(addonType), addonName, version}, "_") + "." + string(format)
+		zipPath := filepath.Join(targetDir, filename)
+		f, err := os.Create(zipPath)
+		if err != nil {
+			return fmt.Errorf("failed to create file: %w", err)
+		}
+		fileWriter = f
+
+		defer func() {
+			if retErr != nil {
+				_ = os.Remove(zipPath)
+				return
+			}
+			fmt.Fprintf(os.Stderr, "Wrote %d bytes to %s\n", size, zipPath)
+		}()
+	}
+
+	shaWriter := sha256.New()
+	w := io.MultiWriter(fileWriter, shaWriter)
+	if size, err = io.Copy(w, res.Body); err != nil {
+		_ = fileWriter.Close()
+		return fmt.Errorf("failed to write: %w", err)
+	}
+	if err := fileWriter.Close(); err != nil {
+		return fmt.Errorf("failed to close: %w", err)
+	}
+	if err := res.Body.Close(); err != nil {
+		return fmt.Errorf("failed to close response body: %w", err)
+	}
+
+	writtenChecksum := fmt.Sprintf("%x", shaWriter.Sum(nil))
+	if writtenChecksum != checksum {
+		return fmt.Errorf("checksum mismatch: expected %s, got %s", checksum, writtenChecksum)
+	}
+
+	return nil
+}

--- a/cli/cmd/addon_download_test.go
+++ b/cli/cmd/addon_download_test.go
@@ -38,7 +38,6 @@ func TestAddonDownload(t *testing.T) {
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.Method != http.MethodGet {
 			t.Fatalf("unexpected method: %s %s", r.Method, r.URL.Path)
-			t.FailNow()
 		}
 		w.Header().Set("Content-Type", "application/json")
 		gotCalls[r.Method+" "+r.URL.Path]++
@@ -109,7 +108,6 @@ func TestAddonDownloadStdout(t *testing.T) {
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.Method != http.MethodGet {
 			t.Fatalf("unexpected method: %s %s", r.Method, r.URL.Path)
-			t.FailNow()
 		}
 		w.Header().Set("Content-Type", "application/json")
 		gotCalls[r.Method+" "+r.URL.Path]++

--- a/cli/cmd/addon_download_test.go
+++ b/cli/cmd/addon_download_test.go
@@ -1,0 +1,158 @@
+package cmd
+
+import (
+	"crypto/sha256"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+
+	cloudquery_api "github.com/cloudquery/cloudquery-api-go"
+	"github.com/google/go-cmp/cmp"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestAddonDownload(t *testing.T) {
+	t.Setenv("CLOUDQUERY_API_KEY", "testkey")
+
+	tempDir := t.TempDir()
+	expectedFileAndPath := filepath.Join(tempDir, "cloudquery_visualization_test_v1.2.3.zip")
+
+	wantCalls := map[string]int{
+		"GET /addons/cloudquery/visualization/test":                        1,
+		"GET /addons/cloudquery/visualization/test/versions/v1.2.3":        1,
+		"GET /addons/cloudquery/visualization/test/versions/v1.2.3/assets": 1,
+		"GET /asset-zip": 1,
+	}
+
+	payload := []byte("test payload")
+
+	s := sha256.New()
+	s.Write(payload)
+	payloadChecksum := fmt.Sprintf("%x", s.Sum(nil))
+
+	gotCalls := map[string]int{}
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			t.Fatalf("unexpected method: %s %s", r.Method, r.URL.Path)
+			t.FailNow()
+		}
+		w.Header().Set("Content-Type", "application/json")
+		gotCalls[r.Method+" "+r.URL.Path]++
+		switch r.URL.Path {
+		case "/addons/cloudquery/visualization/test":
+			checkAuthHeader(t, r)
+			w.WriteHeader(http.StatusOK)
+			b, _ := json.Marshal(cloudquery_api.Addon{
+				AddonFormat: cloudquery_api.Zip,
+				AddonType:   cloudquery_api.Visualization,
+				Name:        "test",
+				TeamName:    "cloudquery",
+			})
+			w.Write(b)
+		case "/addons/cloudquery/visualization/test/versions/v1.2.3":
+			checkAuthHeader(t, r)
+			w.WriteHeader(http.StatusOK)
+			b, _ := json.Marshal(cloudquery_api.AddonVersion{
+				Checksum: payloadChecksum,
+				Name:     "v1.2.3",
+			})
+			w.Write(b)
+		case "/addons/cloudquery/visualization/test/versions/v1.2.3/assets":
+			checkAuthHeader(t, r)
+			w.Header().Set("Location", "http://"+r.Host+"/asset-zip")
+			w.WriteHeader(http.StatusFound)
+		case "/asset-zip":
+			w.Header().Set("Content-Type", "application/octet-stream")
+			w.WriteHeader(http.StatusOK)
+			w.Write(payload)
+		}
+	}))
+	defer ts.Close()
+
+	cmd := NewCmdRoot()
+	t.Setenv(envAPIURL, ts.URL)
+	args := []string{"addon", "download", "cloudquery/visualization/test@v1.2.3", "-t", tempDir}
+	cmd.SetArgs(args)
+	err := cmd.Execute()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if diff := cmp.Diff(wantCalls, gotCalls); diff != "" {
+		t.Fatalf("mismatch (-want +got):\n%s", diff)
+	}
+
+	_, err = os.Stat(expectedFileAndPath)
+	assert.NoError(t, err, "expected file %s to exist", expectedFileAndPath)
+}
+
+func TestAddonDownloadStdout(t *testing.T) {
+	t.Setenv("CLOUDQUERY_API_KEY", "testkey")
+
+	wantCalls := map[string]int{
+		"GET /addons/cloudquery/visualization/test":                        1,
+		"GET /addons/cloudquery/visualization/test/versions/v1.2.3":        1,
+		"GET /addons/cloudquery/visualization/test/versions/v1.2.3/assets": 1,
+		"GET /asset-zip": 1,
+	}
+
+	payload := []byte("payload to stdout")
+
+	s := sha256.New()
+	s.Write(payload)
+	payloadChecksum := fmt.Sprintf("%x", s.Sum(nil))
+
+	gotCalls := map[string]int{}
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			t.Fatalf("unexpected method: %s %s", r.Method, r.URL.Path)
+			t.FailNow()
+		}
+		w.Header().Set("Content-Type", "application/json")
+		gotCalls[r.Method+" "+r.URL.Path]++
+		switch r.URL.Path {
+		case "/addons/cloudquery/visualization/test":
+			checkAuthHeader(t, r)
+			w.WriteHeader(http.StatusOK)
+			b, _ := json.Marshal(cloudquery_api.Addon{
+				AddonFormat: cloudquery_api.Zip,
+				AddonType:   cloudquery_api.Visualization,
+				Name:        "test",
+				TeamName:    "cloudquery",
+			})
+			w.Write(b)
+		case "/addons/cloudquery/visualization/test/versions/v1.2.3":
+			checkAuthHeader(t, r)
+			w.WriteHeader(http.StatusOK)
+			b, _ := json.Marshal(cloudquery_api.AddonVersion{
+				Checksum: payloadChecksum,
+				Name:     "v1.2.3",
+			})
+			w.Write(b)
+		case "/addons/cloudquery/visualization/test/versions/v1.2.3/assets":
+			checkAuthHeader(t, r)
+			w.Header().Set("Location", "http://"+r.Host+"/asset-zip")
+			w.WriteHeader(http.StatusFound)
+		case "/asset-zip":
+			w.Header().Set("Content-Type", "application/octet-stream")
+			w.WriteHeader(http.StatusOK)
+			w.Write(payload)
+		}
+	}))
+	defer ts.Close()
+
+	cmd := NewCmdRoot()
+	t.Setenv(envAPIURL, ts.URL)
+	args := []string{"addon", "download", "cloudquery/visualization/test@v1.2.3", "-t", "-"}
+	cmd.SetArgs(args)
+	err := cmd.Execute()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if diff := cmp.Diff(wantCalls, gotCalls); diff != "" {
+		t.Fatalf("mismatch (-want +got):\n%s", diff)
+	}
+}

--- a/cli/cmd/addon_publish.go
+++ b/cli/cmd/addon_publish.go
@@ -156,7 +156,7 @@ func createNewAddonDraftVersion(ctx context.Context, c *cloudquery_api.ClientWit
 	}
 	body := cloudquery_api.CreateAddonVersionJSONRequestBody{
 		AddonDeps:  &manifest.AddonDeps,
-		PluginDeps: manifest.PluginDeps,
+		PluginDeps: &manifest.PluginDeps,
 	}
 
 	if manifest.PathToDoc != "" {

--- a/cli/cmd/doc_test.go
+++ b/cli/cmd/doc_test.go
@@ -12,6 +12,7 @@ import (
 var docFiles = []string{
 	"cloudquery.md",
 	"cloudquery_addon.md",
+	"cloudquery_addon_download.md",
 	"cloudquery_addon_publish.md",
 	"cloudquery_login.md",
 	"cloudquery_logout.md",

--- a/cli/cmd/root.go
+++ b/cli/cmd/root.go
@@ -138,6 +138,7 @@ func NewCmdRoot() *cobra.Command {
 		Short: "Addon commands",
 	}
 	addonCmd.AddCommand(
+		newCmdAddonDownload(),
 		newCmdAddonPublish(),
 	)
 

--- a/cli/cmd/testdata/addon-v1/manifest.json
+++ b/cli/cmd/testdata/addon-v1/manifest.json
@@ -8,5 +8,6 @@
   "message": "./changelog.md",
   "doc": "./readme.md",
   "path": "./test.zip",
-  "plugin_deps": ["cloudquery/source/test@v1.0.0"]
+  "plugin_deps": ["cloudquery/source/test@v1.0.0"],
+  "addon_deps": []
 }

--- a/cli/go.mod
+++ b/cli/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/apache/arrow/go/v14 v14.0.0-20231031200323-c49e24273160
 	github.com/bradleyjkemp/cupaloy/v2 v2.8.0
 	github.com/cenkalti/backoff/v4 v4.2.1
-	github.com/cloudquery/cloudquery-api-go v1.4.2
+	github.com/cloudquery/cloudquery-api-go v1.4.3
 	github.com/cloudquery/plugin-pb-go v1.13.4
 	github.com/cloudquery/plugin-sdk/v4 v4.17.1
 	github.com/getsentry/sentry-go v0.24.1

--- a/cli/go.sum
+++ b/cli/go.sum
@@ -44,8 +44,8 @@ github.com/chenzhuoyu/iasm v0.9.0 h1:9fhXjVzq5hUy2gkhhgHl95zG2cEAhw9OSGs8toWWAwo
 github.com/chenzhuoyu/iasm v0.9.0/go.mod h1:Xjy2NpN3h7aUqeqM+woSuuvxmIe6+DDsiNLIrkAmYog=
 github.com/cloudquery/arrow/go/v14 v14.0.0-20231023001216-f46436fa3561 h1:sXA8imGI4P8EPdycL1w7mzigIHx2KqyntgAqGuTgTi8=
 github.com/cloudquery/arrow/go/v14 v14.0.0-20231023001216-f46436fa3561/go.mod h1:u3fgh3EdgN/YQ8cVQRguVW3R+seMybFg8QBQ5LU+eBY=
-github.com/cloudquery/cloudquery-api-go v1.4.2 h1:mGSYf+GVXW3FF8YCYer1Cf0fwtBuTMEEiIDozm19TQQ=
-github.com/cloudquery/cloudquery-api-go v1.4.2/go.mod h1:03fojQg0UpdgqXZ9tzZ5gF5CPad/F0sok66bsX6u4RA=
+github.com/cloudquery/cloudquery-api-go v1.4.3 h1:G8JZiwwHDnoNrRhBVRfXve/DGsx1kJLC4+1ggQLz29I=
+github.com/cloudquery/cloudquery-api-go v1.4.3/go.mod h1:03fojQg0UpdgqXZ9tzZ5gF5CPad/F0sok66bsX6u4RA=
 github.com/cloudquery/plugin-pb-go v1.13.4 h1:LyuQy2luWlhIeZaTx081VXaQVE8bhTIdP3J1fwVrYDE=
 github.com/cloudquery/plugin-pb-go v1.13.4/go.mod h1:dNiUZSWSoohVGPm/2ROPlToW+QyqU+EJIAZ866+oz+c=
 github.com/cloudquery/plugin-sdk/v4 v4.17.1 h1:BQkDpWThRfqq5jKld9r7FAwfoXHV3+kMqaWTO+Wr//M=

--- a/website/pages/docs/reference/cli/cloudquery_addon_download.md
+++ b/website/pages/docs/reference/cli/cloudquery_addon_download.md
@@ -1,14 +1,34 @@
 ---
-title: "addon"
+title: "addon_download"
 ---
-## cloudquery addon
+## cloudquery addon download
 
-Addon commands
+Download addon from CloudQuery Hub.
+
+### Synopsis
+
+Download addon from CloudQuery Hub.
+
+This downloads an addon from CloudQuery Hub to local disk.
+
+
+```
+cloudquery addon download addon-team/transformation/addon-name@v1.0.0 [-t directory] [flags]
+```
+
+### Examples
+
+```
+
+# Download an addon to local disk
+cloudquery addon download addon-team/transformation/addon-name@v1.0.0
+```
 
 ### Options
 
 ```
-  -h, --help   help for addon
+  -h, --help            help for download
+  -t, --target string   Download to specified directory (default ".")
 ```
 
 ### Options inherited from parent commands
@@ -25,7 +45,5 @@ Addon commands
 
 ### SEE ALSO
 
-* [cloudquery](/docs/reference/cli/cloudquery)	 - CloudQuery CLI
-* [cloudquery addon download](/docs/reference/cli/cloudquery_addon_download)	 - Download addon from CloudQuery Hub.
-* [cloudquery addon publish](/docs/reference/cli/cloudquery_addon_publish)	 - Publish to CloudQuery Hub.
+* [cloudquery addon](/docs/reference/cli/cloudquery_addon)	 - Addon commands
 

--- a/website/pages/docs/reference/cli/cloudquery_addon_download.md
+++ b/website/pages/docs/reference/cli/cloudquery_addon_download.md
@@ -13,7 +13,7 @@ This downloads an addon from CloudQuery Hub to local disk.
 
 
 ```
-cloudquery addon download addon-team/transformation/addon-name@v1.0.0 [-t directory] [flags]
+cloudquery addon download addon-team/addon-type/addon-name@v1.0.0 [-t directory] [flags]
 ```
 
 ### Examples
@@ -21,14 +21,14 @@ cloudquery addon download addon-team/transformation/addon-name@v1.0.0 [-t direct
 ```
 
 # Download an addon to local disk
-cloudquery addon download addon-team/transformation/addon-name@v1.0.0
+cloudquery addon download addon-team/addon-type/addon-name@v1.0.0
 ```
 
 ### Options
 
 ```
   -h, --help            help for download
-  -t, --target string   Download to specified directory (default ".")
+  -t, --target string   Download to specified directory. Use - for stdout (default ".")
 ```
 
 ### Options inherited from parent commands


### PR DESCRIPTION
```
cloudquery addon download addon-team/addon-type/addon-name@v1.0.0
cloudquery addon download addon-team/addon-type/addon-name@v1.0.0 -t /path/to/dest/dir
cloudquery addon download addon-team/addon-type/addon-name@v1.0.0 -t - | jar t
```

(Apparently the regular infozip `unzip` can't read from stdin? but `jar` can...)

