### PR TITLE
feat: Add teamName to managed plugin configuration

### DIFF
--- a/cli/cmd/install.go
+++ b/cli/cmd/install.go
@@ -55,11 +55,15 @@ func installPlugin(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return fmt.Errorf("failed to get auth token: %w", err)
 	}
-
+	teamName, err := auth.GetTeamForToken(authToken)
+	if err != nil {
+		return fmt.Errorf("failed to get team name: %w", err)
+	}
 	opts := []managedplugin.Option{
 		managedplugin.WithNoExec(),
 		managedplugin.WithLogger(log.Logger),
-		managedplugin.WithAuthToken(authToken),
+		managedplugin.WithAuthToken(authToken.Value),
+		managedplugin.WithTeamName(teamName),
 	}
 	if cqDir != "" {
 		opts = append(opts, managedplugin.WithDirectory(cqDir))

--- a/cli/cmd/migrate.go
+++ b/cli/cmd/migrate.go
@@ -54,10 +54,14 @@ func migrate(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return fmt.Errorf("failed to get auth token: %w", err)
 	}
-
+	teamName, err := auth.GetTeamForToken(authToken)
+	if err != nil {
+		return fmt.Errorf("failed to get team name: %w", err)
+	}
 	opts := []managedplugin.Option{
 		managedplugin.WithLogger(log.Logger),
-		managedplugin.WithAuthToken(authToken),
+		managedplugin.WithAuthToken(authToken.Value),
+		managedplugin.WithTeamName(teamName),
 	}
 	if cqDir != "" {
 		opts = append(opts, managedplugin.WithDirectory(cqDir))

--- a/cli/cmd/sync.go
+++ b/cli/cmd/sync.go
@@ -110,11 +110,16 @@ func sync(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return fmt.Errorf("failed to get auth token: %w", err)
 	}
+	teamName, err := auth.GetTeamForToken(authToken)
+	if err != nil {
+		return fmt.Errorf("failed to get team name from token: %w", err)
+	}
 	for _, source := range sources {
 		opts := []managedplugin.Option{
 			managedplugin.WithLogger(log.Logger),
 			managedplugin.WithOtelEndpoint(source.OtelEndpoint),
-			managedplugin.WithAuthToken(authToken),
+			managedplugin.WithAuthToken(authToken.Value),
+			managedplugin.WithTeamName(teamName),
 		}
 		if cqDir != "" {
 			opts = append(opts, managedplugin.WithDirectory(cqDir))
@@ -147,7 +152,7 @@ func sync(cmd *cobra.Command, args []string) error {
 	for _, destination := range destinations {
 		opts := []managedplugin.Option{
 			managedplugin.WithLogger(log.Logger),
-			managedplugin.WithAuthToken(authToken),
+			managedplugin.WithAuthToken(authToken.Value),
 		}
 		if cqDir != "" {
 			opts = append(opts, managedplugin.WithDirectory(cqDir))

--- a/cli/cmd/tables.go
+++ b/cli/cmd/tables.go
@@ -63,9 +63,10 @@ func tables(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return fmt.Errorf("failed to get auth token: %w", err)
 	}
+	//TODO: add team name
 	opts := []managedplugin.Option{
 		managedplugin.WithLogger(log.Logger),
-		managedplugin.WithAuthToken(authToken),
+		managedplugin.WithAuthToken(authToken.Value),
 	}
 	if cqDir != "" {
 		opts = append(opts, managedplugin.WithDirectory(cqDir))

--- a/cli/cmd/tables.go
+++ b/cli/cmd/tables.go
@@ -63,10 +63,14 @@ func tables(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return fmt.Errorf("failed to get auth token: %w", err)
 	}
-	//TODO: add team name
+	teamName, err := auth.GetTeamForToken(authToken)
+	if err != nil {
+		return fmt.Errorf("failed to get team name: %w", err)
+	}
 	opts := []managedplugin.Option{
 		managedplugin.WithLogger(log.Logger),
 		managedplugin.WithAuthToken(authToken.Value),
+		managedplugin.WithTeamName(teamName),
 	}
 	if cqDir != "" {
 		opts = append(opts, managedplugin.WithDirectory(cqDir))

--- a/cli/internal/auth/team.go
+++ b/cli/internal/auth/team.go
@@ -1,0 +1,21 @@
+package auth
+
+import (
+	"fmt"
+	"github.com/cloudquery/cloudquery-api-go/auth"
+	"github.com/cloudquery/cloudquery-api-go/config"
+)
+
+// GetTeamForToken returns the team for the given token
+// If the token is a bearer token, we need to get the team from the configuration.
+// For api keys the team name is not required as the key is bound to a team name already.
+func GetTeamForToken(token auth.Token) (string, error) {
+	if token.Type == auth.BearerToken {
+		team, err := config.GetValue("team")
+		if err != nil {
+			return "", fmt.Errorf("failed to get team from config: %w", err)
+		}
+		return team, nil
+	}
+	return "", nil
+}

--- a/cli/internal/auth/token.go
+++ b/cli/internal/auth/token.go
@@ -26,11 +26,11 @@ func destinationsNeedToken(destinations []*specs.Destination) bool {
 	return false
 }
 
-func GetAuthTokenIfNeeded(logger zerolog.Logger, sources []*specs.Source, destinations []*specs.Destination) (string, error) {
+func GetAuthTokenIfNeeded(logger zerolog.Logger, sources []*specs.Source, destinations []*specs.Destination) (cqapiauth.Token, error) {
 	needsToken := sourcesNeedToken(sources) || destinationsNeedToken(destinations)
 	if !needsToken {
 		logger.Debug().Msg("no need to get token since no source or destination uses the CloudQuery registry")
-		return "", nil
+		return cqapiauth.UndefinedToken, nil
 	}
 
 	tc := cqapiauth.NewTokenClient()
@@ -39,11 +39,11 @@ func GetAuthTokenIfNeeded(logger zerolog.Logger, sources []*specs.Source, destin
 		recommendLogin := strings.Contains(err.Error(), "Hint:")
 		if recommendLogin {
 			logger.Warn().Msg("when using the CloudQuery registry, it's recommended to log in via `cloudquery login`. Logging in allows for better rate limits and downloading of premium plugins")
-			return "", nil
+			return cqapiauth.UndefinedToken, nil
 		}
 
-		return "", err
+		return cqapiauth.UndefinedToken, err
 	}
 
-	return token.Value, nil
+	return token, nil
 }


### PR DESCRIPTION
This adds the team name to the managed plugins configuration, which will use the `/team/*` endpoints to download plugins - allowing plugin downloads to be attributed to the correct team


fixes: https://github.com/cloudquery/cloudquery-issues/issues/835