### PR TITLE
fix: Provide primary keys for tables (EC2)

### DIFF
--- a/plugins/source/aws/client/transformers.go
+++ b/plugins/source/aws/client/transformers.go
@@ -58,3 +58,11 @@ func TimestampResolverTransformer(field reflect.StructField, path string) schema
 		return r.Set(c.Name, t)
 	}
 }
+
+// TagsResolverTransformer adds possibility to override the column resolver for "Tags" field
+func TagsResolverTransformer(field reflect.StructField, path string) schema.ColumnResolver {
+	if path == "Tags" {
+		return ResolveTags
+	}
+	return transformers.DefaultResolverTransformer(field, path)
+}

--- a/plugins/source/aws/docs/tables/aws_ec2_transit_gateway_attachments.md
+++ b/plugins/source/aws/docs/tables/aws_ec2_transit_gateway_attachments.md
@@ -4,7 +4,7 @@ This table shows data for Amazon Elastic Compute Cloud (EC2) Transit Gateway Att
 
 https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_TransitGatewayAttachment.html
 
-The primary key for this table is **_cq_id**.
+The composite primary key for this table is (**transit_gateway_arn**, **id**).
 
 ## Relations
 
@@ -14,18 +14,19 @@ This table depends on [aws_ec2_transit_gateways](aws_ec2_transit_gateways.md).
 
 | Name          | Type          |
 | ------------- | ------------- |
-|_cq_id (PK)|`uuid`|
+|_cq_id|`uuid`|
 |_cq_parent_id|`uuid`|
 |account_id|`utf8`|
 |region|`utf8`|
-|transit_gateway_arn|`utf8`|
-|tags|`json`|
+|transit_gateway_arn (PK)|`utf8`|
+|id (PK)|`utf8`|
 |association|`json`|
 |creation_time|`timestamp[us, tz=UTC]`|
 |resource_id|`utf8`|
 |resource_owner_id|`utf8`|
 |resource_type|`utf8`|
 |state|`utf8`|
+|tags|`json`|
 |transit_gateway_attachment_id|`utf8`|
 |transit_gateway_id|`utf8`|
 |transit_gateway_owner_id|`utf8`|

--- a/plugins/source/aws/docs/tables/aws_ec2_transit_gateway_multicast_domains.md
+++ b/plugins/source/aws/docs/tables/aws_ec2_transit_gateway_multicast_domains.md
@@ -4,7 +4,7 @@ This table shows data for Amazon Elastic Compute Cloud (EC2) Transit Gateway Mul
 
 https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_TransitGatewayMulticastDomain.html
 
-The primary key for this table is **_cq_id**.
+The composite primary key for this table is (**transit_gateway_arn**, **arn**).
 
 ## Relations
 
@@ -14,16 +14,17 @@ This table depends on [aws_ec2_transit_gateways](aws_ec2_transit_gateways.md).
 
 | Name          | Type          |
 | ------------- | ------------- |
-|_cq_id (PK)|`uuid`|
+|_cq_id|`uuid`|
 |_cq_parent_id|`uuid`|
 |account_id|`utf8`|
 |region|`utf8`|
-|transit_gateway_arn|`utf8`|
-|tags|`json`|
+|transit_gateway_arn (PK)|`utf8`|
+|arn (PK)|`utf8`|
 |creation_time|`timestamp[us, tz=UTC]`|
 |options|`json`|
 |owner_id|`utf8`|
 |state|`utf8`|
+|tags|`json`|
 |transit_gateway_id|`utf8`|
 |transit_gateway_multicast_domain_arn|`utf8`|
 |transit_gateway_multicast_domain_id|`utf8`|

--- a/plugins/source/aws/docs/tables/aws_ec2_transit_gateway_peering_attachments.md
+++ b/plugins/source/aws/docs/tables/aws_ec2_transit_gateway_peering_attachments.md
@@ -4,7 +4,7 @@ This table shows data for Amazon Elastic Compute Cloud (EC2) Transit Gateway Pee
 
 https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_TransitGatewayPeeringAttachment.html
 
