### PR TITLE
fix!: Provide primary keys for tables (S3)

### DIFF
--- a/plugins/source/aws/docs/tables/aws_s3_bucket_cors_rules.md
+++ b/plugins/source/aws/docs/tables/aws_s3_bucket_cors_rules.md
@@ -4,7 +4,7 @@ This table shows data for S3 Bucket Cors Rules.
 
 https://docs.aws.amazon.com/AmazonS3/latest/API/API_CORSRule.html
 
-The primary key for this table is **_cq_id**.
+The composite primary key for this table is (**bucket_arn**, **id**).
 
 ## Relations
 
@@ -14,13 +14,13 @@ This table depends on [aws_s3_buckets](aws_s3_buckets.md).
 
 | Name          | Type          |
 | ------------- | ------------- |
-|_cq_id (PK)|`uuid`|
+|_cq_id|`uuid`|
 |_cq_parent_id|`uuid`|
 |account_id|`utf8`|
-|bucket_arn|`utf8`|
+|bucket_arn (PK)|`utf8`|
 |allowed_methods|`list<item: utf8, nullable>`|
 |allowed_origins|`list<item: utf8, nullable>`|
 |allowed_headers|`list<item: utf8, nullable>`|
 |expose_headers|`list<item: utf8, nullable>`|
-|id|`utf8`|
+|id (PK)|`utf8`|
 |max_age_seconds|`int64`|

--- a/plugins/source/aws/docs/tables/aws_s3_bucket_lifecycles.md
+++ b/plugins/source/aws/docs/tables/aws_s3_bucket_lifecycles.md
@@ -4,7 +4,7 @@ This table shows data for S3 Bucket Lifecycles.
 
 https://docs.aws.amazon.com/AmazonS3/latest/API/API_LifecycleRule.html
 
-The primary key for this table is **_cq_id**.
+The composite primary key for this table is (**bucket_arn**, **id**).
 
 ## Relations
 
@@ -14,14 +14,14 @@ This table depends on [aws_s3_buckets](aws_s3_buckets.md).
 
 | Name          | Type          |
 | ------------- | ------------- |
-|_cq_id (PK)|`uuid`|
+|_cq_id|`uuid`|
 |_cq_parent_id|`uuid`|
 |account_id|`utf8`|
-|bucket_arn|`utf8`|
+|bucket_arn (PK)|`utf8`|
 |status|`utf8`|
 |abort_incomplete_multipart_upload|`json`|
 |expiration|`json`|
-|id|`utf8`|
+|id (PK)|`utf8`|
 |noncurrent_version_expiration|`json`|
 |noncurrent_version_transitions|`json`|
 |prefix|`utf8`|

--- a/plugins/source/aws/docs/tables/aws_s3_bucket_loggings.md
+++ b/plugins/source/aws/docs/tables/aws_s3_bucket_loggings.md
@@ -4,7 +4,7 @@ This table shows data for S3 Bucket Loggings.
 
 https://docs.aws.amazon.com/AmazonS3/latest/API/API_GetBucketLogging.html
 
-The primary key for this table is **_cq_id**.
+The primary key for this table is **bucket_arn**.
 
 ## Relations
 
@@ -14,8 +14,8 @@ This table depends on [aws_s3_buckets](aws_s3_buckets.md).
 
 | Name          | Type          |
 | ------------- | ------------- |
-|_cq_id (PK)|`uuid`|
+|_cq_id|`uuid`|
 |_cq_parent_id|`uuid`|
 |account_id|`utf8`|
-|bucket_arn|`utf8`|
+|bucket_arn (PK)|`utf8`|
 |logging_enabled|`json`|

--- a/plugins/source/aws/docs/tables/aws_s3_bucket_ownership_controls.md
+++ b/plugins/source/aws/docs/tables/aws_s3_bucket_ownership_controls.md
@@ -4,7 +4,7 @@ This table shows data for S3 Bucket Ownership Controls.
 
 https://docs.aws.amazon.com/AmazonS3/latest/API/API_OwnershipControlsRule.html
 
