### PR TITLE
chore: Fix latest tag step

### DIFF
--- a/.github/workflows/release_summary.yml
+++ b/.github/workflows/release_summary.yml
@@ -49,7 +49,7 @@ jobs:
       - name: Get latest tag
         id: tag
         run: |
-          tag_prefix='plugins-source-${{ steps.plugin.outputs.name }}*'
+          tag_prefix='plugins-source-${{ steps.plugin.outputs.name }}-*'
           if [[ $(git tag --list "${tag_prefix}" | wc -l) -gt 0 ]]; then
              tag=$(git describe --tags --match "${tag_prefix}" --abbrev=0)
           else


### PR DESCRIPTION
<!-- 🎉 Thank you for making CloudQuery awesome by submitting a PR 🎉 -->

#### Summary

Follow up to https://github.com/cloudquery/cloudquery/pull/15288. Fixes an old bug where trying to get the latest tag for `azure` sometimes gets the tag for `azuredevops`:
https://github.com/cloudquery/cloudquery/actions/runs/6890494479/job/18743654738#step:5:1

<!--
Use the following steps to ensure your PR is ready to be reviewed

- [ ] Read the [contribution guidelines](../blob/main/CONTRIBUTING.md) 🧑‍🎓
- [ ] Run `make lint` to ensure the proposed changes follow the coding style 🚨 (install golangci-lint [here](https://golangci-lint.run/usage/install/#local-installation))
- [ ] Run `make test` to ensure the proposed changes pass the tests 🧪
- [ ] If changing a source plugin run `make gen` to ensure docs are up to date 📝
- [ ] Ensure the status checks below are successful ✅
--->
