### PR TITLE
chore: Update CLI `plugin docs` command help text

### DIFF
--- a/cli/cmd/plugin_docs_download.go
+++ b/cli/cmd/plugin_docs_download.go
@@ -23,12 +23,12 @@ This downloads documentation for a specific plugin version in CloudQuery hub to 
 `
 	pluginDocsDownloadExample = `
 # Download plugin docs from CloudQuery Hub
-cloudquery plugin docs download test-team/test-plugin@v1.0.0`
+cloudquery plugin docs download test-team/source/test-plugin@v1.0.0`
 )
 
 func newCmdPluginDocsDownload() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:     "download [-D docs] <team_name>/<plugin_name>@<version>",
+		Use:     "download [-D docs] <team_name>/<plugin_kind>/<plugin_name>@<version>",
 		Short:   pluginDocsDownloadShort,
 		Long:    pluginDocsDownloadLong,
 		Example: pluginDocsDownloadExample,

--- a/cli/cmd/plugin_docs_upload.go
+++ b/cli/cmd/plugin_docs_upload.go
@@ -23,12 +23,12 @@ This uploads documentation for a specific plugin version from a local docs direc
 `
 	pluginDocsUploadExample = `
 # Upload plugin docs to CloudQuery Hub
-cloudquery plugin docs upload test-team/test-plugin@v1.0.0`
+cloudquery plugin docs upload test-team/source/test-plugin@v1.0.0`
 )
 
 func newCmdPluginDocsUpload() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:     "upload [-D docs] [--sync] <team_name>/<plugin_name>@<version>",
+		Use:     "upload [-D docs] [--sync] <team_name>/<plugin_kind>/<plugin_name>@<version>",
 		Short:   pluginDocsUploadShort,
 		Long:    pluginDocsUploadLong,
 		Example: pluginDocsUploadExample,


### PR DESCRIPTION
`chore` because the commands are currently hidden.