### PR TITLE
fix!: Change `googleapi.RawMessage` column type from binary to JSON

### DIFF
--- a/plugins/source/gcp/client/transformers.go
+++ b/plugins/source/gcp/client/transformers.go
@@ -8,6 +8,7 @@ import (
 	"github.com/cloudquery/plugin-sdk/v4/schema"
 	"github.com/cloudquery/plugin-sdk/v4/transformers"
 	cqtypes "github.com/cloudquery/plugin-sdk/v4/types"
+	googleapi "google.golang.org/api/googleapi"
 	"google.golang.org/protobuf/reflect/protoreflect"
 	"google.golang.org/protobuf/types/known/durationpb"
 	"google.golang.org/protobuf/types/known/timestamppb"
@@ -46,6 +47,8 @@ func typeTransformer(field reflect.StructField) (arrow.DataType, error) {
 	case *durationpb.Duration,
 		durationpb.Duration:
 		return arrow.PrimitiveTypes.Int64, nil
+	case googleapi.RawMessage:
+		return cqtypes.NewJSONType(), nil
 	case protoreflect.Enum:
 		return arrow.BinaryTypes.String, nil
 	case nil:

--- a/plugins/source/gcp/docs/tables/gcp_artifactregistry_locations.md
+++ b/plugins/source/gcp/docs/tables/gcp_artifactregistry_locations.md
@@ -21,5 +21,5 @@ The following tables depend on gcp_artifactregistry_locations:
 |display_name|`utf8`|
 |labels|`json`|
 |location_id|`utf8`|
-|metadata|`binary`|
+|metadata|`json`|
 |name (PK)|`utf8`|

--- a/plugins/source/gcp/docs/tables/gcp_cloudscheduler_locations.md
+++ b/plugins/source/gcp/docs/tables/gcp_cloudscheduler_locations.md
@@ -21,5 +21,5 @@ The following tables depend on gcp_cloudscheduler_locations:
 |display_name|`utf8`|
 |labels|`json`|
 |location_id|`utf8`|
-|metadata|`binary`|
+|metadata|`json`|
 |name (PK)|`utf8`|

--- a/plugins/source/gcp/docs/tables/gcp_networkconnectivity_locations.md
+++ b/plugins/source/gcp/docs/tables/gcp_networkconnectivity_locations.md
@@ -21,5 +21,5 @@ The following tables depend on gcp_networkconnectivity_locations:
 |display_name|`utf8`|
 |labels|`json`|
 |location_id|`utf8`|
-|metadata|`binary`|
+|metadata|`json`|
 |name (PK)|`utf8`|

--- a/plugins/source/gcp/docs/tables/gcp_run_locations.md
+++ b/plugins/source/gcp/docs/tables/gcp_run_locations.md
@@ -21,5 +21,5 @@ The following tables depend on gcp_run_locations:
 |display_name|`utf8`|
 |labels|`json`|
 |location_id|`utf8`|
-|metadata|`binary`|
+|metadata|`json`|
 |name (PK)|`utf8`|


### PR DESCRIPTION
<!-- 🎉 Thank you for making CloudQuery awesome by submitting a PR 🎉 -->

#### Summary

[`googleapi.RawMessage`](https://pkg.go.dev/google.golang.org/api@v0.151.0/googleapi#RawMessage) is documented as being JSON, but they were being converted to Arrow BINARY type. This was causing `gcp_networkconnectivity_locations.metadata` to not be handled as JSON.

<!--
Use the following steps to ensure your PR is ready to be reviewed

- [x] Read the [contribution guidelines](../blob/main/CONTRIBUTING.md) 🧑‍🎓
- [x] Run `make lint` to ensure the proposed changes follow the coding style 🚨 (install golangci-lint [here](https://golangci-lint.run/usage/install/#local-installation))
- [x] Run `make test` to ensure the proposed changes pass the tests 🧪
- [x] If changing a source plugin run `make gen` to ensure docs are up to date 📝
- [ ] Ensure the status checks below are successful ✅
--->
