### PR TITLE
chore: Tags for Lambda Functions properly set

### DIFF
--- a/plugins/source/aws/resources/services/lambda/functions.go
+++ b/plugins/source/aws/resources/services/lambda/functions.go
@@ -306,7 +306,7 @@ func resolveTags(ctx context.Context, meta schema.ClientMeta, resource *schema.R
 
 	// setting tags value from GetFunction call
 	if r.Code != nil {
-		return resource.Set(col.Name, r.Concurrency)
+		return resource.Set(col.Name, r.Tags)
 	}
 
 	cl := meta.(*client.Client)

--- a/plugins/source/aws/resources/services/lambda/functions_mock_test.go
+++ b/plugins/source/aws/resources/services/lambda/functions_mock_test.go
@@ -33,6 +33,8 @@ func buildLambdaFunctionsMock(t *testing.T, ctrl *gomock.Controller) client.Serv
 	require.NoError(t, faker.FakeObject(&f))
 	f.Configuration.LastModified = &lastModified
 	err := smithy.GenericAPIError{Code: "AccessDenied", Message: "This is an error message"}
+
+	// There are 2 calls to GetFunction, one succeeds and the other fails
 	gomock.InOrder(
 		m.EXPECT().GetFunction(gomock.Any(), gomock.Any(), gomock.Any()).
 			Return(&f, nil),

--- a/plugins/source/aws/resources/services/lambda/functions_mock_test.go
+++ b/plugins/source/aws/resources/services/lambda/functions_mock_test.go
@@ -6,6 +6,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/lambda"
 	"github.com/aws/aws-sdk-go-v2/service/lambda/types"
+	"github.com/aws/smithy-go"
 	"github.com/cloudquery/cloudquery/plugins/source/aws/client"
 	"github.com/cloudquery/cloudquery/plugins/source/aws/client/mocks"
 	"github.com/cloudquery/plugin-sdk/v4/faker"
@@ -19,73 +20,92 @@ func buildLambdaFunctionsMock(t *testing.T, ctrl *gomock.Controller) client.Serv
 
 	lastModified := "1994-11-05T08:15:30.000+0500"
 
+	fc := types.FunctionConfiguration{}
+	require.NoError(t, faker.FakeObject(&fc))
+
+	fc2 := types.FunctionConfiguration{}
+	require.NoError(t, faker.FakeObject(&fc2))
+	fc2.FunctionArn = aws.String("arn:aws:lambda:us-east-1:123456789012:function:my-function:2")
+	m.EXPECT().ListFunctions(gomock.Any(), gomock.Any(), gomock.Any()).
+		Return(&lambda.ListFunctionsOutput{Functions: []types.FunctionConfiguration{fc, fc2}}, nil)
+
 	f := lambda.GetFunctionOutput{}
 	require.NoError(t, faker.FakeObject(&f))
 	f.Configuration.LastModified = &lastModified
-	m.EXPECT().GetFunction(gomock.Any(), gomock.Any(), gomock.Any()).
-		Return(&f, nil)
+	err := smithy.GenericAPIError{Code: "AccessDenied", Message: "This is an error message"}
+	gomock.InOrder(
+		m.EXPECT().GetFunction(gomock.Any(), gomock.Any(), gomock.Any()).
+			Return(&f, nil),
 
-	fc := types.FunctionConfiguration{}
-	require.NoError(t, faker.FakeObject(&fc))
-	m.EXPECT().ListFunctions(gomock.Any(), gomock.Any(), gomock.Any()).
-		Return(&lambda.ListFunctionsOutput{Functions: []types.FunctionConfiguration{fc}}, nil)
-
+		m.EXPECT().GetFunction(gomock.Any(), gomock.Any(), gomock.Any()).
+			Return(nil, &err),
+	)
 	a := types.AliasConfiguration{}
 	require.NoError(t, faker.FakeObject(&a))
 	m.EXPECT().ListAliases(gomock.Any(), gomock.Any(), gomock.Any()).
-		Return(&lambda.ListAliasesOutput{Aliases: []types.AliasConfiguration{a}}, nil)
+		Return(&lambda.ListAliasesOutput{Aliases: []types.AliasConfiguration{a}}, nil).AnyTimes()
 
 	urlConfig := types.FunctionUrlConfig{}
 	require.NoError(t, faker.FakeObject(&urlConfig))
 	urlConfig.CreationTime = aws.String("2012-07-14T01:00:00+01:00")
 	urlConfig.LastModifiedTime = aws.String("2012-07-14T01:00:00+01:00")
 	m.EXPECT().ListFunctionUrlConfigs(gomock.Any(), gomock.Any(), gomock.Any()).
-		Return(&lambda.ListFunctionUrlConfigsOutput{FunctionUrlConfigs: []types.FunctionUrlConfig{urlConfig}}, nil)
+		Return(&lambda.ListFunctionUrlConfigsOutput{FunctionUrlConfigs: []types.FunctionUrlConfig{urlConfig}}, nil).AnyTimes()
+
+	gfco := lambda.GetFunctionConcurrencyOutput{}
+	require.NoError(t, faker.FakeObject(&gfco))
+	m.EXPECT().GetFunctionConcurrency(gomock.Any(), gomock.Any(), gomock.Any()).
+		Return(&gfco, nil).AnyTimes()
+
+	lto := lambda.ListTagsOutput{}
+	require.NoError(t, faker.FakeObject(&lto))
+	m.EXPECT().ListTags(gomock.Any(), gomock.Any(), gomock.Any()).
+		Return(&lto, nil).AnyTimes()
 
 	i := types.FunctionEventInvokeConfig{}
 	require.NoError(t, faker.FakeObject(&i))
 	m.EXPECT().ListFunctionEventInvokeConfigs(gomock.Any(), gomock.Any(), gomock.Any()).
-		Return(&lambda.ListFunctionEventInvokeConfigsOutput{FunctionEventInvokeConfigs: []types.FunctionEventInvokeConfig{i}}, nil)
+		Return(&lambda.ListFunctionEventInvokeConfigsOutput{FunctionEventInvokeConfigs: []types.FunctionEventInvokeConfig{i}}, nil).AnyTimes()
 
 	cc := types.ProvisionedConcurrencyConfigListItem{}
 	require.NoError(t, faker.FakeObject(&cc))
 	cc.LastModified = &lastModified
 	m.EXPECT().ListProvisionedConcurrencyConfigs(gomock.Any(), gomock.Any(), gomock.Any()).
-		Return(&lambda.ListProvisionedConcurrencyConfigsOutput{ProvisionedConcurrencyConfigs: []types.ProvisionedConcurrencyConfigListItem{cc}}, nil)
+		Return(&lambda.ListProvisionedConcurrencyConfigsOutput{ProvisionedConcurrencyConfigs: []types.ProvisionedConcurrencyConfigListItem{cc}}, nil).AnyTimes()
 
 	esm := types.EventSourceMappingConfiguration{}
 	require.NoError(t, faker.FakeObject(&esm))
 	esm.UUID = aws.String(uuid.NewString())
 	m.EXPECT().ListEventSourceMappings(gomock.Any(), gomock.Any(), gomock.Any()).
-		Return(&lambda.ListEventSourceMappingsOutput{EventSourceMappings: []types.EventSourceMappingConfiguration{esm}}, nil)
+		Return(&lambda.ListEventSourceMappingsOutput{EventSourceMappings: []types.EventSourceMappingConfiguration{esm}}, nil).AnyTimes()
 
 	fp := lambda.GetPolicyOutput{}
 	require.NoError(t, faker.FakeObject(&fp))
 	document := "{\"test\":1}"
 	fp.Policy = &document
 	m.EXPECT().GetPolicy(gomock.Any(), gomock.Any(), gomock.Any()).
-		Return(&fp, nil)
+		Return(&fp, nil).AnyTimes()
 
 	csco := lambda.GetFunctionCodeSigningConfigOutput{}
 	require.NoError(t, faker.FakeObject(&csco))
 	m.EXPECT().GetFunctionCodeSigningConfig(gomock.Any(), gomock.Any(), gomock.Any()).
-		Return(&csco, nil)
+		Return(&csco, nil).AnyTimes()
 
 	csc := types.CodeSigningConfig{}
 	require.NoError(t, faker.FakeObject(&csc))
 	isoDate := "2011-10-05T14:48:00.000Z"
 	csc.LastModified = &isoDate
 	m.EXPECT().GetCodeSigningConfig(gomock.Any(), gomock.Any(), gomock.Any()).
-		Return(&lambda.GetCodeSigningConfigOutput{CodeSigningConfig: &csc}, nil)
+		Return(&lambda.GetCodeSigningConfigOutput{CodeSigningConfig: &csc}, nil).AnyTimes()
 
 	fc.LastModified = &lastModified
 	m.EXPECT().ListVersionsByFunction(gomock.Any(), gomock.Any(), gomock.Any()).
-		Return(&lambda.ListVersionsByFunctionOutput{Versions: []types.FunctionConfiguration{fc}}, nil)
+		Return(&lambda.ListVersionsByFunctionOutput{Versions: []types.FunctionConfiguration{fc}}, nil).AnyTimes()
 
 	runtimeManagementConfig := lambda.GetRuntimeManagementConfigOutput{}
 	require.NoError(t, faker.FakeObject(&runtimeManagementConfig))
 	m.EXPECT().GetRuntimeManagementConfig(gomock.Any(), gomock.Any(), gomock.Any()).
-		Return(&runtimeManagementConfig, nil)
+		Return(&runtimeManagementConfig, nil).AnyTimes()
 
 	return client.Services{
 		Lambda: m,


### PR DESCRIPTION
<!-- 🎉 Thank you for making CloudQuery awesome by submitting a PR 🎉 -->

#### Summary

The happy path of `GetFunction` succeeding means that `ListTags` should not be called. This PR adds tests to ensure all paths are properly implemented