### PR TITLE
refactor: Move publish helper functions to internal package

### DIFF
--- a/cli/cmd/addon_download.go
+++ b/cli/cmd/addon_download.go
@@ -2,22 +2,16 @@ package cmd
 
 import (
 	"context"
-	"crypto/sha256"
-	"errors"
 	"fmt"
-	"io"
 	"net/http"
 	"os"
 	"os/signal"
-	"path"
-	"path/filepath"
 	"strings"
 	"syscall"
 
 	cloudquery_api "github.com/cloudquery/cloudquery-api-go"
 	cqapiauth "github.com/cloudquery/cloudquery-api-go/auth"
-	"github.com/cloudquery/cloudquery-api-go/config"
-	"github.com/cloudquery/cloudquery/cli/internal/team"
+	"github.com/cloudquery/cloudquery/cli/internal/publish"
 	"github.com/cloudquery/plugin-pb-go/managedplugin"
 	"github.com/spf13/cobra"
 )
@@ -93,12 +87,12 @@ func runAddonDownload(ctx context.Context, cmd *cobra.Command, args []string) er
 		return err
 	}
 
-	currentTeam, err := getTeamForAnyToken(ctx, c, token.Type)
+	currentTeam, err := publish.GetTeamForAnyToken(ctx, c, token.Type)
 	if err != nil {
 		return err
 	}
 
-	location, checksum, err := getAddonMetadata(ctx, c, currentTeam, addonParts[0], addonParts[1], addonVer[0], addonVer[1])
+	location, checksum, err := publish.GetAddonMetadata(ctx, c, currentTeam, addonParts[0], addonParts[1], addonVer[0], addonVer[1])
 	if err != nil {
 		return err
 	}
@@ -107,6 +101,8 @@ func runAddonDownload(ctx context.Context, cmd *cobra.Command, args []string) er
 	if err != nil {
 		return fmt.Errorf("failed to create request: %w", err)
 	}
+	// TODO: Remove this when https://github.com/timakin/bodyclose/issues/39 is fixed (false positive when close is in another package)
+	// nolint: bodyclose
 	res, err := http.DefaultClient.Do(req)
 	if err != nil {
 		return fmt.Errorf("failed to make download request: %w", err)
@@ -115,101 +111,5 @@ func runAddonDownload(ctx context.Context, cmd *cobra.Command, args []string) er
 		return fmt.Errorf("addon download failed: %d %s", res.StatusCode, location)
 	}
 
