### PR TITLE
chore: Use relative links instead of absolute where applicable

### DIFF
--- a/website/pages/blog/2022-may-monthly.mdx
+++ b/website/pages/blog/2022-may-monthly.mdx
@@ -35,7 +35,7 @@ well as open-up opportunity to build new workflows and alert on things like proj
 
 Sometimes we also remove features instead of adding to ensure we are able to move fast and with quality. This should
 increase developer velocity, both internally and externally, remove 🐛 as well as open the door to support more
-databases! Checkout our [blog](/blog/migration-and-history-deprecation) for full explanation.
+databases! Check out our [blog](/blog/migration-and-history-deprecation) for full explanation.
 
 ## Store Policy Data in The Database
 

--- a/website/pages/blog/2022-may-monthly.mdx
+++ b/website/pages/blog/2022-may-monthly.mdx
@@ -35,7 +35,7 @@ well as open-up opportunity to build new workflows and alert on things like proj
 
 Sometimes we also remove features instead of adding to ensure we are able to move fast and with quality. This should
 increase developer velocity, both internally and externally, remove 🐛 as well as open the door to support more
-databases! Checkout our [blog](https://www.cloudquery.io/blog/migration-and-history-deprecation) for full explanation.
+databases! Checkout our [blog](/blog/migration-and-history-deprecation) for full explanation.
 
 ## Store Policy Data in The Database
 
@@ -56,9 +56,9 @@ To easy the deployment we release:
 
 ## 📚 Blogs
 
-- [Recreating a Deleted SSO IDP](https://www.cloudquery.io/blog/aws-sso-if-deleted-sso-identity-provider): A tutorial
+- [Recreating a Deleted SSO IDP](/blog/aws-sso-if-deleted-sso-identity-provider): A tutorial
   on how to recover when you accidentally delete your AWS SSO Identity Provider from an important account
-- [AWS Resource View](https://www.cloudquery.io/blog/aws-resources-view): Utilizing CloudQuery data create a view
+- [AWS Resource View](/blog/aws-resources-view): Utilizing CloudQuery data create a view
   that allows you to see data from all of your AWS Accounts
 
 - Connecting CloudQuery Database to a BI Tool:

--- a/website/pages/blog/adopting-apache-arrow-at-cloudquery.mdx
+++ b/website/pages/blog/adopting-apache-arrow-at-cloudquery.mdx
@@ -14,11 +14,11 @@ import { BlogHeader } from "../../components/BlogHeader"
 
 This post is a collaboration with and cross-posted on the [Arrow blog](https://arrow.apache.org/blog/2023/05/04/adopting-apache-arrow-at-cloudquery/).
 
-[CloudQuery](https://github.com/cloudquery/cloudquery) is an open source high performance ELT framework written in Go. We [previously](https://www.cloudquery.io/blog/building-cloudquery) discussed some of the architecture and design decisions that we took to build a performant ELT framework. A type system is one of the key components of a performant and scalable ELT framework where sources and destinations are decoupled. In this blog we will go through why we decided to adopt Apache Arrow as our type system and replace our in-house implementation.
+[CloudQuery](https://github.com/cloudquery/cloudquery) is an open source high performance ELT framework written in Go. We [previously](/blog/building-cloudquery) discussed some of the architecture and design decisions that we took to build a performant ELT framework. A type system is one of the key components of a performant and scalable ELT framework where sources and destinations are decoupled. In this blog we will go through why we decided to adopt Apache Arrow as our type system and replace our in-house implementation.
 
 # What is a Type System?
 
-Let’s quickly [recap](https://www.cloudquery.io/blog/building-cloudquery#type-system) what type system is and why it is needed in an ELT framework. At a high level ELT framework extracts data from a source and moves it to a destination with a specific schema.
+Let’s quickly [recap](/blog/building-cloudquery#type-system) what type system is and why it is needed in an ELT framework. At a high level ELT framework extracts data from a source and moves it to a destination with a specific schema.
 
 ```
 API ---> [Source Plugin]  ----->    [Destination Plugin]

--- a/website/pages/blog/announcing-aws-fsbp-policies-snowflake.mdx
+++ b/website/pages/blog/announcing-aws-fsbp-policies-snowflake.mdx
@@ -246,11 +246,11 @@ where
 
 To get started, [check out our documentation](https://hub.cloudquery.io/addons/transformation) and the example queries above.  We'd love to hear your feedback.  We can be reached on [GitHub](https://github.com/cloudquery/cloudquery/issues) and [Discord](https://www.cloudquery.io/discord).
 
-CloudQuery supports additional compliance frameworks and visualizations.  For more information, see our [policies](https://hub.cloudquery.io/addons/transformation) and [dashboards](https://www.cloudquery.io/docs/core-concepts/dashboards) references.
+CloudQuery supports additional compliance frameworks and visualizations.  For more information, see our [policies](https://hub.cloudquery.io/addons/transformation) and [dashboards](/docs/core-concepts/dashboards) references.
 
 ## References
 
 - [AWS Foundational Security Best Practices (FSBP)](https://docs.aws.amazon.com/securityhub/latest/userguide/fsbp-standard.html)
 - [CloudQuery Policies](https://hub.cloudquery.io/addons/transformation)
-- [CloudQuery Dashboards](https://www.cloudquery.io/docs/core-concepts/dashboards)
+- [CloudQuery Dashboards](/docs/core-concepts/dashboards)
 - [CloudQuery Support](https://www.cloudquery.io/pricing)

--- a/website/pages/blog/announcing-aws-partnership.mdx
+++ b/website/pages/blog/announcing-aws-partnership.mdx
@@ -57,17 +57,17 @@ CloudQuery supports additional compliance frameworks including:
 
 Please see our links for policies and dashboards for more information about these offerings:
 * [Policies](https://hub.cloudquery.io/addons/transformation)
-* [Dashboards](https://www.cloudquery.io/docs/core-concepts/dashboards)
+* [Dashboards](/docs/core-concepts/dashboards)
 
 ## Use Cases
 
 CloudQuery supports multiple use cases including security, cost optimization, infrastructure, and development.  Below is a sampling of the use cases that can be built with CloudQuery with AWS infrastructure data:
 
-* [Open Source Cloud Security Posture Management (CSPM)](https://www.cloudquery.io/how-to-guides/open-source-cspm)
-* [Open Source Attack Surface Management with Neo4j (ASM)](https://www.cloudquery.io/how-to-guides/attack-surface-management-with-graph)
-* [Analyzing AWS Cost and Usage Data](https://www.cloudquery.io/how-to-guides/query-aws-cost-and-usage-athena)
-* [Managing AWS Resource and Usage Limits](https://www.cloudquery.io/how-to-guides/aws-resource-limits-and-service-quotas)
-* [Managing Resilience Strategy with AWS Backup](https://www.cloudquery.io/how-to-guides/manage-resilience-with-aws-backup)
+* [Open Source Cloud Security Posture Management (CSPM)](/how-to-guides/open-source-cspm)
+* [Open Source Attack Surface Management with Neo4j (ASM)](/how-to-guides/attack-surface-management-with-graph)
+* [Analyzing AWS Cost and Usage Data](/how-to-guides/query-aws-cost-and-usage-athena)
+* [Managing AWS Resource and Usage Limits](/how-to-guides/aws-resource-limits-and-service-quotas)
+* [Managing Resilience Strategy with AWS Backup](/how-to-guides/manage-resilience-with-aws-backup)
 
 ## Get Started
 

--- a/website/pages/blog/announcing-cloudquery-aws-event-based-sync-beta.mdx
+++ b/website/pages/blog/announcing-cloudquery-aws-event-based-sync-beta.mdx
@@ -121,7 +121,7 @@ This will start a long lived process that will only stop when there is an error 
 
 ## Deploying in production
 
-CloudQuery needs to run in a listening mode as a long-running service. In this mode, it does not support the `overwrite-delete-stale` write model. To delete stale data, you need to set up a recurrent task to run [full table syncs](https://www.cloudquery.io/docs/core-concepts/syncs#full-table-syncs). Additionally, you may need to set up another task with CloudQuery still running regular sync on tables that are currently not supported for the event-based sync. See the [AWS Plugin](https://hub.cloudquery.io/plugins/source/cloudquery/aws) documentation for the list of supported tables.
+CloudQuery needs to run in a listening mode as a long-running service. In this mode, it does not support the `overwrite-delete-stale` write model. To delete stale data, you need to set up a recurrent task to run [full table syncs](/docs/core-concepts/syncs#full-table-syncs). Additionally, you may need to set up another task with CloudQuery still running regular sync on tables that are currently not supported for the event-based sync. See the [AWS Plugin](https://hub.cloudquery.io/plugins/source/cloudquery/aws) documentation for the list of supported tables.
 
 
 Note that these are the limitations of the current beta version of the event-based sync for our AWS plugin. We plan to make configuration and management easier in the future based on user feedback.

--- a/website/pages/blog/announcing-cloudquery-history.mdx
+++ b/website/pages/blog/announcing-cloudquery-history.mdx
@@ -21,7 +21,7 @@ import { Callout } from 'nextra-theme-docs';
 
 Today we are excited to announce the release of CloudQuery History in alpha! CloudQuery History adds [TimescaleDB](https://github.com/timescale/timescaledb) support to give users the ability to track their complete cloud asset inventory snapshots over time!
 
-Achieving better visibility into your cloud infrastructure is key in maintaining security, compliance, cost and operational efficiency, and this is why we started CloudQuery in the [first](https://www.cloudquery.io/blog/announcing-cloudquery-seed-funding) place. Maintaining a historical record of your cloud infrastructure configuration is an integral part of your cloud environment lifecycle.
+Achieving better visibility into your cloud infrastructure is key in maintaining security, compliance, cost and operational efficiency, and this is why we started CloudQuery in the [first](/blog/announcing-cloudquery-seed-funding) place. Maintaining a historical record of your cloud infrastructure configuration is an integral part of your cloud environment lifecycle.
 
 ## Why TimescaleDB?
 
@@ -33,7 +33,7 @@ Current native solutions like AWS CloudTrail, GCP Cloud Audit Log , Azure Activi
 
 Audit logs are great, although they only focus on what **changed** and not on what was the **state** of your whole cloud account at a certain point in time. CloudQuery History provides full historical snapshots of your cloud asset inventory, unlocking the following benefits:
 
-- **Visualize Historical State:** Enhance your current visualization workflows such as Grafana and re-use the [dashboards](https://www.cloudquery.io/blog/open-source-cloud-asset-inventory-with-cloudquery-and-grafana) to view current and historical state.
+- **Visualize Historical State:** Enhance your current visualization workflows such as Grafana and re-use the [dashboards](/blog/open-source-cloud-asset-inventory-with-cloudquery-and-grafana) to view current and historical state.
 - **Alert on change using standard SQL:** Use TimescaleDB's [hyperfunctions](https://docs.timescale.com/api/latest/hyperfunctions/) and [continuous aggregates](https://docs.timescale.com/timescaledb/latest/how-to-guides/continuous-aggregates/) to aggregate at predefined intervals and materialize results and find changes that occurred between fetches.
 - **Compliance:** To ensure you were compliant not only in point in time but also over time, you can re-use pre-made and custom [CloudQuery Policies](https://hub.cloudquery.io/addons/transformation) to prove compliance over-time.
 - **Visibility:** Find resources that might already be deleted. Inspect what was created and understand what happened.

--- a/website/pages/blog/announcing-cloudquery-hub.mdx
+++ b/website/pages/blog/announcing-cloudquery-hub.mdx
@@ -14,7 +14,7 @@ Today, we're excited to announce the availability of [CloudQuery Hub](https://hu
 
 In the 6 month since CloudQuery release, we saw amazing growth and adoption from the community, with our [open-source project](https://github.com/cloudquery/cloudquery) reaching 1.6K stars. This validates the need for a standard and open-source way to query, monitor and analyze cloud infrastructure for visibility, security, compliance and cost challenges to help put the order back in place.
 
-Two months ago we released [CloudQuery SDK](https://www.cloudquery.io/blog/introducing-cloudquery-sdk) to enable developers easily [extend](/docs/developers/creating-new-plugin) CloudQuery with their own maintained providers. As a natural next step we are releasing [CloudQuery Hub](https://www.cloudquery.io).
+Two months ago we released [CloudQuery SDK](/blog/introducing-cloudquery-sdk) to enable developers easily [extend](/docs/developers/creating-new-plugin) CloudQuery with their own maintained providers. As a natural next step we are releasing [CloudQuery Hub](https://www.cloudquery.io).
 
 ## What is CloudQuery Hub?
 

--- a/website/pages/blog/announcing-cloudquery-java-sdk.mdx
+++ b/website/pages/blog/announcing-cloudquery-java-sdk.mdx
@@ -16,7 +16,7 @@ We're excited to announce the first release of a Java SDK for CloudQuery plugin 
 
 CloudQuery is designed with a pluggable architecture and uses [Apache Arrow](https://arrow.apache.org/) over [gRPC](https://grpc.io/) for communication between plugins. Source and destination plugins are independent of one another, and this architecture allows plugins to be written in different languages but still communicate with one another.
 
-Originally, we only provided SDK for writing plugins in Go only, but that is changing now. Recently, we released [SDK for Python](https://www.cloudquery.io/blog/announcing-cloudquery-python-sdk), [JavaScript](https://www.cloudquery.io/blog/announcing-cloudquery-javascript-sdk), and now we are excited for the next language in line: Java!
+Originally, we only provided SDK for writing plugins in Go only, but that is changing now. Recently, we released [SDK for Python](/blog/announcing-cloudquery-python-sdk), [JavaScript](/blog/announcing-cloudquery-javascript-sdk), and now we are excited for the next language in line: Java!
 
 ## Features
 
@@ -91,7 +91,7 @@ To support cross-platform packaging of Java plugins, we introduced a new `docker
 
 ## Start Creating Your Own Plugin
 
-Want to start writing your own plugin? Here is our guide to get you started: https://www.cloudquery.io/docs/developers/creating-new-plugin/java-source.
+Want to start writing your own plugin? Here is our guide to get you started: /docs/developers/creating-new-plugin/java-source.
 
 ## Feedback
 

--- a/website/pages/blog/announcing-cloudquery-javascript-sdk.mdx
+++ b/website/pages/blog/announcing-cloudquery-javascript-sdk.mdx
@@ -16,7 +16,7 @@ We're excited to announce the first release of a JavaScript SDK for CloudQuery p
 
 CloudQuery is designed with a pluggable architecture and uses [Apache Arrow](https://arrow.apache.org/) over [gRPC](https://grpc.io/) for communication between plugins. Source and destination plugins are independent of one another, and this architecture allows plugins to be written in different languages but still communicate with one another.
 
-Originally, we only provided SDK for writing plugins in Go, but that is changing now. Recently, we released [SDK for Python](https://www.cloudquery.io/blog/announcing-cloudquery-python-sdk), and now we are excited to announce the SDK for JavaScript as well!
+Originally, we only provided SDK for writing plugins in Go, but that is changing now. Recently, we released [SDK for Python](/blog/announcing-cloudquery-python-sdk), and now we are excited to announce the SDK for JavaScript as well!
 
 ![cloudquery high-level architecture](/images/cloudquery-architecture.png)
 
@@ -114,7 +114,7 @@ To support cross-platform packaging of JavaScript plugins (and other languages i
 
 ### Start Creating Your Own Plugin
 
-Want to start writing your own plugin? Here is our guide to get you started: https://www.cloudquery.io/docs/developers/creating-new-plugin/javascript-source
+Want to start writing your own plugin? Here is our guide to get you started: /docs/developers/creating-new-plugin/javascript-source
 
 We will also be adding more documentation and examples in the coming weeks, so stay tuned!
 

--- a/website/pages/blog/announcing-cloudquery-seed-funding.mdx
+++ b/website/pages/blog/announcing-cloudquery-seed-funding.mdx
@@ -37,8 +37,8 @@ It became clear that for every task we do 80% of the time is spent on similar bu
 ## What we achieved in the last 11 months
 
 - Our [GitHub repository](https://github.com/cloudquery/cloudquery) grew to over 1.8k stars and over 40 contributors across all our repositories.
-- [CloudQuery SDK](https://www.cloudquery.io/blog/introducing-cloudquery-sdk) - Helps developers write their own providers (plugins) to CloudQuery.
-- [CloudQuery Policies](https://www.cloudquery.io/blog/announcing-cloudquery-policies) - Turns security & compliance rules into a data problem instead of a code problem.
+- [CloudQuery SDK](/blog/introducing-cloudquery-sdk) - Helps developers write their own providers (plugins) to CloudQuery.
+- [CloudQuery Policies](/blog/announcing-cloudquery-policies) - Turns security & compliance rules into a data problem instead of a code problem.
 - [CloudQuery Hub](https://hub.cloudquery.io/) - Hosts both official and community CloudQuery plugins and policies, thus growing the eco-system and enabling knowledge sharing.
 - [Providers](https://hub.cloudquery.io) - We grew our official cloud provider coverage across all 3 big cloud providers (AWS, GCP, Azure), DigitalOcean, Kubernetes, and Okta. We also welcomed our first community provider - Thanks, Yandex Cloud!
 

--- a/website/pages/blog/announcing-cloudquery-terraform-drift-detection.mdx
+++ b/website/pages/blog/announcing-cloudquery-terraform-drift-detection.mdx
@@ -12,7 +12,7 @@ import { Callout } from 'nextra-theme-docs';
 <BlogHeader/>
 
 <Callout type="warning">
-This feature was deprecated, [see blog post](https://www.cloudquery.io/blog/terraform-drift-deprecation).
+This feature was deprecated, [see blog post](/blog/terraform-drift-deprecation).
 </Callout>
 
 ---
@@ -83,7 +83,7 @@ CloudQuery drift detection is currently in alpha (experimental) version, so we w
 
 Currently the easiest way is actually to run the **fetch** step also in the CI and use something like postgres inside GitHub action, it is not ideal for production deployments but for testing and trying it out this is the fastest way to go.
 
-Check out our [documentation](https://www.cloudquery.io/docs) to get started on how to run it locally and in the CI.
+Check out our [documentation](/docs) to get started on how to run it locally and in the CI.
 
 ## What do you think?
 

--- a/website/pages/blog/announcing-gcp-partnership.mdx
+++ b/website/pages/blog/announcing-gcp-partnership.mdx
@@ -43,9 +43,9 @@ CloudQuery supports the following Google Cloud-related destination plugins:
 
 CloudQuery can be hosted in Google Cloud.  Below are examples of how to get CloudQuery running in Google Cloud:
 
-* [Google Cloud VM](https://www.cloudquery.io/docs/deployment/google-cloud-vm)
+* [Google Cloud VM](/docs/deployment/google-cloud-vm)
 
-* [Google Cloud Run](https://www.cloudquery.io/docs/deployment/cloud-run)
+* [Google Cloud Run](/docs/deployment/cloud-run)
 
 
 ### Policies and Dashboards
@@ -59,13 +59,13 @@ CloudQuery supports these compliance frameworks for multiple destinations includ
 
 Please see our links for policies and dashboards for more information about these offerings:
 * [Policies](https://hub.cloudquery.io/addons/transformation)
-* [Dashboards](https://www.cloudquery.io/docs/core-concepts/dashboards)
+* [Dashboards](/docs/core-concepts/dashboards)
 
 ## Use Cases
 
 CloudQuery supports multiple use cases including security, cost optimization, infrastructure, and development.  Below is a sampling of the use cases that can be built with CloudQuery and Google Cloud:
 
-* [Analyzing Google Cloud Cost with BigQuery and CloudQuery](https://www.cloudquery.io/blog/analysing-gcp-cost-with-bigquery-and-cq)
+* [Analyzing Google Cloud Cost with BigQuery and CloudQuery](/blog/analysing-gcp-cost-with-bigquery-and-cq)
 
 ## Get Started
 

--- a/website/pages/blog/announcing-policies-in-cloudquery-hub.mdx
+++ b/website/pages/blog/announcing-policies-in-cloudquery-hub.mdx
@@ -15,11 +15,11 @@ import { Callout } from 'nextra-theme-docs';
 HCL policies were deprecated - see up-to-date policy documentation [here](https://hub.cloudquery.io/addons/transformation).
 </Callout>
 
-Today, we’re excited to announce the availability of [CloudQuery Policies](https://www.cloudquery.io/blog/announcing-cloudquery-policies) in [CloudQuery Hub](https://hub.cloudquery.io/).
+Today, we’re excited to announce the availability of [CloudQuery Policies](/blog/announcing-cloudquery-policies) in [CloudQuery Hub](https://hub.cloudquery.io/).
 
-Less than two months ago we introduced [CloudQuery Hub](https://www.cloudquery.io/blog/announcing-cloudquery-hub) as a single place to browse, install and share CloudQuery pluggable providers and integrations.
+Less than two months ago we introduced [CloudQuery Hub](/blog/announcing-cloudquery-hub) as a single place to browse, install and share CloudQuery pluggable providers and integrations.
 
-Last month we introduced [CloudQuery Policies](https://www.cloudquery.io/blog/announcing-cloudquery-policies) that brought policy-as-code to the CloudQuery ecosystem. CQ Policies enable users to codify, version and run security, governance, cost and compliance rules, using SQL as the query layer and HCL as the logical layer.
+Last month we introduced [CloudQuery Policies](/blog/announcing-cloudquery-policies) that brought policy-as-code to the CloudQuery ecosystem. CQ Policies enable users to codify, version and run security, governance, cost and compliance rules, using SQL as the query layer and HCL as the logical layer.
 
 ## What’s Inside CloudQuery Policy Hub?
 

--- a/website/pages/blog/aws-log4j-and-finding-unrestricted-outbound-access.mdx
+++ b/website/pages/blog/aws-log4j-and-finding-unrestricted-outbound-access.mdx
@@ -44,7 +44,7 @@ Following is a query to identify all security groups with unrestricted outbound 
 
 **Prerequisite**:
 
-- Run `cloudquery sync` (See our [quickstart guide](https://www.cloudquery.io/docs/quickstart))
+- Run `cloudquery sync` (See our [quickstart guide](/docs/quickstart))
 - Create this view
 
 ```sql copy
@@ -101,7 +101,7 @@ The second requirement for outbound access is an internet gateway. Here is a que
 
 **Prerequisite**:
 
-- Run `cloudquery sync` (See our [quickstart guide](https://www.cloudquery.io/docs/quickstart))
+- Run `cloudquery sync` (See our [quickstart guide](/docs/quickstart))
 - Create this view
 
 ```sql copy

--- a/website/pages/blog/aws-priv-esc-identity-center.mdx
+++ b/website/pages/blog/aws-priv-esc-identity-center.mdx
@@ -27,7 +27,7 @@ We will also cover how to find these events with CloudQuery’s new support for 
 
 AWS Identity Center [has requirements for](https://docs.aws.amazon.com/singlesignon/latest/userguide/get-started-prereqs-considerations.html) use including using AWS Organizations for managing AWS Accounts.
 
-Identity Center must be run from either the Organizational management account or a delegated administrator account.  For more information about delegated administrator accounts, see [our blog post and research on delegated administrator](https://www.cloudquery.io/blog/guide-aws-org-delegation).
+Identity Center must be run from either the Organizational management account or a delegated administrator account.  For more information about delegated administrator accounts, see [our blog post and research on delegated administrator](/blog/guide-aws-org-delegation).
 
 Since usage of AWS Identity Center requires usage of AWS Organizations and can only be managed from either the organizational management account or delegated administrator account, privilege escalation with AWS Identity Center requires access to whichever account is used for management of AWS Identity Center: either the organizational management account or the delegated administrator account used for AWS Identity Center.
 
@@ -204,7 +204,7 @@ Examples of permission modification and access disruption include:
 
 AWS CloudTrail offers 90 days of logging to identify API calls made in AWS accounts.  While it’s possible to search directly in CloudTrail for the last 90 days of activity, we’ll show how to identify Identity Center Actions in CloudTrail logs synced with CloudQuery.
 
-We recently added support for [CloudTrail Events](https://hub.cloudquery.io/plugins/source/cloudquery/aws/tables/aws_cloudtrail_events) and [Incremental Tables](https://www.cloudquery.io/docs/advanced-topics/managing-incremental-tables) with CloudQuery as we saw useful use cases for syncing CloudTrail events to the destination of your choice. 
+We recently added support for [CloudTrail Events](https://hub.cloudquery.io/plugins/source/cloudquery/aws/tables/aws_cloudtrail_events) and [Incremental Tables](/docs/advanced-topics/managing-incremental-tables) with CloudQuery as we saw useful use cases for syncing CloudTrail events to the destination of your choice. 
 
 ### CloudQuery Setup and Configuration
 

--- a/website/pages/blog/aws-sso-and-the-lost-iam-keys.mdx
+++ b/website/pages/blog/aws-sso-and-the-lost-iam-keys.mdx
@@ -67,4 +67,4 @@ where okta_users.profile->>'email' is NULL;
 
 ## Continuous Monitoring & Alerting
 
-You can run CQ periodically, either from a local machine or a server/lambda, and create alerts using the above queries and [CQ Policies](https://www.cloudquery.io/blog/announcing-cloudquery-policies).
+You can run CQ periodically, either from a local machine or a server/lambda, and create alerts using the above queries and [CQ Policies](/blog/announcing-cloudquery-policies).

--- a/website/pages/blog/aws-sso-if-deleted-sso-identity-provider.mdx
+++ b/website/pages/blog/aws-sso-if-deleted-sso-identity-provider.mdx
@@ -13,7 +13,7 @@ import { BlogHeader } from "../../components/BlogHeader"
 <BlogHeader/>
 
 
-In this short tutorial we will go through what to do if you accidentally deleted the `AWSSSO_asd123456678_DO_NO_DELETE` identity provider from an org account which is used by AWS SSO (take a look at our previous blog setting up [AWS SSO with Google Workspace](https://www.cloudquery.io/blog/aws-sso-tutorial-with-google-workspace-as-an-idp)).
+In this short tutorial we will go through what to do if you accidentally deleted the `AWSSSO_asd123456678_DO_NO_DELETE` identity provider from an org account which is used by AWS SSO (take a look at our previous blog setting up [AWS SSO with Google Workspace](/blog/aws-sso-tutorial-with-google-workspace-as-an-idp)).
 
 Deleting the `AWSSSO_1233424_DO_NOT_DELETE` identity provider will prevent you from accessing the account via the AWS SSO screen.
 

--- a/website/pages/blog/building-an-infrastructure-data-lake-with-mongodb.mdx
+++ b/website/pages/blog/building-an-infrastructure-data-lake-with-mongodb.mdx
@@ -29,7 +29,7 @@ By utilizing MongoDB as the destination for CloudQuery, developers can efficient
 
 ## Setting up CloudQuery
 
-To start building your cloud infrastructure data lake with CloudQuery and MongoDB, you'll first need to set up CloudQuery. Follow the quickstart guide, which offers precompiled binaries for various platforms, including [Windows](https://www.cloudquery.io/docs/quickstart/windows), [macOS](https://www.cloudquery.io/docs/quickstart/macOS), and [Linux](https://www.cloudquery.io/docs/quickstart/linux). Follow the links to the guide for your respective platform.
+To start building your cloud infrastructure data lake with CloudQuery and MongoDB, you'll first need to set up CloudQuery. Follow the quickstart guide, which offers precompiled binaries for various platforms, including [Windows](/docs/quickstart/windows), [macOS](/docs/quickstart/macOS), and [Linux](/docs/quickstart/linux). Follow the links to the guide for your respective platform.
 
 Next, create a configuration file that specifies the cloud providers and resources you want to include in your infrastructure data lake. For example, you might include [AWS](https://www.cloudquery.io/integrations/aws), [Google Cloud](https://www.cloudquery.io/integrations/gcp), and [Azure](https://www.cloudquery.io/integrations/azure), along with their respective resource types such as EC2 instances, S3 buckets, and virtual machines. You can find all supported cloud providers and resources in [CloudQuery integrations](https://www.cloudquery.io/integrations).
 

--- a/website/pages/blog/building-cloudquery.mdx
+++ b/website/pages/blog/building-cloudquery.mdx
@@ -44,7 +44,7 @@ Pluggable sources are key to scale API coverage both from development and usabil
 - **Versioning:** Given plugins are developed as standalone gRPC binaries users can use different versions of different plugins depending on their needs.
 - **Independent development:** Developers can develop their own plugins in their own repositories without being blocked by a vendor (us in this case) to review PRs.
 
-Our [pluggable system](https://www.cloudquery.io/docs/developers/architecture) is based on gRPC to ensure our plugins can be cross-platform, independent and performant.
+Our [pluggable system](/docs/developers/architecture) is based on gRPC to ensure our plugins can be cross-platform, independent and performant.
 
 ### SDK for Source Plugins
 
@@ -83,7 +83,7 @@ The job of a pluggable ELT platform is to do two things:
 
 CloudQuery transforms every single field to its own rich type system, which contains more than [17 types](https://github.com/cloudquery/plugin-sdk/tree/main/schema) (including things like IP Addresses, MAC Addresses). This ensures all the validation is happening in the transformation phase. Destination plugins then only need transform this, depending on what types each destination supports. This is a big shift from how Singer or Airbyte works. These systems use what is available in JSON and [JSON Schema](https://json-schema.org/), as they couple the encoding together with the type system.
 
-Because of these two design decisions, CloudQuery already supports [5 destinations](https://hub.cloudquery.io/plugins/destination) only two months after our initial [V1 release](https://www.cloudquery.io/blog/cloudquery-v1-release).
+Because of these two design decisions, CloudQuery already supports [5 destinations](https://hub.cloudquery.io/plugins/destination) only two months after our initial [V1 release](/blog/cloudquery-v1-release).
 
 ## Performance
 

--- a/website/pages/blog/cloudquery-raises-15m-series-a.mdx
+++ b/website/pages/blog/cloudquery-raises-15m-series-a.mdx
@@ -29,7 +29,7 @@ ELT platforms are quite the standard in the data engineering world and the moder
 
 If we look at cloud infrastructure world it is all 2011 - sprawl of vendors targeting different subset of APIs, data silos, different query languages, no access to the raw data, inability to create custom workflows, and super expensive solutions that don’t scale well with your infrastructure.
 
-Here at CloudQuery we are set on a mission to bring the best of data engineering practices to cloud security, compliance, search, cost and rebuild them one by one as data apps on top of CloudQuery. Due to the infinite (and growing) number of APIs we believe the only scalable way here is open source, so read more about our open source journey here: [https://www.cloudquery.io/blog/our-open-source-journey-building-cloudquery](https://www.cloudquery.io/blog/our-open-source-journey-building-cloudquery).
+Here at CloudQuery we are set on a mission to bring the best of data engineering practices to cloud security, compliance, search, cost and rebuild them one by one as data apps on top of CloudQuery. Due to the infinite (and growing) number of APIs we believe the only scalable way here is open source, so read more about our open source journey here: [/blog/our-open-source-journey-building-cloudquery](/blog/our-open-source-journey-building-cloudquery).
 
 ## What’s coming
 

--- a/website/pages/blog/cloudquery-v1-release.mdx
+++ b/website/pages/blog/cloudquery-v1-release.mdx
@@ -13,7 +13,7 @@ import { BlogHeader } from "../../components/BlogHeader"
 
 Today is an exciting day for us at CloudQuery. For the last three months, we have been working on a completely new version of CloudQuery: with all the learnings and feedback from our amazing users over the past year. And today we are announcing its release! (We are zero-based, so it's v1 even though it's the second version 🙂) In this post, I will walk through the major features, architecture changes and upcoming work.
 
-Quick Recap: If you are unfamiliar with CloudQuery and why we are bringing the best of data engineering to infrastructure and security teams - check out our post from the recent series A [announcement](https://www.cloudquery.io/blog/cloudquery-raises-15m-series-a#story-time).
+Quick Recap: If you are unfamiliar with CloudQuery and why we are bringing the best of data engineering to infrastructure and security teams - check out our post from the recent series A [announcement](/blog/cloudquery-raises-15m-series-a#story-time).
 
 And now to the new features!
 

--- a/website/pages/blog/exploring-api-data-with-duckdb.mdx
+++ b/website/pages/blog/exploring-api-data-with-duckdb.mdx
@@ -58,7 +58,7 @@ spec:
     connection_string: "./homebrew.duckdb"
 ```
 
-Now we can run `cloudquery sync` to sync data from the Homebrew source to a local DuckDB database file (you will need to have [CloudQuery installed](https://www.cloudquery.io/docs/quickstart) for this step):
+Now we can run `cloudquery sync` to sync data from the Homebrew source to a local DuckDB database file (you will need to have [CloudQuery installed](/docs/quickstart) for this step):
 
 ```bash copy
 cloudquery sync homebrew-duckdb.yml

--- a/website/pages/blog/how-hexagon-built-an-infrastructure-data-lake.mdx
+++ b/website/pages/blog/how-hexagon-built-an-infrastructure-data-lake.mdx
@@ -48,4 +48,4 @@ As with any large undertaking, there were some challenges along the way. The Hex
 
 We’d like to thank the Hexagon CCoE team for collaborating with us to push the boundaries of what is possible with CloudQuery, being active community members and for sharing their story with everyone.
 
-If you are also interested in setting up an AWS infrastructure data lake using Glue and Athena, like Hexagon, you can follow our how-to guide: [How to Load Infrastructure Data into AWS Athena](https://www.cloudquery.io/how-to-guides/how-to-load-infrastructure-data-into-athena). Or if you have any other questions or comments, we are always happy to chat on our Discord.
+If you are also interested in setting up an AWS infrastructure data lake using Glue and Athena, like Hexagon, you can follow our how-to guide: [How to Load Infrastructure Data into AWS Athena](/how-to-guides/how-to-load-infrastructure-data-into-athena). Or if you have any other questions or comments, we are always happy to chat on our Discord.

--- a/website/pages/blog/how-to-setup-aws-cli-with-aws-sso.mdx
+++ b/website/pages/blog/how-to-setup-aws-cli-with-aws-sso.mdx
@@ -20,7 +20,7 @@ AWS CLI added support for SSO [late 2019](https://aws.amazon.com/blogs/developer
 
 ### Setup AWS SSO with an IDP
 
-The first step is to have AWS SSO setup and configured. This should be done by someone with the right admin access permissions to both the IdP and AWS. Check out how to set up [AWS SSO with G Suite as IDP](https://www.cloudquery.io/blog/aws-sso-tutorial-with-google-workspace-as-an-idp).
+The first step is to have AWS SSO setup and configured. This should be done by someone with the right admin access permissions to both the IdP and AWS. Check out how to set up [AWS SSO with G Suite as IDP](/blog/aws-sso-tutorial-with-google-workspace-as-an-idp).
 
 ### Install AWS CLI (v2)
 

--- a/website/pages/blog/introducing-cloudquery-sdk.mdx
+++ b/website/pages/blog/introducing-cloudquery-sdk.mdx
@@ -33,7 +33,7 @@ So far adding support for new cloud providers and resources to CloudQuery requir
 Now, CloudQuery SDK means you as a developer will only have to implement the **E** (in ETL), and the SDK will take care of the rest.
 Also, you will benefit from easy testable code, new features like history, policy packs and others that your providers will get out of the box as the SDK develops.
 
-Full Documentation is available [here](https://www.cloudquery.io/docs/developers/architecture).
+Full Documentation is available [here](/docs/developers/architecture).
 
 For a quick snippet continue reading!
 

--- a/website/pages/blog/introducing-the-github-cloudquery-provider.mdx
+++ b/website/pages/blog/introducing-the-github-cloudquery-provider.mdx
@@ -21,7 +21,7 @@ In this tutorial, we will install CloudQuery and use it to fetch GitHub resource
 
 ## Setup
 
-- [Download CloudQuery](https://www.cloudquery.io/docs/quickstart).
+- [Download CloudQuery](/docs/quickstart).
 - Acquire a GitHub (personal access token)[https://docs.github.com/en/enterprise-server@3.4/authentication/keeping-your-account-and-data-secure/creating-a-personal-access-token]
   with the scopes:
   ```ini copy

--- a/website/pages/blog/migration-and-history-deprecation.mdx
+++ b/website/pages/blog/migration-and-history-deprecation.mdx
@@ -19,7 +19,7 @@ import { Callout } from 'nextra-theme-docs';
 
 This is a short note that v0.24.0 is deprecating migrations from cloudquery together with history.
 
-Late last year we introduced experimental support of historical data with TimescaleDB [(See the blog post)](https://www.cloudquery.io/blog/announcing-cloudquery-history). Giving it a try we learned that maintaining full migrations for every single table is impossible and also affects developer experience of both third-party providers, ours internally and contributors.
+Late last year we introduced experimental support of historical data with TimescaleDB [(See the blog post)](/blog/announcing-cloudquery-history). Giving it a try we learned that maintaining full migrations for every single table is impossible and also affects developer experience of both third-party providers, ours internally and contributors.
 
 
 ## What will change

--- a/website/pages/blog/our-open-source-journey-building-cloudquery.mdx
+++ b/website/pages/blog/our-open-source-journey-building-cloudquery.mdx
@@ -71,7 +71,7 @@ Given these insights, we scribbled the following:
 You can observe the following components:
 
 - **ETL Engine:** The first thing we were out to do at CloudQuery is to consolidate and build one open-source engine with multi-database support.
-- **CloudQuery SDK:** To make life easier for us and for the community we created an [SDK](https://www.cloudquery.io/blog/introducing-cloudquery-sdk) that simplifies the development and testing of new integrations. The SDK gives developers the ability to focus only on the E (Extract) while taking care of the TL (Transform and Load) and giving the option for multi-database support.
+- **CloudQuery SDK:** To make life easier for us and for the community we created an [SDK](/blog/introducing-cloudquery-sdk) that simplifies the development and testing of new integrations. The SDK gives developers the ability to focus only on the E (Extract) while taking care of the TL (Transform and Load) and giving the option for multi-database support.
 - **Decoupling ETL & Analysis Engine:** This was solved by having the data/configuration in the database and giving users raw access to the database. The analysis engine is implemented using standard, well known, and documented query languages.
 
 Replacing acronyms with use-cases: Instead of adding more acronyms we just want to focus on the end use-cases:
@@ -79,7 +79,7 @@ Replacing acronyms with use-cases: Instead of adding more acronyms we just want 
 - **Security & Compliance Policies:** We introduced [CloudQuery Policies](https://hub.cloudquery.io/addons/transformation) which is just a thin layer that gives users the ability to run a pack of SQL queries.
 - **Search & Visibility:** Standard SQL gives you visibility across accounts and clouds.
 - **Cost:** This is something we didn’t actively touch yet, but are looking for feedback and suggestions.
-- **History:** Being able to look back in time and investigate is useful for a variety of use-cases such as post-mortems, incident-response, and compliance. This is why we introduced CloudQuery history with [TimescaleDB](https://www.cloudquery.io/blog/announcing-cloudquery-history)
+- **History:** Being able to look back in time and investigate is useful for a variety of use-cases such as post-mortems, incident-response, and compliance. This is why we introduced CloudQuery history with [TimescaleDB](/blog/announcing-cloudquery-history)
 - **Other:** There are probably many more use-cases, and there is no need to invent new acronyms for them - it can just be a matter of adding a novel query or a new integration. We’re looking forward to seeing what you can do with CQ data - feel free to hop on our discord and join our monthly community hours.
 - **Yet another dashboard disease:** Companies have invested a lot of effort in having their own monitoring and visualization solutions. By giving raw access to the database you can take advantage of your current tools - Grafana, Preset, etc…
 

--- a/website/pages/blog/outdated-aws-iam-policy-language.mdx
+++ b/website/pages/blog/outdated-aws-iam-policy-language.mdx
@@ -97,7 +97,7 @@ aws iam put-user-policy \
 
 ### Finding Identity-Based Policies with CloudQuery
 
-The below queries have a prerequisite to use CloudQuery to sync AWS data to PostgreSQL.  For a guide, see our [quickstart guide](https://www.cloudquery.io/docs/quickstart/macOS).
+The below queries have a prerequisite to use CloudQuery to sync AWS data to PostgreSQL.  For a guide, see our [quickstart guide](/docs/quickstart/macOS).
 
 We will use CloudQuery to check for identity-based with `2008-10-17` explicitly set as the version or for identity-based policies without an explicit version set.
 

--- a/website/pages/blog/postgres-cdc-to-any-destination.mdx
+++ b/website/pages/blog/postgres-cdc-to-any-destination.mdx
@@ -46,7 +46,7 @@ CloudQuery PostgreSQL source plugin provides the ability to sync data and change
 of the supported [destinations](https://hub.cloudquery.io/plugins/destination), without the need for Kafka or any other intermediary. (You can still stream to Kafka or Google PubSub.)
 This gives a much simpler setup to operate: just run one CloudQuery binary!
 
-In the following section, we will go through how our CloudQuery PostgreSQL source plugin works internally. (For running and configuring, refer to the [docs](https://www.cloudquery.io/docs/quickstart).)
+In the following section, we will go through how our CloudQuery PostgreSQL source plugin works internally. (For running and configuring, refer to the [docs](/docs/quickstart).)
 
 ### Set `wal_level` to logical
 

--- a/website/pages/blog/product-updates-1.mdx
+++ b/website/pages/blog/product-updates-1.mdx
@@ -17,14 +17,14 @@ This month we've been really cranking it at CQ so lots of good stuff!
 
 ## CLI Improvements
 
-* We've introduced wildcard matching to specify tables. Check out the [release blog](https://www.cloudquery.io/blog/introducing-wildcard-matching-for-tables)
+* We've introduced wildcard matching to specify tables. Check out the [release blog](/blog/introducing-wildcard-matching-for-tables)
 
 ## Destinations
 
 We've added two new destinations to CQ!
 
-* [SQLite](https://github.com/cloudquery/cloudquery/tree/main/plugins/destination/sqlite). See [release blog](https://www.cloudquery.io/blog/announcing-cloudquery-sqlite-destination)
-* CSV. (Update 20 April 2023: CSV destination has now been replaced by the [File destination](https://hub.cloudquery.io/plugins/destination/cloudquery/file).) See [release blog](https://www.cloudquery.io/blog/scaling-out-elt-with-cq-and-csv).
+* [SQLite](https://github.com/cloudquery/cloudquery/tree/main/plugins/destination/sqlite). See [release blog](/blog/announcing-cloudquery-sqlite-destination)
+* CSV. (Update 20 April 2023: CSV destination has now been replaced by the [File destination](https://hub.cloudquery.io/plugins/destination/cloudquery/file).) See [release blog](/blog/scaling-out-elt-with-cq-and-csv).
 
 ## Sources
 

--- a/website/pages/blog/product-updates-2.mdx
+++ b/website/pages/blog/product-updates-2.mdx
@@ -19,8 +19,8 @@ Hey everyone! Our monthly round-up of CloudQuery product and roadmap updates is 
 
 We've added two new destinations to CQ supporting two of the most popular data warehouses!
 
-* [Snowflake](https://www.cloudquery.io/blog/announcing-cloudquery-snowflake-destination)
-* [BigQuery](https://www.cloudquery.io/blog/announcing-cloudquery-bigquery-destination)
+* [Snowflake](/blog/announcing-cloudquery-snowflake-destination)
+* [BigQuery](/blog/announcing-cloudquery-bigquery-destination)
 
 ## Sources
 
@@ -28,9 +28,9 @@ We've added two new destinations to CQ supporting two of the most popular data w
 
 We've added 3 new source plugins to CQ to cover the long tail of infrastructure apps!
 
-* [Gandi](https://www.cloudquery.io/blog/introducing-the-gandi-source-plugin)
-* [Tailscale](https://www.cloudquery.io/blog/introducing-the-tailscale-source-plugin)
-* [Vercel](https://www.cloudquery.io/blog/announcing-the-vercel-source-plugin)
+* [Gandi](/blog/introducing-the-gandi-source-plugin)
+* [Tailscale](/blog/introducing-the-tailscale-source-plugin)
+* [Vercel](/blog/announcing-the-vercel-source-plugin)
 
 ### AWS
 
@@ -53,13 +53,13 @@ See full [changelog](https://github.com/cloudquery/cloudquery/blob/main/plugins/
 
 ### Engineering
 
-- [Building CQ: High Performance Data Integration Framework in Go](https://www.cloudquery.io/blog/building-cloudquery) got on HN front page! 
+- [Building CQ: High Performance Data Integration Framework in Go](/blog/building-cloudquery) got on HN front page! 
 
 ### Security
 
-- [Finding Cross-Account AWS EventBridge Usage (customer story)](https://www.cloudquery.io/blog/how-to-find-cross-account-aws-eventbridge-usage)
-- [S3 Security Settings for Enabling S3 Blog Public Access and Disabling ACLs](https://www.cloudquery.io/blog/finding-enabled-s3-acls-and-disabled-s3-block-public-access)
+- [Finding Cross-Account AWS EventBridge Usage (customer story)](/blog/how-to-find-cross-account-aws-eventbridge-usage)
+- [S3 Security Settings for Enabling S3 Blog Public Access and Disabling ACLs](/blog/finding-enabled-s3-acls-and-disabled-s3-block-public-access)
 
 ### FinOps
 
-- [Harnessing the Power of BigQuery and CloudQuery for Google Cloud Cost Optimization](https://www.cloudquery.io/blog/analysing-gcp-cost-with-bigquery-and-cq)
+- [Harnessing the Power of BigQuery and CloudQuery for Google Cloud Cost Optimization](/blog/analysing-gcp-cost-with-bigquery-and-cq)

--- a/website/pages/blog/product-updates-7.mdx
+++ b/website/pages/blog/product-updates-7.mdx
@@ -20,14 +20,14 @@ TLDR:
 
 ## SDKs!
 
-With the recent [Adoption of Apache Arrow](https://www.cloudquery.io/blog/adopting-apache-arrow-at-cloudquery) as CloudQuery's
+With the recent [Adoption of Apache Arrow](/blog/adopting-apache-arrow-at-cloudquery) as CloudQuery's
 in-memory data format, the CloudQuery SDK is now expanding beyond Go (which means you can write CloudQuery plugins in other languages)!
 
 The first one is, of course, the undisputed king of data engineering--Python! and the 2nd after is the undisputed king of the web--JavaScript!
 
-* Check out our [Python announcement blog](https://www.cloudquery.io/blog/announcing-cloudquery-python-sdk)!
-* Creating a [Python source](https://www.cloudquery.io/docs/developers/creating-new-plugin/python-source)
-* Creating a [JavaScript source](https://www.cloudquery.io/docs/developers/creating-new-plugin/javascript-source)
+* Check out our [Python announcement blog](/blog/announcing-cloudquery-python-sdk)!
+* Creating a [Python source](/docs/developers/creating-new-plugin/python-source)
+* Creating a [JavaScript source](/docs/developers/creating-new-plugin/javascript-source)
 
 ## Sources
 

--- a/website/pages/blog/product-updates-8.mdx
+++ b/website/pages/blog/product-updates-8.mdx
@@ -18,10 +18,10 @@ Hey everyone! Our monthly round-up of CloudQuery product and roadmap updates is 
 
 ## SDKs!
 
-In case you missed it, we published [Python](https://www.cloudquery.io/blog/announcing-cloudquery-python-sdk) and [JavaScript](https://www.cloudquery.io/blog/announcing-cloudquery-javascript-sdk) SDKs last month and this month, we followed with Java!
+In case you missed it, we published [Python](/blog/announcing-cloudquery-python-sdk) and [JavaScript](/blog/announcing-cloudquery-javascript-sdk) SDKs last month and this month, we followed with Java!
 
-- Check out our [Java announcement blog](https://www.cloudquery.io/blog/announcing-cloudquery-java-sdk)!
-- Creating a [Java source](https://www.cloudquery.io/docs/developers/creating-new-plugin/java-source)
+- Check out our [Java announcement blog](/blog/announcing-cloudquery-java-sdk)!
+- Creating a [Java source](/docs/developers/creating-new-plugin/java-source)
 
 ## Sources
 
@@ -33,11 +33,11 @@ In case you missed it, we published [Python](https://www.cloudquery.io/blog/anno
 
 ### AWS, GCP, Azure Highlights
 
-- CloudQuery is now an official AWS Partner! Read more about this in our [announcement](https://www.cloudquery.io/blog/announcing-aws-partnership).
+- CloudQuery is now an official AWS Partner! Read more about this in our [announcement](/blog/announcing-aws-partnership).
 
-- We launched a closed beta for event-based sync with the AWS plugin. This helps with keeping your data fresh without running full syncs. [Sign up for beta](https://cloudquery.typeform.com/to/Dvdn6P2u) or [read the full announcement](https://www.cloudquery.io/blog/announcing-cloudquery-aws-event-based-sync-beta) first.
+- We launched a closed beta for event-based sync with the AWS plugin. This helps with keeping your data fresh without running full syncs. [Sign up for beta](https://cloudquery.typeform.com/to/Dvdn6P2u) or [read the full announcement](/blog/announcing-cloudquery-aws-event-based-sync-beta) first.
 
-- The AWS plugin has a new scheduler strategy that reduces the number of concurrent calls made to AWS APIs in syncs with multiple tables. This means the probability of hitting rate limits is lower. Read more about this in our documentation on [performance tuning](https://www.cloudquery.io/docs/advanced-topics/performance-tuning#use-a-different-scheduler).
+- The AWS plugin has a new scheduler strategy that reduces the number of concurrent calls made to AWS APIs in syncs with multiple tables. This means the probability of hitting rate limits is lower. Read more about this in our documentation on [performance tuning](/docs/advanced-topics/performance-tuning#use-a-different-scheduler).
 
 Check out the full changelog for [AWS](https://github.com/cloudquery/cloudquery/blob/97d86a5c282e587420c1abd714bb0218d9c86f5a/plugins/source/aws/CHANGELOG.md),
 [GCP](https://github.com/cloudquery/cloudquery/blob/97d86a5c282e587420c1abd714bb0218d9c86f5a/plugins/source/gcp/CHANGELOG.md) and [Azure](https://github.com/cloudquery/cloudquery/blob/97d86a5c282e587420c1abd714bb0218d9c86f5a/plugins/source/azure/CHANGELOG.md)
@@ -49,7 +49,7 @@ for full updates.
 
 ## Policies
 
-- We released [AWS Foundational Security Best Practices for Snowflake](https://www.cloudquery.io/blog/announcing-aws-fsbp-policies-snowflake)! With this release, there are now over 200 controls with coverage for more than 40 AWS services.
+- We released [AWS Foundational Security Best Practices for Snowflake](/blog/announcing-aws-fsbp-policies-snowflake)! With this release, there are now over 200 controls with coverage for more than 40 AWS services.
 - Bug fixes on AWS policies
 
 ## Other notable blogs and use-cases

--- a/website/pages/blog/releasing-cloudquery-0.20.0.mdx
+++ b/website/pages/blog/releasing-cloudquery-0.20.0.mdx
@@ -22,7 +22,7 @@ import { BlogHeader } from "../../components/BlogHeader"
 
 ### What is CloudQuery ?
 
-CloudQuery is the open-source cloud asset inventory powered by SQL, enabling you to [assets, audit, and evaluate the configurations](https://hub.cloudquery.io/addons/transformation) and even [drifts](https://www.cloudquery.io/blog/announcing-cloudquery-terraform-drift-detection) of your cloud assets.
+CloudQuery is the open-source cloud asset inventory powered by SQL, enabling you to [assets, audit, and evaluate the configurations](https://hub.cloudquery.io/addons/transformation) and even [drifts](/blog/announcing-cloudquery-terraform-drift-detection) of your cloud assets.
 
 CloudQuery key use-cases and features:
 

--- a/website/pages/blog/terraform-drift-deprecation.mdx
+++ b/website/pages/blog/terraform-drift-deprecation.mdx
@@ -13,7 +13,7 @@ import { BlogHeader } from "../../components/BlogHeader"
 
 This is a short note that v0.27.0 is deprecating Terraform drift functionality.
 
-Late last year we introduced experimental support for Terraform Drift detection [(See the blog post)](https://www.cloudquery.io/blog/announcing-cloudquery-terraform-drift-detection) and learned a lot from the community and the feedback you shared!
+Late last year we introduced experimental support for Terraform Drift detection [(See the blog post)](/blog/announcing-cloudquery-terraform-drift-detection) and learned a lot from the community and the feedback you shared!
 
 We’ve learned a couple of major things:
 

--- a/website/pages/blog/what-is-the-modern-data-stack.mdx
+++ b/website/pages/blog/what-is-the-modern-data-stack.mdx
@@ -42,7 +42,7 @@ The introduction of data warehouses and data lakes also made it possible to shif
 
 This refers to the data we want to ingest and involves different types of sources:
 
-- **Databases**: Companies have many databases for different workloads. Since these databases are not optimized for analytical workloads, it is often necessary to ingest data from production databases to analytical databases where you can run complex queries without impacting the production system. Additionally, there have been many advances around Change Data Capture ([CDC](https://www.cloudquery.io/blog/postgres-cdc-to-any-destination)) for databases, allowing you to ingest data in real-time from databases. This enables efficient, near-real time syncing between source databases and destinations.
+- **Databases**: Companies have many databases for different workloads. Since these databases are not optimized for analytical workloads, it is often necessary to ingest data from production databases to analytical databases where you can run complex queries without impacting the production system. Additionally, there have been many advances around Change Data Capture ([CDC](/blog/postgres-cdc-to-any-destination)) for databases, allowing you to ingest data in real-time from databases. This enables efficient, near-real time syncing between source databases and destinations.
 - **APIs**: Most SaaS products expose their data via APIs. So, data for anything from marketing or finance products such as Salesforce and Stripe, to infrastructure platforms such as AWS, GCP, Azure can be loaded.**
 - **Event Streams**: This is another popular source type where you might want to subscribe to an event queue and send it to an analytical destination.
 
@@ -58,7 +58,7 @@ Other important features of EL tools:
 - **Performance -** The better the performance, the cheaper the EL workload will be, and the faster data will be ingested.
 - **Pluggable Architecture -** Given the large number of sources and destinations, it is essential that sources and destinations are decoupled; otherwise, each source will need to support a growing number of destinations.
 
-You can learn more about CloudQuery’s [Architecture](https://www.cloudquery.io/docs/developers/architecture) and How we’ve built [CloudQuery a High Performance ELT Framework in Go](https://www.cloudquery.io/blog/building-cloudquery).
+You can learn more about CloudQuery’s [Architecture](/docs/developers/architecture) and How we’ve built [CloudQuery a High Performance ELT Framework in Go](/blog/building-cloudquery).
 
 ## Data Storage
 

--- a/website/pages/case-studies/how-hexagon-built-an-infrastructure-data-lake.mdx
+++ b/website/pages/case-studies/how-hexagon-built-an-infrastructure-data-lake.mdx
@@ -47,4 +47,4 @@ As with any large undertaking, there were some challenges along the way. The Hex
 
 We’d like to thank the Hexagon CCoE team for collaborating with us to push the boundaries of what is possible with CloudQuery, being active community members and for sharing their story with everyone.
 
-If you are also interested in setting up an AWS infrastructure data lake using Glue and Athena, like Hexagon, you can follow our how-to guide: [How to Load Infrastructure Data into AWS Athena](https://www.cloudquery.io/how-to-guides/how-to-load-infrastructure-data-into-athena). Or if you have any other questions or comments, we are always happy to chat on our Discord.
+If you are also interested in setting up an AWS infrastructure data lake using Glue and Athena, like Hexagon, you can follow our how-to guide: [How to Load Infrastructure Data into AWS Athena](/how-to-guides/how-to-load-infrastructure-data-into-athena). Or if you have any other questions or comments, we are always happy to chat on our Discord.

--- a/website/pages/docs/deployment/google-cloud-vm.mdx
+++ b/website/pages/docs/deployment/google-cloud-vm.mdx
@@ -42,7 +42,7 @@ src="https://www.youtube.com/embed/rz4aU1IMF30">
 ## Step 2: Install CloudQuery
 
 1. SSH into your instance. You can do this by clicking on the SSH button next to your instance in the Google Cloud Console.
-2. Download CloudQuery by running the following command from the [Quickstart guide for Linux](https://www.cloudquery.io/docs/quickstart/linux):
+2. Download CloudQuery by running the following command from the [Quickstart guide for Linux](/docs/quickstart/linux):
 
 ```bash copy
 curl -L https://github.com/cloudquery/cloudquery/releases/download/cli-vVERSION_CLI/cloudquery_linux_amd64 -o cloudquery

--- a/website/pages/docs/developers/build.md
+++ b/website/pages/docs/developers/build.md
@@ -13,6 +13,6 @@ To build CloudQuery CLI from source, follow the steps:
 2. Fork and clone the CloudQuery repository. If you’re not sure how to do this, please watch [these videos](https://egghead.io/courses/how-to-contribute-to-an-open-source-project-on-github).
 3. From the cloned repository root, change directory to `./cli` and run `go build -o cloudquery` to build the CloudQuery CLI. The binary will be created in the same directory.
 
-Building a plugin from source is similar. Most plugins have a makefile in their directory to make this easier. For example, to build the `aws` plugin, run `make build` from the `./plugins/source/aws` directory. The resulting binary can be used by providing the path to it as the `path` parameter in a [plugin config](https://www.cloudquery.io/docs/reference/source-spec), together with the `local` registry. Python plugins have `make build-docker` to build a Docker image that can be used with the `docker` registry.
+Building a plugin from source is similar. Most plugins have a makefile in their directory to make this easier. For example, to build the `aws` plugin, run `make build` from the `./plugins/source/aws` directory. The resulting binary can be used by providing the path to it as the `path` parameter in a [plugin config](/docs/reference/source-spec), together with the `local` registry. Python plugins have `make build-docker` to build a Docker image that can be used with the `docker` registry.
 
 

--- a/website/pages/how-to-guides/aws-resource-limits-and-service-quotas.mdx
+++ b/website/pages/how-to-guides/aws-resource-limits-and-service-quotas.mdx
@@ -129,7 +129,7 @@ We can also look for additional use cases such as API limits.  For this query, w
 ### Next Steps
 
 Additional insights can be made with data loaded from CloudQuery.  For example, [`CloudTrail events`](https://hub.cloudquery.io/plugins/source/cloudquery/aws/tables/aws_cloudtrail_events).
- can be used to check for API calls.  CloudQuery can also be used to monitor service limit increases via Support Cases and customizable dashboards can be [built with Grafana](https://www.cloudquery.io/how-to-guides/open-source-cspm).  We'd love to hear your use cases with CloudQuery!
+ can be used to check for API calls.  CloudQuery can also be used to monitor service limit increases via Support Cases and customizable dashboards can be [built with Grafana](/how-to-guides/open-source-cspm).  We'd love to hear your use cases with CloudQuery!
 
 ## Summary
 

--- a/website/pages/how-to-guides/cloud-asset-inventory-cloudquery-apache-superset.mdx
+++ b/website/pages/how-to-guides/cloud-asset-inventory-cloudquery-apache-superset.mdx
@@ -58,13 +58,13 @@ If all your credentials are correct, click **connect** and then **finish**
 
 To be able to create **charts** that you will later add to a **dashboard** you first need to create a **dataset** (for full details see [Creating Charts and Dashboards in Superset](https://superset.apache.org/docs/creating-charts-dashboards/creating-your-first-dashboard)).
 
-In this guide we will create a dataset from a [view](https://github.com/cloudquery/cq-provider-aws/blob/main/views/resources.sql) (also, see [blog](https://www.cloudquery.io/blog/aws-resources-view)) we already created on our database but you can also create a dataset from any complex query you can think off in **Superset SQL Lab**.
+In this guide we will create a dataset from a [view](https://github.com/cloudquery/cq-provider-aws/blob/main/views/resources.sql) (also, see [blog](/blog/aws-resources-view)) we already created on our database but you can also create a dataset from any complex query you can think off in **Superset SQL Lab**.
 
 ![](/images/blog/cloud-asset-inventory-cloudquery-apache-superset/2.png)
 
 ### Step 5: Create your first chart!
 
-Now you are ready to create your first chart on top of our [AWS Resource View](https://github.com/cloudquery/cq-provider-aws/blob/main/views/resources.sql) (Also, see [blog](https://www.cloudquery.io/blog/aws-resources-view))! Choose the dataset you created in the last step (in this case `aws_resources`) and choose the chart type you want to create (we will take the **Bar Chart** but you can also change this in the chart screen).
+Now you are ready to create your first chart on top of our [AWS Resource View](https://github.com/cloudquery/cq-provider-aws/blob/main/views/resources.sql) (Also, see [blog](/blog/aws-resources-view))! Choose the dataset you created in the last step (in this case `aws_resources`) and choose the chart type you want to create (we will take the **Bar Chart** but you can also change this in the chart screen).
 
 ![](/images/blog/cloud-asset-inventory-cloudquery-apache-superset/3.png)
 

--- a/website/pages/how-to-guides/cloudquery-postgraphile.mdx
+++ b/website/pages/how-to-guides/cloudquery-postgraphile.mdx
@@ -65,7 +65,7 @@ Open the browser with the `http://localhost:6060/graphiql` endpoint to see the G
 
 ### Step 4: Create New Views
 
-By default PostGraphile exposes all tables and relationships of the existing tables but let’s say you want to create a new view. All you need to do is to create a new view and PostGraphile will automatically generate the model for that. For example, check out this [blog](https://www.cloudquery.io/blog/aws-resources-view) on how to create a unified AWS resource [view](https://github.com/cloudquery/cq-provider-aws/tree/main/views) (or GCP [View](https://github.com/cloudquery/cq-provider-gcp/tree/main/views)). And just like that you can now query and search all your resources by `arn`, `tags`, `name` with GraphQL!
+By default PostGraphile exposes all tables and relationships of the existing tables but let’s say you want to create a new view. All you need to do is to create a new view and PostGraphile will automatically generate the model for that. For example, check out this [blog](/blog/aws-resources-view) on how to create a unified AWS resource [view](https://github.com/cloudquery/cq-provider-aws/tree/main/views) (or GCP [View](https://github.com/cloudquery/cq-provider-gcp/tree/main/views)). And just like that you can now query and search all your resources by `arn`, `tags`, `name` with GraphQL!
 
 ![](/images/blog/cloudquery-postgraphile/step4.png)
 

--- a/website/pages/how-to-guides/cloudquery-postgrest.mdx
+++ b/website/pages/how-to-guides/cloudquery-postgrest.mdx
@@ -80,7 +80,7 @@ curl "http://localhost:3000/aws_ec2_instances?arn=eq.arnsomething"
 
 ### Step 4: Create New Views
 
-By default, PostgREST exposes all tables and relationships of the existing table. But let’s say you want to create a new view. All you need to do is create the new view, and PostgREST will automatically generate the model for that. For example, checkout this [blog](https://www.cloudquery.io/blog/aws-resources-view) on how to create a unified AWS resource [view](https://github.com/cloudquery/cq-provider-aws/tree/main/views) (or GCP [View](https://github.com/cloudquery/cloudquery/tree/main/plugins/source/gcp/views)). And just like that you can now query and search all your resources by ARN, tags, or name using GraphQL!
+By default, PostgREST exposes all tables and relationships of the existing table. But let’s say you want to create a new view. All you need to do is create the new view, and PostgREST will automatically generate the model for that. For example, checkout this [blog](/blog/aws-resources-view) on how to create a unified AWS resource [view](https://github.com/cloudquery/cq-provider-aws/tree/main/views) (or GCP [View](https://github.com/cloudquery/cloudquery/tree/main/plugins/source/gcp/views)). And just like that you can now query and search all your resources by ARN, tags, or name using GraphQL!
 
 ### Step 5: Deploying in production
 

--- a/website/pages/logo.mdx
+++ b/website/pages/logo.mdx
@@ -12,7 +12,7 @@ import Head from "next/head";
         property="og:description"
         content="Official logo of CloudQuery in SVG, AI and PNG formats for press and other matters. Brand kit."
     />
-    <meta property="og:url" content="https://www.cloudquery.io/logo" />
+    <meta property="og:url" content="https://docs.cloudquery.io/logo" />
 </Head>
 
 # CloudQuery Logo


### PR DESCRIPTION
<!-- 🎉 Thank you for making CloudQuery awesome by submitting a PR 🎉 -->

#### Summary

Should fix https://github.com/cloudquery/cloudquery/actions/runs/6980525525/job/18995945959.
`https://www.cloudquery.io` now hosts our new landing page, and `https://www.cloudquery.io/blog`, `https://www.cloudquery.io/docs` redirect back to `https://docs.cloudquery.io`, so we're creating additional unnecessary  hops for our users.

The solution is to use relative links instead of absolute ones.

<!--
Use the following steps to ensure your PR is ready to be reviewed

- [ ] Read the [contribution guidelines](../blob/main/CONTRIBUTING.md) 🧑‍🎓
- [ ] Run `make lint` to ensure the proposed changes follow the coding style 🚨 (install golangci-lint [here](https://golangci-lint.run/usage/install/#local-installation))
- [ ] Run `make test` to ensure the proposed changes pass the tests 🧪
- [ ] If changing a source plugin run `make gen` to ensure docs are up to date 📝
- [ ] Ensure the status checks below are successful ✅
--->