-The primary key for this table is **_cq_id**.
+The composite primary key for this table is (**bucket_arn**, **object_ownership**).
 
 ## Relations
 
@@ -14,8 +14,8 @@ This table depends on [aws_s3_buckets](aws_s3_buckets.md).
 
 | Name          | Type          |
 | ------------- | ------------- |
-|_cq_id (PK)|`uuid`|
+|_cq_id|`uuid`|
 |_cq_parent_id|`uuid`|
 |account_id|`utf8`|
-|bucket_arn|`utf8`|
-|object_ownership|`utf8`|
+|bucket_arn (PK)|`utf8`|
+|object_ownership (PK)|`utf8`|

--- a/plugins/source/aws/docs/tables/aws_s3_bucket_policies.md
+++ b/plugins/source/aws/docs/tables/aws_s3_bucket_policies.md
@@ -4,7 +4,7 @@ This table shows data for S3 Bucket Policies.
 
 https://docs.aws.amazon.com/AmazonS3/latest/API/API_GetBucketPolicy.html
 
-The primary key for this table is **_cq_id**.
+The primary key for this table is **bucket_arn**.
 
 ## Relations
 
@@ -14,9 +14,9 @@ This table depends on [aws_s3_buckets](aws_s3_buckets.md).
 
 | Name          | Type          |
 | ------------- | ------------- |
-|_cq_id (PK)|`uuid`|
+|_cq_id|`uuid`|
 |_cq_parent_id|`uuid`|
 |account_id|`utf8`|
-|bucket_arn|`utf8`|
+|bucket_arn (PK)|`utf8`|
 |policy_json|`json`|
 |policy|`utf8`|

--- a/plugins/source/aws/docs/tables/aws_s3_bucket_public_access_blocks.md
+++ b/plugins/source/aws/docs/tables/aws_s3_bucket_public_access_blocks.md
@@ -4,7 +4,7 @@ This table shows data for S3 Bucket Public Access Blocks.
 
 https://docs.aws.amazon.com/AmazonS3/latest/API/API_GetPublicAccessBlock.html
 
-The primary key for this table is **_cq_id**.
+The primary key for this table is **bucket_arn**.
 
 ## Relations
 
@@ -14,8 +14,8 @@ This table depends on [aws_s3_buckets](aws_s3_buckets.md).
 
 | Name          | Type          |
 | ------------- | ------------- |
-|_cq_id (PK)|`uuid`|
+|_cq_id|`uuid`|
 |_cq_parent_id|`uuid`|
 |account_id|`utf8`|
-|bucket_arn|`utf8`|
+|bucket_arn (PK)|`utf8`|
 |public_access_block_configuration|`json`|

--- a/plugins/source/aws/docs/tables/aws_s3_bucket_replications.md
+++ b/plugins/source/aws/docs/tables/aws_s3_bucket_replications.md
@@ -4,7 +4,7 @@ This table shows data for S3 Bucket Replications.
 
 https://docs.aws.amazon.com/AmazonS3/latest/API/API_GetBucketReplication.html
 
-The primary key for this table is **_cq_id**.
+The primary key for this table is **bucket_arn**.
 
 ## Relations
 
@@ -14,8 +14,8 @@ This table depends on [aws_s3_buckets](aws_s3_buckets.md).
 
 | Name          | Type          |
 | ------------- | ------------- |
-|_cq_id (PK)|`uuid`|
+|_cq_id|`uuid`|
 |_cq_parent_id|`uuid`|
 |account_id|`utf8`|
-|bucket_arn|`utf8`|
+|bucket_arn (PK)|`utf8`|
 |replication_configuration|`json`|

