### PR TITLE
chore: Add `write_mode: "append"` to s3 docs

### DIFF
--- a/plugins/destination/s3/docs/_configuration.md
+++ b/plugins/destination/s3/docs/_configuration.md
@@ -9,6 +9,7 @@ spec:
   path: "cloudquery/s3"
   registry: "cloudquery"
   version: "VERSION_DESTINATION_S3"
+  write_mode: "append"
   spec:
     bucket: "bucket_name"
     region: "region-name" # Example: us-east-1


### PR DESCRIPTION
<!-- 🎉 Thank you for making CloudQuery awesome by submitting a PR 🎉 -->

#### Summary

S3 destination supports only append mode

<!--
Use the following steps to ensure your PR is ready to be reviewed

- [ ] Read the [contribution guidelines](../blob/main/CONTRIBUTING.md) 🧑‍🎓
- [ ] Run `make lint` to ensure the proposed changes follow the coding style 🚨 (install golangci-lint [here](https://golangci-lint.run/usage/install/#local-installation))
- [ ] Run `make test` to ensure the proposed changes pass the tests 🧪
- [ ] If changing a source plugin run `make gen` to ensure docs are up to date 📝
- [ ] Ensure the status checks below are successful ✅
--->
