### PR TITLE
chore: Support Mixed Client For GCP Testing

### DIFF
--- a/plugins/source/gcp/client/client.go
+++ b/plugins/source/gcp/client/client.go
@@ -52,9 +52,10 @@ type Client struct {
 	// this is set by table client Location multiplexer
 	Location string
 	// Logger
-	logger zerolog.Logger
-
-	Backend state.Client
+	logger              zerolog.Logger
+	Backend             state.Client
+	TestingGRPCEndpoint string
+	TestingHTTPEndpoint string
 }
 
 func (c *Client) WithBackend(backend state.Client) *Client {

--- a/plugins/source/gcp/client/client.go
+++ b/plugins/source/gcp/client/client.go
@@ -54,8 +54,8 @@ type Client struct {
 	// Logger
 	logger              zerolog.Logger
 	Backend             state.Client
-	TestingGRPCEndpoint string
-	TestingHTTPEndpoint string
+	TestingGRPCEndpoint *string
+	TestingHTTPEndpoint *string
 }
 
 func (c *Client) WithBackend(backend state.Client) *Client {

--- a/plugins/source/gcp/client/testing.go
+++ b/plugins/source/gcp/client/testing.go
@@ -110,8 +110,8 @@ func MockTestHelper(t *testing.T, table *schema.Table, opts ...Option) {
 		logger:              l,
 		orgs:                []*crmv1.Organization{{Name: "organizations/testOrg"}},
 		projects:            []string{"testProject"},
-		TestingGRPCEndpoint: grpcEndpoint,
-		TestingHTTPEndpoint: httpTestEndpoint,
+		TestingGRPCEndpoint: &grpcEndpoint,
+		TestingHTTPEndpoint: &httpTestEndpoint,
 	}
 
 	sched := scheduler.NewScheduler(scheduler.WithLogger(l))

--- a/plugins/source/gcp/client/testing.go
+++ b/plugins/source/gcp/client/testing.go
@@ -58,6 +58,7 @@ func MockTestHelper(t *testing.T, table *schema.Table, opts ...Option) {
 	}
 	var gsrv *grpc.Server
 	var eg *errgroup.Group
+	var grpcEndpoint string
 	if options.CreateGrpcService != nil {
 		gsrv = grpc.NewServer()
 		listener, err := net.Listen("tcp", "localhost:0")
@@ -72,17 +73,18 @@ func MockTestHelper(t *testing.T, table *schema.Table, opts ...Option) {
 		eg.Go(func() error {
 			return gsrv.Serve(listener)
 		})
-
-		clientOptions = append(clientOptions, option.WithEndpoint(listener.Addr().String()))
+		grpcEndpoint = listener.Addr().String()
+		clientOptions = append(clientOptions, option.WithEndpoint(grpcEndpoint))
 	}
 
 	var mux *httprouter.Router
 	var ts *httptest.Server
 	var wg *sync.WaitGroup
+	var httpTestEndpoint string
 	if options.CreateHTTPServer != nil {
 		mux = httprouter.New()
 		ts = httptest.NewUnstartedServer(mux)
-		tsURL := "http://" + ts.Listener.Addr().String()
+		httpTestEndpoint = "http://" + ts.Listener.Addr().String()
 		defer ts.Close()
 		if err := options.CreateHTTPServer(mux); err != nil {
 			t.Fatal(err)
@@ -94,7 +96,7 @@ func MockTestHelper(t *testing.T, table *schema.Table, opts ...Option) {
 			ts.Start()
 		}()
 		clientOptions = append(clientOptions,
-			option.WithEndpoint(tsURL),
+			option.WithEndpoint(httpTestEndpoint),
 			option.WithGRPCDialOption(grpc.WithBlock()),
 		)
 	}
@@ -102,12 +104,14 @@ func MockTestHelper(t *testing.T, table *schema.Table, opts ...Option) {
 		zerolog.ConsoleWriter{Out: os.Stderr, TimeFormat: time.StampMicro},
 	).Level(zerolog.DebugLevel).With().Timestamp().Logger()
 	c := &Client{
-		Backend:       &state.NoOpClient{},
-		ClientOptions: clientOptions,
-		folderIds:     []string{"testFolder"},
-		logger:        l,
-		orgs:          []*crmv1.Organization{{Name: "organizations/testOrg"}},
-		projects:      []string{"testProject"},
+		Backend:             &state.NoOpClient{},
+		ClientOptions:       clientOptions,
+		folderIds:           []string{"testFolder"},
+		logger:              l,
+		orgs:                []*crmv1.Organization{{Name: "organizations/testOrg"}},
+		projects:            []string{"testProject"},
+		TestingGRPCEndpoint: grpcEndpoint,
+		TestingHTTPEndpoint: httpTestEndpoint,
 	}
 
 	sched := scheduler.NewScheduler(scheduler.WithLogger(l))


### PR DESCRIPTION
<!-- 🎉 Thank you for making CloudQuery awesome by submitting a PR 🎉 -->

#### Summary

Currently there is no way to test tables where nested tables use a different client type (gRPC vs Rest) as the endpoint is passed in via the `client.Options` ... The "cleanest" way to support this would be to have some sort of reverse proxy in front of the 2 types of test servers that proxies the requests to the correct endpoint.

This PR provides a way for the resolver to override the endpoint at resolve time rather than at plugin configuration time