### PR TITLE
feat: Allow reading spec(s) from stdin with `-`

### DIFF
--- a/cli/cmd/migrate_test.go
+++ b/cli/cmd/migrate_test.go
@@ -35,7 +35,7 @@ func TestMigrate(t *testing.T) {
 		{
 			name:   "should fail with missing path error when path is missing",
 			config: "sync-missing-path-error.yml",
-			err:    "Error: failed to validate destination test: path is required",
+			err:    "failed to validate destination test: path is required",
 		},
 	}
 	_, filename, _, _ := runtime.Caller(0)

--- a/cli/cmd/sync_test.go
+++ b/cli/cmd/sync_test.go
@@ -39,7 +39,7 @@ func TestSync(t *testing.T) {
 		{
 			name:   "should fail with missing path error when path is missing",
 			config: "sync-missing-path-error.yml",
-			err:    "Error: failed to validate destination test: path is required",
+			err:    "failed to validate destination test: path is required",
 		},
 	}
 	_, filename, _, _ := runtime.Caller(0)

--- a/cli/internal/specs/v0/spec_reader_test.go
+++ b/cli/internal/specs/v0/spec_reader_test.go
@@ -134,7 +134,7 @@ var specLoaderTestCases = []specLoaderTestCase{
 		name: "environment variables with error",
 		path: []string{getPath("env_variables.yml")},
 		err: func() string {
-			return "failed to expand environment variable in file testdata/env_variables.yml (section 3): env variable CONNECTION_STRING not found"
+			return "failed to load file testdata/env_variables.yml: failed to expand environment variable (section 3): env variable CONNECTION_STRING not found"
 		},
 		sources: []*Source{
 			{Name: "aws", Path: "cloudquery/aws", Version: "v1", Registry: RegistryGithub, Destinations: []string{"postgresql"}, Tables: []string{"test"}},
@@ -168,7 +168,7 @@ var specLoaderTestCases = []specLoaderTestCase{
 		name: "environment variables in string with error",
 		path: []string{getPath("env_variable_in_string.yml")},
 		err: func() string {
-			return "failed to expand environment variable in file testdata/env_variable_in_string.yml (section 2): env variable VERSION not found"
+			return "failed to load file testdata/env_variable_in_string.yml: failed to expand environment variable (section 2): env variable VERSION not found"
 		},
 		sources: []*Source{
 			{Name: "test", Path: "cloudquery/test", Version: "v1", Registry: RegistryCloudQuery, Destinations: []string{"postgresql"}, Tables: []string{"test"}},
@@ -231,14 +231,13 @@ func TestLoadSpecs(t *testing.T) {
 			}
 			specReader, err := NewSpecReader(tc.path)
 			expectedErr := tc.err()
-			if err != nil {
-				if err.Error() != expectedErr {
-					t.Fatalf("expected error: '%s', got: '%s'", expectedErr, err)
-				}
-				return
-			}
 			if expectedErr != "" {
-				t.Fatalf("expected error: %s, got nil", expectedErr)
+				require.ErrorContains(t, err, expectedErr)
+			} else {
+				require.NoError(t, err)
+			}
+			if err != nil {
+				return // specReader is nil
 			}
 
 			for _, s := range tc.sources {


### PR DESCRIPTION
Loading from stdin in addition to filesystem also works:
```
cat ./src.yml | ./cli sync - ./dest.yml
```
> Loading spec(s) from -, ./dest.yml
