### PR TITLE
chore: Use Node.js 20 in source_airtable.yml

### DIFF
--- a/.github/workflows/source_airtable.yml
+++ b/.github/workflows/source_airtable.yml
@@ -28,7 +28,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v3
         with:
-          node-version: '16'
+          node-version: '20'
           cache: 'npm'
           cache-dependency-path: './plugins/source/airtable/package-lock.json'
 


### PR DESCRIPTION
<!-- 🎉 Thank you for making CloudQuery awesome by submitting a PR 🎉 -->

#### Summary

Since https://github.com/cloudquery/cloudquery/pull/15721/files#diff-a1b22c80628ca652952e2c245e1e591636ad67549f7b8180b3552faeb83316e1R75 the plugin requires Node.js 20 so the CI should reflect it

<!--
Use the following steps to ensure your PR is ready to be reviewed

- [ ] Read the [contribution guidelines](https://github.com/cloudquery/cloudquery/blob/main/CONTRIBUTING.md) 🧑‍🎓
- [ ] Run `make lint` to ensure the proposed changes follow the coding style 🚨 (install golangci-lint [here](https://golangci-lint.run/usage/install/#local-installation))
- [ ] Run `make test` to ensure the proposed changes pass the tests 🧪
- [ ] If changing a source plugin run `make gen` to ensure docs are up to date 📝
- [ ] Ensure the status checks below are successful ✅
--->
