### PR TITLE
refactor: Moving client and configuration to be more inline with other plugins e.g. Gandi

### DIFF
--- a/plugins/source/googleanalytics/client/client.go
+++ b/plugins/source/googleanalytics/client/client.go
@@ -2,129 +2,24 @@ package client
 
 import (
 	"context"
-	"encoding/json"
-	"fmt"
-
-	"github.com/cloudquery/plugin-sdk/v4/message"
-	"github.com/cloudquery/plugin-sdk/v4/plugin"
-	"github.com/cloudquery/plugin-sdk/v4/scheduler"
 	"github.com/cloudquery/plugin-sdk/v4/schema"
 	"github.com/cloudquery/plugin-sdk/v4/state"
 	"github.com/rs/zerolog"
 	analyticsdata "google.golang.org/api/analyticsdata/v1beta"
 	"google.golang.org/api/option"
-	"google.golang.org/grpc"
-	"google.golang.org/grpc/credentials/insecure"
-)
-
-const (
-	maxMsgSize = 100 * 1024 * 1024 // 100 MiB
 )
 
 type Client struct {
-	plugin.UnimplementedDestination
-	scheduler *scheduler.Scheduler
-	options   plugin.NewClientOptions
-	service   *analyticsdata.Service
-	backend   state.Client
-
-	reports []Report
-
-	PropertyID string
-	StartDate  string
+	service *analyticsdata.Service
+	Spec    Spec
+	backend state.Client
 
 	logger zerolog.Logger
 }
 
 var _ schema.ClientMeta = (*Client)(nil)
 
