### PR TITLE
feat: Add `isPaid` indication to JSON docs

### DIFF
--- a/cli/internal/docs/json.go
+++ b/cli/internal/docs/json.go
@@ -15,6 +15,7 @@ type jsonTable struct {
 	Description string       `json:"description"`
 	Columns     []jsonColumn `json:"columns"`
 	Relations   []jsonTable  `json:"relations"`
+	IsPaid      bool         `json:"is_paid,omitempty"`
 }
 
 type jsonColumn struct {
@@ -55,6 +56,7 @@ func (g *Generator) jsonifyTables(tables schema.Tables) []jsonTable {
 			Title:       table.Title,
 			Description: table.Description,
 			Columns:     jsonColumns,
+			IsPaid:      table.IsPaid,
 			Relations:   g.jsonifyTables(table.Relations),
 		}
 	}

--- a/cli/internal/docs/testdata/TestGeneratePluginDocs-JSON-__tables.json
+++ b/cli/internal/docs/testdata/TestGeneratePluginDocs-JSON-__tables.json
@@ -27,7 +27,8 @@
     "title": "Paid Table",
     "description": "Description for paid table",
     "columns": [],
-    "relations": []
+    "relations": [],
+    "is_paid": true
   },
   {
     "name": "test_table",


### PR DESCRIPTION
<!-- 🎉 Thank you for making CloudQuery awesome by submitting a PR 🎉 -->

#### Summary

This should make it easier to add an indication for paid tables in plugins docs (additionally to the per table indication we have). Related to https://github.com/cloudquery/cloudquery-issues/issues/939 (internal issue)

<!--
Use the following steps to ensure your PR is ready to be reviewed

- [ ] Read the [contribution guidelines](../blob/main/CONTRIBUTING.md) 🧑‍🎓
- [ ] Run `make lint` to ensure the proposed changes follow the coding style 🚨 (install golangci-lint [here](https://golangci-lint.run/usage/install/#local-installation))
- [ ] Run `make test` to ensure the proposed changes pass the tests 🧪
- [ ] If changing a source plugin run `make gen` to ensure docs are up to date 📝
- [ ] Ensure the status checks below are successful ✅
--->
