### PR TITLE
fix: Add `X-Meta-User-Team-Name` during docker push

### DIFF
--- a/cli/internal/publish/plugins.go
+++ b/cli/internal/publish/plugins.go
@@ -555,7 +555,7 @@ func PublishToDockerRegistry(ctx context.Context, token, distDir string, pkgJSON
 	// and talking to the registry directly since the Docker Engine API doesn't support the manifest API yet
 
 	// Loading and pushing the images is done via the Docker Go SDK
-	additionalHeaders := map[string]string{"X-Meta-Plugin-Version": pkgJSON.Version}
+	additionalHeaders := map[string]string{"X-Meta-Plugin-Version": pkgJSON.Version, "X-Meta-User-Team-Name": pkgJSON.Team}
 	dockerClient, err := client.NewClientWithOpts(client.FromEnv, client.WithHTTPHeaders(additionalHeaders))
 	if err != nil {
 		return fmt.Errorf("failed to create Docker client: %v", err)


### PR DESCRIPTION
<!-- 🎉 Thank you for making CloudQuery awesome by submitting a PR 🎉 -->

#### Summary

The requirement for this header was added recently in the backend to track downloads, so the backend needs to know the team that's downloading the plugin. It's less relevant for the push operation though, but still needed. It's ok to use the team from the manifest - it just has to be any team the user is a part of. During push we already verify the token used to push has access to the team.

<!--
Use the following steps to ensure your PR is ready to be reviewed

- [ ] Read the [contribution guidelines](https://github.com/cloudquery/cloudquery/blob/main/CONTRIBUTING.md) 🧑‍🎓
- [ ] Run `make lint` to ensure the proposed changes follow the coding style 🚨 (install golangci-lint [here](https://golangci-lint.run/usage/install/#local-installation))
- [ ] Run `make test` to ensure the proposed changes pass the tests 🧪
- [ ] If changing a source plugin run `make gen` to ensure docs are up to date 📝
- [ ] Ensure the status checks below are successful ✅
--->
