### PR TITLE
fix: Don't try to ListTags on DynamoDB backups if `Advanced DynamoDB Backups` is disabled

### DIFF
--- a/plugins/source/aws/resources/services/backup/vault_recovery_points.go
+++ b/plugins/source/aws/resources/services/backup/vault_recovery_points.go
@@ -75,8 +75,16 @@ func resolveRecoveryPointTags(ctx context.Context, meta schema.ClientMeta, resou
 
 	// decide if the backed up resource supports tags
 	switch client.AWSService(resourceARN.Service) {
-	case client.S3Service, client.EFSService, client.DynamoDBService:
+	case client.S3Service, client.EFSService:
+
 		// these services are ok
+	case client.DynamoDBService:
+		// DynamoDB backups in accounts without "Advanced DynamoDB Backups" do not have Full Backup Management and do not support tagging.
+		// DynamoDB backups in such accounts are in the "dynamodb" service namespace, instead of "awsbackup".
+		// https://docs.aws.amazon.com/aws-backup/latest/devguide/advanced-ddb-backup.html#advanced-ddb-backup-other-benefits
+		if resourceARN.Service == "dynamodb" {
+			return nil
+		}
 	case client.EC2Service:
 		if !strings.HasPrefix(resourceARN.Resource, "instance/") {
 			return nil
@@ -98,10 +106,6 @@ func resolveRecoveryPointTags(ctx context.Context, meta schema.ClientMeta, resou
 		if err != nil {
 			if client.IsAWSError(err, "ERROR_2603") {
 				// ignoring "ERROR_2603: Cannot find recovery point."
-				return nil
-			}
-			if resourceARN.Service == string(client.DynamoDBService) && client.IsAWSError(err, "ERROR_3930") {
-				// advanced backup features are not enabled for dynamodb
 				return nil
 			}
 			return err


### PR DESCRIPTION
## Error Summary

We noticed a lot of errors being thrown when syncing our `aws_backup_vault_recovery_points` table, upon further investigation we noticed that these errors were only being thrown when syncing DynamoDB backup resources. We also discovered this would only happen in an AWS account with [Advanced DynamoDB Backups](https://docs.aws.amazon.com/aws-backup/latest/devguide/advanced-ddb-backup.html) disabled.

<img width="1643" alt="image" src="https://github.com/cloudquery/cloudquery/assets/21217225/0b34c98b-2e89-4c94-ba5a-058168179a1a">


[Apparently](https://docs.aws.amazon.com/aws-backup/latest/devguide/API_ListTags.html) the ListTags API can only be used for backups that support "Full Backup Management", which DynamoDB backups do not support without "Advanced DynamoDB Backups" enabled.

## Fix

It looks like there might have been an attempt to fix this in the past but AWS have since changed their error codes and CloudQuery's fix no longer works. This PR addresses the problem by only calling ListTags on backups that support it.

We check support for ListTags by looking at the resource namespace, [in theory DynamoDB backups will be in the `backup` namespace if they have the advanced features enabled](https://docs.aws.amazon.com/aws-backup/latest/devguide/advanced-ddb-backup.html#advanced-ddb-backup-other-benefits), and in the `dynamodb` namespace if not.

<!--
Explain what problem this PR addresses
-->

<!--
Use the following steps to ensure your PR is ready to be reviewed

- [ ] Read the [contribution guidelines](https://github.com/cloudquery/cloudquery/blob/main/CONTRIBUTING.md) 🧑‍🎓
- [ ] Run `make lint` to ensure the proposed changes follow the coding style 🚨 (install golangci-lint [here](https://golangci-lint.run/usage/install/#local-installation))
- [ ] Run `make test` to ensure the proposed changes pass the tests 🧪
- [ ] If changing a source plugin run `make gen` to ensure docs are up to date 📝
- [ ] Ensure the status checks below are successful ✅
--->
