### PR TITLE
fix: Check proper table options for `aws_alpha_costexplorer_cost_custom`

### DIFF
--- a/plugins/source/aws/resources/services/costexplorer/cost_custom.go
+++ b/plugins/source/aws/resources/services/costexplorer/cost_custom.go
@@ -72,12 +72,12 @@ type wrappedResultByTime struct {
 func fetchCustom(ctx context.Context, meta schema.ClientMeta, parent *schema.Resource, res chan<- any) error {
 	cl := meta.(*client.Client)
 
-	if len(cl.Spec.TableOptions.CloudwatchMetrics) > 0 && !cl.Spec.UsePaidAPIs {
-		return client.ErrPaidAPIsNotEnabled
-	}
-
 	if cl.Spec.TableOptions.CustomCostExplorer == nil {
 		return fmt.Errorf("skipping `%s` because `get_cost_and_usage` is not specified in `table_options`", tableName)
+	}
+
+	if !cl.Spec.UsePaidAPIs {
+		return client.ErrPaidAPIsNotEnabled
 	}
 
 	svc := cl.Services(client.AWSServiceCostexplorer).Costexplorer


### PR DESCRIPTION
I suspect this was a copy-paste induced typo, as there's no other place in the `aws_alpha_costexplorer_cost_custom` resolver where we access the `CloudwatchMetrics` member of table options.