-The primary key for this table is **_cq_id**.
+The composite primary key for this table is (**transit_gateway_arn**, **id**).
 
 ## Relations
 
@@ -14,12 +14,12 @@ This table depends on [aws_ec2_transit_gateways](aws_ec2_transit_gateways.md).
 
 | Name          | Type          |
 | ------------- | ------------- |
-|_cq_id (PK)|`uuid`|
+|_cq_id|`uuid`|
 |_cq_parent_id|`uuid`|
 |account_id|`utf8`|
 |region|`utf8`|
-|transit_gateway_arn|`utf8`|
-|tags|`json`|
+|transit_gateway_arn (PK)|`utf8`|
+|id (PK)|`utf8`|
 |accepter_tgw_info|`json`|
 |accepter_transit_gateway_attachment_id|`utf8`|
 |creation_time|`timestamp[us, tz=UTC]`|
@@ -27,4 +27,5 @@ This table depends on [aws_ec2_transit_gateways](aws_ec2_transit_gateways.md).
 |requester_tgw_info|`json`|
 |state|`utf8`|
 |status|`json`|
+|tags|`json`|
 |transit_gateway_attachment_id|`utf8`|

--- a/plugins/source/aws/docs/tables/aws_ec2_transit_gateway_route_tables.md
+++ b/plugins/source/aws/docs/tables/aws_ec2_transit_gateway_route_tables.md
@@ -4,7 +4,7 @@ This table shows data for Amazon Elastic Compute Cloud (EC2) Transit Gateway Rou
 
 https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_TransitGatewayRouteTable.html
 
-The primary key for this table is **_cq_id**.
+The composite primary key for this table is (**transit_gateway_arn**, **id**).
 
 ## Relations
 
@@ -14,15 +14,16 @@ This table depends on [aws_ec2_transit_gateways](aws_ec2_transit_gateways.md).
 
 | Name          | Type          |
 | ------------- | ------------- |
-|_cq_id (PK)|`uuid`|
+|_cq_id|`uuid`|
 |_cq_parent_id|`uuid`|
 |account_id|`utf8`|
 |region|`utf8`|
-|transit_gateway_arn|`utf8`|
-|tags|`json`|
+|transit_gateway_arn (PK)|`utf8`|
+|id (PK)|`utf8`|
 |creation_time|`timestamp[us, tz=UTC]`|
 |default_association_route_table|`bool`|
 |default_propagation_route_table|`bool`|
 |state|`utf8`|
+|tags|`json`|
 |transit_gateway_id|`utf8`|
 |transit_gateway_route_table_id|`utf8`|

--- a/plugins/source/aws/docs/tables/aws_ec2_transit_gateway_vpc_attachments.md
+++ b/plugins/source/aws/docs/tables/aws_ec2_transit_gateway_vpc_attachments.md
@@ -4,7 +4,7 @@ This table shows data for Amazon Elastic Compute Cloud (EC2) Transit Gateway VPC
 
 https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_TransitGatewayVpcAttachment.html
 
-The primary key for this table is **_cq_id**.
+The composite primary key for this table is (**transit_gateway_arn**, **id**).
 
 ## Relations
 
@@ -14,16 +14,17 @@ This table depends on [aws_ec2_transit_gateways](aws_ec2_transit_gateways.md).
 
 | Name          | Type          |
 | ------------- | ------------- |
-|_cq_id (PK)|`uuid`|
+|_cq_id|`uuid`|
 |_cq_parent_id|`uuid`|
 |account_id|`utf8`|
 |region|`utf8`|
-|transit_gateway_arn|`utf8`|
-|tags|`json`|
+|transit_gateway_arn (PK)|`utf8`|
+|id (PK)|`utf8`|
 |creation_time|`timestamp[us, tz=UTC]`|
 |options|`json`|
 |state|`utf8`|
 |subnet_ids|`list<item: utf8, nullable>`|
