### PR TITLE
feat: Add `skip_answers` option to spec to have more privacy options

### DIFF
--- a/plugins/source/typeform/plugin/client/client.py
+++ b/plugins/source/typeform/plugin/client/client.py
@@ -13,6 +13,7 @@ class Spec:
     concurrency: int = field(default=DEFAULT_CONCURRENCY)
     queue_size: int = field(default=DEFAULT_QUEUE_SIZE)
     skip_answers: bool = field(default=False)
+
     def validate(self):
         if self.access_token is None:
             raise Exception("access_token must be provided")

--- a/plugins/source/typeform/plugin/client/client.py
+++ b/plugins/source/typeform/plugin/client/client.py
@@ -12,7 +12,7 @@ class Spec:
     base_url: str = field(default="https://api.typeform.com")
     concurrency: int = field(default=DEFAULT_CONCURRENCY)
     queue_size: int = field(default=DEFAULT_QUEUE_SIZE)
-
+    skip_answers: bool = field(default=False)
     def validate(self):
         if self.access_token is None:
             raise Exception("access_token must be provided")

--- a/plugins/source/typeform/plugin/tables/form_responses.py
+++ b/plugins/source/typeform/plugin/tables/form_responses.py
@@ -47,4 +47,6 @@ class FormResponsesResolver(TableResolver):
             form_id=parent_resource.item["id"]
         ):
             form_response["form_id"] = parent_resource.item["id"]
+            if client._spec.skip_answers:
+                form_response.pop("answers", None)
             yield form_response

--- a/website/pages/docs/plugins/sources/typeform/overview.md
+++ b/website/pages/docs/plugins/sources/typeform/overview.md
@@ -41,3 +41,8 @@ This is the (nested) spec used by the Typeform source plugin:
 - `queue_size` (integer, optional. Default: 10000):
 
   Maximum number of items to have in the queue before waiting for an unfinished request to complete.
+
+- `skip_answers` (boolean, optional. Default: false):
+  
+  The `answers` column in the `typeform_form_responses` table will be empty. Use this option if you care only about statistics but not the individual answers to protect data privacy.
+  


### PR DESCRIPTION
We need to load typeform responses in an environment where we don't want to store any personal data. `skip_answers` will remove the answers column, thus allowing collecting general statistics, but not the actual answers.