-	return downloadAddonFromResponse(res, checksum, targetDir)
-}
-
-func getTeamForAnyToken(ctx context.Context, c *cloudquery_api.ClientWithResponses, tokenType cqapiauth.TokenType) (string, error) {
-	switch tokenType {
-	case cqapiauth.BearerToken:
-		currentTeam, err := config.GetValue("team")
-		if err != nil && !errors.Is(err, os.ErrNotExist) {
-			return "", fmt.Errorf("failed to get team from config: %w", err)
-		}
-		if currentTeam == "" {
-			return "", fmt.Errorf("team is required. Hint: use `cloudquery switch` to set a team")
-		}
-		return currentTeam, nil
-	case cqapiauth.APIKey:
-		teams, err := team.NewClientFromAPI(c).ListAllTeams(ctx)
-		if err != nil {
-			return "", err
-		}
-		switch l := len(teams); l {
-		case 0:
-			return "", errors.New("api key has no assigned team")
-		case 1:
-			return teams[0], nil
-		default:
-			return "", fmt.Errorf("api key has more than one team: %s", strings.Join(teams, ", "))
-		}
-	default:
-		return "", fmt.Errorf("unknown token type %v", tokenType)
-	}
-}
-
-func getAddonMetadata(ctx context.Context, c *cloudquery_api.ClientWithResponses, currentTeam, addonTeam, addonType, addonName, addonVersion string) (location, checksum string, retErr error) {
-	aj := "application/json"
-	resp, err := c.DownloadAddonAssetByTeamWithResponse(ctx, currentTeam, addonTeam, cloudquery_api.AddonType(addonType), addonName, addonVersion, &cloudquery_api.DownloadAddonAssetByTeamParams{Accept: &aj})
-	if err != nil {
-		return "", "", fmt.Errorf("failed to get team addon metadata: %w", err)
-	}
-	if resp.StatusCode() > 299 || resp.JSON200 == nil {
-		return "", "", fmt.Errorf("failed to read team addon metadata: %w", errorFromHTTPResponse(resp.HTTPResponse, resp))
-	}
-	return resp.JSON200.Location, resp.JSON200.Checksum, nil
-}
-
-func downloadAddonFromResponse(res *http.Response, expectedChecksum, targetDir string) (retErr error) {
-	var (
-		fileWriter io.WriteCloser
-		size       int64
-		err        error
-	)
-
-	switch targetDir {
-	case "-":
-		fileWriter = os.Stdout
-	default:
-		zipPath := filepath.Join(targetDir, path.Base(res.Request.URL.Path))
-		if st, err := os.Stat(zipPath); err == nil {
-			if st.IsDir() {
-				return fmt.Errorf("file %s already exists: is a directory", zipPath)
-			}
-			return fmt.Errorf("file %s already exists", zipPath)
-		}
-
-		f, err := os.Create(zipPath)
-		if err != nil {
-			return fmt.Errorf("failed to create file: %w", err)
-		}
-		fileWriter = f
-
-		defer func() {
-			if retErr != nil {
-				_ = os.Remove(zipPath)
-				return
-			}
-			fmt.Fprintf(os.Stderr, "Wrote %d bytes to %s\n", size, zipPath)
-		}()
-	}
-
-	shaWriter := sha256.New()
-	w := io.MultiWriter(fileWriter, shaWriter)
-	if size, err = io.Copy(w, res.Body); err != nil {
-		_ = fileWriter.Close()
-		return fmt.Errorf("failed to write: %w", err)
-	}
-	if err := fileWriter.Close(); err != nil {
-		return fmt.Errorf("failed to close: %w", err)
-	}
-	if err := res.Body.Close(); err != nil {
-		return fmt.Errorf("failed to close response body: %w", err)
-	}
-
-	writtenChecksum := fmt.Sprintf("%x", shaWriter.Sum(nil))
-	if writtenChecksum != expectedChecksum {
-		return fmt.Errorf("checksum mismatch: expected %s, got %s", expectedChecksum, writtenChecksum)
-	}
-
-	return nil
+	return publish.DownloadAddonFromResponse(res, checksum, targetDir)
 }

--- a/cli/cmd/plugin_docs_download.go
+++ b/cli/cmd/plugin_docs_download.go
@@ -12,6 +12,7 @@ import (
 
 	cloudquery_api "github.com/cloudquery/cloudquery-api-go"
 	"github.com/cloudquery/cloudquery-api-go/auth"
+	"github.com/cloudquery/cloudquery/cli/internal/hub"
 	"github.com/spf13/cobra"
 )
 
@@ -60,7 +61,7 @@ func runPluginDocsDownload(ctx context.Context, cmd *cobra.Command, args []strin
 		return fmt.Errorf("failed to get auth token: %w", err)
 	}
 
-	pluginRef, err := parseHubPluginRef(args[0])
+	pluginRef, err := hub.ParseHubPluginRef(args[0])
 	if err != nil {
 		return err
 	}
