### PR TITLE
chore: Disable github.com/cloudquery/cloudquery-api-go updates for plugins

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -20,7 +20,7 @@
       allowedVersions: "<5",
     },
     {
-      matchPackageNames: ["github.com/cloudquery/plugin-pb-go"],
+      matchPackageNames: ["github.com/cloudquery/plugin-pb-go", "github.com/cloudquery/cloudquery-api-go"],
       matchFileNames: ["plugins/**"],
       enabled: false,
     },


### PR DESCRIPTION
<!-- 🎉 Thank you for making CloudQuery awesome by submitting a PR 🎉 -->

#### Summary

Similar to `plugin-pb-go`, `cloudquery-api-go` is an indirect dependency for plugins and will be updated via SDK updates. So no need for https://github.com/cloudquery/cloudquery/pull/15167

<!--
Use the following steps to ensure your PR is ready to be reviewed

- [ ] Read the [contribution guidelines](../blob/main/CONTRIBUTING.md) 🧑‍🎓
- [ ] Run `make lint` to ensure the proposed changes follow the coding style 🚨 (install golangci-lint [here](https://golangci-lint.run/usage/install/#local-installation))
- [ ] Run `make test` to ensure the proposed changes pass the tests 🧪
- [ ] If changing a source plugin run `make gen` to ensure docs are up to date 📝
- [ ] Ensure the status checks below are successful ✅
--->