--- a/plugins/source/aws/docs/tables/aws_s3_bucket_versionings.md
+++ b/plugins/source/aws/docs/tables/aws_s3_bucket_versionings.md
@@ -4,7 +4,7 @@ This table shows data for S3 Bucket Versionings.
 
 https://docs.aws.amazon.com/AmazonS3/latest/API/API_GetBucketVersioning.html
 
-The primary key for this table is **_cq_id**.
+The primary key for this table is **bucket_arn**.
 
 ## Relations
 
@@ -14,9 +14,9 @@ This table depends on [aws_s3_buckets](aws_s3_buckets.md).
 
 | Name          | Type          |
 | ------------- | ------------- |
-|_cq_id (PK)|`uuid`|
+|_cq_id|`uuid`|
 |_cq_parent_id|`uuid`|
 |account_id|`utf8`|
-|bucket_arn|`utf8`|
+|bucket_arn (PK)|`utf8`|
 |mfa_delete|`utf8`|
 |status|`utf8`|

--- a/plugins/source/aws/docs/tables/aws_s3_bucket_websites.md
+++ b/plugins/source/aws/docs/tables/aws_s3_bucket_websites.md
@@ -4,7 +4,7 @@ This table shows data for S3 Bucket Websites.
 
 https://docs.aws.amazon.com/AmazonS3/latest/API/API_WebsiteConfiguration.html
 
-The primary key for this table is **_cq_id**.
+The primary key for this table is **bucket_arn**.
 
 ## Relations
 
@@ -14,10 +14,10 @@ This table depends on [aws_s3_buckets](aws_s3_buckets.md).
 
 | Name          | Type          |
 | ------------- | ------------- |
-|_cq_id (PK)|`uuid`|
+|_cq_id|`uuid`|
 |_cq_parent_id|`uuid`|
 |account_id|`utf8`|
-|bucket_arn|`utf8`|
+|bucket_arn (PK)|`utf8`|
 |error_document|`json`|
 |index_document|`json`|
 |redirect_all_requests_to|`json`|

--- a/plugins/source/aws/resources/services/s3/bucket_cors_rules.go
+++ b/plugins/source/aws/resources/services/s3/bucket_cors_rules.go
@@ -18,13 +18,14 @@ func bucketCorsRules() *schema.Table {
 		Name:        "aws_s3_bucket_cors_rules",
 		Description: `https://docs.aws.amazon.com/AmazonS3/latest/API/API_CORSRule.html`,
 		Resolver:    fetchS3BucketCorsRules,
-		Transform:   transformers.TransformWithStruct(&types.CORSRule{}),
+		Transform:   transformers.TransformWithStruct(&types.CORSRule{}, transformers.WithPrimaryKeys("ID")),
 		Columns: []schema.Column{
 			client.DefaultAccountIDColumn(false),
 			{
-				Name:     "bucket_arn",
-				Type:     arrow.BinaryTypes.String,
-				Resolver: schema.ParentColumnResolver("arn"),
+				Name:       "bucket_arn",
+				Type:       arrow.BinaryTypes.String,
+				Resolver:   schema.ParentColumnResolver("arn"),
+				PrimaryKey: true,
 			},
 		},
 	}

--- a/plugins/source/aws/resources/services/s3/bucket_lifecycles.go
+++ b/plugins/source/aws/resources/services/s3/bucket_lifecycles.go
@@ -18,13 +18,14 @@ func bucketLifecycles() *schema.Table {
 		Name:        "aws_s3_bucket_lifecycles",
 		Description: `https://docs.aws.amazon.com/AmazonS3/latest/API/API_LifecycleRule.html`,
 		Resolver:    fetchS3BucketLifecycles,
-		Transform:   transformers.TransformWithStruct(&types.LifecycleRule{}),
+		Transform:   transformers.TransformWithStruct(&types.LifecycleRule{}, transformers.WithPrimaryKeys("ID")),
 		Columns: []schema.Column{
 			client.DefaultAccountIDColumn(false),
 			{
-				Name:     "bucket_arn",
-				Type:     arrow.BinaryTypes.String,
-				Resolver: schema.ParentColumnResolver("arn"),
+				Name:       "bucket_arn",
+				Type:       arrow.BinaryTypes.String,
+				Resolver:   schema.ParentColumnResolver("arn"),
+				PrimaryKey: true,
 			},
 		},
 	}