@@ -98,7 +99,7 @@ func runPluginDocsDownload(ctx context.Context, cmd *cobra.Command, args []strin
 		return fmt.Errorf("failed to read docs: %w", err)
 	}
 	if resp.StatusCode() != http.StatusOK {
-		return errorFromHTTPResponse(resp.HTTPResponse, resp)
+		return hub.ErrorFromHTTPResponse(resp.HTTPResponse, resp)
 	}
 	if resp.JSON200 == nil {
 		return fmt.Errorf("failed to read docs: nil response")

--- a/cli/cmd/plugin_docs_upload.go
+++ b/cli/cmd/plugin_docs_upload.go
@@ -10,6 +10,8 @@ import (
 
 	cloudquery_api "github.com/cloudquery/cloudquery-api-go"
 	"github.com/cloudquery/cloudquery-api-go/auth"
+	"github.com/cloudquery/cloudquery/cli/internal/hub"
+	"github.com/cloudquery/cloudquery/cli/internal/publish"
 	"github.com/spf13/cobra"
 )
 
@@ -59,7 +61,7 @@ func runPluginDocsUpload(ctx context.Context, cmd *cobra.Command, args []string)
 		return fmt.Errorf("failed to get auth token: %w", err)
 	}
 
-	pluginRef, err := parseHubPluginRef(args[0])
+	pluginRef, err := hub.ParseHubPluginRef(args[0])
 	if err != nil {
 		return err
 	}
@@ -88,7 +90,7 @@ func runPluginDocsUpload(ctx context.Context, cmd *cobra.Command, args []string)
 		return err
 	}
 
-	if err := uploadDocs(ctx, c, pluginRef.TeamName, pluginRef.Kind, pluginRef.Name, pluginRef.Version, docsDir, doSync); err != nil {
+	if err := publish.UploadPluginDocs(ctx, c, pluginRef.TeamName, pluginRef.Kind, pluginRef.Name, pluginRef.Version, docsDir, doSync); err != nil {
 		return fmt.Errorf("failed to upload docs: %w", err)
 	}
 

--- a/cli/cmd/plugin_publish_test.go
+++ b/cli/cmd/plugin_publish_test.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/cloudquery/cloudquery/cli/internal/hub"
 	"github.com/google/go-cmp/cmp"
 )
 
@@ -372,5 +373,5 @@ func readFile(name string) string {
 	if err != nil {
 		panic(err)
 	}
-	return normalizeContent(string(b))
+	return hub.NormalizeContent(string(b))
 }