+|tags|`json`|
 |transit_gateway_attachment_id|`utf8`|
 |transit_gateway_id|`utf8`|
 |vpc_id|`utf8`|

--- a/plugins/source/aws/docs/tables/aws_ec2_transit_gateways.md
+++ b/plugins/source/aws/docs/tables/aws_ec2_transit_gateways.md
@@ -25,11 +25,11 @@ The following tables depend on aws_ec2_transit_gateways:
 |region (PK)|`utf8`|
 |id|`utf8`|
 |arn (PK)|`utf8`|
-|tags|`json`|
 |creation_time|`timestamp[us, tz=UTC]`|
 |description|`utf8`|
 |options|`json`|
 |owner_id|`utf8`|
 |state|`utf8`|
+|tags|`json`|
 |transit_gateway_arn|`utf8`|
 |transit_gateway_id|`utf8`|

--- a/plugins/source/aws/resources/services/ec2/transit_gateway_attachments.go
+++ b/plugins/source/aws/resources/services/ec2/transit_gateway_attachments.go
@@ -2,7 +2,6 @@ package ec2
 
 import (
 	"context"
-	"reflect"
 
 	"github.com/apache/arrow/go/v14/arrow"
 	"github.com/aws/aws-sdk-go-v2/aws"
@@ -19,16 +18,7 @@ func transitGatewayAttachments() *schema.Table {
 		Name:        tableName,
 		Description: `https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_TransitGatewayAttachment.html`,
 		Resolver:    fetchEc2TransitGatewayAttachments,
-		Transform: transformers.TransformWithStruct(&types.TransitGatewayAttachment{},
-			transformers.WithResolverTransformer(
-				func(field reflect.StructField, path string) schema.ColumnResolver {
-					if path == "Tags" {
-						return client.ResolveTags
-					}
-					return transformers.DefaultResolverTransformer(field, path)
-				},
-			),
-		),
+		Transform:   transformers.TransformWithStruct(&types.TransitGatewayAttachment{}, transformers.WithResolverTransformer(client.TagsResolverTransformer)),
 		Columns: []schema.Column{
 			client.DefaultAccountIDColumn(false),
 			client.DefaultRegionColumn(false),

--- a/plugins/source/aws/resources/services/ec2/transit_gateway_attachments.go
+++ b/plugins/source/aws/resources/services/ec2/transit_gateway_attachments.go
@@ -2,6 +2,7 @@ package ec2
 
 import (
 	"context"
+	"reflect"
 
 	"github.com/apache/arrow/go/v14/arrow"
 	"github.com/aws/aws-sdk-go-v2/aws"
@@ -10,7 +11,6 @@ import (
 	"github.com/cloudquery/cloudquery/plugins/source/aws/client"
 	"github.com/cloudquery/plugin-sdk/v4/schema"
 	"github.com/cloudquery/plugin-sdk/v4/transformers"
-	sdkTypes "github.com/cloudquery/plugin-sdk/v4/types"
 )
 
 func transitGatewayAttachments() *schema.Table {
@@ -19,19 +19,28 @@ func transitGatewayAttachments() *schema.Table {
 		Name:        tableName,
 		Description: `https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_TransitGatewayAttachment.html`,
 		Resolver:    fetchEc2TransitGatewayAttachments,
-		Transform:   transformers.TransformWithStruct(&types.TransitGatewayAttachment{}),
+		Transform: transformers.TransformWithStruct(&types.TransitGatewayAttachment{},
+			transformers.WithResolverTransformer(func(field reflect.StructField, path string) schema.ColumnResolver {
+				if path == "Tags" {
+					return client.ResolveTags
+				}
+				return transformers.DefaultResolverTransformer(field, path)
+			}),
+		),
 		Columns: []schema.Column{
 			client.DefaultAccountIDColumn(false),
 			client.DefaultRegionColumn(false),
 			{
-				Name:     "transit_gateway_arn",
-				Type:     arrow.BinaryTypes.String,
-				Resolver: schema.ParentColumnResolver("arn"),
+				Name:       "transit_gateway_arn",
+				Type:       arrow.BinaryTypes.String,
+				Resolver:   schema.ParentColumnResolver("arn"),
+				PrimaryKey: true,
 			},
 			{
-				Name:     "tags",
-				Type:     sdkTypes.ExtensionTypes.JSON,
-				Resolver: client.ResolveTags,
+				Name:       "id",
+				Type:       arrow.BinaryTypes.String,
+				Resolver:   schema.PathResolver("TransitGatewayAttachmentId"),
+				PrimaryKey: true,
 			},
 		},
 	}

--- a/plugins/source/aws/resources/services/ec2/transit_gateway_attachments.go
+++ b/plugins/source/aws/resources/services/ec2/transit_gateway_attachments.go
@@ -20,12 +20,14 @@ func transitGatewayAttachments() *schema.Table {
 		Description: `https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_TransitGatewayAttachment.html`,
 		Resolver:    fetchEc2TransitGatewayAttachments,
 		Transform: transformers.TransformWithStruct(&types.TransitGatewayAttachment{},
-			transformers.WithResolverTransformer(func(field reflect.StructField, path string) schema.ColumnResolver {
-				if path == "Tags" {
-					return client.ResolveTags
-				}
-				return transformers.DefaultResolverTransformer(field, path)
-			}),
+			transformers.WithResolverTransformer(
+				func(field reflect.StructField, path string) schema.ColumnResolver {
+					if path == "Tags" {
+						return client.ResolveTags
+					}
+					return transformers.DefaultResolverTransformer(field, path)
+				},
+			),
 		),
 		Columns: []schema.Column{
 			client.DefaultAccountIDColumn(false),

--- a/plugins/source/aws/resources/services/ec2/transit_gateway_multicast_domains.go
+++ b/plugins/source/aws/resources/services/ec2/transit_gateway_multicast_domains.go
@@ -10,7 +10,6 @@ import (
 	"github.com/cloudquery/cloudquery/plugins/source/aws/client"
 	"github.com/cloudquery/plugin-sdk/v4/schema"
 	"github.com/cloudquery/plugin-sdk/v4/transformers"
-	sdkTypes "github.com/cloudquery/plugin-sdk/v4/types"
 )
 
 func transitGatewayMulticastDomains() *schema.Table {
@@ -19,19 +18,21 @@ func transitGatewayMulticastDomains() *schema.Table {
 		Name:        tableName,
 		Description: `https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_TransitGatewayMulticastDomain.html`,
 		Resolver:    fetchEc2TransitGatewayMulticastDomains,
-		Transform:   transformers.TransformWithStruct(&types.TransitGatewayMulticastDomain{}),
+		Transform:   transformers.TransformWithStruct(&types.TransitGatewayMulticastDomain{}, transformers.WithResolverTransformer(client.TagsResolverTransformer)),
 		Columns: []schema.Column{
 			client.DefaultAccountIDColumn(false),
 			client.DefaultRegionColumn(false),
 			{
-				Name:     "transit_gateway_arn",
-				Type:     arrow.BinaryTypes.String,
-				Resolver: schema.ParentColumnResolver("arn"),
+				Name:       "transit_gateway_arn",
+				Type:       arrow.BinaryTypes.String,
+				Resolver:   schema.ParentColumnResolver("arn"),
+				PrimaryKey: true,
 			},
 			{
-				Name:     "tags",
-				Type:     sdkTypes.ExtensionTypes.JSON,
-				Resolver: client.ResolveTags,
+				Name:       "arn",
+				Type:       arrow.BinaryTypes.String,
+				Resolver:   schema.PathResolver("TransitGatewayMulticastDomainArn"),
+				PrimaryKey: true,
 			},
 		},
 	}

--- a/plugins/source/aws/resources/services/ec2/transit_gateway_peering_attachments.go
+++ b/plugins/source/aws/resources/services/ec2/transit_gateway_peering_attachments.go
@@ -10,7 +10,6 @@ import (
 	"github.com/cloudquery/cloudquery/plugins/source/aws/client"
 	"github.com/cloudquery/plugin-sdk/v4/schema"
 	"github.com/cloudquery/plugin-sdk/v4/transformers"
-	sdkTypes "github.com/cloudquery/plugin-sdk/v4/types"
 )
 
 func transitGatewayPeeringAttachments() *schema.Table {
@@ -19,19 +18,21 @@ func transitGatewayPeeringAttachments() *schema.Table {
 		Name:        tableName,
 		Description: `https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_TransitGatewayPeeringAttachment.html`,
 		Resolver:    fetchEc2TransitGatewayPeeringAttachments,
-		Transform:   transformers.TransformWithStruct(&types.TransitGatewayPeeringAttachment{}),
+		Transform:   transformers.TransformWithStruct(&types.TransitGatewayPeeringAttachment{}, transformers.WithResolverTransformer(client.TagsResolverTransformer)),
 		Columns: []schema.Column{
 			client.DefaultAccountIDColumn(false),
 			client.DefaultRegionColumn(false),
 			{
-				Name:     "transit_gateway_arn",
-				Type:     arrow.BinaryTypes.String,
-				Resolver: schema.ParentColumnResolver("arn"),
+				Name:       "transit_gateway_arn",
+				Type:       arrow.BinaryTypes.String,
+				Resolver:   schema.ParentColumnResolver("arn"),
+				PrimaryKey: true,
 			},
 			{
-				Name:     "tags",
-				Type:     sdkTypes.ExtensionTypes.JSON,
-				Resolver: client.ResolveTags,
+				Name:       "id",
+				Type:       arrow.BinaryTypes.String,
+				Resolver:   schema.PathResolver("TransitGatewayAttachmentId"),
+				PrimaryKey: true,
 			},
 		},
 	}

--- a/plugins/source/aws/resources/services/ec2/transit_gateway_route_tables.go
+++ b/plugins/source/aws/resources/services/ec2/transit_gateway_route_tables.go
@@ -2,7 +2,6 @@ package ec2
 
 import (
 	"context"
-	"reflect"
 
 	"github.com/apache/arrow/go/v14/arrow"
 	"github.com/aws/aws-sdk-go-v2/aws"
@@ -19,16 +18,7 @@ func transitGatewayRouteTables() *schema.Table {
 		Name:        tableName,
 		Description: `https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_TransitGatewayRouteTable.html`,
 		Resolver:    fetchEc2TransitGatewayRouteTables,
-		Transform: transformers.TransformWithStruct(&types.TransitGatewayRouteTable{},
-			transformers.WithResolverTransformer(
-				func(field reflect.StructField, path string) schema.ColumnResolver {
-					if path == "Tags" {
-						return client.ResolveTags
-					}
-					return transformers.DefaultResolverTransformer(field, path)
-				},
-			),
-		),
+		Transform:   transformers.TransformWithStruct(&types.TransitGatewayRouteTable{}, transformers.WithResolverTransformer(client.TagsResolverTransformer)),
 		Columns: []schema.Column{
 			client.DefaultAccountIDColumn(false),
 			client.DefaultRegionColumn(false),

--- a/plugins/source/aws/resources/services/ec2/transit_gateway_vpc_attachments.go
+++ b/plugins/source/aws/resources/services/ec2/transit_gateway_vpc_attachments.go
@@ -10,7 +10,6 @@ import (
 	"github.com/cloudquery/cloudquery/plugins/source/aws/client"
 	"github.com/cloudquery/plugin-sdk/v4/schema"
 	"github.com/cloudquery/plugin-sdk/v4/transformers"
-	sdkTypes "github.com/cloudquery/plugin-sdk/v4/types"
 )
 
 func transitGatewayVpcAttachments() *schema.Table {
@@ -19,19 +18,21 @@ func transitGatewayVpcAttachments() *schema.Table {
 		Name:        tableName,
 		Description: `https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_TransitGatewayVpcAttachment.html`,
 		Resolver:    fetchEc2TransitGatewayVpcAttachments,
-		Transform:   transformers.TransformWithStruct(&types.TransitGatewayVpcAttachment{}),
+		Transform:   transformers.TransformWithStruct(&types.TransitGatewayVpcAttachment{}, transformers.WithResolverTransformer(client.TagsResolverTransformer)),
 		Columns: []schema.Column{
 			client.DefaultAccountIDColumn(false),
 			client.DefaultRegionColumn(false),
 			{
-				Name:     "transit_gateway_arn",
-				Type:     arrow.BinaryTypes.String,
-				Resolver: schema.ParentColumnResolver("arn"),
+				Name:       "transit_gateway_arn",
+				Type:       arrow.BinaryTypes.String,
+				Resolver:   schema.ParentColumnResolver("arn"),
+				PrimaryKey: true,
 			},
 			{
-				Name:     "tags",
-				Type:     sdkTypes.ExtensionTypes.JSON,
-				Resolver: client.ResolveTags,
+				Name:       "id",
+				Type:       arrow.BinaryTypes.String,
+				Resolver:   schema.PathResolver("TransitGatewayAttachmentId"),
+				PrimaryKey: true,
 			},
 		},
 	}

--- a/plugins/source/aws/resources/services/ec2/transit_gateways.go
+++ b/plugins/source/aws/resources/services/ec2/transit_gateways.go
@@ -9,7 +9,6 @@ import (
 	"github.com/cloudquery/cloudquery/plugins/source/aws/client"
 	"github.com/cloudquery/plugin-sdk/v4/schema"
 	"github.com/cloudquery/plugin-sdk/v4/transformers"
-	sdkTypes "github.com/cloudquery/plugin-sdk/v4/types"
 )
 
 func TransitGateways() *schema.Table {
@@ -19,7 +18,7 @@ func TransitGateways() *schema.Table {
 		Description: `https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_TransitGateway.html`,
 		Resolver:    fetchEc2TransitGateways,
 		Multiplex:   client.ServiceAccountRegionMultiplexer(tableName, "ec2"),
-		Transform:   transformers.TransformWithStruct(&types.TransitGateway{}),
+		Transform:   transformers.TransformWithStruct(&types.TransitGateway{}, transformers.WithResolverTransformer(client.TagsResolverTransformer)),
 		Columns: []schema.Column{
 			client.DefaultAccountIDColumn(true),
 			client.DefaultRegionColumn(true),
@@ -33,11 +32,6 @@ func TransitGateways() *schema.Table {
 				Type:       arrow.BinaryTypes.String,
 				Resolver:   schema.PathResolver("TransitGatewayArn"),
 				PrimaryKey: true,
-			},
-			{
-				Name:     "tags",
-				Type:     sdkTypes.ExtensionTypes.JSON,
-				Resolver: client.ResolveTags,
 			},
 		},
 


### PR DESCRIPTION
Part of https://github.com/cloudquery/cloudquery/issues/15381

BEGIN_COMMIT_OVERRIDE
fix: Provide primary keys for tables (EC2) (https://github.com/cloudquery/cloudquery/pull/15415)
BREAKING-CHANGE: Provide primary keys for tables (EC2) (https://github.com/cloudquery/cloudquery/pull/15415). The following tables are affected:
* `aws_ec2_transit_gateway_*`

END_COMMIT_OVERRIDE