-func (c *Client) Logger() *zerolog.Logger {
-	return &c.logger
-}
-
-func (c *Client) ID() string {
-	return "googleanalytics:property-id:{" + c.PropertyID + "}"
-}
-
-func (*Client) Close(_ context.Context) error {
-	return nil
-}
-
-func (c *Client) Tables(_ context.Context, options plugin.TableOptions) (schema.Tables, error) {
-	if c.options.NoConnection {
-		return schema.Tables{}, nil
-	}
-	tables := make(schema.Tables, len(c.reports))
-	for i, r := range c.reports {
-		tables[i] = r.table(c.PropertyID)
-	}
-	tables, err := tables.FilterDfs(options.Tables, options.SkipTables, options.SkipDependentTables)
-	if err != nil {
-		return nil, err
-	}
-	return tables, nil
-}
-
-func (c *Client) Sync(ctx context.Context, options plugin.SyncOptions, res chan<- message.SyncMessage) error {
-	if c.options.NoConnection {
-		return fmt.Errorf("no connection")
-	}
-
-	var stateClient state.Client
-	if options.BackendOptions == nil {
-		c.logger.Info().Msg("No backend options provided, using no state backend")
-		stateClient = &state.NoOpClient{}
-	} else {
-		conn, err := grpc.DialContext(ctx, options.BackendOptions.Connection,
-			grpc.WithTransportCredentials(insecure.NewCredentials()),
-			grpc.WithDefaultCallOptions(
-				grpc.MaxCallRecvMsgSize(maxMsgSize),
-				grpc.MaxCallSendMsgSize(maxMsgSize),
-			),
-		)
-		if err != nil {
-			return fmt.Errorf("failed to dial grpc source plugin at %s: %w", options.BackendOptions.Connection, err)
-		}
-		stateClient, err = state.NewClient(ctx, conn, options.BackendOptions.TableName)
-		if err != nil {
-			return fmt.Errorf("failed to create state client: %w", err)
-		}
-		c.logger.Info().Str("table_name", options.BackendOptions.TableName).Msg("Connected to state backend")
-	}
-	c.backend = stateClient
-
-	tables, err := c.Tables(ctx, plugin.TableOptions{
-		Tables:              options.Tables,
-		SkipTables:          options.SkipTables,
-		SkipDependentTables: options.SkipDependentTables,
-	})
-	if err != nil {
-		return err
-	}
-	err = c.scheduler.Sync(ctx, c, tables, res, scheduler.WithSyncDeterministicCQID(options.DeterministicCQID))
-	if err != nil {
-		return fmt.Errorf("failed to sync: %w", err)
-	}
-	return stateClient.Flush(ctx)
-}
-
-func Configure(ctx context.Context, logger zerolog.Logger, specBytes []byte, options plugin.NewClientOptions) (plugin.Client, error) {
-	if options.NoConnection {
-		return &Client{
-			logger:  logger,
-			options: options,
-		}, nil
-	}
-	spec := new(Spec)
-	if err := json.Unmarshal(specBytes, spec); err != nil {
-		return nil, err
-	}
-
-	spec.setDefaults()
-	if err := spec.validate(); err != nil {
-		return nil, err
-	}
-
+func New(ctx context.Context, logger zerolog.Logger, spec Spec, backend state.Client) (*Client, error) {
 	opts := []option.ClientOption{
 		option.WithScopes(analyticsdata.AnalyticsReadonlyScope),
 		option.WithRequestReason("cloudquery resource fetch"),
@@ -140,23 +35,25 @@ func Configure(ctx context.Context, logger zerolog.Logger, specBytes []byte, opt
 		opts = append(opts, option.WithTokenSource(tokenSource))
 	}
 
-	svc, err := analyticsdata.NewService(context.Background(), opts...)
+	svc, err := analyticsdata.NewService(ctx, opts...)
 	if err != nil {
 		return nil, err
 	}
 
 	svc.UserAgent = "cloudquery:source-googleanalytics"
 
-	c := &Client{
-		service:    svc,
-		StartDate:  spec.StartDate,
-		PropertyID: spec.PropertyID,
-		reports:    spec.Reports,
-		logger: logger.With().
-			Str("plugin", "googleanalytics").
-			Str("property_id", spec.PropertyID).
-			Logger(),
-	}
-	c.scheduler = scheduler.NewScheduler(scheduler.WithConcurrency(spec.Concurrency))
-	return c, nil
+	return &Client{
+		logger:  logger,
+		Spec:    spec,
+		backend: backend,
+		service: svc,
+	}, nil
+}
+
+func (c *Client) Logger() *zerolog.Logger {
+	return &c.logger
+}
+
+func (c *Client) ID() string {
+	return "googleanalytics:property-id:{" + c.Spec.PropertyID + "}"
 }

--- a/plugins/source/googleanalytics/client/columns.go
+++ b/plugins/source/googleanalytics/client/columns.go
@@ -14,7 +14,7 @@ var PropertyIDColumn = schema.Column{
 	PrimaryKey:  true,
 	NotNull:     true,
 	Resolver: func(_ context.Context, m schema.ClientMeta, r *schema.Resource, c schema.Column) error {
-		return r.Set(c.Name, m.(*Client).PropertyID)
+		return r.Set(c.Name, m.(*Client).Spec.PropertyID)
 	},
 }
 

--- a/plugins/source/googleanalytics/client/fetch.go
+++ b/plugins/source/googleanalytics/client/fetch.go
@@ -13,7 +13,7 @@ func fetch(tableName string, request *analyticsdata.RunReportRequest) schema.Tab
 		c := meta.(*Client)
 		logger := c.Logger().With().Str("table", tableName).Logger()
 
-		req := c.service.Properties.RunReport(c.PropertyID, request).Context(ctx)
+		req := c.service.Properties.RunReport(c.Spec.PropertyID, request).Context(ctx)
 
 		dates, err := genDates(ctx, c, tableName)
 		if err != nil {

--- a/plugins/source/googleanalytics/client/report.go
+++ b/plugins/source/googleanalytics/client/report.go
@@ -84,7 +84,7 @@ func (r *Report) toGA(propertyID string) *analyticsdata.RunReportRequest {
 	return req
 }
 
-func (r *Report) table(propertyID string) *schema.Table {
+func (r *Report) Table(propertyID string) *schema.Table {
 	tableName := "ga_" + r.Name
 	return &schema.Table{
 		Name:          tableName,

--- a/plugins/source/googleanalytics/client/spec.go
+++ b/plugins/source/googleanalytics/client/spec.go
@@ -36,7 +36,7 @@ type Spec struct {
 	Concurrency int `json:"concurrency,omitempty" jsonschema:"minimum=1,default=10000"`
 }
 
-func (s *Spec) setDefaults() {
+func (s *Spec) SetDefaults() {
 	if len(s.StartDate) == 0 {
 		// date 7 days prior
 		s.StartDate = time.Now().UTC().Add(-7 * 24 * time.Hour).Format(time.DateOnly)
@@ -50,7 +50,7 @@ func (s *Spec) setDefaults() {
 func (Spec) JSONSchemaExtend(sc *jsonschema.Schema) {
 }
 
-func (s *Spec) validate() error {
+func (s *Spec) Validate() error {
 	if len(s.PropertyID) == 0 {
 		return fmt.Errorf(`required field "property_id" is missing`)
 	}

--- a/plugins/source/googleanalytics/client/time.go
+++ b/plugins/source/googleanalytics/client/time.go
@@ -11,7 +11,7 @@ func genDates(ctx context.Context, c *Client, table string) (<-chan time.Time, e
 		return nil, err
 	}
 
-	startDate := c.StartDate
+	startDate := c.Spec.StartDate
 	if len(res) > 0 {
 		startDate = res
 	}

--- a/plugins/source/googleanalytics/go.mod
+++ b/plugins/source/googleanalytics/go.mod
@@ -13,6 +13,7 @@ require (
 	golang.org/x/exp v0.0.0-20231006140011-7918f672742d
 	golang.org/x/oauth2 v0.10.0
 	google.golang.org/api v0.126.0
+	google.golang.org/grpc v1.58.3
 )
 
 require (
@@ -128,7 +129,6 @@ require (
 	google.golang.org/genproto v0.0.0-20230920204549-e6e6cdab5c13 // indirect
 	google.golang.org/genproto/googleapis/api v0.0.0-20230920204549-e6e6cdab5c13 // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20231002182017-d307bd883b97 // indirect
-	google.golang.org/grpc v1.58.3 // indirect
 	google.golang.org/protobuf v1.31.0 // indirect
 	gopkg.in/ini.v1 v1.67.0 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect

--- a/plugins/source/googleanalytics/go.mod
+++ b/plugins/source/googleanalytics/go.mod
@@ -13,7 +13,6 @@ require (
 	golang.org/x/exp v0.0.0-20231006140011-7918f672742d
 	golang.org/x/oauth2 v0.10.0
 	google.golang.org/api v0.126.0
-	google.golang.org/grpc v1.58.3
 )
 
 require (
@@ -129,6 +128,7 @@ require (
 	google.golang.org/genproto v0.0.0-20230920204549-e6e6cdab5c13 // indirect
 	google.golang.org/genproto/googleapis/api v0.0.0-20230920204549-e6e6cdab5c13 // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20231002182017-d307bd883b97 // indirect
+	google.golang.org/grpc v1.58.3 // indirect
 	google.golang.org/protobuf v1.31.0 // indirect
 	gopkg.in/ini.v1 v1.67.0 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect

--- a/plugins/source/googleanalytics/resources/plugin/client.go
+++ b/plugins/source/googleanalytics/resources/plugin/client.go
@@ -1,0 +1,124 @@
+package plugin
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"github.com/cloudquery/cloudquery/plugins/source/googleanalytics/client"
+
+	"github.com/cloudquery/plugin-sdk/v4/message"
+	"github.com/cloudquery/plugin-sdk/v4/plugin"
+	"github.com/cloudquery/plugin-sdk/v4/scheduler"
+	"github.com/cloudquery/plugin-sdk/v4/schema"
+	"github.com/cloudquery/plugin-sdk/v4/state"
+	"github.com/rs/zerolog"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
+)
+
+const (
+	maxMsgSize = 100 * 1024 * 1024 // 100 MiB
+)
+
+type Client struct {
+	plugin.UnimplementedDestination
+	scheduler *scheduler.Scheduler
+	options   plugin.NewClientOptions
+	spec      client.Spec
+
+	logger zerolog.Logger
+}
+
+func (*Client) Close(_ context.Context) error {
+	return nil
+}
+
+func (c *Client) Tables(_ context.Context, options plugin.TableOptions) (schema.Tables, error) {
+	if c.options.NoConnection {
+		return schema.Tables{}, nil
+	}
+	tables := make(schema.Tables, len(c.spec.Reports))
+	for i, r := range c.spec.Reports {
+		tables[i] = r.Table(c.spec.PropertyID)
+	}
+	tables, err := tables.FilterDfs(options.Tables, options.SkipTables, options.SkipDependentTables)
+	if err != nil {
+		return nil, err
+	}
+	return tables, nil
+}
+
+func (c *Client) Sync(ctx context.Context, options plugin.SyncOptions, res chan<- message.SyncMessage) error {
+	if c.options.NoConnection {
+		return fmt.Errorf("no connection")
+	}
+
+	var stateClient state.Client
+	if options.BackendOptions == nil {
+		c.logger.Info().Msg("No backend options provided, using no state backend")
+		stateClient = &state.NoOpClient{}
+	} else {
+		conn, err := grpc.DialContext(ctx, options.BackendOptions.Connection,
+			grpc.WithTransportCredentials(insecure.NewCredentials()),
+			grpc.WithDefaultCallOptions(
+				grpc.MaxCallRecvMsgSize(maxMsgSize),
+				grpc.MaxCallSendMsgSize(maxMsgSize),
+			),
+		)
+		if err != nil {
+			return fmt.Errorf("failed to dial grpc source plugin at %s: %w", options.BackendOptions.Connection, err)
+		}
+		stateClient, err = state.NewClient(ctx, conn, options.BackendOptions.TableName)
+		if err != nil {
+			return fmt.Errorf("failed to create state client: %w", err)
+		}
+		c.logger.Info().Str("table_name", options.BackendOptions.TableName).Msg("Connected to state backend")
+	}
+
+	tables, err := c.Tables(ctx, plugin.TableOptions{
+		Tables:              options.Tables,
+		SkipTables:          options.SkipTables,
+		SkipDependentTables: options.SkipDependentTables,
+	})
+	if err != nil {
+		return err
+	}
+	syncClient, err := client.New(ctx, c.logger, c.spec, stateClient)
+	if err != nil {
+		return err
+	}
+	err = c.scheduler.Sync(ctx, syncClient, tables, res, scheduler.WithSyncDeterministicCQID(options.DeterministicCQID))
+	if err != nil {
+		return fmt.Errorf("failed to sync: %w", err)
+	}
+	return stateClient.Flush(ctx)
+}
+
+func Configure(ctx context.Context, logger zerolog.Logger, specBytes []byte, options plugin.NewClientOptions) (plugin.Client, error) {
+	if options.NoConnection {
+		return &Client{
+			logger:  logger,
+			options: options,
+		}, nil
+	}
+	spec := new(client.Spec)
+	if err := json.Unmarshal(specBytes, spec); err != nil {
+		return nil, err
+	}
+
+	spec.SetDefaults()
+	if err := spec.Validate(); err != nil {
+		return nil, err
+	}
+
+	c := &Client{
+		spec:    *spec,
+		options: options,
+		logger: logger.With().
+			Str("plugin", "googleanalytics").
+			Str("property_id", spec.PropertyID).
+			Logger(),
+	}
+	c.scheduler = scheduler.NewScheduler(scheduler.WithConcurrency(spec.Concurrency))
+	return c, nil
+}

--- a/plugins/source/googleanalytics/resources/plugin/plugin.go
+++ b/plugins/source/googleanalytics/resources/plugin/plugin.go
@@ -1,7 +1,6 @@
 package plugin
 
 import (
-	"github.com/cloudquery/cloudquery/plugins/source/googleanalytics/client"
 	"github.com/cloudquery/plugin-sdk/v4/plugin"
 )
 
@@ -16,7 +15,7 @@ func Plugin() *plugin.Plugin {
 	return plugin.NewPlugin(
 		Name,
 		Version,
-		client.Configure,
+		Configure,
 		plugin.WithKind(Kind),
 		plugin.WithTeam(Team),
 	)


### PR DESCRIPTION
This mostly was about breaking out the existing `Client` struct into a googleanalytics service and a plugin client, which is typically how it is done in other plugins.