--- a/cli/internal/hub/util.go
+++ b/cli/internal/hub/util.go
@@ -1,4 +1,4 @@
-package cmd
+package hub
 
 import (
 	"errors"
@@ -9,10 +9,6 @@ import (
 	"reflect"
 	"strings"
 )
-
-type SchemaVersion struct {
-	SchemaVersion int `json:"schema_version"`
-}
 
 type HubPluginRef struct {
 	TeamName string
@@ -25,7 +21,7 @@ func (h HubPluginRef) String() string {
 	return fmt.Sprintf("%s/%s/%s@%s", h.TeamName, h.Kind, h.Name, h.Version)
 }
 
-func parseHubPluginRef(ref string) (*HubPluginRef, error) {
+func ParseHubPluginRef(ref string) (*HubPluginRef, error) {
 	versionParts := strings.Split(ref, "@")
 	if len(versionParts) != 2 {
 		return nil, errors.New("invalid plugin version: Must be in format <team_name>/<kind>/<plugin_name>@<version>")
@@ -51,7 +47,7 @@ func parseHubPluginRef(ref string) (*HubPluginRef, error) {
 	}, nil
 }
 
-func errorFromHTTPResponse(httpResp *http.Response, resp any) error {
+func ErrorFromHTTPResponse(httpResp *http.Response, resp any) error {
 	fields := make(map[string]any)
 	el := reflect.ValueOf(resp).Elem()
 	for i := 0; i < el.NumField(); i++ {
@@ -70,7 +66,7 @@ func errorFromHTTPResponse(httpResp *http.Response, resp any) error {
 	return fmt.Errorf("error code: %v", httpResp.StatusCode)
 }
 
-func uploadFile(uploadURL, localPath string) error {
+func UploadFile(uploadURL, localPath string) error {
 	file, err := os.Open(localPath)
 	if err != nil {
 		return fmt.Errorf("failed to open file: %w", err)
@@ -98,7 +94,7 @@ func uploadFile(uploadURL, localPath string) error {
 	return nil
 }
 
-func normalizeContent(s string) string {
+func NormalizeContent(s string) string {
 	s = strings.TrimSpace(s)
 	s = strings.ReplaceAll(s, "\r\n", "\n")
 	s = strings.ReplaceAll(s, "\r", "\n")

--- a/cli/internal/publish/addons.go
+++ b/cli/internal/publish/addons.go
@@ -1,0 +1,237 @@
+package publish
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"path"
+	"path/filepath"
+	"strings"
+
+	cloudquery_api "github.com/cloudquery/cloudquery-api-go"
+	cqapiauth "github.com/cloudquery/cloudquery-api-go/auth"
+	"github.com/cloudquery/cloudquery-api-go/config"
+	"github.com/cloudquery/cloudquery/cli/internal/hub"
+	"github.com/cloudquery/cloudquery/cli/internal/team"
+)
+
+type ManifestJSONV1 struct {
+	Type        string `json:"type"` // always "addon"
+	TeamName    string `json:"team_name"`
+	AddonName   string `json:"addon_name"`
+	AddonType   string `json:"addon_type"`
+	AddonFormat string `json:"addon_format"` // unused
+
+	Message   string `json:"message"`
+	PathToZip string `json:"path"`
+	PathToDoc string `json:"doc"`
+
+	PluginDeps []string `json:"plugin_deps"`
+	AddonDeps  []string `json:"addon_deps"`
+}
+
+func ReadManifestJSON(manifestPath string) (ManifestJSONV1, error) {
+	v := SchemaVersion{}
+	b, err := os.ReadFile(manifestPath)
+	if err != nil {
+		return ManifestJSONV1{}, err
+	}
+
+	if err := json.Unmarshal(b, &v); err != nil {
+		return ManifestJSONV1{}, err
+	}
+	if v.SchemaVersion != 1 {
+		return ManifestJSONV1{}, errors.New("unsupported schema version. This CLI version only supports manifest.json v1. Try upgrading your CloudQuery CLI version")
+	}
+
+	manifest := ManifestJSONV1{}
+	if err := json.Unmarshal(b, &manifest); err != nil {
+		return ManifestJSONV1{}, err
+	}
+	return manifest, nil
+}
+
+func CreateNewAddonDraftVersion(ctx context.Context, c *cloudquery_api.ClientWithResponses, manifest ManifestJSONV1, version, manifestDir, zipPath string) error {
+	if manifest.PluginDeps == nil {
+		manifest.PluginDeps = []string{}
+	}
+	if manifest.AddonDeps == nil {
+		manifest.AddonDeps = []string{}
+	}
+	body := cloudquery_api.CreateAddonVersionJSONRequestBody{
+		AddonDeps:  &manifest.AddonDeps,
+		PluginDeps: &manifest.PluginDeps,
+	}
+
+	if manifest.PathToDoc != "" {
+		b, err := os.ReadFile(filepath.Join(manifestDir, manifest.PathToDoc))
+		if err != nil {
+			return fmt.Errorf("failed to read doc file: %w", err)
+		}
+		body.Doc = string(b)
+	}
+
+	if manifest.Message != "" {
+		if strings.HasPrefix(manifest.Message, "@") {
+			messageFile := filepath.Join(manifestDir, strings.TrimPrefix(manifest.Message, "@"))
+			messageBytes, err := os.ReadFile(messageFile)
+			if err != nil {
+				return fmt.Errorf("failed to read message file: %w", err)
+			}
+			body.Message = string(messageBytes)
+		} else {
+			body.Message = manifest.Message
+		}
+	}
+
+	f, err := os.Open(zipPath)
+	if err != nil {
+		return fmt.Errorf("failed to open file: %w", err)
+	}
+	defer f.Close()
+	s := sha256.New()
+	if _, err := io.Copy(s, f); err != nil {
+		return fmt.Errorf("failed to calculate checksum: %w", err)
+	}
+	body.Checksum = fmt.Sprintf("%x", s.Sum(nil))
+
+	resp, err := c.CreateAddonVersionWithResponse(ctx, manifest.TeamName, cloudquery_api.AddonType(manifest.AddonType), manifest.AddonName, version, body)
+	if err != nil {
+		return fmt.Errorf("failed to create addon version: %w", err)
+	}
+	if resp.HTTPResponse.StatusCode > 299 {
+		err := hub.ErrorFromHTTPResponse(resp.HTTPResponse, resp)
+		if resp.HTTPResponse.StatusCode == http.StatusForbidden {
+			return fmt.Errorf("%w. Hint: You may need to create the addon first", err)
+		}
+		return err
+	}
+	return nil
+}
+
+func UploadAddon(ctx context.Context, c *cloudquery_api.ClientWithResponses, manifest ManifestJSONV1, version, localPath string) error {
+	resp, err := c.UploadAddonAssetWithResponse(ctx, manifest.TeamName, cloudquery_api.AddonType(manifest.AddonType), manifest.AddonName, version)
+	if err != nil {
+		return fmt.Errorf("failed to upload addon: %w", err)
+	}
+	if resp.HTTPResponse.StatusCode > 299 {
+		msg := fmt.Sprintf("failed to upload addon: %s", resp.HTTPResponse.Status)
+		switch {
+		case resp.JSON403 != nil:
+			msg = fmt.Sprintf("%s: %s", msg, resp.JSON403.Message)
+		case resp.JSON401 != nil:
+			msg = fmt.Sprintf("%s: %s", msg, resp.JSON401.Message)
+		}
+		return fmt.Errorf(msg)
+	}
+	if resp.JSON201 == nil {
+		return fmt.Errorf("upload response is nil, failed to upload addon")
+	}
+	uploadURL := resp.JSON201.Url
+
+	if err := hub.UploadFile(uploadURL, localPath); err != nil {
+		return fmt.Errorf("failed to upload file: %w", err)
+	}
+	return nil
+}
+
+func GetTeamForAnyToken(ctx context.Context, c *cloudquery_api.ClientWithResponses, tokenType cqapiauth.TokenType) (string, error) {
+	switch tokenType {
+	case cqapiauth.BearerToken:
+		currentTeam, err := config.GetValue("team")
+		if err != nil && !errors.Is(err, os.ErrNotExist) {
+			return "", fmt.Errorf("failed to get team from config: %w", err)
+		}
+		if currentTeam == "" {
+			return "", fmt.Errorf("team is required. Hint: use `cloudquery switch` to set a team")
+		}
+		return currentTeam, nil
+	case cqapiauth.APIKey:
+		teams, err := team.NewClientFromAPI(c).ListAllTeams(ctx)
+		if err != nil {
+			return "", err
+		}
+		switch l := len(teams); l {
+		case 0:
+			return "", errors.New("api key has no assigned team")
+		case 1:
+			return teams[0], nil
+		default:
+			return "", fmt.Errorf("api key has more than one team: %s", strings.Join(teams, ", "))
+		}
+	default:
+		return "", fmt.Errorf("unknown token type %v", tokenType)
+	}
+}
+
+func GetAddonMetadata(ctx context.Context, c *cloudquery_api.ClientWithResponses, currentTeam, addonTeam, addonType, addonName, addonVersion string) (location, checksum string, retErr error) {
+	aj := "application/json"
+	resp, err := c.DownloadAddonAssetByTeamWithResponse(ctx, currentTeam, addonTeam, cloudquery_api.AddonType(addonType), addonName, addonVersion, &cloudquery_api.DownloadAddonAssetByTeamParams{Accept: &aj})
+	if err != nil {
+		return "", "", fmt.Errorf("failed to get team addon metadata: %w", err)
+	}
+	if resp.StatusCode() > 299 || resp.JSON200 == nil {
+		return "", "", fmt.Errorf("failed to read team addon metadata: %w", hub.ErrorFromHTTPResponse(resp.HTTPResponse, resp))
+	}
+	return resp.JSON200.Location, resp.JSON200.Checksum, nil
+}
+
+func DownloadAddonFromResponse(res *http.Response, expectedChecksum, targetDir string) (retErr error) {
+	var (
+		fileWriter io.WriteCloser
+		size       int64
+		err        error
+	)
+
+	switch targetDir {
+	case "-":
+		fileWriter = os.Stdout
+	default:
+		zipPath := filepath.Join(targetDir, path.Base(res.Request.URL.Path))
+		if st, err := os.Stat(zipPath); err == nil {
+			if st.IsDir() {
+				return fmt.Errorf("file %s already exists: is a directory", zipPath)
+			}
+			return fmt.Errorf("file %s already exists", zipPath)
+		}
+
+		f, err := os.Create(zipPath)
+		if err != nil {
+			return fmt.Errorf("failed to create file: %w", err)
+		}
+		fileWriter = f
+
+		defer func() {
+			if retErr != nil {
+				_ = os.Remove(zipPath)
+				return
+			}
+			fmt.Fprintf(os.Stderr, "Wrote %d bytes to %s\n", size, zipPath)
+		}()
+	}
+
+	shaWriter := sha256.New()
+	w := io.MultiWriter(fileWriter, shaWriter)
+	if size, err = io.Copy(w, res.Body); err != nil {
+		_ = fileWriter.Close()
+		return fmt.Errorf("failed to write: %w", err)
+	}
+	if err := fileWriter.Close(); err != nil {
+		return fmt.Errorf("failed to close: %w", err)
+	}
+	if err := res.Body.Close(); err != nil {
+		return fmt.Errorf("failed to close response body: %w", err)
+	}
+
+	writtenChecksum := fmt.Sprintf("%x", shaWriter.Sum(nil))
+	if writtenChecksum != expectedChecksum {
+		return fmt.Errorf("checksum mismatch: expected %s, got %s", expectedChecksum, writtenChecksum)
+	}
+
+	return nil
+}

--- a/cli/internal/publish/plugins.go
+++ b/cli/internal/publish/plugins.go
@@ -1,0 +1,186 @@
+package publish
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+
+	cloudquery_api "github.com/cloudquery/cloudquery-api-go"
+	"github.com/cloudquery/cloudquery/cli/internal/hub"
+)
+
+type PackageJSONV1 struct {
+	Team             string                    `json:"team"`
+	Name             string                    `json:"name"`
+	Message          string                    `json:"message"`
+	Version          string                    `json:"version"`
+	Kind             cloudquery_api.PluginKind `json:"kind"`
+	Protocols        []int                     `json:"protocols"`
+	SupportedTargets []TargetBuild             `json:"supported_targets"`
+	PackageType      string                    `json:"package_type"`
+}
+
+type TargetBuild struct {
+	OS       string `json:"os"`
+	Arch     string `json:"arch"`
+	Path     string `json:"path"`
+	Checksum string `json:"checksum"`
+}
+
+func ReadPackageJSON(distDir string) (PackageJSONV1, error) {
+	v := SchemaVersion{}
+	b, err := os.ReadFile(filepath.Join(distDir, "package.json"))
+	if err != nil {
+		return PackageJSONV1{}, err
+	}
+	err = json.Unmarshal(b, &v)
+	if err != nil {
+		return PackageJSONV1{}, err
+	}
+	if v.SchemaVersion != 1 {
+		return PackageJSONV1{}, errors.New("unsupported schema version. This CLI version only supports package.json v1. Try upgrading your CloudQuery CLI version")
+	}
+	pkgJSON := PackageJSONV1{}
+	err = json.Unmarshal(b, &pkgJSON)
+	if err != nil {
+		return PackageJSONV1{}, err
+	}
+	return pkgJSON, nil
+}
+
+func UploadPluginDocs(ctx context.Context, c *cloudquery_api.ClientWithResponses, teamName, pluginKind, pluginName, version, docsDir string, replace bool) error {
+	dirEntries, err := os.ReadDir(docsDir)
+	if err != nil {
+		return fmt.Errorf("failed to read docs directory: %w", err)
+	}
+
+	pages := make([]cloudquery_api.PluginDocsPageCreate, 0, len(dirEntries))
+	for _, dirEntry := range dirEntries {
+		if dirEntry.IsDir() {
+			continue
+		}
+		fileExt := filepath.Ext(dirEntry.Name())
+		if fileExt != ".md" {
+			continue
+		}
+		content, err := os.ReadFile(filepath.Join(docsDir, dirEntry.Name()))
+		if err != nil {
+			return fmt.Errorf("failed to read docs file: %w", err)
+		}
+		contentStr := hub.NormalizeContent(string(content))
+		pages = append(pages, cloudquery_api.PluginDocsPageCreate{
+			Content: contentStr,
+			Name:    strings.TrimSuffix(dirEntry.Name(), fileExt),
+		})
+	}
+
+	if replace {
+		body := cloudquery_api.ReplacePluginVersionDocsJSONRequestBody{
+			Pages: pages,
+		}
+		resp, err := c.ReplacePluginVersionDocsWithResponse(ctx, teamName, cloudquery_api.PluginKind(pluginKind), pluginName, version, body)
+		if err != nil {
+			return fmt.Errorf("failed to upload docs: %w", err)
+		}
+		if resp.HTTPResponse.StatusCode > 299 {
+			return hub.ErrorFromHTTPResponse(resp.HTTPResponse, resp)
+		}
+	} else {
+		body := cloudquery_api.CreatePluginVersionDocsJSONRequestBody{
+			Pages: pages,
+		}
+		resp, err := c.CreatePluginVersionDocsWithResponse(ctx, teamName, cloudquery_api.PluginKind(pluginKind), pluginName, version, body)
+		if err != nil {
+			return fmt.Errorf("failed to upload docs: %w", err)
+		}
+		if resp.HTTPResponse.StatusCode > 299 {
+			return hub.ErrorFromHTTPResponse(resp.HTTPResponse, resp)
+		}
+	}
+
+	return nil
+}
+
+func CreateNewPluginDraftVersion(ctx context.Context, c *cloudquery_api.ClientWithResponses, teamName, pluginName string, pkgJSON PackageJSONV1) error {
+	targets := make([]string, len(pkgJSON.SupportedTargets))
+	checksums := make([]string, len(pkgJSON.SupportedTargets))
+	for i, t := range pkgJSON.SupportedTargets {
+		targets[i] = fmt.Sprintf("%s_%s", t.OS, t.Arch)
+		checksums[i] = strings.TrimPrefix(t.Checksum, "sha256:")
+	}
+
+	body := cloudquery_api.CreatePluginVersionJSONRequestBody{
+		Message:          pkgJSON.Message,
+		PackageType:      cloudquery_api.CreatePluginVersionJSONBodyPackageType(pkgJSON.PackageType),
+		Protocols:        pkgJSON.Protocols,
+		SupportedTargets: targets,
+		Checksums:        checksums,
+	}
+	resp, err := c.CreatePluginVersionWithResponse(ctx, teamName, pkgJSON.Kind, pluginName, pkgJSON.Version, body)
+	if err != nil {
+		return fmt.Errorf("failed to create plugin version: %w", err)
+	}
+	if resp.HTTPResponse.StatusCode > 299 {
+		err := hub.ErrorFromHTTPResponse(resp.HTTPResponse, resp)
+		if resp.HTTPResponse.StatusCode == http.StatusForbidden {
+			return fmt.Errorf("%w. Hint: You may need to create the plugin first", err)
+		}
+		return err
+	}
+	return nil
+}
+
+func UploadTableSchemas(ctx context.Context, c *cloudquery_api.ClientWithResponses, teamName, pluginName, tablesJSONPath string, pkgJSON PackageJSONV1) error {
+	b, err := os.ReadFile(tablesJSONPath)
+	if err != nil {
+		return fmt.Errorf("failed to read tables.json: %w", err)
+	}
+	tables := make([]cloudquery_api.PluginTableCreate, 0)
+	err = json.Unmarshal(b, &tables)
+	if err != nil {
+		return fmt.Errorf("failed to parse tables.json: %w", err)
+	}
+	body := cloudquery_api.CreatePluginVersionTablesJSONRequestBody{
+		Tables: tables,
+	}
+	resp, err := c.CreatePluginVersionTablesWithResponse(ctx, teamName, pkgJSON.Kind, pluginName, pkgJSON.Version, body)
+	if err != nil {
+		return fmt.Errorf("failed to upload table schemas: %w", err)
+	}
+	if resp.HTTPResponse.StatusCode > 299 {
+		return hub.ErrorFromHTTPResponse(resp.HTTPResponse, resp)
+	}
+	return nil
+}
+
+func UploadPluginBinary(ctx context.Context, c *cloudquery_api.ClientWithResponses, teamName, pluginName, goos, goarch, localPath string, pkgJSON PackageJSONV1) error {
+	target := goos + "_" + goarch
+	resp, err := c.UploadPluginAssetWithResponse(ctx, teamName, pkgJSON.Kind, pluginName, pkgJSON.Version, target)
+	if err != nil {
+		return fmt.Errorf("failed to upload binary: %w", err)
+	}
+	if resp.HTTPResponse.StatusCode > 299 {
+		msg := fmt.Sprintf("failed to upload binary: %s", resp.HTTPResponse.Status)
+		switch {
+		case resp.JSON403 != nil:
+			msg = fmt.Sprintf("%s: %s", msg, resp.JSON403.Message)
+		case resp.JSON401 != nil:
+			msg = fmt.Sprintf("%s: %s", msg, resp.JSON401.Message)
+		}
+		return fmt.Errorf(msg)
+	}
+	if resp.JSON201 == nil {
+		return fmt.Errorf("upload response is nil, failed to upload binary")
+	}
+	uploadURL := resp.JSON201.Url
+	err = hub.UploadFile(uploadURL, localPath)
+	if err != nil {
+		return fmt.Errorf("failed to upload file: %w", err)
+	}
+	return nil
+}

--- a/cli/internal/publish/shared.go
+++ b/cli/internal/publish/shared.go
@@ -1,0 +1,5 @@
+package publish
+
+type SchemaVersion struct {
+	SchemaVersion int `json:"schema_version"`
+}


### PR DESCRIPTION
<!-- 🎉 Thank you for making CloudQuery awesome by submitting a PR 🎉 -->

#### Summary

Some refactoring to make it easier to support Docker publishing. This PR moves some functions to internal helper packages `publish` and `hub` instead of having all the code under the top level commands implementation.

<!--
Use the following steps to ensure your PR is ready to be reviewed

- [ ] Read the [contribution guidelines](../blob/main/CONTRIBUTING.md) 🧑‍🎓
- [ ] Run `make lint` to ensure the proposed changes follow the coding style 🚨 (install golangci-lint [here](https://golangci-lint.run/usage/install/#local-installation))
- [ ] Run `make test` to ensure the proposed changes pass the tests 🧪
- [ ] If changing a source plugin run `make gen` to ensure docs are up to date 📝
- [ ] Ensure the status checks below are successful ✅
--->
