### PR TITLE
fix: Allow using service name from const directly

### DIFF
--- a/plugins/source/aws/client/service_names.go
+++ b/plugins/source/aws/client/service_names.go
@@ -126,7 +126,7 @@ const (
 type AWSServiceName int
 
 func (s AWSServiceName) String() string {
-	return AllAWSServiceNames[*s]
+	return AllAWSServiceNames[s]
 }
 
 var AllAWSServiceNames = [...]string{

--- a/plugins/source/aws/client/service_names.go
+++ b/plugins/source/aws/client/service_names.go
@@ -125,10 +125,7 @@ const (
 
 type AWSServiceName int
 
-func (s *AWSServiceName) String() string {
-	if s == nil {
-		return ""
-	}
+func (s AWSServiceName) String() string {
 	return AllAWSServiceNames[*s]
 }
 


### PR DESCRIPTION
This will allow using the proper service name like so
```go
client.ServiceAccountRegionMultiplexer(tableName, client.AWSServiceS3.String())
```