### PR TITLE
feat: Add `azure_resources_providers` table

### DIFF
--- a/plugins/source/azure/docs/tables/README.md
+++ b/plugins/source/azure/docs/tables/README.md
@@ -253,6 +253,7 @@
 - [azure_reservations_reservation](azure_reservations_reservation.md)
 - [azure_reservations_reservation_order](azure_reservations_reservation_order.md)
 - [azure_resources_links](azure_resources_links.md)
+- [azure_resources_providers](azure_resources_providers.md)
 - [azure_resources_resource_groups](azure_resources_resource_groups.md)
 - [azure_resources_resources](azure_resources_resources.md)
 - [azure_role_management_policy_assignments](azure_role_management_policy_assignments.md)

--- a/plugins/source/azure/docs/tables/azure_resources_providers.md
+++ b/plugins/source/azure/docs/tables/azure_resources_providers.md
@@ -1,0 +1,21 @@
+# Table: azure_resources_providers
+
+This table shows data for Azure Resources Providers.
+
+https://docs.microsoft.com/en-us/rest/api/resources/providers/list
+
+The primary key for this table is **id**.
+
+## Columns
+
+| Name          | Type          |
+| ------------- | ------------- |
+|_cq_id|`uuid`|
+|_cq_parent_id|`uuid`|
+|subscription_id|`utf8`|
+|namespace|`utf8`|
+|provider_authorization_consent_state|`utf8`|
+|id (PK)|`utf8`|
+|registration_policy|`utf8`|
+|registration_state|`utf8`|
+|resource_types|`json`|

--- a/plugins/source/azure/resources/plugin/tables.go
+++ b/plugins/source/azure/resources/plugin/tables.go
@@ -307,6 +307,7 @@ func getTables() schema.Tables {
 		resources.Resources(),
 		resources.ResourceGroups(),
 		resources.Links(),
+		resources.Providers(),
 		policy.Assignments(),
 		policy.DataPolicyManifests(),
 		policy.Definitions(),

--- a/plugins/source/azure/resources/services/resources/providers.go
+++ b/plugins/source/azure/resources/services/resources/providers.go
@@ -1,0 +1,42 @@
+package resources
+
+import (
+	"context"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
+	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resources/armresources"
+	"github.com/cloudquery/cloudquery/plugins/source/azure/client"
+	"github.com/cloudquery/plugin-sdk/v4/schema"
+	"github.com/cloudquery/plugin-sdk/v4/transformers"
+)
+
+func Providers() *schema.Table {
+	return &schema.Table{
+		Name:                 "azure_resources_providers",
+		Resolver:             fetchProviders,
+		PostResourceResolver: client.LowercaseIDResolver,
+		Description:          "https://docs.microsoft.com/en-us/rest/api/resources/providers/list",
+		Multiplex:            client.SubscriptionMultiplex,
+		Transform:            transformers.TransformWithStruct(&armresources.Provider{}, transformers.WithPrimaryKeys("ID")),
+		Columns:              schema.ColumnList{client.SubscriptionID},
+	}
+}
+
+func fetchProviders(ctx context.Context, meta schema.ClientMeta, parent *schema.Resource, res chan<- any) error {
+	cl := meta.(*client.Client)
+	svc, err := armresources.NewProvidersClient(cl.SubscriptionId, cl.Creds, cl.Options)
+	if err != nil {
+		return err
+	}
+	pager := svc.NewListPager(&armresources.ProvidersClientListOptions{
+		Expand: to.Ptr("resourceTypes/aliases"),
+	})
+	for pager.More() {
+		p, err := pager.NextPage(ctx)
+		if err != nil {
+			return err
+		}
+		res <- p.Value
+	}
+	return nil
+}

--- a/plugins/source/azure/resources/services/resources/providers_mock_test.go
+++ b/plugins/source/azure/resources/services/resources/providers_mock_test.go
@@ -1,0 +1,39 @@
+package resources
+
+import (
+	"encoding/json"
+	"net/http"
+	"testing"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resources/armresources"
+	"github.com/cloudquery/cloudquery/plugins/source/azure/client"
+	"github.com/cloudquery/plugin-sdk/v4/faker"
+	"github.com/gorilla/mux"
+)
+
+func createProviders(router *mux.Router) error {
+	var item armresources.ProvidersClientListResponse
+	if err := faker.FakeObject(&item); err != nil {
+		return err
+	}
+
+	emptyStr := ""
+	item.NextLink = &emptyStr
+
+	router.HandleFunc("/subscriptions/{subscriptionId}/providers", func(w http.ResponseWriter, r *http.Request) {
+		b, err := json.Marshal(&item)
+		if err != nil {
+			http.Error(w, "unable to marshal request: "+err.Error(), http.StatusBadRequest)
+			return
+		}
+		if _, err := w.Write(b); err != nil {
+			http.Error(w, "failed to write", http.StatusBadRequest)
+			return
+		}
+	})
+	return nil
+}
+
+func TestProviders(t *testing.T) {
+	client.MockTestHelper(t, Providers(), createProviders)
+}


### PR DESCRIPTION
<!-- 🎉 Thank you for making CloudQuery awesome by submitting a PR 🎉 -->

#### Summary

Added `azure_resources_providers` table, which retrieve azure resource provider information using the following rest api.
https://learn.microsoft.com/en-us/rest/api/resources/providers/list?view=rest-resources-2021-04-01&tabs=HTTP

<!--
Explain what problem this PR addresses
-->

<!--
Use the following steps to ensure your PR is ready to be reviewed

- [ ] Read the [contribution guidelines](../blob/main/CONTRIBUTING.md) 🧑‍🎓
- [ ] Run `make lint` to ensure the proposed changes follow the coding style 🚨 (install golangci-lint [here](https://golangci-lint.run/usage/install/#local-installation))
- [ ] Run `make test` to ensure the proposed changes pass the tests 🧪
- [ ] If changing a source plugin run `make gen` to ensure docs are up to date 📝
- [ ] Ensure the status checks below are successful ✅
--->