--- a/plugins/source/aws/resources/services/s3/bucket_logging.go
+++ b/plugins/source/aws/resources/services/s3/bucket_logging.go
@@ -20,9 +20,10 @@ func bucketLogging() *schema.Table {
 		Columns: []schema.Column{
 			client.DefaultAccountIDColumn(false),
 			{
-				Name:     "bucket_arn",
-				Type:     arrow.BinaryTypes.String,
-				Resolver: schema.ParentColumnResolver("arn"),
+				Name:       "bucket_arn",
+				Type:       arrow.BinaryTypes.String,
+				Resolver:   schema.ParentColumnResolver("arn"),
+				PrimaryKey: true,
 			},
 		},
 	}

--- a/plugins/source/aws/resources/services/s3/bucket_ownership_controls.go
+++ b/plugins/source/aws/resources/services/s3/bucket_ownership_controls.go
@@ -17,13 +17,14 @@ func bucketOwnershipControls() *schema.Table {
 		Name:        "aws_s3_bucket_ownership_controls",
 		Description: `https://docs.aws.amazon.com/AmazonS3/latest/API/API_OwnershipControlsRule.html`,
 		Resolver:    fetchBucketOwnershipControls,
-		Transform:   transformers.TransformWithStruct(&types.OwnershipControlsRule{}, transformers.WithSkipFields("ResultMetadata")),
+		Transform:   transformers.TransformWithStruct(&types.OwnershipControlsRule{}, transformers.WithPrimaryKeys("ObjectOwnership"), transformers.WithSkipFields("ResultMetadata")),
 		Columns: []schema.Column{
 			client.DefaultAccountIDColumn(false),
 			{
-				Name:     "bucket_arn",
-				Type:     arrow.BinaryTypes.String,
-				Resolver: schema.ParentColumnResolver("arn"),
+				Name:       "bucket_arn",
+				Type:       arrow.BinaryTypes.String,
+				Resolver:   schema.ParentColumnResolver("arn"),
+				PrimaryKey: true,
 			},
 		},
 	}
@@ -49,7 +50,7 @@ func fetchBucketOwnershipControls(ctx context.Context, meta schema.ClientMeta, p
 		return err
 	}
 
