### PR TITLE
feat: Support Multiple Instances of AWS Identity Center Instances

### DIFF
--- a/plugins/source/aws/resources/services/identitystore/instance_fetch.go
+++ b/plugins/source/aws/resources/services/identitystore/instance_fetch.go
@@ -16,8 +16,7 @@ func getIamInstances(ctx context.Context, meta schema.ClientMeta) ([]types.Insta
 	paginator := ssoadmin.NewListInstancesPaginator(svc, &config)
 	instances := make([]types.InstanceMetadata, 0)
 	for paginator.HasMorePages() {
-
-		page, err := svc.ListInstances(ctx, &config, func(options *ssoadmin.Options) {
+		page, err := paginator.NextPage(ctx, func(options *ssoadmin.Options) {
 			options.Region = cl.Region
 		})
 		if err != nil {


### PR DESCRIPTION
<!-- 🎉 Thank you for making CloudQuery awesome by submitting a PR 🎉 -->

#### Summary

New release by AWS supports multiple instances of AWS Identity Center Instances (formerly SSO Instances)
https://aws.amazon.com/blogs/security/how-to-use-multiple-instances-of-aws-iam-identity-center/