### PR TITLE
fix: Update lambda functions resolveTags() to use Tags field instead of Concurrency

### DIFF
--- a/plugins/source/aws/resources/services/lambda/functions.go
+++ b/plugins/source/aws/resources/services/lambda/functions.go
@@ -306,7 +306,7 @@ func resolveTags(ctx context.Context, meta schema.ClientMeta, resource *schema.R
 
 	// setting tags value from GetFunction call
 	if r.Code != nil {
-		return resource.Set(col.Name, r.Concurrency)
+		return resource.Set(col.Name, r.Tags)
 	}
 
 	cl := meta.(*client.Client)


### PR DESCRIPTION
<!-- 🎉 Thank you for making CloudQuery awesome by submitting a PR 🎉 -->

#### Summary


<!--
Explain what problem this PR addresses
-->

Fixes https://github.com/cloudquery/cloudquery/issues/15727. Currently Lambda tags don't make it into the table due to a simple bug.

~I haven't tested this, and I'm not really sure how at the moment. There aren't already any unit tests I can leverage and I don't know how to install a custom plugin. Since this is such a simple change, I figured it was worth a shot submitting it anyway.~

I found the docs to test locally and used CloudQuery to write to a local file. The difference between my local plugin and the upstream plugin showed that this change worked as expected!

<!--
Use the following steps to ensure your PR is ready to be reviewed

- [x] Read the [contribution guidelines](https://github.com/cloudquery/cloudquery/blob/main/CONTRIBUTING.md) 🧑‍🎓
- [x] Run `make lint` to ensure the proposed changes follow the coding style 🚨 (install golangci-lint [here](https://golangci-lint.run/usage/install/#local-installation))
- [x] Run `make test` to ensure the proposed changes pass the tests 🧪
- [x] If changing a source plugin run `make gen` to ensure docs are up to date 📝
- [ ] Ensure the status checks below are successful ✅
--->