-	if getBucketOwnershipControlOutput == nil {
+	if getBucketOwnershipControlOutput == nil || getBucketOwnershipControlOutput.OwnershipControls == nil {
 		return nil
 	}
 

--- a/plugins/source/aws/resources/services/s3/bucket_policies.go
+++ b/plugins/source/aws/resources/services/s3/bucket_policies.go
@@ -21,9 +21,10 @@ func bucketPolicies() *schema.Table {
 		Columns: []schema.Column{
 			client.DefaultAccountIDColumn(false),
 			{
-				Name:     "bucket_arn",
-				Type:     arrow.BinaryTypes.String,
-				Resolver: schema.ParentColumnResolver("arn"),
+				Name:       "bucket_arn",
+				Type:       arrow.BinaryTypes.String,
+				Resolver:   schema.ParentColumnResolver("arn"),
+				PrimaryKey: true,
 			},
 			{
 				Name:     "policy_json",

--- a/plugins/source/aws/resources/services/s3/bucket_public_access_block.go
+++ b/plugins/source/aws/resources/services/s3/bucket_public_access_block.go
@@ -20,9 +20,10 @@ func bucketPublicAccessBlock() *schema.Table {
 		Columns: []schema.Column{
 			client.DefaultAccountIDColumn(false),
 			{
-				Name:     "bucket_arn",
-				Type:     arrow.BinaryTypes.String,
-				Resolver: schema.ParentColumnResolver("arn"),
+				Name:       "bucket_arn",
+				Type:       arrow.BinaryTypes.String,
+				Resolver:   schema.ParentColumnResolver("arn"),
+				PrimaryKey: true,
 			},
 		},
 	}

--- a/plugins/source/aws/resources/services/s3/bucket_replications.go
+++ b/plugins/source/aws/resources/services/s3/bucket_replications.go
@@ -20,9 +20,10 @@ func bucketReplications() *schema.Table {
 		Columns: []schema.Column{
 			client.DefaultAccountIDColumn(false),
 			{
-				Name:     "bucket_arn",
-				Type:     arrow.BinaryTypes.String,
-				Resolver: schema.ParentColumnResolver("arn"),
+				Name:       "bucket_arn",
+				Type:       arrow.BinaryTypes.String,
+				Resolver:   schema.ParentColumnResolver("arn"),
+				PrimaryKey: true,
 			},
 		},
 	}

--- a/plugins/source/aws/resources/services/s3/bucket_versioning.go
+++ b/plugins/source/aws/resources/services/s3/bucket_versioning.go
@@ -20,9 +20,10 @@ func bucketVersionings() *schema.Table {
 		Columns: []schema.Column{
 			client.DefaultAccountIDColumn(false),
 			{
-				Name:     "bucket_arn",
-				Type:     arrow.BinaryTypes.String,
-				Resolver: schema.ParentColumnResolver("arn"),
+				Name:       "bucket_arn",
+				Type:       arrow.BinaryTypes.String,
+				Resolver:   schema.ParentColumnResolver("arn"),
+				PrimaryKey: true,
 			},
 		},
 	}

--- a/plugins/source/aws/resources/services/s3/bucket_websites.go
+++ b/plugins/source/aws/resources/services/s3/bucket_websites.go
@@ -21,9 +21,9 @@ func bucketWebsites() *schema.Table {
 		Columns: []schema.Column{
 			client.DefaultAccountIDColumn(false),
 			{
-				Name:     "bucket_arn",
-				Type:     arrow.BinaryTypes.String,
-				Resolver: schema.ParentColumnResolver("arn"),
+				Name:       "bucket_arn",
+				Type:       arrow.BinaryTypes.String,
+				Resolver:   schema.ParentColumnResolver("arn"),
 				PrimaryKey: true,
 			},
 		},

--- a/plugins/source/aws/resources/services/s3/bucket_websites.go
+++ b/plugins/source/aws/resources/services/s3/bucket_websites.go
@@ -24,6 +24,7 @@ func bucketWebsites() *schema.Table {
 				Name:     "bucket_arn",
 				Type:     arrow.BinaryTypes.String,
 				Resolver: schema.ParentColumnResolver("arn"),
+				PrimaryKey: true,
 			},
 		},
 	}


### PR DESCRIPTION
Part of https://github.com/cloudquery/cloudquery/issues/15381
Closes https://github.com/cloudquery/cloudquery/issues/15476

BEGIN_COMMIT_OVERRIDE
fix: Provide primary keys for tables (S3) (https://github.com/cloudquery/cloudquery/pull/15494)
BREAKING-CHANGE: Provide primary keys for tables (S3) (https://github.com/cloudquery/cloudquery/pull/15494). The following tables are affected:
* `aws_s3_bucket_cors_rules`
* `aws_s3_bucket_lifecycles`
* `aws_s3_bucket_loggings`
* `aws_s3_bucket_ownership_controls`
* `aws_s3_bucket_policies`
* `aws_s3_bucket_public_access_blocks`
* `aws_s3_bucket_replications`
* `aws_s3_bucket_versionings`
* `aws_s3_bucket_websites`

END_COMMIT_OVERRIDE