### PR TITLE
chore: Handle pre-releases release notes during publishing to the hub

### DIFF
--- a/.github/workflows/publish_plugin_to_hub.yml
+++ b/.github/workflows/publish_plugin_to_hub.yml
@@ -94,10 +94,16 @@ jobs:
       - name: Get Release Notes
         id: release-notes
         uses: actions/github-script@v6
+        env:
+          PRERELEASE: ${{ needs.prepare.outputs.prerelease }}
         with:
           result-encoding: string
           script: |
             const shellescape = require('shell-escape');
+            const { PRERELEASE } = process.env;
+            if (PRERELEASE) {
+              return shellescape(["This is a pre-release version of the plugin and should be used for testing purposes only"])
+            }
             const { data } = await github.rest.repos.getReleaseByTag({
               owner: "cloudquery",
               repo: context.repo.repo,

--- a/.github/workflows/publish_plugin_to_hub_duckdb.yml
+++ b/.github/workflows/publish_plugin_to_hub_duckdb.yml
@@ -76,10 +76,16 @@ jobs:
       - name: Get Release Notes
         id: release-notes
         uses: actions/github-script@v6
+        env:
+          PRERELEASE: ${{ needs.prepare.outputs.prerelease }}
         with:
           result-encoding: string
           script: |
             const shellescape = require('shell-escape');
+            const { PRERELEASE } = process.env;
+            if (PRERELEASE) {
+              return shellescape(["This is a pre-release version of the plugin and should be used for testing purposes only"])
+            }
             const { data } = await github.rest.repos.getReleaseByTag({
               owner: "cloudquery",
               repo: context.repo.repo,

--- a/.github/workflows/publish_plugin_to_hub_snowflake.yml
+++ b/.github/workflows/publish_plugin_to_hub_snowflake.yml
@@ -77,10 +77,16 @@ jobs:
       - name: Get Release Notes
         id: release-notes
         uses: actions/github-script@v6
+        env:
+          PRERELEASE: ${{ needs.prepare.outputs.prerelease }}
         with:
           result-encoding: string
           script: |
             const shellescape = require('shell-escape');
+            const { PRERELEASE } = process.env;
+            if (PRERELEASE) {
+              return shellescape(["This is a pre-release version of the plugin and should be used for testing purposes only"])
+            }
             const { data } = await github.rest.repos.getReleaseByTag({
               owner: "cloudquery",
               repo: context.repo.repo,

--- a/.github/workflows/publish_plugin_to_hub_sqlite.yml
+++ b/.github/workflows/publish_plugin_to_hub_sqlite.yml
@@ -76,10 +76,16 @@ jobs:
       - name: Get Release Notes
         id: release-notes
         uses: actions/github-script@v6
+        env:
+          PRERELEASE: ${{ needs.prepare.outputs.prerelease }}
         with:
           result-encoding: string
           script: |
             const shellescape = require('shell-escape');
+            const { PRERELEASE } = process.env;
+            if (PRERELEASE) {
+              return shellescape(["This is a pre-release version of the plugin and should be used for testing purposes only"])
+            }
             const { data } = await github.rest.repos.getReleaseByTag({
               owner: "cloudquery",
               repo: context.repo.repo,


### PR DESCRIPTION
<!-- 🎉 Thank you for making CloudQuery awesome by submitting a PR 🎉 -->

#### Summary

Part of https://github.com/cloudquery/cloudquery-issues/issues/765 (internal issue). This should allow us to push a pre-release tag and have it published to the Hub

<!--
Use the following steps to ensure your PR is ready to be reviewed

- [ ] Read the [contribution guidelines](../blob/main/CONTRIBUTING.md) 🧑‍🎓
- [ ] Run `make lint` to ensure the proposed changes follow the coding style 🚨 (install golangci-lint [here](https://golangci-lint.run/usage/install/#local-installation))
- [ ] Run `make test` to ensure the proposed changes pass the tests 🧪
- [ ] If changing a source plugin run `make gen` to ensure docs are up to date 📝
- [ ] Ensure the status checks below are successful ✅
--->
