### PR TITLE
refactor: Ease `client.Services` & `client.ServiceManager` logic

### DIFF
--- a/plugins/source/aws/client/account.go
+++ b/plugins/source/aws/client/account.go
@@ -19,7 +19,7 @@ import (
 type svcsDetail struct {
 	partition string
 	accountId string
-	svcs      Services
+	svcs      *Services
 }
 
 func (c *Client) setupAWSAccount(ctx context.Context, logger zerolog.Logger, awsPluginSpec *spec.Spec, adminAccountSts AssumeRoleAPIClient, account spec.Account) (*svcsDetail, error) {

--- a/plugins/source/aws/client/client.go
+++ b/plugins/source/aws/client/client.go
@@ -80,10 +80,6 @@ func (c *Client) ID() string {
 	return strings.TrimRight(strings.Join(idStrings, ":"), ":")
 }
 
-func (c *Client) updateService(service AWSServiceName) {
-	c.ServicesManager.ServicesByPartitionAccount(c.Partition, c.AccountID).InitService(service)
-}
-
 func (c *Client) Services(serviceNames ...AWSServiceName) *Services {
 	svc := c.ServicesManager.ServicesByPartitionAccount(c.Partition, c.AccountID)
 	for _, service := range serviceNames {

--- a/plugins/source/aws/client/service_manager.go
+++ b/plugins/source/aws/client/service_manager.go
@@ -2,31 +2,29 @@ package client
 
 import "github.com/thoas/go-funk"
 
-type ServicesPartitionAccountMap map[string]map[string]*Services
-
 // ServicesManager will hold the entire map of (account X region) services
-type ServicesManager struct {
-	services ServicesPartitionAccountMap
+type ServicesManager map[string]map[string]*Services
+
+func (s ServicesManager) ServicesByPartitionAccount(partition, accountId string) *Services {
+	return s[partition][accountId]
 }
 
-func (s *ServicesManager) ServicesByPartitionAccount(partition, accountId string) *Services {
-	return s.services[partition][accountId]
-}
-
-func (s *ServicesManager) InitServices(details svcsDetail) {
+func (s ServicesManager) InitServices(details svcsDetail) {
 	s.InitServicesForPartitionAccount(details.partition, details.accountId, details.svcs)
 }
 
-func (s *ServicesManager) InitServicesForPartitionAccount(partition, accountId string, svcs Services) {
-	if s.services == nil {
-		s.services = make(map[string]map[string]*Services)
-	}
-	if s.services[partition] == nil {
-		s.services[partition] = make(map[string]*Services)
-	}
-	if s.services[partition][accountId] == nil {
-		s.services[partition][accountId] = &svcs
+func (s ServicesManager) InitServicesForPartitionAccount(partition, accountID string, svcs *Services) {
+	p, ok := s[partition]
+	if !ok {
+		p = make(map[string]*Services)
+		s[partition] = p
 	}
 
-	s.services[partition][accountId].Regions = funk.UniqString(append(s.services[partition][accountId].Regions, svcs.Regions...))
+	svc, ok := p[accountID]
+	if !ok {
+		p[accountID] = svcs
+		return
+	}
+
+	svc.Regions = funk.UniqString(append(svc.Regions, svcs.Regions...))
 }

--- a/plugins/source/aws/client/testing.go
+++ b/plugins/source/aws/client/testing.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"os"
 	"slices"
-	"sync"
 	"testing"
 	"time"
 
@@ -24,7 +23,7 @@ type TestOptions struct {
 	SkipEmptyCheckColumns map[string][]string
 }
 
-func AwsMockTestHelper(t *testing.T, parentTable *schema.Table, builder func(*testing.T, *gomock.Controller) Services, testOpts TestOptions) {
+func AwsMockTestHelper(t *testing.T, parentTable *schema.Table, builder func(*testing.T, *gomock.Controller) *Services, testOpts TestOptions) {
 	parentTable.IgnoreInTests = false
 	if testOpts.Region == "" {
 		testOpts.Region = "us-east-1"
@@ -42,7 +41,6 @@ func AwsMockTestHelper(t *testing.T, parentTable *schema.Table, builder func(*te
 	services := builder(t, ctrl)
 	services.Regions = []string{testOpts.Region}
 	services.AWSConfig.Region = testOpts.Region
-	c.accountMutex["testAccount"] = &sync.Mutex{}
 	c.ServicesManager.InitServicesForPartitionAccount("aws", "testAccount", services)
 	c.Partition = "aws"
 	tables := schema.Tables{parentTable}
@@ -62,7 +60,7 @@ func AwsMockTestHelper(t *testing.T, parentTable *schema.Table, builder func(*te
 	validateNoEmptyColumnsExcept(t, tables, messages, testOpts.SkipEmptyCheckColumns)
 }
 
-func AwsCreateMockClient(t *testing.T, ctrl *gomock.Controller, builder func(*testing.T, *gomock.Controller) Services, testOpts TestOptions) Client {
+func AwsCreateMockClient(t *testing.T, ctrl *gomock.Controller, builder func(*testing.T, *gomock.Controller) *Services, testOpts TestOptions) Client {
 	if testOpts.Region == "" {
 		testOpts.Region = "us-east-1"
 	}
@@ -80,8 +78,6 @@ func AwsCreateMockClient(t *testing.T, ctrl *gomock.Controller, builder func(*te
 		services.Regions = []string{testOpts.Region}
 		c.ServicesManager.InitServicesForPartitionAccount("aws", "testAccount", services)
 	}
-
-	c.accountMutex["testAccount"] = &sync.Mutex{}
 
 	c.Partition = "aws"
 	return c

--- a/plugins/source/aws/resources/services/accessanalyzer/analyzers_mock_test.go
+++ b/plugins/source/aws/resources/services/accessanalyzer/analyzers_mock_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func buildAccessAnalyzer(t *testing.T, ctrl *gomock.Controller) client.Services {
+func buildAccessAnalyzer(t *testing.T, ctrl *gomock.Controller) *client.Services {
 	m := mocks.NewMockAccessanalyzerClient(ctrl)
 	u := types.AnalyzerSummary{}
 	require.NoError(t, faker.FakeObject(&u))
@@ -38,7 +38,7 @@ func buildAccessAnalyzer(t *testing.T, ctrl *gomock.Controller) client.Services 
 			ArchiveRules: []types.ArchiveRuleSummary{arch},
 		}, nil)
 
-	return client.Services{
+	return &client.Services{
 		Accessanalyzer: m,
 	}
 }

--- a/plugins/source/aws/resources/services/account/alternate_contacts_mock_test.go
+++ b/plugins/source/aws/resources/services/account/alternate_contacts_mock_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func buildAlternateContacts(t *testing.T, ctrl *gomock.Controller) client.Services {
+func buildAlternateContacts(t *testing.T, ctrl *gomock.Controller) *client.Services {
 	mock := mocks.NewMockAccountClient(ctrl)
 
 	var ac types.AlternateContact
@@ -27,7 +27,7 @@ func buildAlternateContacts(t *testing.T, ctrl *gomock.Controller) client.Servic
 		nil,
 	).MinTimes(1)
 
-	return client.Services{Account: mock}
+	return &client.Services{Account: mock}
 }
 
 func TestAlternateContacts(t *testing.T) {

--- a/plugins/source/aws/resources/services/account/contacts_mock_test.go
+++ b/plugins/source/aws/resources/services/account/contacts_mock_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func buildContacts(t *testing.T, ctrl *gomock.Controller) client.Services {
+func buildContacts(t *testing.T, ctrl *gomock.Controller) *client.Services {
 	mock := mocks.NewMockAccountClient(ctrl)
 
 	var ci types.ContactInformation
@@ -27,7 +27,7 @@ func buildContacts(t *testing.T, ctrl *gomock.Controller) client.Services {
 		nil,
 	)
 
-	return client.Services{Account: mock}
+	return &client.Services{Account: mock}
 }
 
 func TestContacts(t *testing.T) {

--- a/plugins/source/aws/resources/services/acm/certificates_mock_test.go
+++ b/plugins/source/aws/resources/services/acm/certificates_mock_test.go
@@ -13,7 +13,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func buildACMCertificates(t *testing.T, ctrl *gomock.Controller) client.Services {
+func buildACMCertificates(t *testing.T, ctrl *gomock.Controller) *client.Services {
 	mock := mocks.NewMockAcmClient(ctrl)
 
 	var cs types.CertificateSummary
@@ -60,7 +60,7 @@ func buildACMCertificates(t *testing.T, ctrl *gomock.Controller) client.Services
 		},
 		nil,
 	)
-	return client.Services{Acm: mock}
+	return &client.Services{Acm: mock}
 }
 
 func TestACMCertificates(t *testing.T) {

--- a/plugins/source/aws/resources/services/acmpca/certificate_authorities_mock_test.go
+++ b/plugins/source/aws/resources/services/acmpca/certificate_authorities_mock_test.go
@@ -13,7 +13,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func buildACMPCACertificateAuthorities(t *testing.T, ctrl *gomock.Controller) client.Services {
+func buildACMPCACertificateAuthorities(t *testing.T, ctrl *gomock.Controller) *client.Services {
 	mock := mocks.NewMockAcmpcaClient(ctrl)
 
 	var ca types.CertificateAuthority
@@ -40,7 +40,7 @@ func buildACMPCACertificateAuthorities(t *testing.T, ctrl *gomock.Controller) cl
 		},
 		nil,
 	)
-	return client.Services{Acmpca: mock}
+	return &client.Services{Acmpca: mock}
 }
 
 func TestACMPCACertificateAuthorities(t *testing.T) {

--- a/plugins/source/aws/resources/services/amp/workspaces_mock_test.go
+++ b/plugins/source/aws/resources/services/amp/workspaces_mock_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func buildWorkspaces(t *testing.T, ctrl *gomock.Controller) client.Services {
+func buildWorkspaces(t *testing.T, ctrl *gomock.Controller) *client.Services {
 	m := mocks.NewMockAmpClient(ctrl)
 
 	var summary types.WorkspaceSummary
@@ -57,7 +57,7 @@ func buildWorkspaces(t *testing.T, ctrl *gomock.Controller) client.Services {
 
 	buildRuleGroupsNamespaces(t, m)
 
-	return client.Services{Amp: m}
+	return &client.Services{Amp: m}
 }
 
 func TestWorkspaces(t *testing.T) {

--- a/plugins/source/aws/resources/services/amplify/apps_mock_test.go
+++ b/plugins/source/aws/resources/services/amplify/apps_mock_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func buildApps(t *testing.T, ctrl *gomock.Controller) client.Services {
+func buildApps(t *testing.T, ctrl *gomock.Controller) *client.Services {
 	m := mocks.NewMockAmplifyClient(ctrl)
 
 	var app types.App
@@ -25,7 +25,7 @@ func buildApps(t *testing.T, ctrl *gomock.Controller) client.Services {
 		nil,
 	)
 
-	return client.Services{Amplify: m}
+	return &client.Services{Amplify: m}
 }
 
 func TestApps(t *testing.T) {

--- a/plugins/source/aws/resources/services/apigateway/api_keys_mock_test.go
+++ b/plugins/source/aws/resources/services/apigateway/api_keys_mock_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func buildApiKeysMock(t *testing.T, ctrl *gomock.Controller) client.Services {
+func buildApiKeysMock(t *testing.T, ctrl *gomock.Controller) *client.Services {
 	m := mocks.NewMockApigatewayClient(ctrl)
 
 	a := types.ApiKey{}
@@ -23,7 +23,7 @@ func buildApiKeysMock(t *testing.T, ctrl *gomock.Controller) client.Services {
 			Items: []types.ApiKey{a},
 		}, nil)
 
-	return client.Services{
+	return &client.Services{
 		Apigateway: m,
 	}
 }

--- a/plugins/source/aws/resources/services/apigateway/client_certificates_mock_test.go
+++ b/plugins/source/aws/resources/services/apigateway/client_certificates_mock_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func buildApigatewayClientCertificates(t *testing.T, ctrl *gomock.Controller) client.Services {
+func buildApigatewayClientCertificates(t *testing.T, ctrl *gomock.Controller) *client.Services {
 	m := mocks.NewMockApigatewayClient(ctrl)
 
 	c := types.ClientCertificate{}
@@ -23,7 +23,7 @@ func buildApigatewayClientCertificates(t *testing.T, ctrl *gomock.Controller) cl
 			Items: []types.ClientCertificate{c},
 		}, nil)
 
-	return client.Services{
+	return &client.Services{
 		Apigateway: m,
 	}
 }

--- a/plugins/source/aws/resources/services/apigateway/domain_names_mock_test.go
+++ b/plugins/source/aws/resources/services/apigateway/domain_names_mock_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func buildApigatewayDomainNames(t *testing.T, ctrl *gomock.Controller) client.Services {
+func buildApigatewayDomainNames(t *testing.T, ctrl *gomock.Controller) *client.Services {
 	m := mocks.NewMockApigatewayClient(ctrl)
 
 	dm := types.DomainName{}
@@ -31,7 +31,7 @@ func buildApigatewayDomainNames(t *testing.T, ctrl *gomock.Controller) client.Se
 			Items: []types.BasePathMapping{bpm},
 		}, nil)
 
-	return client.Services{
+	return &client.Services{
 		Apigateway: m,
 	}
 }

--- a/plugins/source/aws/resources/services/apigateway/rest_apis_mock_test.go
+++ b/plugins/source/aws/resources/services/apigateway/rest_apis_mock_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func buildApigatewayRestApis(t *testing.T, ctrl *gomock.Controller) client.Services {
+func buildApigatewayRestApis(t *testing.T, ctrl *gomock.Controller) *client.Services {
 	m := mocks.NewMockApigatewayClient(ctrl)
 
 	r := types.RestApi{}
@@ -113,7 +113,7 @@ func buildApigatewayRestApis(t *testing.T, ctrl *gomock.Controller) client.Servi
 			Item: []types.Stage{s},
 		}, nil)
 
-	return client.Services{
+	return &client.Services{
 		Apigateway: m,
 	}
 }

--- a/plugins/source/aws/resources/services/apigateway/usage_plans_mock_test.go
+++ b/plugins/source/aws/resources/services/apigateway/usage_plans_mock_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func buildApigatewayUsagePlans(t *testing.T, ctrl *gomock.Controller) client.Services {
+func buildApigatewayUsagePlans(t *testing.T, ctrl *gomock.Controller) *client.Services {
 	m := mocks.NewMockApigatewayClient(ctrl)
 
 	u := types.UsagePlan{}
@@ -31,7 +31,7 @@ func buildApigatewayUsagePlans(t *testing.T, ctrl *gomock.Controller) client.Ser
 			Items: []types.UsagePlanKey{uk},
 		}, nil)
 
-	return client.Services{
+	return &client.Services{
 		Apigateway: m,
 	}
 }

--- a/plugins/source/aws/resources/services/apigateway/vpc_links_mock_test.go
+++ b/plugins/source/aws/resources/services/apigateway/vpc_links_mock_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func buildApigatewayVpcLinks(t *testing.T, ctrl *gomock.Controller) client.Services {
+func buildApigatewayVpcLinks(t *testing.T, ctrl *gomock.Controller) *client.Services {
 	m := mocks.NewMockApigatewayClient(ctrl)
 
 	l := types.VpcLink{}
@@ -23,7 +23,7 @@ func buildApigatewayVpcLinks(t *testing.T, ctrl *gomock.Controller) client.Servi
 			Items: []types.VpcLink{l},
 		}, nil)
 
-	return client.Services{
+	return &client.Services{
 		Apigateway: m,
 	}
 }

--- a/plugins/source/aws/resources/services/apigatewayv2/apis_mock_test.go
+++ b/plugins/source/aws/resources/services/apigatewayv2/apis_mock_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func buildApigatewayv2Apis(t *testing.T, ctrl *gomock.Controller) client.Services {
+func buildApigatewayv2Apis(t *testing.T, ctrl *gomock.Controller) *client.Services {
 	m := mocks.NewMockApigatewayv2Client(ctrl)
 
 	a := types.Api{}
@@ -83,7 +83,7 @@ func buildApigatewayv2Apis(t *testing.T, ctrl *gomock.Controller) client.Service
 			Items: []types.RouteResponse{rr},
 		}, nil)
 
-	return client.Services{
+	return &client.Services{
 		Apigatewayv2: m,
 	}
 }

--- a/plugins/source/aws/resources/services/apigatewayv2/domain_names_mock_test.go
+++ b/plugins/source/aws/resources/services/apigatewayv2/domain_names_mock_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func buildApigatewayv2DomainNames(t *testing.T, ctrl *gomock.Controller) client.Services {
+func buildApigatewayv2DomainNames(t *testing.T, ctrl *gomock.Controller) *client.Services {
 	m := mocks.NewMockApigatewayv2Client(ctrl)
 
 	dn := types.DomainName{}
@@ -29,7 +29,7 @@ func buildApigatewayv2DomainNames(t *testing.T, ctrl *gomock.Controller) client.
 			Items: []types.ApiMapping{am},
 		}, nil)
 
-	return client.Services{
+	return &client.Services{
 		Apigatewayv2: m,
 	}
 }

--- a/plugins/source/aws/resources/services/apigatewayv2/vpc_links_mock_test.go
+++ b/plugins/source/aws/resources/services/apigatewayv2/vpc_links_mock_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func buildApigatewayv2VpcLinks(t *testing.T, ctrl *gomock.Controller) client.Services {
+func buildApigatewayv2VpcLinks(t *testing.T, ctrl *gomock.Controller) *client.Services {
 	m := mocks.NewMockApigatewayv2Client(ctrl)
 
 	v := types.VpcLink{}
@@ -22,7 +22,7 @@ func buildApigatewayv2VpcLinks(t *testing.T, ctrl *gomock.Controller) client.Ser
 			Items: []types.VpcLink{v},
 		}, nil)
 
-	return client.Services{
+	return &client.Services{
 		Apigatewayv2: m,
 	}
 }

--- a/plugins/source/aws/resources/services/appconfig/applications_mock_test.go
+++ b/plugins/source/aws/resources/services/appconfig/applications_mock_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func buildApps(t *testing.T, ctrl *gomock.Controller) client.Services {
+func buildApps(t *testing.T, ctrl *gomock.Controller) *client.Services {
 	m := mocks.NewMockAppconfigClient(ctrl)
 
 	var app types.Application
@@ -69,7 +69,7 @@ func buildApps(t *testing.T, ctrl *gomock.Controller) client.Services {
 		nil,
 	)
 
-	return client.Services{Appconfig: m}
+	return &client.Services{Appconfig: m}
 }
 
 func TestApps(t *testing.T) {

--- a/plugins/source/aws/resources/services/appconfig/deployment_strategies_mock_test.go
+++ b/plugins/source/aws/resources/services/appconfig/deployment_strategies_mock_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func buildDeploymentStrategies(t *testing.T, ctrl *gomock.Controller) client.Services {
+func buildDeploymentStrategies(t *testing.T, ctrl *gomock.Controller) *client.Services {
 	m := mocks.NewMockAppconfigClient(ctrl)
 
 	var ds types.DeploymentStrategy
@@ -25,7 +25,7 @@ func buildDeploymentStrategies(t *testing.T, ctrl *gomock.Controller) client.Ser
 		nil,
 	)
 
-	return client.Services{Appconfig: m}
+	return &client.Services{Appconfig: m}
 }
 
 func TestDeploymentStrategies(t *testing.T) {

--- a/plugins/source/aws/resources/services/appflow/flows_mock_test.go
+++ b/plugins/source/aws/resources/services/appflow/flows_mock_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func buildFlows(t *testing.T, ctrl *gomock.Controller) client.Services {
+func buildFlows(t *testing.T, ctrl *gomock.Controller) *client.Services {
 	mock := mocks.NewMockAppflowClient(ctrl)
 
 	var fd types.FlowDefinition
@@ -41,7 +41,7 @@ func buildFlows(t *testing.T, ctrl *gomock.Controller) client.Services {
 		nil,
 	)
 
-	return client.Services{Appflow: mock}
+	return &client.Services{Appflow: mock}
 }
 
 func TestFlows(t *testing.T) {

--- a/plugins/source/aws/resources/services/applicationautoscaling/policies_mock_test.go
+++ b/plugins/source/aws/resources/services/applicationautoscaling/policies_mock_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func buildApplicationAutoscalingPoliciesMock(t *testing.T, ctrl *gomock.Controller) client.Services {
+func buildApplicationAutoscalingPoliciesMock(t *testing.T, ctrl *gomock.Controller) *client.Services {
 	m := mocks.NewMockApplicationautoscalingClient(ctrl)
 	services := client.Services{
 		Applicationautoscaling: m,

--- a/plugins/source/aws/resources/services/applicationautoscaling/policies_mock_test.go
+++ b/plugins/source/aws/resources/services/applicationautoscaling/policies_mock_test.go
@@ -14,7 +14,7 @@ import (
 
 func buildApplicationAutoscalingPoliciesMock(t *testing.T, ctrl *gomock.Controller) *client.Services {
 	m := mocks.NewMockApplicationautoscalingClient(ctrl)
-	services := client.Services{
+	services := &client.Services{
 		Applicationautoscaling: m,
 	}
 	c := types.ScalingPolicy{}

--- a/plugins/source/aws/resources/services/applicationautoscaling/scalable_targets_mock_test.go
+++ b/plugins/source/aws/resources/services/applicationautoscaling/scalable_targets_mock_test.go
@@ -14,7 +14,7 @@ import (
 
 func buildScalableTargets(t *testing.T, ctrl *gomock.Controller) *client.Services {
 	m := mocks.NewMockApplicationautoscalingClient(ctrl)
-	services := client.Services{
+	services := &client.Services{
 		Applicationautoscaling: m,
 	}
 	c := types.ScalableTarget{}

--- a/plugins/source/aws/resources/services/applicationautoscaling/scalable_targets_mock_test.go
+++ b/plugins/source/aws/resources/services/applicationautoscaling/scalable_targets_mock_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func buildScalableTargets(t *testing.T, ctrl *gomock.Controller) client.Services {
+func buildScalableTargets(t *testing.T, ctrl *gomock.Controller) *client.Services {
 	m := mocks.NewMockApplicationautoscalingClient(ctrl)
 	services := client.Services{
 		Applicationautoscaling: m,

--- a/plugins/source/aws/resources/services/applicationautoscaling/scaling_activities_mock_test.go
+++ b/plugins/source/aws/resources/services/applicationautoscaling/scaling_activities_mock_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func buildScalingActivities(t *testing.T, ctrl *gomock.Controller) client.Services {
+func buildScalingActivities(t *testing.T, ctrl *gomock.Controller) *client.Services {
 	m := mocks.NewMockApplicationautoscalingClient(ctrl)
 	services := client.Services{
 		Applicationautoscaling: m,

--- a/plugins/source/aws/resources/services/applicationautoscaling/scaling_activities_mock_test.go
+++ b/plugins/source/aws/resources/services/applicationautoscaling/scaling_activities_mock_test.go
@@ -14,7 +14,7 @@ import (
 
 func buildScalingActivities(t *testing.T, ctrl *gomock.Controller) *client.Services {
 	m := mocks.NewMockApplicationautoscalingClient(ctrl)
-	services := client.Services{
+	services := &client.Services{
 		Applicationautoscaling: m,
 	}
 	c := types.ScalingActivity{}

--- a/plugins/source/aws/resources/services/applicationautoscaling/scheduled_actions_mock_test.go
+++ b/plugins/source/aws/resources/services/applicationautoscaling/scheduled_actions_mock_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func buildScheduledActions(t *testing.T, ctrl *gomock.Controller) client.Services {
+func buildScheduledActions(t *testing.T, ctrl *gomock.Controller) *client.Services {
 	m := mocks.NewMockApplicationautoscalingClient(ctrl)
 	services := client.Services{
 		Applicationautoscaling: m,

--- a/plugins/source/aws/resources/services/applicationautoscaling/scheduled_actions_mock_test.go
+++ b/plugins/source/aws/resources/services/applicationautoscaling/scheduled_actions_mock_test.go
@@ -14,7 +14,7 @@ import (
 
 func buildScheduledActions(t *testing.T, ctrl *gomock.Controller) *client.Services {
 	m := mocks.NewMockApplicationautoscalingClient(ctrl)
-	services := client.Services{
+	services := &client.Services{
 		Applicationautoscaling: m,
 	}
 	c := types.ScheduledAction{}

--- a/plugins/source/aws/resources/services/appmesh/meshes_mock_test.go
+++ b/plugins/source/aws/resources/services/appmesh/meshes_mock_test.go
@@ -13,7 +13,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func buildMeshes(t *testing.T, ctrl *gomock.Controller) client.Services {
+func buildMeshes(t *testing.T, ctrl *gomock.Controller) *client.Services {
 	mock := mocks.NewMockAppmeshClient(ctrl)
 
 	var mr types.MeshRef
@@ -187,7 +187,7 @@ func buildMeshes(t *testing.T, ctrl *gomock.Controller) client.Services {
 		},
 		nil,
 	)
-	return client.Services{Appmesh: mock}
+	return &client.Services{Appmesh: mock}
 }
 
 func TestMeshes(t *testing.T) {

--- a/plugins/source/aws/resources/services/apprunner/auto_scaling_configuration_mock_test.go
+++ b/plugins/source/aws/resources/services/apprunner/auto_scaling_configuration_mock_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func buildApprunnerAutoScalingConfigurationsMock(t *testing.T, ctrl *gomock.Controller) client.Services {
+func buildApprunnerAutoScalingConfigurationsMock(t *testing.T, ctrl *gomock.Controller) *client.Services {
 	m := mocks.NewMockApprunnerClient(ctrl)
 	as := types.AutoScalingConfiguration{}
 	require.NoError(t, faker.FakeObject(&as))
@@ -33,7 +33,7 @@ func buildApprunnerAutoScalingConfigurationsMock(t *testing.T, ctrl *gomock.Cont
 
 	m.EXPECT().ListTagsForResource(gomock.Any(), gomock.Any(), gomock.Any()).Return(
 		&apprunner.ListTagsForResourceOutput{Tags: []types.Tag{tags}}, nil)
-	return client.Services{
+	return &client.Services{
 		Apprunner: m,
 	}
 }

--- a/plugins/source/aws/resources/services/apprunner/connections_mock_test.go
+++ b/plugins/source/aws/resources/services/apprunner/connections_mock_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func buildConnections(t *testing.T, ctrl *gomock.Controller) client.Services {
+func buildConnections(t *testing.T, ctrl *gomock.Controller) *client.Services {
 	m := mocks.NewMockApprunnerClient(ctrl)
 	s := types.ConnectionSummary{}
 	require.NoError(t, faker.FakeObject(&s))
@@ -27,7 +27,7 @@ func buildConnections(t *testing.T, ctrl *gomock.Controller) client.Services {
 	m.EXPECT().ListTagsForResource(gomock.Any(), gomock.Any(), gomock.Any()).Return(
 		&apprunner.ListTagsForResourceOutput{Tags: []types.Tag{tags}}, nil)
 
-	return client.Services{
+	return &client.Services{
 		Apprunner: m,
 	}
 }

--- a/plugins/source/aws/resources/services/apprunner/observability_configuration_mock_test.go
+++ b/plugins/source/aws/resources/services/apprunner/observability_configuration_mock_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func buildObservabilityConfiguration(t *testing.T, ctrl *gomock.Controller) client.Services {
+func buildObservabilityConfiguration(t *testing.T, ctrl *gomock.Controller) *client.Services {
 	m := mocks.NewMockApprunnerClient(ctrl)
 	s := types.ObservabilityConfiguration{}
 	require.NoError(t, faker.FakeObject(&s))
@@ -33,7 +33,7 @@ func buildObservabilityConfiguration(t *testing.T, ctrl *gomock.Controller) clie
 
 	m.EXPECT().ListTagsForResource(gomock.Any(), gomock.Any(), gomock.Any()).Return(
 		&apprunner.ListTagsForResourceOutput{Tags: []types.Tag{tags}}, nil)
-	return client.Services{
+	return &client.Services{
 		Apprunner: m,
 	}
 }

--- a/plugins/source/aws/resources/services/apprunner/services_mock_test.go
+++ b/plugins/source/aws/resources/services/apprunner/services_mock_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func buildApprunnerGraphqlApisMock(t *testing.T, ctrl *gomock.Controller) client.Services {
+func buildApprunnerGraphqlApisMock(t *testing.T, ctrl *gomock.Controller) *client.Services {
 	m := mocks.NewMockApprunnerClient(ctrl)
 	s := types.Service{}
 	require.NoError(t, faker.FakeObject(&s))
@@ -53,7 +53,7 @@ func buildApprunnerGraphqlApisMock(t *testing.T, ctrl *gomock.Controller) client
 
 	m.EXPECT().ListTagsForResource(gomock.Any(), gomock.Any(), gomock.Any()).Return(
 		&apprunner.ListTagsForResourceOutput{Tags: []types.Tag{tags}}, nil)
-	return client.Services{
+	return &client.Services{
 		Apprunner: m,
 	}
 }

--- a/plugins/source/aws/resources/services/apprunner/vpc_connector_mock_test.go
+++ b/plugins/source/aws/resources/services/apprunner/vpc_connector_mock_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func buildApprunnerVpcConnectorsMock(t *testing.T, ctrl *gomock.Controller) client.Services {
+func buildApprunnerVpcConnectorsMock(t *testing.T, ctrl *gomock.Controller) *client.Services {
 	m := mocks.NewMockApprunnerClient(ctrl)
 	vc := types.VpcConnector{}
 	require.NoError(t, faker.FakeObject(&vc))
@@ -27,7 +27,7 @@ func buildApprunnerVpcConnectorsMock(t *testing.T, ctrl *gomock.Controller) clie
 	m.EXPECT().ListTagsForResource(gomock.Any(), gomock.Any(), gomock.Any()).Return(
 		&apprunner.ListTagsForResourceOutput{Tags: []types.Tag{tags}}, nil)
 
-	return client.Services{
+	return &client.Services{
 		Apprunner: m,
 	}
 }

--- a/plugins/source/aws/resources/services/apprunner/vpc_ingress_connection_mock_test.go
+++ b/plugins/source/aws/resources/services/apprunner/vpc_ingress_connection_mock_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func buildApprunnerVpcIngressConnectionsMock(t *testing.T, ctrl *gomock.Controller) client.Services {
+func buildApprunnerVpcIngressConnectionsMock(t *testing.T, ctrl *gomock.Controller) *client.Services {
 	m := mocks.NewMockApprunnerClient(ctrl)
 	vc := types.VpcIngressConnection{}
 	require.NoError(t, faker.FakeObject(&vc))
@@ -30,7 +30,7 @@ func buildApprunnerVpcIngressConnectionsMock(t *testing.T, ctrl *gomock.Controll
 	m.EXPECT().ListTagsForResource(gomock.Any(), gomock.Any(), gomock.Any()).Return(
 		&apprunner.ListTagsForResourceOutput{Tags: []types.Tag{tags}}, nil)
 
-	return client.Services{
+	return &client.Services{
 		Apprunner: m,
 	}
 }

--- a/plugins/source/aws/resources/services/appstream/app_blocks_mock_test.go
+++ b/plugins/source/aws/resources/services/appstream/app_blocks_mock_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func buildAppstreamAppBlocksMock(t *testing.T, ctrl *gomock.Controller) client.Services {
+func buildAppstreamAppBlocksMock(t *testing.T, ctrl *gomock.Controller) *client.Services {
 	m := mocks.NewMockAppstreamClient(ctrl)
 	object := types.AppBlock{}
 	require.NoError(t, faker.FakeObject(&object))
@@ -26,7 +26,7 @@ func buildAppstreamAppBlocksMock(t *testing.T, ctrl *gomock.Controller) client.S
 	require.NoError(t, faker.FakeObject(&tagsOutput))
 	m.EXPECT().ListTagsForResource(gomock.Any(), gomock.Any()).Return(&tagsOutput, nil).AnyTimes()
 
-	return client.Services{
+	return &client.Services{
 		Appstream: m,
 	}
 }

--- a/plugins/source/aws/resources/services/appstream/applications_mock_test.go
+++ b/plugins/source/aws/resources/services/appstream/applications_mock_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func buildAppstreamApplicationsMock(t *testing.T, ctrl *gomock.Controller) client.Services {
+func buildAppstreamApplicationsMock(t *testing.T, ctrl *gomock.Controller) *client.Services {
 	m := mocks.NewMockAppstreamClient(ctrl)
 	application := types.Application{}
 	require.NoError(t, faker.FakeObject(&application))
@@ -30,7 +30,7 @@ func buildAppstreamApplicationsMock(t *testing.T, ctrl *gomock.Controller) clien
 			ApplicationFleetAssociations: []types.ApplicationFleetAssociation{applicationFleetAssociation},
 		}, nil)
 
-	return client.Services{
+	return &client.Services{
 		Appstream: m,
 	}
 }

--- a/plugins/source/aws/resources/services/appstream/directory_configs_mock_test.go
+++ b/plugins/source/aws/resources/services/appstream/directory_configs_mock_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func buildAppstreamDirectoryConfigsMock(t *testing.T, ctrl *gomock.Controller) client.Services {
+func buildAppstreamDirectoryConfigsMock(t *testing.T, ctrl *gomock.Controller) *client.Services {
 	m := mocks.NewMockAppstreamClient(ctrl)
 	object := types.DirectoryConfig{}
 	require.NoError(t, faker.FakeObject(&object))
@@ -26,7 +26,7 @@ func buildAppstreamDirectoryConfigsMock(t *testing.T, ctrl *gomock.Controller) c
 	require.NoError(t, faker.FakeObject(&tagsOutput))
 	m.EXPECT().ListTagsForResource(gomock.Any(), gomock.Any()).Return(&tagsOutput, nil).AnyTimes()
 
-	return client.Services{
+	return &client.Services{
 		Appstream: m,
 	}
 }

--- a/plugins/source/aws/resources/services/appstream/fleets_mock_test.go
+++ b/plugins/source/aws/resources/services/appstream/fleets_mock_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func buildAppstreamFleetsMock(t *testing.T, ctrl *gomock.Controller) client.Services {
+func buildAppstreamFleetsMock(t *testing.T, ctrl *gomock.Controller) *client.Services {
 	m := mocks.NewMockAppstreamClient(ctrl)
 	object := types.Fleet{}
 	require.NoError(t, faker.FakeObject(&object))
@@ -26,7 +26,7 @@ func buildAppstreamFleetsMock(t *testing.T, ctrl *gomock.Controller) client.Serv
 	require.NoError(t, faker.FakeObject(&tagsOutput))
 	m.EXPECT().ListTagsForResource(gomock.Any(), gomock.Any()).Return(&tagsOutput, nil).AnyTimes()
 
-	return client.Services{
+	return &client.Services{
 		Appstream: m,
 	}
 }

--- a/plugins/source/aws/resources/services/appstream/image_builders_mock_test.go
+++ b/plugins/source/aws/resources/services/appstream/image_builders_mock_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func buildAppstreamImageBuildersMock(t *testing.T, ctrl *gomock.Controller) client.Services {
+func buildAppstreamImageBuildersMock(t *testing.T, ctrl *gomock.Controller) *client.Services {
 	m := mocks.NewMockAppstreamClient(ctrl)
 	object := types.ImageBuilder{}
 	require.NoError(t, faker.FakeObject(&object))
@@ -26,7 +26,7 @@ func buildAppstreamImageBuildersMock(t *testing.T, ctrl *gomock.Controller) clie
 	require.NoError(t, faker.FakeObject(&tagsOutput))
 	m.EXPECT().ListTagsForResource(gomock.Any(), gomock.Any()).Return(&tagsOutput, nil).AnyTimes()
 
-	return client.Services{
+	return &client.Services{
 		Appstream: m,
 	}
 }

--- a/plugins/source/aws/resources/services/appstream/images_mock_test.go
+++ b/plugins/source/aws/resources/services/appstream/images_mock_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func buildAppstreamImagesMock(t *testing.T, ctrl *gomock.Controller) client.Services {
+func buildAppstreamImagesMock(t *testing.T, ctrl *gomock.Controller) *client.Services {
 	m := mocks.NewMockAppstreamClient(ctrl)
 	object := types.Image{}
 	require.NoError(t, faker.FakeObject(&object))
@@ -26,7 +26,7 @@ func buildAppstreamImagesMock(t *testing.T, ctrl *gomock.Controller) client.Serv
 	require.NoError(t, faker.FakeObject(&tagsOutput))
 	m.EXPECT().ListTagsForResource(gomock.Any(), gomock.Any()).Return(&tagsOutput, nil).AnyTimes()
 
-	return client.Services{
+	return &client.Services{
 		Appstream: m,
 	}
 }

--- a/plugins/source/aws/resources/services/appstream/stacks_mock_test.go
+++ b/plugins/source/aws/resources/services/appstream/stacks_mock_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func buildAppstreamStacksMock(t *testing.T, ctrl *gomock.Controller) client.Services {
+func buildAppstreamStacksMock(t *testing.T, ctrl *gomock.Controller) *client.Services {
 	m := mocks.NewMockAppstreamClient(ctrl)
 	stack := types.Stack{}
 	require.NoError(t, faker.FakeObject(&stack))
@@ -38,7 +38,7 @@ func buildAppstreamStacksMock(t *testing.T, ctrl *gomock.Controller) client.Serv
 			UserStackAssociations: []types.UserStackAssociation{stackUserAssociations},
 		}, nil)
 
-	return client.Services{
+	return &client.Services{
 		Appstream: m,
 	}
 }

--- a/plugins/source/aws/resources/services/appstream/usage_report_subscriptions_mock_test.go
+++ b/plugins/source/aws/resources/services/appstream/usage_report_subscriptions_mock_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func buildAppstreamUsageReportSubscriptionsMock(t *testing.T, ctrl *gomock.Controller) client.Services {
+func buildAppstreamUsageReportSubscriptionsMock(t *testing.T, ctrl *gomock.Controller) *client.Services {
 	m := mocks.NewMockAppstreamClient(ctrl)
 	object := types.UsageReportSubscription{}
 	require.NoError(t, faker.FakeObject(&object))
@@ -26,7 +26,7 @@ func buildAppstreamUsageReportSubscriptionsMock(t *testing.T, ctrl *gomock.Contr
 	require.NoError(t, faker.FakeObject(&tagsOutput))
 	m.EXPECT().ListTagsForResource(gomock.Any(), gomock.Any()).Return(&tagsOutput, nil).AnyTimes()
 
-	return client.Services{
+	return &client.Services{
 		Appstream: m,
 	}
 }

--- a/plugins/source/aws/resources/services/appstream/users_mock_test.go
+++ b/plugins/source/aws/resources/services/appstream/users_mock_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func buildAppstreamUsersMock(t *testing.T, ctrl *gomock.Controller) client.Services {
+func buildAppstreamUsersMock(t *testing.T, ctrl *gomock.Controller) *client.Services {
 	m := mocks.NewMockAppstreamClient(ctrl)
 	object := types.User{}
 	require.NoError(t, faker.FakeObject(&object))
@@ -22,7 +22,7 @@ func buildAppstreamUsersMock(t *testing.T, ctrl *gomock.Controller) client.Servi
 			Users: []types.User{object},
 		}, nil)
 
-	return client.Services{
+	return &client.Services{
 		Appstream: m,
 	}
 }

--- a/plugins/source/aws/resources/services/appsync/graphql_apis_mock_test.go
+++ b/plugins/source/aws/resources/services/appsync/graphql_apis_mock_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func buildAppsyncGraphqlApisMock(t *testing.T, ctrl *gomock.Controller) client.Services {
+func buildAppsyncGraphqlApisMock(t *testing.T, ctrl *gomock.Controller) *client.Services {
 	m := mocks.NewMockAppsyncClient(ctrl)
 	l := types.GraphqlApi{}
 	require.NoError(t, faker.FakeObject(&l))
@@ -22,7 +22,7 @@ func buildAppsyncGraphqlApisMock(t *testing.T, ctrl *gomock.Controller) client.S
 			GraphqlApis: []types.GraphqlApi{l},
 		}, nil)
 
-	return client.Services{
+	return &client.Services{
 		Appsync: m,
 	}
 }

--- a/plugins/source/aws/resources/services/athena/data_catalogs_mock_test.go
+++ b/plugins/source/aws/resources/services/athena/data_catalogs_mock_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func buildDataCatalogs(t *testing.T, ctrl *gomock.Controller) client.Services {
+func buildDataCatalogs(t *testing.T, ctrl *gomock.Controller) *client.Services {
 	m := mocks.NewMockAthenaClient(ctrl)
 
 	catalogs := athena.ListDataCatalogsOutput{}
@@ -44,7 +44,7 @@ func buildDataCatalogs(t *testing.T, ctrl *gomock.Controller) client.Services {
 	tables.NextToken = nil
 	m.EXPECT().ListTableMetadata(gomock.Any(), gomock.Any(), gomock.Any()).Return(&tables, nil)
 
-	return client.Services{
+	return &client.Services{
 		Athena: m,
 	}
 }

--- a/plugins/source/aws/resources/services/athena/work_groups_mock_test.go
+++ b/plugins/source/aws/resources/services/athena/work_groups_mock_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func buildWorkGroups(t *testing.T, ctrl *gomock.Controller) client.Services {
+func buildWorkGroups(t *testing.T, ctrl *gomock.Controller) *client.Services {
 	m := mocks.NewMockAthenaClient(ctrl)
 
 	workGroupsOutput := athena.ListWorkGroupsOutput{}
@@ -63,7 +63,7 @@ func buildWorkGroups(t *testing.T, ctrl *gomock.Controller) client.Services {
 
 	m.EXPECT().GetQueryExecution(gomock.Any(), gomock.Any(), gomock.Any()).Return(&queryExecution, nil)
 
-	return client.Services{
+	return &client.Services{
 		Athena: m,
 	}
 }

--- a/plugins/source/aws/resources/services/auditmanager/assesments_mock_test.go
+++ b/plugins/source/aws/resources/services/auditmanager/assesments_mock_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func buildAssessments(t *testing.T, ctrl *gomock.Controller) client.Services {
+func buildAssessments(t *testing.T, ctrl *gomock.Controller) *client.Services {
 	m := mocks.NewMockAuditmanagerClient(ctrl)
 	ami := types.AssessmentMetadataItem{}
 	require.NoError(t, faker.FakeObject(&ami))
@@ -29,7 +29,7 @@ func buildAssessments(t *testing.T, ctrl *gomock.Controller) client.Services {
 		&auditmanager.GetAssessmentOutput{
 			Assessment: &assessment,
 		}, nil)
-	return client.Services{
+	return &client.Services{
 		Auditmanager: m,
 	}
 }

--- a/plugins/source/aws/resources/services/autoscaling/groups_mock_test.go
+++ b/plugins/source/aws/resources/services/autoscaling/groups_mock_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func buildAutoscalingGroups(t *testing.T, ctrl *gomock.Controller) client.Services {
+func buildAutoscalingGroups(t *testing.T, ctrl *gomock.Controller) *client.Services {
 	m := mocks.NewMockAutoscalingClient(ctrl)
 
 	groups := autoscaling.DescribeAutoScalingGroupsOutput{}
@@ -44,7 +44,7 @@ func buildAutoscalingGroups(t *testing.T, ctrl *gomock.Controller) client.Servic
 	require.NoError(t, faker.FakeObject(&lifecycleHooks))
 	m.EXPECT().DescribeLifecycleHooks(gomock.Any(), gomock.Any(), gomock.Any()).Return(&lifecycleHooks, nil)
 
-	return client.Services{
+	return &client.Services{
 		Autoscaling: m,
 	}
 }

--- a/plugins/source/aws/resources/services/autoscaling/launch_configuration_mock_test.go
+++ b/plugins/source/aws/resources/services/autoscaling/launch_configuration_mock_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func buildAutoscalingLaunchConfigurationsMock(t *testing.T, ctrl *gomock.Controller) client.Services {
+func buildAutoscalingLaunchConfigurationsMock(t *testing.T, ctrl *gomock.Controller) *client.Services {
 	m := mocks.NewMockAutoscalingClient(ctrl)
 	services := client.Services{
 		Autoscaling: m,

--- a/plugins/source/aws/resources/services/autoscaling/launch_configuration_mock_test.go
+++ b/plugins/source/aws/resources/services/autoscaling/launch_configuration_mock_test.go
@@ -14,7 +14,7 @@ import (
 
 func buildAutoscalingLaunchConfigurationsMock(t *testing.T, ctrl *gomock.Controller) *client.Services {
 	m := mocks.NewMockAutoscalingClient(ctrl)
-	services := client.Services{
+	services := &client.Services{
 		Autoscaling: m,
 	}
 	l := types.LaunchConfiguration{}

--- a/plugins/source/aws/resources/services/autoscaling/scheduled_actions_mock_test.go
+++ b/plugins/source/aws/resources/services/autoscaling/scheduled_actions_mock_test.go
@@ -14,7 +14,7 @@ import (
 
 func buildAutoscalingSheduledActionMock(t *testing.T, ctrl *gomock.Controller) *client.Services {
 	m := mocks.NewMockAutoscalingClient(ctrl)
-	services := client.Services{
+	services := &client.Services{
 		Autoscaling: m,
 	}
 	l := types.ScheduledUpdateGroupAction{}

--- a/plugins/source/aws/resources/services/autoscaling/scheduled_actions_mock_test.go
+++ b/plugins/source/aws/resources/services/autoscaling/scheduled_actions_mock_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func buildAutoscalingSheduledActionMock(t *testing.T, ctrl *gomock.Controller) client.Services {
+func buildAutoscalingSheduledActionMock(t *testing.T, ctrl *gomock.Controller) *client.Services {
 	m := mocks.NewMockAutoscalingClient(ctrl)
 	services := client.Services{
 		Autoscaling: m,

--- a/plugins/source/aws/resources/services/autoscalingplans/plans_mock_test.go
+++ b/plugins/source/aws/resources/services/autoscalingplans/plans_mock_test.go
@@ -14,7 +14,7 @@ import (
 
 func buildPlans(t *testing.T, ctrl *gomock.Controller) *client.Services {
 	m := mocks.NewMockAutoscalingplansClient(ctrl)
-	services := client.Services{
+	services := &client.Services{
 		Autoscalingplans: m,
 	}
 	p := types.ScalingPlan{}

--- a/plugins/source/aws/resources/services/autoscalingplans/plans_mock_test.go
+++ b/plugins/source/aws/resources/services/autoscalingplans/plans_mock_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func buildPlans(t *testing.T, ctrl *gomock.Controller) client.Services {
+func buildPlans(t *testing.T, ctrl *gomock.Controller) *client.Services {
 	m := mocks.NewMockAutoscalingplansClient(ctrl)
 	services := client.Services{
 		Autoscalingplans: m,

--- a/plugins/source/aws/resources/services/backup/global_settings_mock_test.go
+++ b/plugins/source/aws/resources/services/backup/global_settings_mock_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func buildBackupGlobalSettingsMock(t *testing.T, ctrl *gomock.Controller) client.Services {
+func buildBackupGlobalSettingsMock(t *testing.T, ctrl *gomock.Controller) *client.Services {
 	m := mocks.NewMockBackupClient(ctrl)
 
 	var settings backup.DescribeGlobalSettingsOutput
@@ -26,7 +26,7 @@ func buildBackupGlobalSettingsMock(t *testing.T, ctrl *gomock.Controller) client
 		nil,
 	)
 
-	return client.Services{
+	return &client.Services{
 		Backup: m,
 	}
 }

--- a/plugins/source/aws/resources/services/backup/jobs_mock_test.go
+++ b/plugins/source/aws/resources/services/backup/jobs_mock_test.go
@@ -13,7 +13,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func buildBackupJobsMock(t *testing.T, ctrl *gomock.Controller) client.Services {
+func buildBackupJobsMock(t *testing.T, ctrl *gomock.Controller) *client.Services {
 	m := mocks.NewMockBackupClient(ctrl)
 
 	var job types.BackupJob
@@ -28,7 +28,7 @@ func buildBackupJobsMock(t *testing.T, ctrl *gomock.Controller) client.Services 
 		nil,
 	)
 
-	return client.Services{
+	return &client.Services{
 		Backup: m,
 	}
 }

--- a/plugins/source/aws/resources/services/backup/plans_mock_test.go
+++ b/plugins/source/aws/resources/services/backup/plans_mock_test.go
@@ -13,7 +13,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func buildBackupPlansMock(t *testing.T, ctrl *gomock.Controller) client.Services {
+func buildBackupPlansMock(t *testing.T, ctrl *gomock.Controller) *client.Services {
 	m := mocks.NewMockBackupClient(ctrl)
 
 	var plan backup.GetBackupPlanOutput
@@ -80,7 +80,7 @@ func buildBackupPlansMock(t *testing.T, ctrl *gomock.Controller) client.Services
 		gomock.Any(),
 	).Return(&selection, nil)
 
-	return client.Services{
+	return &client.Services{
 		Backup: m,
 	}
 }

--- a/plugins/source/aws/resources/services/backup/protected_resources_mock_test.go
+++ b/plugins/source/aws/resources/services/backup/protected_resources_mock_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func buildProtectedResourcesMock(t *testing.T, ctrl *gomock.Controller) client.Services {
+func buildProtectedResourcesMock(t *testing.T, ctrl *gomock.Controller) *client.Services {
 	m := mocks.NewMockBackupClient(ctrl)
 
 	var pr types.ProtectedResource
@@ -29,7 +29,7 @@ func buildProtectedResourcesMock(t *testing.T, ctrl *gomock.Controller) client.S
 		nil,
 	)
 
-	return client.Services{
+	return &client.Services{
 		Backup: m,
 	}
 }

--- a/plugins/source/aws/resources/services/backup/region_settings_mock_test.go
+++ b/plugins/source/aws/resources/services/backup/region_settings_mock_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func buildBackupRegionSettingsMock(t *testing.T, ctrl *gomock.Controller) client.Services {
+func buildBackupRegionSettingsMock(t *testing.T, ctrl *gomock.Controller) *client.Services {
 	m := mocks.NewMockBackupClient(ctrl)
 
 	var settings backup.DescribeRegionSettingsOutput
@@ -26,7 +26,7 @@ func buildBackupRegionSettingsMock(t *testing.T, ctrl *gomock.Controller) client
 		nil,
 	)
 
-	return client.Services{
+	return &client.Services{
 		Backup: m,
 	}
 }

--- a/plugins/source/aws/resources/services/backup/report_plans_mock_test.go
+++ b/plugins/source/aws/resources/services/backup/report_plans_mock_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func buildReportPlansMock(t *testing.T, ctrl *gomock.Controller) client.Services {
+func buildReportPlansMock(t *testing.T, ctrl *gomock.Controller) *client.Services {
 	m := mocks.NewMockBackupClient(ctrl)
 
 	var reportPlan types.ReportPlan
@@ -40,7 +40,7 @@ func buildReportPlansMock(t *testing.T, ctrl *gomock.Controller) client.Services
 		nil,
 	)
 
-	return client.Services{
+	return &client.Services{
 		Backup: m,
 	}
 }

--- a/plugins/source/aws/resources/services/backup/vaults_mock_test.go
+++ b/plugins/source/aws/resources/services/backup/vaults_mock_test.go
@@ -13,7 +13,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func buildBackupVaultsMock(t *testing.T, ctrl *gomock.Controller) client.Services {
+func buildBackupVaultsMock(t *testing.T, ctrl *gomock.Controller) *client.Services {
 	m := mocks.NewMockBackupClient(ctrl)
 
 	var vault types.BackupVaultListMember
@@ -89,7 +89,7 @@ func buildBackupVaultsMock(t *testing.T, ctrl *gomock.Controller) client.Service
 		nil,
 	)
 
-	return client.Services{
+	return &client.Services{
 		Backup: m,
 	}
 }

--- a/plugins/source/aws/resources/services/batch/compute_environments_mock_test.go
+++ b/plugins/source/aws/resources/services/batch/compute_environments_mock_test.go
@@ -14,7 +14,7 @@ import (
 
 func buildBatchComputeEnvironmentsMock(t *testing.T, ctrl *gomock.Controller) *client.Services {
 	m := mocks.NewMockBatchClient(ctrl)
-	services := client.Services{
+	services := &client.Services{
 		Batch: m,
 	}
 	a := types.ComputeEnvironmentDetail{}

--- a/plugins/source/aws/resources/services/batch/compute_environments_mock_test.go
+++ b/plugins/source/aws/resources/services/batch/compute_environments_mock_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func buildBatchComputeEnvironmentsMock(t *testing.T, ctrl *gomock.Controller) client.Services {
+func buildBatchComputeEnvironmentsMock(t *testing.T, ctrl *gomock.Controller) *client.Services {
 	m := mocks.NewMockBatchClient(ctrl)
 	services := client.Services{
 		Batch: m,

--- a/plugins/source/aws/resources/services/batch/job_definitions_mock_test.go
+++ b/plugins/source/aws/resources/services/batch/job_definitions_mock_test.go
@@ -14,7 +14,7 @@ import (
 
 func buildBatchJobDefinitionsMock(t *testing.T, ctrl *gomock.Controller) *client.Services {
 	m := mocks.NewMockBatchClient(ctrl)
-	services := client.Services{
+	services := &client.Services{
 		Batch: m,
 	}
 	a := types.JobDefinition{}

--- a/plugins/source/aws/resources/services/batch/job_definitions_mock_test.go
+++ b/plugins/source/aws/resources/services/batch/job_definitions_mock_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func buildBatchJobDefinitionsMock(t *testing.T, ctrl *gomock.Controller) client.Services {
+func buildBatchJobDefinitionsMock(t *testing.T, ctrl *gomock.Controller) *client.Services {
 	m := mocks.NewMockBatchClient(ctrl)
 	services := client.Services{
 		Batch: m,

--- a/plugins/source/aws/resources/services/batch/job_queues_mock_test.go
+++ b/plugins/source/aws/resources/services/batch/job_queues_mock_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func buildBatchJobQueuesMock(t *testing.T, ctrl *gomock.Controller) client.Services {
+func buildBatchJobQueuesMock(t *testing.T, ctrl *gomock.Controller) *client.Services {
 	m := mocks.NewMockBatchClient(ctrl)
 
 	buildBatchJobsMock(t, m)

--- a/plugins/source/aws/resources/services/batch/job_queues_mock_test.go
+++ b/plugins/source/aws/resources/services/batch/job_queues_mock_test.go
@@ -17,7 +17,7 @@ func buildBatchJobQueuesMock(t *testing.T, ctrl *gomock.Controller) *client.Serv
 
 	buildBatchJobsMock(t, m)
 
-	services := client.Services{
+	services := &client.Services{
 		Batch: m,
 	}
 	a := types.JobQueueDetail{}

--- a/plugins/source/aws/resources/services/batch/jobs_mock_test.go
+++ b/plugins/source/aws/resources/services/batch/jobs_mock_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func buildBatchJobsMock(t *testing.T, m *mocks.MockBatchClient) client.Services {
+func buildBatchJobsMock(t *testing.T, m *mocks.MockBatchClient) *client.Services {
 	services := client.Services{
 		Batch: m,
 	}

--- a/plugins/source/aws/resources/services/batch/jobs_mock_test.go
+++ b/plugins/source/aws/resources/services/batch/jobs_mock_test.go
@@ -13,7 +13,7 @@ import (
 )
 
 func buildBatchJobsMock(t *testing.T, m *mocks.MockBatchClient) *client.Services {
-	services := client.Services{
+	services := &client.Services{
 		Batch: m,
 	}
 	a := types.JobSummary{}

--- a/plugins/source/aws/resources/services/cloudformation/stacks_mock_test.go
+++ b/plugins/source/aws/resources/services/cloudformation/stacks_mock_test.go
@@ -13,8 +13,8 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func buildStacksWithTemplate(tmpl string) func(t *testing.T, ctrl *gomock.Controller) client.Services {
-	return func(t *testing.T, ctrl *gomock.Controller) client.Services {
+func buildStacksWithTemplate(tmpl string) func(t *testing.T, ctrl *gomock.Controller) *client.Services {
+	return func(t *testing.T, ctrl *gomock.Controller) *client.Services {
 		mock := mocks.NewMockCloudformationClient(ctrl)
 
 		var stack types.Stack
@@ -65,7 +65,7 @@ func buildStacksWithTemplate(tmpl string) func(t *testing.T, ctrl *gomock.Contro
 			nil,
 		)
 
-		return client.Services{Cloudformation: mock}
+		return &client.Services{Cloudformation: mock}
 	}
 }
 

--- a/plugins/source/aws/resources/services/cloudformation/stackset_mock_test.go
+++ b/plugins/source/aws/resources/services/cloudformation/stackset_mock_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func buildStackSet(t *testing.T, ctrl *gomock.Controller) client.Services {
+func buildStackSet(t *testing.T, ctrl *gomock.Controller) *client.Services {
 	mock := mocks.NewMockCloudformationClient(ctrl)
 
 	var stack types.StackSet
@@ -103,7 +103,7 @@ func buildStackSet(t *testing.T, ctrl *gomock.Controller) client.Services {
 		nil,
 	)
 
-	return client.Services{Cloudformation: mock}
+	return &client.Services{Cloudformation: mock}
 }
 
 func TestCloudformationStackSet(t *testing.T) {

--- a/plugins/source/aws/resources/services/cloudfront/cache_policies_mock_test.go
+++ b/plugins/source/aws/resources/services/cloudfront/cache_policies_mock_test.go
@@ -12,9 +12,9 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func buildCloudfrontCachePoliciesMock(t *testing.T, ctrl *gomock.Controller) client.Services {
+func buildCloudfrontCachePoliciesMock(t *testing.T, ctrl *gomock.Controller) *client.Services {
 	m := mocks.NewMockCloudfrontClient(ctrl)
-	services := client.Services{
+	services := &client.Services{
 		Cloudfront: m,
 	}
 	cp := cloudfrontTypes.CachePolicySummary{}

--- a/plugins/source/aws/resources/services/cloudfront/distributions_mock_test.go
+++ b/plugins/source/aws/resources/services/cloudfront/distributions_mock_test.go
@@ -12,9 +12,9 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func buildCloudfrontDistributionsMock(t *testing.T, ctrl *gomock.Controller) client.Services {
+func buildCloudfrontDistributionsMock(t *testing.T, ctrl *gomock.Controller) *client.Services {
 	m := mocks.NewMockCloudfrontClient(ctrl)
-	services := client.Services{
+	services := &client.Services{
 		Cloudfront: m,
 	}
 	ds := cloudfrontTypes.DistributionSummary{}

--- a/plugins/source/aws/resources/services/cloudfront/functions_mock_test.go
+++ b/plugins/source/aws/resources/services/cloudfront/functions_mock_test.go
@@ -12,9 +12,9 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func buildCloudfronFunctionsMock(t *testing.T, ctrl *gomock.Controller) client.Services {
+func buildCloudfronFunctionsMock(t *testing.T, ctrl *gomock.Controller) *client.Services {
 	m := mocks.NewMockCloudfrontClient(ctrl)
-	services := client.Services{
+	services := &client.Services{
 		Cloudfront: m,
 	}
 	fs := cloudfrontTypes.FunctionSummary{}

--- a/plugins/source/aws/resources/services/cloudfront/origin_access_identities_mock_test.go
+++ b/plugins/source/aws/resources/services/cloudfront/origin_access_identities_mock_test.go
@@ -12,9 +12,9 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func buildOriginAccessIdentitiesMock(t *testing.T, ctrl *gomock.Controller) client.Services {
+func buildOriginAccessIdentitiesMock(t *testing.T, ctrl *gomock.Controller) *client.Services {
 	m := mocks.NewMockCloudfrontClient(ctrl)
-	services := client.Services{
+	services := &client.Services{
 		Cloudfront: m,
 	}
 	coai := cloudfrontTypes.CloudFrontOriginAccessIdentitySummary{}

--- a/plugins/source/aws/resources/services/cloudfront/origin_request_policies_mock_test.go
+++ b/plugins/source/aws/resources/services/cloudfront/origin_request_policies_mock_test.go
@@ -12,9 +12,9 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func buildOriginRequestPoliciesMock(t *testing.T, ctrl *gomock.Controller) client.Services {
+func buildOriginRequestPoliciesMock(t *testing.T, ctrl *gomock.Controller) *client.Services {
 	m := mocks.NewMockCloudfrontClient(ctrl)
-	services := client.Services{
+	services := &client.Services{
 		Cloudfront: m,
 	}
 	cp := cloudfrontTypes.OriginRequestPolicySummary{}

--- a/plugins/source/aws/resources/services/cloudfront/response_headers_policies_mock_test.go
+++ b/plugins/source/aws/resources/services/cloudfront/response_headers_policies_mock_test.go
@@ -12,9 +12,9 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func buildCloudfrontResponseHeaderPoliciesMock(t *testing.T, ctrl *gomock.Controller) client.Services {
+func buildCloudfrontResponseHeaderPoliciesMock(t *testing.T, ctrl *gomock.Controller) *client.Services {
 	m := mocks.NewMockCloudfrontClient(ctrl)
-	services := client.Services{
+	services := &client.Services{
 		Cloudfront: m,
 	}
 	cp := cloudfrontTypes.ResponseHeadersPolicySummary{}

--- a/plugins/source/aws/resources/services/cloudhsmv2/backups_mock_test.go
+++ b/plugins/source/aws/resources/services/cloudhsmv2/backups_mock_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func buildHSMBackups(t *testing.T, ctrl *gomock.Controller) client.Services {
+func buildHSMBackups(t *testing.T, ctrl *gomock.Controller) *client.Services {
 	mock := mocks.NewMockCloudhsmv2Client(ctrl)
 
 	var backups []types.Backup
@@ -27,7 +27,7 @@ func buildHSMBackups(t *testing.T, ctrl *gomock.Controller) client.Services {
 		nil,
 	)
 
-	return client.Services{Cloudhsmv2: mock}
+	return &client.Services{Cloudhsmv2: mock}
 }
 
 func TestBackups(t *testing.T) {

--- a/plugins/source/aws/resources/services/cloudhsmv2/clusters_mock_test.go
+++ b/plugins/source/aws/resources/services/cloudhsmv2/clusters_mock_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func buildHSMClusters(t *testing.T, ctrl *gomock.Controller) client.Services {
+func buildHSMClusters(t *testing.T, ctrl *gomock.Controller) *client.Services {
 	mock := mocks.NewMockCloudhsmv2Client(ctrl)
 
 	var clusters []types.Cluster
@@ -27,7 +27,7 @@ func buildHSMClusters(t *testing.T, ctrl *gomock.Controller) client.Services {
 		nil,
 	)
 
-	return client.Services{Cloudhsmv2: mock}
+	return &client.Services{Cloudhsmv2: mock}
 }
 
 func TestClusters(t *testing.T) {

--- a/plugins/source/aws/resources/services/cloudtrail/channels_mock_test.go
+++ b/plugins/source/aws/resources/services/cloudtrail/channels_mock_test.go
@@ -12,9 +12,9 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func buildCloudtrailChannelsMock(t *testing.T, ctrl *gomock.Controller) client.Services {
+func buildCloudtrailChannelsMock(t *testing.T, ctrl *gomock.Controller) *client.Services {
 	m := mocks.NewMockCloudtrailClient(ctrl)
-	services := client.Services{
+	services := &client.Services{
 		Cloudtrail: m,
 	}
 	channel := types.Channel{}

--- a/plugins/source/aws/resources/services/cloudtrail/events_mock_test.go
+++ b/plugins/source/aws/resources/services/cloudtrail/events_mock_test.go
@@ -13,9 +13,9 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func buildCloudtrailEventsMock(t *testing.T, ctrl *gomock.Controller) client.Services {
+func buildCloudtrailEventsMock(t *testing.T, ctrl *gomock.Controller) *client.Services {
 	m := mocks.NewMockCloudtrailClient(ctrl)
-	services := client.Services{
+	services := &client.Services{
 		Cloudtrail: m,
 	}
 	event := types.Event{}

--- a/plugins/source/aws/resources/services/cloudtrail/imports_mock_test.go
+++ b/plugins/source/aws/resources/services/cloudtrail/imports_mock_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func buildCloutrailImports(t *testing.T, ctrl *gomock.Controller) client.Services {
+func buildCloutrailImports(t *testing.T, ctrl *gomock.Controller) *client.Services {
 	m := mocks.NewMockCloudtrailClient(ctrl)
 
 	var desc types.ImportsListItem
@@ -41,7 +41,7 @@ func buildCloutrailImports(t *testing.T, ctrl *gomock.Controller) client.Service
 		nil,
 	)
 
-	return client.Services{Cloudtrail: m}
+	return &client.Services{Cloudtrail: m}
 }
 
 func TestImports(t *testing.T) {

--- a/plugins/source/aws/resources/services/cloudtrail/trails_mock_test.go
+++ b/plugins/source/aws/resources/services/cloudtrail/trails_mock_test.go
@@ -13,9 +13,9 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func buildCloudtrailTrailsMock(t *testing.T, ctrl *gomock.Controller) client.Services {
+func buildCloudtrailTrailsMock(t *testing.T, ctrl *gomock.Controller) *client.Services {
 	m := mocks.NewMockCloudtrailClient(ctrl)
-	services := client.Services{
+	services := &client.Services{
 		Cloudtrail: m,
 	}
 	trail := types.Trail{}

--- a/plugins/source/aws/resources/services/cloudwatch/alarms_mock_test.go
+++ b/plugins/source/aws/resources/services/cloudwatch/alarms_mock_test.go
@@ -12,9 +12,9 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func buildCloudWatchAlarmsMock(t *testing.T, ctrl *gomock.Controller) client.Services {
+func buildCloudWatchAlarmsMock(t *testing.T, ctrl *gomock.Controller) *client.Services {
 	m := mocks.NewMockCloudwatchClient(ctrl)
-	services := client.Services{
+	services := &client.Services{
 		Cloudwatch: m,
 	}
 	a := types.MetricAlarm{}

--- a/plugins/source/aws/resources/services/cloudwatchlogs/log_groups_mock_test.go
+++ b/plugins/source/aws/resources/services/cloudwatchlogs/log_groups_mock_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func buildCloudwatchLogsLogGroupsMock(t *testing.T, ctrl *gomock.Controller) client.Services {
+func buildCloudwatchLogsLogGroupsMock(t *testing.T, ctrl *gomock.Controller) *client.Services {
 	m := mocks.NewMockCloudwatchlogsClient(ctrl)
 	l := types.LogGroup{}
 	require.NoError(t, faker.FakeObject(&l))
@@ -38,7 +38,7 @@ func buildCloudwatchLogsLogGroupsMock(t *testing.T, ctrl *gomock.Controller) cli
 
 	m.EXPECT().GetDataProtectionPolicy(gomock.Any(), gomock.Any(), gomock.Any()).Return(dataProtectionPolicy, nil)
 
-	return client.Services{
+	return &client.Services{
 		Cloudwatchlogs: m,
 	}
 }

--- a/plugins/source/aws/resources/services/cloudwatchlogs/metric_filters_mock_test.go
+++ b/plugins/source/aws/resources/services/cloudwatchlogs/metric_filters_mock_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func buildMetricFiltersMock(t *testing.T, ctrl *gomock.Controller) client.Services {
+func buildMetricFiltersMock(t *testing.T, ctrl *gomock.Controller) *client.Services {
 	m := mocks.NewMockCloudwatchlogsClient(ctrl)
 	l := types.MetricFilter{}
 	require.NoError(t, faker.FakeObject(&l))
@@ -20,7 +20,7 @@ func buildMetricFiltersMock(t *testing.T, ctrl *gomock.Controller) client.Servic
 		&cloudwatchlogs.DescribeMetricFiltersOutput{
 			MetricFilters: []types.MetricFilter{l},
 		}, nil)
-	return client.Services{
+	return &client.Services{
 		Cloudwatchlogs: m,
 	}
 }

--- a/plugins/source/aws/resources/services/cloudwatchlogs/resource_policies_mock_test.go
+++ b/plugins/source/aws/resources/services/cloudwatchlogs/resource_policies_mock_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func buildResourcePolicies(t *testing.T, ctrl *gomock.Controller) client.Services {
+func buildResourcePolicies(t *testing.T, ctrl *gomock.Controller) *client.Services {
 	m := mocks.NewMockCloudwatchlogsClient(ctrl)
 	rp := types.ResourcePolicy{}
 	require.NoError(t, faker.FakeObject(&rp))
@@ -22,7 +22,7 @@ func buildResourcePolicies(t *testing.T, ctrl *gomock.Controller) client.Service
 		&cloudwatchlogs.DescribeResourcePoliciesOutput{
 			ResourcePolicies: []types.ResourcePolicy{rp},
 		}, nil)
-	return client.Services{
+	return &client.Services{
 		Cloudwatchlogs: m,
 	}
 }

--- a/plugins/source/aws/resources/services/codeartifact/domains_mock_test.go
+++ b/plugins/source/aws/resources/services/codeartifact/domains_mock_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func buildDomains(t *testing.T, ctrl *gomock.Controller) client.Services {
+func buildDomains(t *testing.T, ctrl *gomock.Controller) *client.Services {
 	m := mocks.NewMockCodeartifactClient(ctrl)
 
 	domainSummary := types.DomainSummary{}
@@ -56,7 +56,7 @@ func buildDomains(t *testing.T, ctrl *gomock.Controller) client.Services {
 		},
 		nil,
 	)
-	return client.Services{Codeartifact: m}
+	return &client.Services{Codeartifact: m}
 }
 
 func TestDomains(t *testing.T) {

--- a/plugins/source/aws/resources/services/codeartifact/repositories_mock_test.go
+++ b/plugins/source/aws/resources/services/codeartifact/repositories_mock_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func buildRepositories(t *testing.T, ctrl *gomock.Controller) client.Services {
+func buildRepositories(t *testing.T, ctrl *gomock.Controller) *client.Services {
 	m := mocks.NewMockCodeartifactClient(ctrl)
 
 	repoSummary := types.RepositorySummary{}
@@ -58,7 +58,7 @@ func buildRepositories(t *testing.T, ctrl *gomock.Controller) client.Services {
 		nil,
 	)
 
-	return client.Services{Codeartifact: m}
+	return &client.Services{Codeartifact: m}
 }
 
 func TestRepositories(t *testing.T) {

--- a/plugins/source/aws/resources/services/codebuild/projects_mock_test.go
+++ b/plugins/source/aws/resources/services/codebuild/projects_mock_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func buildCodebuildProjects(t *testing.T, ctrl *gomock.Controller) client.Services {
+func buildCodebuildProjects(t *testing.T, ctrl *gomock.Controller) *client.Services {
 	m := mocks.NewMockCodebuildClient(ctrl)
 
 	projectsList := codebuild.ListProjectsOutput{}
@@ -65,7 +65,7 @@ func buildCodebuildProjects(t *testing.T, ctrl *gomock.Controller) client.Servic
 		nil,
 	).MinTimes(1)
 
-	return client.Services{Codebuild: m}
+	return &client.Services{Codebuild: m}
 }
 
 func TestCodebuildProjects(t *testing.T) {

--- a/plugins/source/aws/resources/services/codebuild/source_credentials_mock_test.go
+++ b/plugins/source/aws/resources/services/codebuild/source_credentials_mock_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func buildSourceCredentials(t *testing.T, ctrl *gomock.Controller) client.Services {
+func buildSourceCredentials(t *testing.T, ctrl *gomock.Controller) *client.Services {
 	m := mocks.NewMockCodebuildClient(ctrl)
 
 	sourceCredentials := codebuild.ListSourceCredentialsOutput{}
@@ -25,7 +25,7 @@ func buildSourceCredentials(t *testing.T, ctrl *gomock.Controller) client.Servic
 		&sourceCredentials,
 		nil,
 	)
-	return client.Services{Codebuild: m}
+	return &client.Services{Codebuild: m}
 }
 
 func TestSourceCredentials(t *testing.T) {

--- a/plugins/source/aws/resources/services/codecommit/repositories_mock_test.go
+++ b/plugins/source/aws/resources/services/codecommit/repositories_mock_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func buildRepositories(t *testing.T, ctrl *gomock.Controller) client.Services {
+func buildRepositories(t *testing.T, ctrl *gomock.Controller) *client.Services {
 	m := mocks.NewMockCodecommitClient(ctrl)
 
 	repoMetadata := types.RepositoryMetadata{}
@@ -43,7 +43,7 @@ func buildRepositories(t *testing.T, ctrl *gomock.Controller) client.Services {
 		Times(200).
 		Return(&codecommit.ListTagsForResourceOutput{Tags: tags}, nil)
 
-	return client.Services{Codecommit: m}
+	return &client.Services{Codecommit: m}
 }
 
 func TestRepositories(t *testing.T) {

--- a/plugins/source/aws/resources/services/codepipeline/pipelines_mock_test.go
+++ b/plugins/source/aws/resources/services/codepipeline/pipelines_mock_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func buildPipelines(t *testing.T, ctrl *gomock.Controller) client.Services {
+func buildPipelines(t *testing.T, ctrl *gomock.Controller) *client.Services {
 	mock := mocks.NewMockCodepipelineClient(ctrl)
 
 	var pipeSummary types.PipelineSummary
@@ -48,7 +48,7 @@ func buildPipelines(t *testing.T, ctrl *gomock.Controller) client.Services {
 		nil,
 	)
 
-	return client.Services{Codepipeline: mock}
+	return &client.Services{Codepipeline: mock}
 }
 
 func TestCodePipelinePipelines(t *testing.T) {

--- a/plugins/source/aws/resources/services/codepipeline/webhooks_mock_test.go
+++ b/plugins/source/aws/resources/services/codepipeline/webhooks_mock_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func buildWebhooks(t *testing.T, ctrl *gomock.Controller) client.Services {
+func buildWebhooks(t *testing.T, ctrl *gomock.Controller) *client.Services {
 	mock := mocks.NewMockCodepipelineClient(ctrl)
 
 	var webhook types.ListWebhookItem
@@ -27,7 +27,7 @@ func buildWebhooks(t *testing.T, ctrl *gomock.Controller) client.Services {
 		nil,
 	)
 
-	return client.Services{Codepipeline: mock}
+	return &client.Services{Codepipeline: mock}
 }
 
 func TestCodePipelineWebhooks(t *testing.T) {

--- a/plugins/source/aws/resources/services/cognito/identity_pools_mock_test.go
+++ b/plugins/source/aws/resources/services/cognito/identity_pools_mock_test.go
@@ -13,7 +13,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func buildCognitoIdentityPools(t *testing.T, ctrl *gomock.Controller) client.Services {
+func buildCognitoIdentityPools(t *testing.T, ctrl *gomock.Controller) *client.Services {
 	m := mocks.NewMockCognitoidentityClient(ctrl)
 
 	var desc types.IdentityPoolShortDescription
@@ -39,7 +39,7 @@ func buildCognitoIdentityPools(t *testing.T, ctrl *gomock.Controller) client.Ser
 		gomock.Any(),
 	).Return(&ipo, nil)
 
-	return client.Services{Cognitoidentity: m}
+	return &client.Services{Cognitoidentity: m}
 }
 
 func TestCognitoIdentityPools(t *testing.T) {

--- a/plugins/source/aws/resources/services/cognito/user_pools_mock_test.go
+++ b/plugins/source/aws/resources/services/cognito/user_pools_mock_test.go
@@ -13,7 +13,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func buildCognitoUserPools(t *testing.T, ctrl *gomock.Controller) client.Services {
+func buildCognitoUserPools(t *testing.T, ctrl *gomock.Controller) *client.Services {
 	m := mocks.NewMockCognitoidentityproviderClient(ctrl)
 
 	var desc types.UserPoolDescriptionType
@@ -70,7 +70,7 @@ func buildCognitoUserPools(t *testing.T, ctrl *gomock.Controller) client.Service
 		nil,
 	)
 
-	return client.Services{Cognitoidentityprovider: m}
+	return &client.Services{Cognitoidentityprovider: m}
 }
 
 func TestCognitoUserPools(t *testing.T) {

--- a/plugins/source/aws/resources/services/computeoptimizer/autoscaling_groups_recommendations_mock_test.go
+++ b/plugins/source/aws/resources/services/computeoptimizer/autoscaling_groups_recommendations_mock_test.go
@@ -12,9 +12,9 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func buildAutoscalingGroupsRecommendations(t *testing.T, ctrl *gomock.Controller) client.Services {
+func buildAutoscalingGroupsRecommendations(t *testing.T, ctrl *gomock.Controller) *client.Services {
 	m := mocks.NewMockComputeoptimizerClient(ctrl)
-	services := client.Services{
+	services := &client.Services{
 		Computeoptimizer: m,
 	}
 	item := types.AutoScalingGroupRecommendation{}

--- a/plugins/source/aws/resources/services/computeoptimizer/ebs_volume_recommendations_mock_test.go
+++ b/plugins/source/aws/resources/services/computeoptimizer/ebs_volume_recommendations_mock_test.go
@@ -12,9 +12,9 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func buildEbsVolumeRecommendations(t *testing.T, ctrl *gomock.Controller) client.Services {
+func buildEbsVolumeRecommendations(t *testing.T, ctrl *gomock.Controller) *client.Services {
 	m := mocks.NewMockComputeoptimizerClient(ctrl)
-	services := client.Services{
+	services := &client.Services{
 		Computeoptimizer: m,
 	}
 	item := types.VolumeRecommendation{}

--- a/plugins/source/aws/resources/services/computeoptimizer/ec2_instance_recommendations_mock_test.go
+++ b/plugins/source/aws/resources/services/computeoptimizer/ec2_instance_recommendations_mock_test.go
@@ -12,9 +12,9 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func buildEc2InstanceRecommendations(t *testing.T, ctrl *gomock.Controller) client.Services {
+func buildEc2InstanceRecommendations(t *testing.T, ctrl *gomock.Controller) *client.Services {
 	m := mocks.NewMockComputeoptimizerClient(ctrl)
-	services := client.Services{
+	services := &client.Services{
 		Computeoptimizer: m,
 	}
 	item := types.InstanceRecommendation{}

--- a/plugins/source/aws/resources/services/computeoptimizer/ecs_service_recommendations_mock_test.go
+++ b/plugins/source/aws/resources/services/computeoptimizer/ecs_service_recommendations_mock_test.go
@@ -12,9 +12,9 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func buildEcsServiceRecommendations(t *testing.T, ctrl *gomock.Controller) client.Services {
+func buildEcsServiceRecommendations(t *testing.T, ctrl *gomock.Controller) *client.Services {
 	m := mocks.NewMockComputeoptimizerClient(ctrl)
-	services := client.Services{
+	services := &client.Services{
 		Computeoptimizer: m,
 	}
 	item := types.ECSServiceRecommendation{}

--- a/plugins/source/aws/resources/services/computeoptimizer/enrollment_status_mock_test.go
+++ b/plugins/source/aws/resources/services/computeoptimizer/enrollment_status_mock_test.go
@@ -11,9 +11,9 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func buildEnrollmentStatuses(t *testing.T, ctrl *gomock.Controller) client.Services {
+func buildEnrollmentStatuses(t *testing.T, ctrl *gomock.Controller) *client.Services {
 	m := mocks.NewMockComputeoptimizerClient(ctrl)
-	services := client.Services{
+	services := &client.Services{
 		Computeoptimizer: m,
 	}
 	item := computeoptimizer.GetEnrollmentStatusOutput{}

--- a/plugins/source/aws/resources/services/computeoptimizer/lambda_functions_recommendations_mock_test.go
+++ b/plugins/source/aws/resources/services/computeoptimizer/lambda_functions_recommendations_mock_test.go
@@ -12,9 +12,9 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func buildLambdaFunctionRecommendations(t *testing.T, ctrl *gomock.Controller) client.Services {
+func buildLambdaFunctionRecommendations(t *testing.T, ctrl *gomock.Controller) *client.Services {
 	m := mocks.NewMockComputeoptimizerClient(ctrl)
-	services := client.Services{
+	services := &client.Services{
 		Computeoptimizer: m,
 	}
 	item := types.LambdaFunctionRecommendation{}

--- a/plugins/source/aws/resources/services/config/config_rule_compliance_details_mock_test.go
+++ b/plugins/source/aws/resources/services/config/config_rule_compliance_details_mock_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func buildComplianceDetails(t *testing.T, m *mocks.MockConfigserviceClient) client.Services {
+func buildComplianceDetails(t *testing.T, m *mocks.MockConfigserviceClient) *client.Services {
 	l := types.EvaluationResult{}
 	require.NoError(t, faker.FakeObject(&l))
 
@@ -20,7 +20,7 @@ func buildComplianceDetails(t *testing.T, m *mocks.MockConfigserviceClient) clie
 		&configservice.GetComplianceDetailsByConfigRuleOutput{
 			EvaluationResults: []types.EvaluationResult{l},
 		}, nil)
-	return client.Services{
+	return &client.Services{
 		Configservice: m,
 	}
 }

--- a/plugins/source/aws/resources/services/config/config_rules_mock_test.go
+++ b/plugins/source/aws/resources/services/config/config_rules_mock_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func buildConfigRules(t *testing.T, ctrl *gomock.Controller) client.Services {
+func buildConfigRules(t *testing.T, ctrl *gomock.Controller) *client.Services {
 	m := mocks.NewMockConfigserviceClient(ctrl)
 	l := types.ConfigRule{}
 	require.NoError(t, faker.FakeObject(&l))
@@ -30,7 +30,7 @@ func buildConfigRules(t *testing.T, ctrl *gomock.Controller) client.Services {
 		}, nil)
 	buildRemediationConfigurations(t, m)
 	buildComplianceDetails(t, m)
-	return client.Services{
+	return &client.Services{
 		Configservice: m,
 	}
 }

--- a/plugins/source/aws/resources/services/config/configuration_aggregators_mock_test.go
+++ b/plugins/source/aws/resources/services/config/configuration_aggregators_mock_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func buildConfigurationAggregators(t *testing.T, ctrl *gomock.Controller) client.Services {
+func buildConfigurationAggregators(t *testing.T, ctrl *gomock.Controller) *client.Services {
 	m := mocks.NewMockConfigserviceClient(ctrl)
 	l := types.ConfigurationAggregator{}
 	require.NoError(t, faker.FakeObject(&l))
@@ -21,7 +21,7 @@ func buildConfigurationAggregators(t *testing.T, ctrl *gomock.Controller) client
 		&configservice.DescribeConfigurationAggregatorsOutput{
 			ConfigurationAggregators: []types.ConfigurationAggregator{l},
 		}, nil)
-	return client.Services{
+	return &client.Services{
 		Configservice: m,
 	}
 }

--- a/plugins/source/aws/resources/services/config/configuration_recorders_mock_test.go
+++ b/plugins/source/aws/resources/services/config/configuration_recorders_mock_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func buildConfigConfigurationRecorders(t *testing.T, ctrl *gomock.Controller) client.Services {
+func buildConfigConfigurationRecorders(t *testing.T, ctrl *gomock.Controller) *client.Services {
 	m := mocks.NewMockConfigserviceClient(ctrl)
 	l := types.ConfigurationRecorder{}
 	require.NoError(t, faker.FakeObject(&l))
@@ -29,7 +29,7 @@ func buildConfigConfigurationRecorders(t *testing.T, ctrl *gomock.Controller) cl
 		&configservice.DescribeConfigurationRecordersOutput{
 			ConfigurationRecorders: []types.ConfigurationRecorder{l},
 		}, nil)
-	return client.Services{
+	return &client.Services{
 		Configservice: m,
 	}
 }

--- a/plugins/source/aws/resources/services/config/conformance_pack_mock_test.go
+++ b/plugins/source/aws/resources/services/config/conformance_pack_mock_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func buildConfigConformancePack(t *testing.T, ctrl *gomock.Controller) client.Services {
+func buildConfigConformancePack(t *testing.T, ctrl *gomock.Controller) *client.Services {
 	m := mocks.NewMockConfigserviceClient(ctrl)
 
 	var cpd types.ConformancePackDetail
@@ -37,7 +37,7 @@ func buildConfigConformancePack(t *testing.T, ctrl *gomock.Controller) client.Se
 			ConformancePackRuleEvaluationResults: []types.ConformancePackEvaluationResult{cpre},
 		}, nil)
 
-	return client.Services{
+	return &client.Services{
 		Configservice: m,
 	}
 }

--- a/plugins/source/aws/resources/services/config/delivery_channels_mock_test.go
+++ b/plugins/source/aws/resources/services/config/delivery_channels_mock_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func buildConfigDeliveryChannels(t *testing.T, ctrl *gomock.Controller) client.Services {
+func buildConfigDeliveryChannels(t *testing.T, ctrl *gomock.Controller) *client.Services {
 	m := mocks.NewMockConfigserviceClient(ctrl)
 
 	var dc types.DeliveryChannel
@@ -30,7 +30,7 @@ func buildConfigDeliveryChannels(t *testing.T, ctrl *gomock.Controller) client.S
 			DeliveryChannelsStatus: []types.DeliveryChannelStatus{dcs},
 		}, nil)
 
-	return client.Services{
+	return &client.Services{
 		Configservice: m,
 	}
 }

--- a/plugins/source/aws/resources/services/config/remediation_configurations_mock_test.go
+++ b/plugins/source/aws/resources/services/config/remediation_configurations_mock_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func buildRemediationConfigurations(t *testing.T, m *mocks.MockConfigserviceClient) client.Services {
+func buildRemediationConfigurations(t *testing.T, m *mocks.MockConfigserviceClient) *client.Services {
 	l := types.RemediationConfiguration{}
 	require.NoError(t, faker.FakeObject(&l))
 
@@ -20,7 +20,7 @@ func buildRemediationConfigurations(t *testing.T, m *mocks.MockConfigserviceClie
 		&configservice.DescribeRemediationConfigurationsOutput{
 			RemediationConfigurations: []types.RemediationConfiguration{l},
 		}, nil)
-	return client.Services{
+	return &client.Services{
 		Configservice: m,
 	}
 }

--- a/plugins/source/aws/resources/services/config/retention_configurations_mock_test.go
+++ b/plugins/source/aws/resources/services/config/retention_configurations_mock_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func buildRetentionConfigurations(t *testing.T, ctrl *gomock.Controller) client.Services {
+func buildRetentionConfigurations(t *testing.T, ctrl *gomock.Controller) *client.Services {
 	m := mocks.NewMockConfigserviceClient(ctrl)
 	l := types.RetentionConfiguration{}
 	require.NoError(t, faker.FakeObject(&l))
@@ -21,7 +21,7 @@ func buildRetentionConfigurations(t *testing.T, ctrl *gomock.Controller) client.
 		&configservice.DescribeRetentionConfigurationsOutput{
 			RetentionConfigurations: []types.RetentionConfiguration{l},
 		}, nil)
-	return client.Services{
+	return &client.Services{
 		Configservice: m,
 	}
 }

--- a/plugins/source/aws/resources/services/costexplorer/cost_current_month_mock_test.go
+++ b/plugins/source/aws/resources/services/costexplorer/cost_current_month_mock_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func build30DayCost(t *testing.T, ctrl *gomock.Controller) client.Services {
+func build30DayCost(t *testing.T, ctrl *gomock.Controller) *client.Services {
 	m := mocks.NewMockCostexplorerClient(ctrl)
 
 	gcuo := costexplorer.GetCostAndUsageOutput{}
@@ -20,7 +20,7 @@ func build30DayCost(t *testing.T, ctrl *gomock.Controller) client.Services {
 	m.EXPECT().GetCostAndUsage(gomock.Any(), gomock.Any(), gomock.Any()).MinTimes(1).Return(
 		&gcuo, nil)
 
-	return client.Services{
+	return &client.Services{
 		Costexplorer: m,
 	}
 }

--- a/plugins/source/aws/resources/services/costexplorer/forecast_thirty_days_mock_test.go
+++ b/plugins/source/aws/resources/services/costexplorer/forecast_thirty_days_mock_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func build30DayForecast(t *testing.T, ctrl *gomock.Controller) client.Services {
+func build30DayForecast(t *testing.T, ctrl *gomock.Controller) *client.Services {
 	m := mocks.NewMockCostexplorerClient(ctrl)
 
 	gcfo := costexplorer.GetCostForecastOutput{}
@@ -19,7 +19,7 @@ func build30DayForecast(t *testing.T, ctrl *gomock.Controller) client.Services {
 	m.EXPECT().GetCostForecast(gomock.Any(), gomock.Any(), gomock.Any()).MinTimes(1).Return(
 		&gcfo, nil)
 
-	return client.Services{
+	return &client.Services{
 		Costexplorer: m,
 	}
 }

--- a/plugins/source/aws/resources/services/dax/clusters_mock_test.go
+++ b/plugins/source/aws/resources/services/dax/clusters_mock_test.go
@@ -12,9 +12,9 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func buildDAXClustersMock(t *testing.T, ctrl *gomock.Controller) client.Services {
+func buildDAXClustersMock(t *testing.T, ctrl *gomock.Controller) *client.Services {
 	m := mocks.NewMockDaxClient(ctrl)
-	services := client.Services{
+	services := &client.Services{
 		Dax: m,
 	}
 	c := types.Cluster{}

--- a/plugins/source/aws/resources/services/detective/graphs_mock_test.go
+++ b/plugins/source/aws/resources/services/detective/graphs_mock_test.go
@@ -12,9 +12,9 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func buildGraphs(t *testing.T, ctrl *gomock.Controller) client.Services {
+func buildGraphs(t *testing.T, ctrl *gomock.Controller) *client.Services {
 	m := mocks.NewMockDetectiveClient(ctrl)
-	services := client.Services{
+	services := &client.Services{
 		Detective: m,
 	}
 	c := types.Graph{}

--- a/plugins/source/aws/resources/services/directconnect/connections_mock_test.go
+++ b/plugins/source/aws/resources/services/directconnect/connections_mock_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func buildDirectconnectConnection(t *testing.T, ctrl *gomock.Controller) client.Services {
+func buildDirectconnectConnection(t *testing.T, ctrl *gomock.Controller) *client.Services {
 	m := mocks.NewMockDirectconnectClient(ctrl)
 	conn := types.Connection{}
 	require.NoError(t, faker.FakeObject(&conn))
@@ -20,7 +20,7 @@ func buildDirectconnectConnection(t *testing.T, ctrl *gomock.Controller) client.
 		&directconnect.DescribeConnectionsOutput{
 			Connections: []types.Connection{conn},
 		}, nil)
-	return client.Services{
+	return &client.Services{
 		Directconnect: m,
 	}
 }

--- a/plugins/source/aws/resources/services/directconnect/gateway_mock_test.go
+++ b/plugins/source/aws/resources/services/directconnect/gateway_mock_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func buildDirectconnectGatewaysMock(t *testing.T, ctrl *gomock.Controller) client.Services {
+func buildDirectconnectGatewaysMock(t *testing.T, ctrl *gomock.Controller) *client.Services {
 	m := mocks.NewMockDirectconnectClient(ctrl)
 	l := types.DirectConnectGateway{}
 	association := types.DirectConnectGatewayAssociation{}
@@ -32,7 +32,7 @@ func buildDirectconnectGatewaysMock(t *testing.T, ctrl *gomock.Controller) clien
 		&directconnect.DescribeDirectConnectGatewayAttachmentsOutput{
 			DirectConnectGatewayAttachments: []types.DirectConnectGatewayAttachment{attachment},
 		}, nil)
-	return client.Services{
+	return &client.Services{
 		Directconnect: m,
 	}
 }

--- a/plugins/source/aws/resources/services/directconnect/lags_mock_test.go
+++ b/plugins/source/aws/resources/services/directconnect/lags_mock_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func buildDirectconnectLag(t *testing.T, ctrl *gomock.Controller) client.Services {
+func buildDirectconnectLag(t *testing.T, ctrl *gomock.Controller) *client.Services {
 	m := mocks.NewMockDirectconnectClient(ctrl)
 	lag := types.Lag{}
 	require.NoError(t, faker.FakeObject(&lag))
@@ -20,7 +20,7 @@ func buildDirectconnectLag(t *testing.T, ctrl *gomock.Controller) client.Service
 		&directconnect.DescribeLagsOutput{
 			Lags: []types.Lag{lag},
 		}, nil)
-	return client.Services{
+	return &client.Services{
 		Directconnect: m,
 	}
 }

--- a/plugins/source/aws/resources/services/directconnect/locations_mock_test.go
+++ b/plugins/source/aws/resources/services/directconnect/locations_mock_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func buildDirectconnectLocations(t *testing.T, ctrl *gomock.Controller) client.Services {
+func buildDirectconnectLocations(t *testing.T, ctrl *gomock.Controller) *client.Services {
 	m := mocks.NewMockDirectconnectClient(ctrl)
 	loc := types.Location{}
 	require.NoError(t, faker.FakeObject(&loc))
@@ -20,7 +20,7 @@ func buildDirectconnectLocations(t *testing.T, ctrl *gomock.Controller) client.S
 		&directconnect.DescribeLocationsOutput{
 			Locations: []types.Location{loc},
 		}, nil)
-	return client.Services{
+	return &client.Services{
 		Directconnect: m,
 	}
 }

--- a/plugins/source/aws/resources/services/directconnect/virtual_gateways_mock_test.go
+++ b/plugins/source/aws/resources/services/directconnect/virtual_gateways_mock_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func buildDirectconnectVirtualGatewaysMock(t *testing.T, ctrl *gomock.Controller) client.Services {
+func buildDirectconnectVirtualGatewaysMock(t *testing.T, ctrl *gomock.Controller) *client.Services {
 	m := mocks.NewMockDirectconnectClient(ctrl)
 	l := types.VirtualGateway{}
 	require.NoError(t, faker.FakeObject(&l))
@@ -20,7 +20,7 @@ func buildDirectconnectVirtualGatewaysMock(t *testing.T, ctrl *gomock.Controller
 		&directconnect.DescribeVirtualGatewaysOutput{
 			VirtualGateways: []types.VirtualGateway{l},
 		}, nil)
-	return client.Services{
+	return &client.Services{
 		Directconnect: m,
 	}
 }

--- a/plugins/source/aws/resources/services/directconnect/virtual_interfaces_mock_test.go
+++ b/plugins/source/aws/resources/services/directconnect/virtual_interfaces_mock_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func buildDirectconnectVirtualInterfacesMock(t *testing.T, ctrl *gomock.Controller) client.Services {
+func buildDirectconnectVirtualInterfacesMock(t *testing.T, ctrl *gomock.Controller) *client.Services {
 	m := mocks.NewMockDirectconnectClient(ctrl)
 	l := types.VirtualInterface{}
 	require.NoError(t, faker.FakeObject(&l))
@@ -20,7 +20,7 @@ func buildDirectconnectVirtualInterfacesMock(t *testing.T, ctrl *gomock.Controll
 		&directconnect.DescribeVirtualInterfacesOutput{
 			VirtualInterfaces: []types.VirtualInterface{l},
 		}, nil)
-	return client.Services{
+	return &client.Services{
 		Directconnect: m,
 	}
 }

--- a/plugins/source/aws/resources/services/dms/replication_instances_mock_test.go
+++ b/plugins/source/aws/resources/services/dms/replication_instances_mock_test.go
@@ -13,7 +13,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func buildDmsReplicationInstances(t *testing.T, ctrl *gomock.Controller) client.Services {
+func buildDmsReplicationInstances(t *testing.T, ctrl *gomock.Controller) *client.Services {
 	m := mocks.NewMockDatabasemigrationserviceClient(ctrl)
 	l := types.ReplicationInstance{}
 	require.NoError(t, faker.FakeObject(&l))
@@ -34,7 +34,7 @@ func buildDmsReplicationInstances(t *testing.T, ctrl *gomock.Controller) client.
 		&databasemigrationservice.ListTagsForResourceOutput{
 			TagList: []types.Tag{lt},
 		}, nil)
-	return client.Services{
+	return &client.Services{
 		Databasemigrationservice: m,
 	}
 }

--- a/plugins/source/aws/resources/services/docdb/certificates_mock_test.go
+++ b/plugins/source/aws/resources/services/docdb/certificates_mock_test.go
@@ -11,9 +11,9 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func buildCertificatesMock(t *testing.T, ctrl *gomock.Controller) client.Services {
+func buildCertificatesMock(t *testing.T, ctrl *gomock.Controller) *client.Services {
 	m := mocks.NewMockDocdbClient(ctrl)
-	services := client.Services{
+	services := &client.Services{
 		Docdb: m,
 	}
 	var parameterGroups docdb.DescribeCertificatesOutput

--- a/plugins/source/aws/resources/services/docdb/cluster_parameter_groups_mock_test.go
+++ b/plugins/source/aws/resources/services/docdb/cluster_parameter_groups_mock_test.go
@@ -11,9 +11,9 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func buildClusterParameterGroupsMock(t *testing.T, ctrl *gomock.Controller) client.Services {
+func buildClusterParameterGroupsMock(t *testing.T, ctrl *gomock.Controller) *client.Services {
 	m := mocks.NewMockDocdbClient(ctrl)
-	services := client.Services{
+	services := &client.Services{
 		Docdb: m,
 	}
 	var parameterGroups docdb.DescribeDBClusterParameterGroupsOutput

--- a/plugins/source/aws/resources/services/docdb/clusters_mock_test.go
+++ b/plugins/source/aws/resources/services/docdb/clusters_mock_test.go
@@ -11,9 +11,9 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func buildClustersMock(t *testing.T, ctrl *gomock.Controller) client.Services {
+func buildClustersMock(t *testing.T, ctrl *gomock.Controller) *client.Services {
 	m := mocks.NewMockDocdbClient(ctrl)
-	services := client.Services{
+	services := &client.Services{
 		Docdb: m,
 	}
 	var clusters docdb.DescribeDBClustersOutput

--- a/plugins/source/aws/resources/services/docdb/engine_versions_mock_test.go
+++ b/plugins/source/aws/resources/services/docdb/engine_versions_mock_test.go
@@ -11,9 +11,9 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func buildEngineVersionsMock(t *testing.T, ctrl *gomock.Controller) client.Services {
+func buildEngineVersionsMock(t *testing.T, ctrl *gomock.Controller) *client.Services {
 	m := mocks.NewMockDocdbClient(ctrl)
-	services := client.Services{
+	services := &client.Services{
 		Docdb: m,
 	}
 	var ev docdb.DescribeDBEngineVersionsOutput

--- a/plugins/source/aws/resources/services/docdb/event_categories_mock_test.go
+++ b/plugins/source/aws/resources/services/docdb/event_categories_mock_test.go
@@ -11,9 +11,9 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func buildEventCategoriesMock(t *testing.T, ctrl *gomock.Controller) client.Services {
+func buildEventCategoriesMock(t *testing.T, ctrl *gomock.Controller) *client.Services {
 	m := mocks.NewMockDocdbClient(ctrl)
-	services := client.Services{
+	services := &client.Services{
 		Docdb: m,
 	}
 	var ec docdb.DescribeEventCategoriesOutput

--- a/plugins/source/aws/resources/services/docdb/event_subscriptions_mock_test.go
+++ b/plugins/source/aws/resources/services/docdb/event_subscriptions_mock_test.go
@@ -11,9 +11,9 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func buildEventSubscriptionsMock(t *testing.T, ctrl *gomock.Controller) client.Services {
+func buildEventSubscriptionsMock(t *testing.T, ctrl *gomock.Controller) *client.Services {
 	m := mocks.NewMockDocdbClient(ctrl)
-	services := client.Services{
+	services := &client.Services{
 		Docdb: m,
 	}
 	var ec docdb.DescribeEventSubscriptionsOutput

--- a/plugins/source/aws/resources/services/docdb/events_mock_test.go
+++ b/plugins/source/aws/resources/services/docdb/events_mock_test.go
@@ -11,9 +11,9 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func buildEventsMock(t *testing.T, ctrl *gomock.Controller) client.Services {
+func buildEventsMock(t *testing.T, ctrl *gomock.Controller) *client.Services {
 	m := mocks.NewMockDocdbClient(ctrl)
-	services := client.Services{
+	services := &client.Services{
 		Docdb: m,
 	}
 	var e docdb.DescribeEventsOutput

--- a/plugins/source/aws/resources/services/docdb/pending_maintenance_actions_mock_test.go
+++ b/plugins/source/aws/resources/services/docdb/pending_maintenance_actions_mock_test.go
@@ -11,9 +11,9 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func buildPendingMaintenanceActionsMock(t *testing.T, ctrl *gomock.Controller) client.Services {
+func buildPendingMaintenanceActionsMock(t *testing.T, ctrl *gomock.Controller) *client.Services {
 	m := mocks.NewMockDocdbClient(ctrl)
-	services := client.Services{
+	services := &client.Services{
 		Docdb: m,
 	}
 	var ev docdb.DescribePendingMaintenanceActionsOutput

--- a/plugins/source/aws/resources/services/docdb/subnet_groups_mock_test.go
+++ b/plugins/source/aws/resources/services/docdb/subnet_groups_mock_test.go
@@ -11,9 +11,9 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func buildSubnetGroupsMock(t *testing.T, ctrl *gomock.Controller) client.Services {
+func buildSubnetGroupsMock(t *testing.T, ctrl *gomock.Controller) *client.Services {
 	m := mocks.NewMockDocdbClient(ctrl)
-	services := client.Services{
+	services := &client.Services{
 		Docdb: m,
 	}
 	var ev docdb.DescribeDBSubnetGroupsOutput

--- a/plugins/source/aws/resources/services/dynamodb/backups_mock_test.go
+++ b/plugins/source/aws/resources/services/dynamodb/backups_mock_test.go
@@ -12,9 +12,9 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func buildDynamodbBackupMock(t *testing.T, ctrl *gomock.Controller) client.Services {
+func buildDynamodbBackupMock(t *testing.T, ctrl *gomock.Controller) *client.Services {
 	m := mocks.NewMockDynamodbClient(ctrl)
-	services := client.Services{
+	services := &client.Services{
 		Dynamodb: m,
 	}
 	var bs types.BackupSummary

--- a/plugins/source/aws/resources/services/dynamodb/export_mock_test.go
+++ b/plugins/source/aws/resources/services/dynamodb/export_mock_test.go
@@ -12,9 +12,9 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func buildDynamodbExportsMock(t *testing.T, ctrl *gomock.Controller) client.Services {
+func buildDynamodbExportsMock(t *testing.T, ctrl *gomock.Controller) *client.Services {
 	m := mocks.NewMockDynamodbClient(ctrl)
-	services := client.Services{
+	services := &client.Services{
 		Dynamodb: m,
 	}
 	var es types.ExportSummary

--- a/plugins/source/aws/resources/services/dynamodb/global_tables_mock_test.go
+++ b/plugins/source/aws/resources/services/dynamodb/global_tables_mock_test.go
@@ -12,9 +12,9 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func buildDynamodbGlobalTablesMock(t *testing.T, ctrl *gomock.Controller) client.Services {
+func buildDynamodbGlobalTablesMock(t *testing.T, ctrl *gomock.Controller) *client.Services {
 	m := mocks.NewMockDynamodbClient(ctrl)
-	services := client.Services{
+	services := &client.Services{
 		Dynamodb: m,
 	}
 	var globalTable types.GlobalTable

--- a/plugins/source/aws/resources/services/dynamodb/tables_mock_test.go
+++ b/plugins/source/aws/resources/services/dynamodb/tables_mock_test.go
@@ -12,9 +12,9 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func buildDynamodbTablesMock(t *testing.T, ctrl *gomock.Controller) client.Services {
+func buildDynamodbTablesMock(t *testing.T, ctrl *gomock.Controller) *client.Services {
 	m := mocks.NewMockDynamodbClient(ctrl)
-	services := client.Services{
+	services := &client.Services{
 		Dynamodb: m,
 	}
 	var tableName string

--- a/plugins/source/aws/resources/services/dynamodbstreams/streams_mock_test.go
+++ b/plugins/source/aws/resources/services/dynamodbstreams/streams_mock_test.go
@@ -12,9 +12,9 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func buildDynamodbstreamsStreamsMock(t *testing.T, ctrl *gomock.Controller) client.Services {
+func buildDynamodbstreamsStreamsMock(t *testing.T, ctrl *gomock.Controller) *client.Services {
 	m := mocks.NewMockDynamodbstreamsClient(ctrl)
-	services := client.Services{
+	services := &client.Services{
 		Dynamodbstreams: m,
 	}
 	stream := types.Stream{}

--- a/plugins/source/aws/resources/services/ec2/account_attributes_mock_test.go
+++ b/plugins/source/aws/resources/services/ec2/account_attributes_mock_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func buildAccountAttributesMock(t *testing.T, ctrl *gomock.Controller) client.Services {
+func buildAccountAttributesMock(t *testing.T, ctrl *gomock.Controller) *client.Services {
 	m := mocks.NewMockEc2Client(ctrl)
 	ac := types.AccountAttribute{}
 	require.NoError(t, faker.FakeObject(&ac))
@@ -22,7 +22,7 @@ func buildAccountAttributesMock(t *testing.T, ctrl *gomock.Controller) client.Se
 			AccountAttributes: []types.AccountAttribute{ac},
 		}, nil)
 
-	return client.Services{
+	return &client.Services{
 		Ec2: m,
 	}
 }

--- a/plugins/source/aws/resources/services/ec2/azs_mock_test.go
+++ b/plugins/source/aws/resources/services/ec2/azs_mock_test.go
@@ -13,7 +13,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func buildAzsMock(t *testing.T, ctrl *gomock.Controller) client.Services {
+func buildAzsMock(t *testing.T, ctrl *gomock.Controller) *client.Services {
 	m := mocks.NewMockEc2Client(ctrl)
 	r := types.AvailabilityZone{}
 	require.NoError(t, faker.FakeObject(&r))
@@ -25,7 +25,7 @@ func buildAzsMock(t *testing.T, ctrl *gomock.Controller) client.Services {
 			AvailabilityZones: []types.AvailabilityZone{r},
 		}, nil)
 
-	return client.Services{
+	return &client.Services{
 		Ec2: m,
 	}
 }

--- a/plugins/source/aws/resources/services/ec2/byoip_cidrs_mock_test.go
+++ b/plugins/source/aws/resources/services/ec2/byoip_cidrs_mock_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func buildEc2ByoipCidrsMock(t *testing.T, ctrl *gomock.Controller) client.Services {
+func buildEc2ByoipCidrsMock(t *testing.T, ctrl *gomock.Controller) *client.Services {
 	m := mocks.NewMockEc2Client(ctrl)
 	l := types.ByoipCidr{}
 	require.NoError(t, faker.FakeObject(&l))
@@ -21,7 +21,7 @@ func buildEc2ByoipCidrsMock(t *testing.T, ctrl *gomock.Controller) client.Servic
 		&ec2.DescribeByoipCidrsOutput{
 			ByoipCidrs: []types.ByoipCidr{l},
 		}, nil)
-	return client.Services{
+	return &client.Services{
 		Ec2: m,
 	}
 }

--- a/plugins/source/aws/resources/services/ec2/capacity_reservations_mock_test.go
+++ b/plugins/source/aws/resources/services/ec2/capacity_reservations_mock_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func buildEc2CapacityReservations(t *testing.T, ctrl *gomock.Controller) client.Services {
+func buildEc2CapacityReservations(t *testing.T, ctrl *gomock.Controller) *client.Services {
 	m := mocks.NewMockEc2Client(ctrl)
 	l := types.CapacityReservation{}
 	require.NoError(t, faker.FakeObject(&l))
@@ -21,7 +21,7 @@ func buildEc2CapacityReservations(t *testing.T, ctrl *gomock.Controller) client.
 		&ec2.DescribeCapacityReservationsOutput{
 			CapacityReservations: []types.CapacityReservation{l},
 		}, nil)
-	return client.Services{
+	return &client.Services{
 		Ec2: m,
 	}
 }

--- a/plugins/source/aws/resources/services/ec2/customer_gateways_mock_test.go
+++ b/plugins/source/aws/resources/services/ec2/customer_gateways_mock_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func buildEc2CustomerGateways(t *testing.T, ctrl *gomock.Controller) client.Services {
+func buildEc2CustomerGateways(t *testing.T, ctrl *gomock.Controller) *client.Services {
 	m := mocks.NewMockEc2Client(ctrl)
 	l := types.CustomerGateway{}
 	require.NoError(t, faker.FakeObject(&l))
@@ -21,7 +21,7 @@ func buildEc2CustomerGateways(t *testing.T, ctrl *gomock.Controller) client.Serv
 		&ec2.DescribeCustomerGatewaysOutput{
 			CustomerGateways: []types.CustomerGateway{l},
 		}, nil)
-	return client.Services{
+	return &client.Services{
 		Ec2: m,
 	}
 }

--- a/plugins/source/aws/resources/services/ec2/dhcp_options_mock_test.go
+++ b/plugins/source/aws/resources/services/ec2/dhcp_options_mock_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func buildDHCPOptions(t *testing.T, ctrl *gomock.Controller) client.Services {
+func buildDHCPOptions(t *testing.T, ctrl *gomock.Controller) *client.Services {
 	m := mocks.NewMockEc2Client(ctrl)
 	item := types.DhcpOptions{}
 	require.NoError(t, faker.FakeObject(&item))
@@ -21,7 +21,7 @@ func buildDHCPOptions(t *testing.T, ctrl *gomock.Controller) client.Services {
 		&ec2.DescribeDhcpOptionsOutput{
 			DhcpOptions: []types.DhcpOptions{item},
 		}, nil)
-	return client.Services{
+	return &client.Services{
 		Ec2: m,
 	}
 }

--- a/plugins/source/aws/resources/services/ec2/ebs_snapshots_mock_test.go
+++ b/plugins/source/aws/resources/services/ec2/ebs_snapshots_mock_test.go
@@ -13,7 +13,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func buildEc2EbsSnapshots(t *testing.T, ctrl *gomock.Controller) client.Services {
+func buildEc2EbsSnapshots(t *testing.T, ctrl *gomock.Controller) *client.Services {
 	m := mocks.NewMockEc2Client(ctrl)
 
 	sa := ec2.DescribeSnapshotAttributeOutput{}
@@ -30,7 +30,7 @@ func buildEc2EbsSnapshots(t *testing.T, ctrl *gomock.Controller) client.Services
 
 	m.EXPECT().DescribeSnapshotAttribute(gomock.Any(), gomock.Any(), gomock.Any()).MinTimes(1).Return(
 		&sa, nil)
-	return client.Services{
+	return &client.Services{
 		Ec2: m,
 	}
 }

--- a/plugins/source/aws/resources/services/ec2/ebs_volume_statuses_mock_test.go
+++ b/plugins/source/aws/resources/services/ec2/ebs_volume_statuses_mock_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func buildEc2EbsVolumeStatuses(t *testing.T, ctrl *gomock.Controller) client.Services {
+func buildEc2EbsVolumeStatuses(t *testing.T, ctrl *gomock.Controller) *client.Services {
 	m := mocks.NewMockEc2Client(ctrl)
 	statusOutput := ec2.DescribeVolumeStatusOutput{}
 	require.NoError(t, faker.FakeObject(&statusOutput))
@@ -19,7 +19,7 @@ func buildEc2EbsVolumeStatuses(t *testing.T, ctrl *gomock.Controller) client.Ser
 	statusOutput.NextToken = nil
 	m.EXPECT().DescribeVolumeStatus(gomock.Any(), gomock.Any(), gomock.Any()).Return(
 		&statusOutput, nil)
-	return client.Services{
+	return &client.Services{
 		Ec2: m,
 	}
 }

--- a/plugins/source/aws/resources/services/ec2/ebs_volumes_mock_test.go
+++ b/plugins/source/aws/resources/services/ec2/ebs_volumes_mock_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func buildEc2EbsVolumes(t *testing.T, ctrl *gomock.Controller) client.Services {
+func buildEc2EbsVolumes(t *testing.T, ctrl *gomock.Controller) *client.Services {
 	m := mocks.NewMockEc2Client(ctrl)
 	volumesOutput := ec2.DescribeVolumesOutput{}
 	require.NoError(t, faker.FakeObject(&volumesOutput))
@@ -19,7 +19,7 @@ func buildEc2EbsVolumes(t *testing.T, ctrl *gomock.Controller) client.Services {
 	volumesOutput.NextToken = nil
 	m.EXPECT().DescribeVolumes(gomock.Any(), gomock.Any(), gomock.Any()).Return(
 		&volumesOutput, nil)
-	return client.Services{
+	return &client.Services{
 		Ec2: m,
 	}
 }

--- a/plugins/source/aws/resources/services/ec2/egress_only_internet_gateways_mock_test.go
+++ b/plugins/source/aws/resources/services/ec2/egress_only_internet_gateways_mock_test.go
@@ -11,14 +11,14 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func buildEgressOnlyInternetGateways(t *testing.T, ctrl *gomock.Controller) client.Services {
+func buildEgressOnlyInternetGateways(t *testing.T, ctrl *gomock.Controller) *client.Services {
 	m := mocks.NewMockEc2Client(ctrl)
 	egressOutput := ec2.DescribeEgressOnlyInternetGatewaysOutput{}
 	require.NoError(t, faker.FakeObject(&egressOutput))
 
 	egressOutput.NextToken = nil
 	m.EXPECT().DescribeEgressOnlyInternetGateways(gomock.Any(), gomock.Any(), gomock.Any()).Return(&egressOutput, nil)
-	return client.Services{
+	return &client.Services{
 		Ec2: m,
 	}
 }

--- a/plugins/source/aws/resources/services/ec2/eips_mock_test.go
+++ b/plugins/source/aws/resources/services/ec2/eips_mock_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func buildEc2Eips(t *testing.T, ctrl *gomock.Controller) client.Services {
+func buildEc2Eips(t *testing.T, ctrl *gomock.Controller) *client.Services {
 	m := mocks.NewMockEc2Client(ctrl)
 	a := types.Address{}
 	require.NoError(t, faker.FakeObject(&a))
@@ -30,7 +30,7 @@ func buildEc2Eips(t *testing.T, ctrl *gomock.Controller) client.Services {
 		&ec2.DescribeAddressesOutput{
 			Addresses: []types.Address{a},
 		}, nil)
-	return client.Services{
+	return &client.Services{
 		Ec2: m,
 	}
 }

--- a/plugins/source/aws/resources/services/ec2/flow_logs_mock_test.go
+++ b/plugins/source/aws/resources/services/ec2/flow_logs_mock_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func buildEc2FlowLogsMock(t *testing.T, ctrl *gomock.Controller) client.Services {
+func buildEc2FlowLogsMock(t *testing.T, ctrl *gomock.Controller) *client.Services {
 	m := mocks.NewMockEc2Client(ctrl)
 
 	g := types.FlowLog{}
@@ -22,7 +22,7 @@ func buildEc2FlowLogsMock(t *testing.T, ctrl *gomock.Controller) client.Services
 		&ec2.DescribeFlowLogsOutput{
 			FlowLogs: []types.FlowLog{g},
 		}, nil)
-	return client.Services{
+	return &client.Services{
 		Ec2: m,
 	}
 }

--- a/plugins/source/aws/resources/services/ec2/hosts_mock_test.go
+++ b/plugins/source/aws/resources/services/ec2/hosts_mock_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func buildEc2Hosts(t *testing.T, ctrl *gomock.Controller) client.Services {
+func buildEc2Hosts(t *testing.T, ctrl *gomock.Controller) *client.Services {
 	m := mocks.NewMockEc2Client(ctrl)
 
 	g := types.Host{}
@@ -23,7 +23,7 @@ func buildEc2Hosts(t *testing.T, ctrl *gomock.Controller) client.Services {
 			Hosts: []types.Host{g},
 		}, nil)
 
-	services := client.Services{
+	services := &client.Services{
 		Ec2: m,
 	}
 	return services

--- a/plugins/source/aws/resources/services/ec2/images_mock_test.go
+++ b/plugins/source/aws/resources/services/ec2/images_mock_test.go
@@ -13,9 +13,9 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func buildEc2ImagesMock(t *testing.T, ctrl *gomock.Controller) client.Services {
+func buildEc2ImagesMock(t *testing.T, ctrl *gomock.Controller) *client.Services {
 	m := mocks.NewMockEc2Client(ctrl)
-	services := client.Services{Ec2: m}
+	services := &client.Services{Ec2: m}
 	g := types.Image{}
 	require.NoError(t, faker.FakeObject(&g))
 

--- a/plugins/source/aws/resources/services/ec2/instance_connect_mock_test.go
+++ b/plugins/source/aws/resources/services/ec2/instance_connect_mock_test.go
@@ -13,7 +13,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func buildInstanceConnectEndpoint(t *testing.T, ctrl *gomock.Controller) client.Services {
+func buildInstanceConnectEndpoint(t *testing.T, ctrl *gomock.Controller) *client.Services {
 	m := mocks.NewMockEc2Client(ctrl)
 	endpoint := types.Ec2InstanceConnectEndpoint{}
 	require.NoError(t, faker.FakeObject(&endpoint))
@@ -24,7 +24,7 @@ func buildInstanceConnectEndpoint(t *testing.T, ctrl *gomock.Controller) client.
 			NextToken:                nil,
 			ResultMetadata:           middleware.Metadata{},
 		}, nil)
-	return client.Services{
+	return &client.Services{
 		Ec2: m,
 	}
 }

--- a/plugins/source/aws/resources/services/ec2/instance_statuses_mock_test.go
+++ b/plugins/source/aws/resources/services/ec2/instance_statuses_mock_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func buildEc2InstanceStatuses(t *testing.T, ctrl *gomock.Controller) client.Services {
+func buildEc2InstanceStatuses(t *testing.T, ctrl *gomock.Controller) *client.Services {
 	m := mocks.NewMockEc2Client(ctrl)
 	l := types.InstanceStatus{}
 	require.NoError(t, faker.FakeObject(&l))
@@ -21,7 +21,7 @@ func buildEc2InstanceStatuses(t *testing.T, ctrl *gomock.Controller) client.Serv
 		&ec2.DescribeInstanceStatusOutput{
 			InstanceStatuses: []types.InstanceStatus{l},
 		}, nil)
-	return client.Services{
+	return &client.Services{
 		Ec2: m,
 	}
 }

--- a/plugins/source/aws/resources/services/ec2/instance_types_mock_test.go
+++ b/plugins/source/aws/resources/services/ec2/instance_types_mock_test.go
@@ -13,7 +13,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func buildEc2InstanceTypes(t *testing.T, ctrl *gomock.Controller) client.Services {
+func buildEc2InstanceTypes(t *testing.T, ctrl *gomock.Controller) *client.Services {
 	m := mocks.NewMockEc2Client(ctrl)
 	info := types.InstanceTypeInfo{}
 	require.NoError(t, faker.FakeObject(&info))
@@ -24,7 +24,7 @@ func buildEc2InstanceTypes(t *testing.T, ctrl *gomock.Controller) client.Service
 			NextToken:      nil,
 			ResultMetadata: middleware.Metadata{},
 		}, nil)
-	return client.Services{
+	return &client.Services{
 		Ec2: m,
 	}
 }

--- a/plugins/source/aws/resources/services/ec2/instances_mock_test.go
+++ b/plugins/source/aws/resources/services/ec2/instances_mock_test.go
@@ -13,7 +13,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func buildEc2Instances(t *testing.T, ctrl *gomock.Controller) client.Services {
+func buildEc2Instances(t *testing.T, ctrl *gomock.Controller) *client.Services {
 	m := mocks.NewMockEc2Client(ctrl)
 	l := types.Reservation{}
 	require.NoError(t, faker.FakeObject(&l))
@@ -33,7 +33,7 @@ func buildEc2Instances(t *testing.T, ctrl *gomock.Controller) client.Services {
 			Reservations: []types.Reservation{l},
 			NextToken:    nil,
 		}, nil)
-	return client.Services{
+	return &client.Services{
 		Ec2: m,
 	}
 }

--- a/plugins/source/aws/resources/services/ec2/internet_gateways_mock_test.go
+++ b/plugins/source/aws/resources/services/ec2/internet_gateways_mock_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func buildEc2InternetGateways(t *testing.T, ctrl *gomock.Controller) client.Services {
+func buildEc2InternetGateways(t *testing.T, ctrl *gomock.Controller) *client.Services {
 	m := mocks.NewMockEc2Client(ctrl)
 	l := types.InternetGateway{}
 	require.NoError(t, faker.FakeObject(&l))
@@ -21,7 +21,7 @@ func buildEc2InternetGateways(t *testing.T, ctrl *gomock.Controller) client.Serv
 		&ec2.DescribeInternetGatewaysOutput{
 			InternetGateways: []types.InternetGateway{l},
 		}, nil)
-	return client.Services{
+	return &client.Services{
 		Ec2: m,
 	}
 }

--- a/plugins/source/aws/resources/services/ec2/key_pairs_mock_test.go
+++ b/plugins/source/aws/resources/services/ec2/key_pairs_mock_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func buildEc2KeyPairs(t *testing.T, ctrl *gomock.Controller) client.Services {
+func buildEc2KeyPairs(t *testing.T, ctrl *gomock.Controller) *client.Services {
 	m := mocks.NewMockEc2Client(ctrl)
 	l := types.KeyPairInfo{}
 	require.NoError(t, faker.FakeObject(&l))
@@ -21,7 +21,7 @@ func buildEc2KeyPairs(t *testing.T, ctrl *gomock.Controller) client.Services {
 		&ec2.DescribeKeyPairsOutput{
 			KeyPairs: []types.KeyPairInfo{l},
 		}, nil)
-	return client.Services{
+	return &client.Services{
 		Ec2: m,
 	}
 }

--- a/plugins/source/aws/resources/services/ec2/launch_templates_mock_test.go
+++ b/plugins/source/aws/resources/services/ec2/launch_templates_mock_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func buildEc2LaunchTemplates(t *testing.T, ctrl *gomock.Controller) client.Services {
+func buildEc2LaunchTemplates(t *testing.T, ctrl *gomock.Controller) *client.Services {
 	m := mocks.NewMockEc2Client(ctrl)
 	lt := types.LaunchTemplate{}
 	ltv := types.LaunchTemplateVersion{}
@@ -30,7 +30,7 @@ func buildEc2LaunchTemplates(t *testing.T, ctrl *gomock.Controller) client.Servi
 			LaunchTemplateVersions: []types.LaunchTemplateVersion{ltv},
 		}, nil)
 
-	return client.Services{
+	return &client.Services{
 		Ec2: m,
 	}
 }

--- a/plugins/source/aws/resources/services/ec2/managed_prefix_lists_mock_test.go
+++ b/plugins/source/aws/resources/services/ec2/managed_prefix_lists_mock_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func buildEc2ManagedPrefixList(t *testing.T, ctrl *gomock.Controller) client.Services {
+func buildEc2ManagedPrefixList(t *testing.T, ctrl *gomock.Controller) *client.Services {
 	m := mocks.NewMockEc2Client(ctrl)
 	l := types.ManagedPrefixList{}
 	require.NoError(t, faker.FakeObject(&l))
@@ -21,7 +21,7 @@ func buildEc2ManagedPrefixList(t *testing.T, ctrl *gomock.Controller) client.Ser
 		&ec2.DescribeManagedPrefixListsOutput{
 			PrefixLists: []types.ManagedPrefixList{l},
 		}, nil)
-	return client.Services{
+	return &client.Services{
 		Ec2: m,
 	}
 }

--- a/plugins/source/aws/resources/services/ec2/nat_gateways_mock_test.go
+++ b/plugins/source/aws/resources/services/ec2/nat_gateways_mock_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func buildEc2NatGateways(t *testing.T, ctrl *gomock.Controller) client.Services {
+func buildEc2NatGateways(t *testing.T, ctrl *gomock.Controller) *client.Services {
 	m := mocks.NewMockEc2Client(ctrl)
 	l := types.NatGateway{}
 	require.NoError(t, faker.FakeObject(&l))
@@ -21,7 +21,7 @@ func buildEc2NatGateways(t *testing.T, ctrl *gomock.Controller) client.Services 
 		&ec2.DescribeNatGatewaysOutput{
 			NatGateways: []types.NatGateway{l},
 		}, nil)
-	return client.Services{
+	return &client.Services{
 		Ec2: m,
 	}
 }

--- a/plugins/source/aws/resources/services/ec2/network_acls_mock_test.go
+++ b/plugins/source/aws/resources/services/ec2/network_acls_mock_test.go
@@ -13,7 +13,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func buildEc2NetworkAcls(t *testing.T, ctrl *gomock.Controller) client.Services {
+func buildEc2NetworkAcls(t *testing.T, ctrl *gomock.Controller) *client.Services {
 	m := mocks.NewMockEc2Client(ctrl)
 
 	l := types.NetworkAcl{}
@@ -24,7 +24,7 @@ func buildEc2NetworkAcls(t *testing.T, ctrl *gomock.Controller) client.Services 
 		&ec2.DescribeNetworkAclsOutput{
 			NetworkAcls: []types.NetworkAcl{l},
 		}, nil)
-	return client.Services{
+	return &client.Services{
 		Ec2: m,
 	}
 }

--- a/plugins/source/aws/resources/services/ec2/network_interfaces_mock_test.go
+++ b/plugins/source/aws/resources/services/ec2/network_interfaces_mock_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func buildEc2NetworkInterfaces(t *testing.T, ctrl *gomock.Controller) client.Services {
+func buildEc2NetworkInterfaces(t *testing.T, ctrl *gomock.Controller) *client.Services {
 	m := mocks.NewMockEc2Client(ctrl)
 
 	niOutput := ec2.DescribeNetworkInterfacesOutput{}
@@ -19,7 +19,7 @@ func buildEc2NetworkInterfaces(t *testing.T, ctrl *gomock.Controller) client.Ser
 
 	niOutput.NextToken = nil
 	m.EXPECT().DescribeNetworkInterfaces(gomock.Any(), gomock.Any(), gomock.Any()).Return(&niOutput, nil)
-	return client.Services{
+	return &client.Services{
 		Ec2: m,
 	}
 }

--- a/plugins/source/aws/resources/services/ec2/regional_config_mock_test.go
+++ b/plugins/source/aws/resources/services/ec2/regional_config_mock_test.go
@@ -10,12 +10,12 @@ import (
 	"github.com/golang/mock/gomock"
 )
 
-func buildEc2RegionalConfig(t *testing.T, ctrl *gomock.Controller) client.Services {
+func buildEc2RegionalConfig(t *testing.T, ctrl *gomock.Controller) *client.Services {
 	m := mocks.NewMockEc2Client(ctrl)
 	m.EXPECT().GetEbsDefaultKmsKeyId(gomock.Any(), gomock.Any(), gomock.Any()).Return(&ec2.GetEbsDefaultKmsKeyIdOutput{KmsKeyId: aws.String("some/key/id")}, nil)
 	m.EXPECT().GetEbsEncryptionByDefault(gomock.Any(), gomock.Any(), gomock.Any()).Return(&ec2.GetEbsEncryptionByDefaultOutput{EbsEncryptionByDefault: aws.Bool(true)}, nil)
 
-	return client.Services{
+	return &client.Services{
 		Ec2: m,
 	}
 }

--- a/plugins/source/aws/resources/services/ec2/regions_mock_test.go
+++ b/plugins/source/aws/resources/services/ec2/regions_mock_test.go
@@ -13,7 +13,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func buildRegionsMock(t *testing.T, ctrl *gomock.Controller) client.Services {
+func buildRegionsMock(t *testing.T, ctrl *gomock.Controller) *client.Services {
 	m := mocks.NewMockEc2Client(ctrl)
 	r := types.Region{}
 	require.NoError(t, faker.FakeObject(&r))
@@ -25,7 +25,7 @@ func buildRegionsMock(t *testing.T, ctrl *gomock.Controller) client.Services {
 			Regions: []types.Region{r},
 		}, nil)
 
-	return client.Services{
+	return &client.Services{
 		Ec2: m,
 	}
 }

--- a/plugins/source/aws/resources/services/ec2/reserved_instances_mock_test.go
+++ b/plugins/source/aws/resources/services/ec2/reserved_instances_mock_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func buildReservedEc2Instances(t *testing.T, ctrl *gomock.Controller) client.Services {
+func buildReservedEc2Instances(t *testing.T, ctrl *gomock.Controller) *client.Services {
 	m := mocks.NewMockEc2Client(ctrl)
 	l := types.ReservedInstances{}
 	require.NoError(t, faker.FakeObject(&l))
@@ -21,7 +21,7 @@ func buildReservedEc2Instances(t *testing.T, ctrl *gomock.Controller) client.Ser
 		&ec2.DescribeReservedInstancesOutput{
 			ReservedInstances: []types.ReservedInstances{l},
 		}, nil)
-	return client.Services{
+	return &client.Services{
 		Ec2: m,
 	}
 }

--- a/plugins/source/aws/resources/services/ec2/route_tables_mock_test.go
+++ b/plugins/source/aws/resources/services/ec2/route_tables_mock_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func buildEc2RouteTables(t *testing.T, ctrl *gomock.Controller) client.Services {
+func buildEc2RouteTables(t *testing.T, ctrl *gomock.Controller) *client.Services {
 	m := mocks.NewMockEc2Client(ctrl)
 	l := types.RouteTable{}
 	require.NoError(t, faker.FakeObject(&l))
@@ -21,7 +21,7 @@ func buildEc2RouteTables(t *testing.T, ctrl *gomock.Controller) client.Services 
 		&ec2.DescribeRouteTablesOutput{
 			RouteTables: []types.RouteTable{l},
 		}, nil)
-	return client.Services{
+	return &client.Services{
 		Ec2: m,
 	}
 }

--- a/plugins/source/aws/resources/services/ec2/security_groups_mock_test.go
+++ b/plugins/source/aws/resources/services/ec2/security_groups_mock_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func buildEc2SecurityGroups(t *testing.T, ctrl *gomock.Controller) client.Services {
+func buildEc2SecurityGroups(t *testing.T, ctrl *gomock.Controller) *client.Services {
 	m := mocks.NewMockEc2Client(ctrl)
 	l := types.SecurityGroup{}
 	require.NoError(t, faker.FakeObject(&l))
@@ -21,7 +21,7 @@ func buildEc2SecurityGroups(t *testing.T, ctrl *gomock.Controller) client.Servic
 		&ec2.DescribeSecurityGroupsOutput{
 			SecurityGroups: []types.SecurityGroup{l},
 		}, nil)
-	return client.Services{
+	return &client.Services{
 		Ec2: m,
 	}
 }

--- a/plugins/source/aws/resources/services/ec2/spot_fleet_requests_mock_test.go
+++ b/plugins/source/aws/resources/services/ec2/spot_fleet_requests_mock_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func buildSpotFleetRequests(t *testing.T, ctrl *gomock.Controller) client.Services {
+func buildSpotFleetRequests(t *testing.T, ctrl *gomock.Controller) *client.Services {
 	m := mocks.NewMockEc2Client(ctrl)
 	item := types.SpotFleetRequestConfig{}
 	require.NoError(t, faker.FakeObject(&item))
@@ -29,7 +29,7 @@ func buildSpotFleetRequests(t *testing.T, ctrl *gomock.Controller) client.Servic
 		&ec2.DescribeSpotFleetInstancesOutput{
 			ActiveInstances: []types.ActiveInstance{ins},
 		}, nil)
-	return client.Services{
+	return &client.Services{
 		Ec2: m,
 	}
 }

--- a/plugins/source/aws/resources/services/ec2/spot_instance_requests_mock_test.go
+++ b/plugins/source/aws/resources/services/ec2/spot_instance_requests_mock_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func buildSpotInstanceRequests(t *testing.T, ctrl *gomock.Controller) client.Services {
+func buildSpotInstanceRequests(t *testing.T, ctrl *gomock.Controller) *client.Services {
 	m := mocks.NewMockEc2Client(ctrl)
 	item := types.SpotInstanceRequest{}
 	require.NoError(t, faker.FakeObject(&item))
@@ -22,7 +22,7 @@ func buildSpotInstanceRequests(t *testing.T, ctrl *gomock.Controller) client.Ser
 			SpotInstanceRequests: []types.SpotInstanceRequest{item},
 		}, nil)
 
-	return client.Services{
+	return &client.Services{
 		Ec2: m,
 	}
 }

--- a/plugins/source/aws/resources/services/ec2/subnets_mock_test.go
+++ b/plugins/source/aws/resources/services/ec2/subnets_mock_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func buildEc2Subnets(t *testing.T, ctrl *gomock.Controller) client.Services {
+func buildEc2Subnets(t *testing.T, ctrl *gomock.Controller) *client.Services {
 	m := mocks.NewMockEc2Client(ctrl)
 	l := types.Subnet{}
 	require.NoError(t, faker.FakeObject(&l))
@@ -21,7 +21,7 @@ func buildEc2Subnets(t *testing.T, ctrl *gomock.Controller) client.Services {
 		&ec2.DescribeSubnetsOutput{
 			Subnets: []types.Subnet{l},
 		}, nil)
-	return client.Services{
+	return &client.Services{
 		Ec2: m,
 	}
 }

--- a/plugins/source/aws/resources/services/ec2/transit_gateways_mock_test.go
+++ b/plugins/source/aws/resources/services/ec2/transit_gateways_mock_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func buildEc2TransitGateways(t *testing.T, ctrl *gomock.Controller) client.Services {
+func buildEc2TransitGateways(t *testing.T, ctrl *gomock.Controller) *client.Services {
 	m := mocks.NewMockEc2Client(ctrl)
 	tgw := types.TransitGateway{}
 	require.NoError(t, faker.FakeObject(&tgw))
@@ -59,7 +59,7 @@ func buildEc2TransitGateways(t *testing.T, ctrl *gomock.Controller) client.Servi
 		&ec2.DescribeTransitGatewaysOutput{
 			TransitGateways: []types.TransitGateway{tgw},
 		}, nil)
-	return client.Services{
+	return &client.Services{
 		Ec2: m,
 	}
 }

--- a/plugins/source/aws/resources/services/ec2/vpc_endpoint_connections_mock_test.go
+++ b/plugins/source/aws/resources/services/ec2/vpc_endpoint_connections_mock_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func buildEc2VpcEndpointConnections(t *testing.T, ctrl *gomock.Controller) client.Services {
+func buildEc2VpcEndpointConnections(t *testing.T, ctrl *gomock.Controller) *client.Services {
 	m := mocks.NewMockEc2Client(ctrl)
 	sc := types.VpcEndpointConnection{}
 	require.NoError(t, faker.FakeObject(&sc))
@@ -21,7 +21,7 @@ func buildEc2VpcEndpointConnections(t *testing.T, ctrl *gomock.Controller) clien
 		&ec2.DescribeVpcEndpointConnectionsOutput{
 			VpcEndpointConnections: []types.VpcEndpointConnection{sc},
 		}, nil)
-	return client.Services{
+	return &client.Services{
 		Ec2: m,
 	}
 }

--- a/plugins/source/aws/resources/services/ec2/vpc_endpoint_service_configurations_mock_test.go
+++ b/plugins/source/aws/resources/services/ec2/vpc_endpoint_service_configurations_mock_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func buildEc2VpcEndpointServiceConfigurations(t *testing.T, ctrl *gomock.Controller) client.Services {
+func buildEc2VpcEndpointServiceConfigurations(t *testing.T, ctrl *gomock.Controller) *client.Services {
 	m := mocks.NewMockEc2Client(ctrl)
 	sc := types.ServiceConfiguration{}
 	require.NoError(t, faker.FakeObject(&sc))
@@ -21,7 +21,7 @@ func buildEc2VpcEndpointServiceConfigurations(t *testing.T, ctrl *gomock.Control
 		&ec2.DescribeVpcEndpointServiceConfigurationsOutput{
 			ServiceConfigurations: []types.ServiceConfiguration{sc},
 		}, nil)
-	return client.Services{
+	return &client.Services{
 		Ec2: m,
 	}
 }

--- a/plugins/source/aws/resources/services/ec2/vpc_endpoint_services_mock_test.go
+++ b/plugins/source/aws/resources/services/ec2/vpc_endpoint_services_mock_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func buildEc2VpcEndpointServices(t *testing.T, ctrl *gomock.Controller) client.Services {
+func buildEc2VpcEndpointServices(t *testing.T, ctrl *gomock.Controller) *client.Services {
 	m := mocks.NewMockEc2Client(ctrl)
 	sd := types.ServiceDetail{}
 	require.NoError(t, faker.FakeObject(&sd))
@@ -30,7 +30,7 @@ func buildEc2VpcEndpointServices(t *testing.T, ctrl *gomock.Controller) client.S
 			AllowedPrincipals: []types.AllowedPrincipal{ap},
 		}, nil)
 
-	return client.Services{
+	return &client.Services{
 		Ec2: m,
 	}
 }

--- a/plugins/source/aws/resources/services/ec2/vpc_endpoints_mock_test.go
+++ b/plugins/source/aws/resources/services/ec2/vpc_endpoints_mock_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func buildEc2VpcEndpoints(t *testing.T, ctrl *gomock.Controller) client.Services {
+func buildEc2VpcEndpoints(t *testing.T, ctrl *gomock.Controller) *client.Services {
 	m := mocks.NewMockEc2Client(ctrl)
 	e := types.VpcEndpoint{}
 	require.NoError(t, faker.FakeObject(&e))
@@ -21,7 +21,7 @@ func buildEc2VpcEndpoints(t *testing.T, ctrl *gomock.Controller) client.Services
 		&ec2.DescribeVpcEndpointsOutput{
 			VpcEndpoints: []types.VpcEndpoint{e},
 		}, nil)
-	return client.Services{
+	return &client.Services{
 		Ec2: m,
 	}
 }

--- a/plugins/source/aws/resources/services/ec2/vpcs_mock_test.go
+++ b/plugins/source/aws/resources/services/ec2/vpcs_mock_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func buildEc2Vpcs(t *testing.T, ctrl *gomock.Controller) client.Services {
+func buildEc2Vpcs(t *testing.T, ctrl *gomock.Controller) *client.Services {
 	m := mocks.NewMockEc2Client(ctrl)
 	l := types.Vpc{}
 	require.NoError(t, faker.FakeObject(&l))
@@ -21,7 +21,7 @@ func buildEc2Vpcs(t *testing.T, ctrl *gomock.Controller) client.Services {
 		&ec2.DescribeVpcsOutput{
 			Vpcs: []types.Vpc{l},
 		}, nil)
-	return client.Services{
+	return &client.Services{
 		Ec2: m,
 	}
 }

--- a/plugins/source/aws/resources/services/ec2/vpcs_peering_connections_mock_test.go
+++ b/plugins/source/aws/resources/services/ec2/vpcs_peering_connections_mock_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func buildEc2VpcsPeeringConnections(t *testing.T, ctrl *gomock.Controller) client.Services {
+func buildEc2VpcsPeeringConnections(t *testing.T, ctrl *gomock.Controller) *client.Services {
 	m := mocks.NewMockEc2Client(ctrl)
 	l := types.VpcPeeringConnection{}
 	require.NoError(t, faker.FakeObject(&l))
@@ -21,7 +21,7 @@ func buildEc2VpcsPeeringConnections(t *testing.T, ctrl *gomock.Controller) clien
 		&ec2.DescribeVpcPeeringConnectionsOutput{
 			VpcPeeringConnections: []types.VpcPeeringConnection{l},
 		}, nil)
-	return client.Services{
+	return &client.Services{
 		Ec2: m,
 	}
 }

--- a/plugins/source/aws/resources/services/ec2/vpn_connections_mock_test.go
+++ b/plugins/source/aws/resources/services/ec2/vpn_connections_mock_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func buildVpnConnections(t *testing.T, ctrl *gomock.Controller) client.Services {
+func buildVpnConnections(t *testing.T, ctrl *gomock.Controller) *client.Services {
 	m := mocks.NewMockEc2Client(ctrl)
 	l := types.VpnConnection{}
 	require.NoError(t, faker.FakeObject(&l))
@@ -21,7 +21,7 @@ func buildVpnConnections(t *testing.T, ctrl *gomock.Controller) client.Services 
 		&ec2.DescribeVpnConnectionsOutput{
 			VpnConnections: []types.VpnConnection{l},
 		}, nil)
-	return client.Services{
+	return &client.Services{
 		Ec2: m,
 	}
 }

--- a/plugins/source/aws/resources/services/ec2/vpn_gateways_mock_test.go
+++ b/plugins/source/aws/resources/services/ec2/vpn_gateways_mock_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func buildEc2VpnGateways(t *testing.T, ctrl *gomock.Controller) client.Services {
+func buildEc2VpnGateways(t *testing.T, ctrl *gomock.Controller) *client.Services {
 	m := mocks.NewMockEc2Client(ctrl)
 	l := types.VpnGateway{}
 	require.NoError(t, faker.FakeObject(&l))
@@ -20,7 +20,7 @@ func buildEc2VpnGateways(t *testing.T, ctrl *gomock.Controller) client.Services 
 		&ec2.DescribeVpnGatewaysOutput{
 			VpnGateways: []types.VpnGateway{l},
 		}, nil)
-	return client.Services{
+	return &client.Services{
 		Ec2: m,
 	}
 }

--- a/plugins/source/aws/resources/services/ecr/pull_through_cache_rules_mock_test.go
+++ b/plugins/source/aws/resources/services/ecr/pull_through_cache_rules_mock_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func buildPullThroughCacheRules(t *testing.T, ctrl *gomock.Controller) client.Services {
+func buildPullThroughCacheRules(t *testing.T, ctrl *gomock.Controller) *client.Services {
 	m := mocks.NewMockEcrClient(ctrl)
 
 	ptcr := types.PullThroughCacheRule{}
@@ -23,7 +23,7 @@ func buildPullThroughCacheRules(t *testing.T, ctrl *gomock.Controller) client.Se
 			PullThroughCacheRules: []types.PullThroughCacheRule{ptcr},
 		}, nil)
 
-	return client.Services{
+	return &client.Services{
 		Ecr: m,
 	}
 }

--- a/plugins/source/aws/resources/services/ecr/registries_mock_test.go
+++ b/plugins/source/aws/resources/services/ecr/registries_mock_test.go
@@ -13,7 +13,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func buildEcrRegistriesMock(t *testing.T, ctrl *gomock.Controller) client.Services {
+func buildEcrRegistriesMock(t *testing.T, ctrl *gomock.Controller) *client.Services {
 	m := mocks.NewMockEcrClient(ctrl)
 	var registryId string
 	require.NoError(t, faker.FakeObject(&registryId))
@@ -27,7 +27,7 @@ func buildEcrRegistriesMock(t *testing.T, ctrl *gomock.Controller) client.Servic
 			RegistryId:               aws.String(registryId),
 		}, nil)
 
-	return client.Services{
+	return &client.Services{
 		Ecr: m,
 	}
 }

--- a/plugins/source/aws/resources/services/ecr/registry_policies_mock_test.go
+++ b/plugins/source/aws/resources/services/ecr/registry_policies_mock_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func buildEcrRegistryPoliciesMock(t *testing.T, ctrl *gomock.Controller) client.Services {
+func buildEcrRegistryPoliciesMock(t *testing.T, ctrl *gomock.Controller) *client.Services {
 	m := mocks.NewMockEcrClient(ctrl)
 	var registryId string
 	require.NoError(t, faker.FakeObject(&registryId))
@@ -46,7 +46,7 @@ func buildEcrRegistryPoliciesMock(t *testing.T, ctrl *gomock.Controller) client.
 			RegistryId: aws.String(registryId),
 		}, nil)
 
-	return client.Services{
+	return &client.Services{
 		Ecr: m,
 	}
 }

--- a/plugins/source/aws/resources/services/ecr/repositories_mock_test.go
+++ b/plugins/source/aws/resources/services/ecr/repositories_mock_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func buildEcrRepositoriesMock(t *testing.T, ctrl *gomock.Controller) client.Services {
+func buildEcrRepositoriesMock(t *testing.T, ctrl *gomock.Controller) *client.Services {
 	m := mocks.NewMockEcrClient(ctrl)
 	l := types.Repository{}
 	require.NoError(t, faker.FakeObject(&l))
@@ -54,7 +54,7 @@ func buildEcrRepositoriesMock(t *testing.T, ctrl *gomock.Controller) client.Serv
 	lifecyclePolicyText := `{"rules":[{"rulePriority":1,"description":"Expire images older than 14 days","selection":{"tagStatus":"untagged","countType":"sinceImagePushed","countUnit":"days","countNumber":14},"action":{"type":"expire"}}]}`
 	lifeCyclePolicy.LifecyclePolicyText = &lifecyclePolicyText
 	m.EXPECT().GetLifecyclePolicy(gomock.Any(), gomock.Any(), gomock.Any()).Return(&lifeCyclePolicy, nil)
-	return client.Services{
+	return &client.Services{
 		Ecr: m,
 	}
 }

--- a/plugins/source/aws/resources/services/ecrpublic/repositories_mock_test.go
+++ b/plugins/source/aws/resources/services/ecrpublic/repositories_mock_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func buildEcrPublicRepositoriesMock(t *testing.T, ctrl *gomock.Controller) client.Services {
+func buildEcrPublicRepositoriesMock(t *testing.T, ctrl *gomock.Controller) *client.Services {
 	m := mocks.NewMockEcrpublicClient(ctrl)
 	l := types.Repository{}
 	require.NoError(t, faker.FakeObject(&l))
@@ -33,7 +33,7 @@ func buildEcrPublicRepositoriesMock(t *testing.T, ctrl *gomock.Controller) clien
 	require.NoError(t, faker.FakeObject(&tagResponse))
 	m.EXPECT().ListTagsForResource(gomock.Any(), gomock.Any(), gomock.Any()).Return(&tagResponse, nil)
 
-	return client.Services{
+	return &client.Services{
 		Ecrpublic: m,
 	}
 }

--- a/plugins/source/aws/resources/services/ecs/cluster_mock_test.go
+++ b/plugins/source/aws/resources/services/ecs/cluster_mock_test.go
@@ -12,9 +12,9 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func buildEcsClusterMock(t *testing.T, ctrl *gomock.Controller) client.Services {
+func buildEcsClusterMock(t *testing.T, ctrl *gomock.Controller) *client.Services {
 	m := mocks.NewMockEcsClient(ctrl)
-	services := client.Services{
+	services := &client.Services{
 		Ecs: m,
 	}
 	c := types.Cluster{}

--- a/plugins/source/aws/resources/services/ecs/task_definitions_mock_test.go
+++ b/plugins/source/aws/resources/services/ecs/task_definitions_mock_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func buildEcsTaskDefinitions(t *testing.T, ctrl *gomock.Controller) client.Services {
+func buildEcsTaskDefinitions(t *testing.T, ctrl *gomock.Controller) *client.Services {
 	m := mocks.NewMockEcsClient(ctrl)
 
 	listTaskDefinitionsOutput := ecs.ListTaskDefinitionsOutput{}
@@ -23,7 +23,7 @@ func buildEcsTaskDefinitions(t *testing.T, ctrl *gomock.Controller) client.Servi
 	require.NoError(t, faker.FakeObject(&taskDefinition))
 	m.EXPECT().DescribeTaskDefinition(gomock.Any(), gomock.Any(), gomock.Any()).Return(taskDefinition, nil)
 
-	return client.Services{
+	return &client.Services{
 		Ecs: m,
 	}
 }

--- a/plugins/source/aws/resources/services/efs/accesspoints_mock_test.go
+++ b/plugins/source/aws/resources/services/efs/accesspoints_mock_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func buildEfsAccessPointsMock(t *testing.T, ctrl *gomock.Controller) client.Services {
+func buildEfsAccessPointsMock(t *testing.T, ctrl *gomock.Controller) *client.Services {
 	m := mocks.NewMockEfsClient(ctrl)
 	l := types.AccessPointDescription{}
 	require.NoError(t, faker.FakeObject(&l))
@@ -22,7 +22,7 @@ func buildEfsAccessPointsMock(t *testing.T, ctrl *gomock.Controller) client.Serv
 			AccessPoints: []types.AccessPointDescription{l},
 		}, nil)
 
-	return client.Services{
+	return &client.Services{
 		Efs: m,
 	}
 }

--- a/plugins/source/aws/resources/services/efs/filesystems_mock_test.go
+++ b/plugins/source/aws/resources/services/efs/filesystems_mock_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func buildEfsFilesystemsMock(t *testing.T, ctrl *gomock.Controller) client.Services {
+func buildEfsFilesystemsMock(t *testing.T, ctrl *gomock.Controller) *client.Services {
 	m := mocks.NewMockEfsClient(ctrl)
 	l := types.FileSystemDescription{}
 	require.NoError(t, faker.FakeObject(&l))
@@ -33,7 +33,7 @@ func buildEfsFilesystemsMock(t *testing.T, ctrl *gomock.Controller) client.Servi
 	m.EXPECT().DescribeFileSystemPolicy(gomock.Any(), gomock.Any(), gomock.Any()).Return(
 		&p, nil)
 
-	return client.Services{
+	return &client.Services{
 		Efs: m,
 	}
 }

--- a/plugins/source/aws/resources/services/eks/clusters_mock_test.go
+++ b/plugins/source/aws/resources/services/eks/clusters_mock_test.go
@@ -13,7 +13,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func buildEksClusters(t *testing.T, ctrl *gomock.Controller) client.Services {
+func buildEksClusters(t *testing.T, ctrl *gomock.Controller) *client.Services {
 	m := mocks.NewMockEksClient(ctrl)
 	l := eks.DescribeClusterOutput{}
 	require.NoError(t, faker.FakeObject(&l))
@@ -76,7 +76,7 @@ func buildEksClusters(t *testing.T, ctrl *gomock.Controller) client.Services {
 			},
 		}, nil)
 
-	return client.Services{
+	return &client.Services{
 		Eks: m,
 	}
 }

--- a/plugins/source/aws/resources/services/elasticache/clusters_mock_test.go
+++ b/plugins/source/aws/resources/services/elasticache/clusters_mock_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func buildElasticacheClusters(t *testing.T, ctrl *gomock.Controller) client.Services {
+func buildElasticacheClusters(t *testing.T, ctrl *gomock.Controller) *client.Services {
 	mockElasticache := mocks.NewMockElasticacheClient(ctrl)
 	output := elasticache.DescribeCacheClustersOutput{}
 	require.NoError(t, faker.FakeObject(&output))
@@ -24,7 +24,7 @@ func buildElasticacheClusters(t *testing.T, ctrl *gomock.Controller) client.Serv
 	mockElasticache.EXPECT().DescribeCacheClusters(gomock.Any(), gomock.Any(), gomock.Any()).Return(&output, nil)
 	mockElasticache.EXPECT().ListTagsForResource(gomock.Any(), &elasticache.ListTagsForResourceInput{ResourceName: output.CacheClusters[0].ARN}, gomock.Any()).Return(&elasticache.ListTagsForResourceOutput{TagList: []types.Tag{ta}}, nil)
 
-	return client.Services{
+	return &client.Services{
 		Elasticache: mockElasticache,
 	}
 }

--- a/plugins/source/aws/resources/services/elasticache/engine_versions_mock_test.go
+++ b/plugins/source/aws/resources/services/elasticache/engine_versions_mock_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func buildElasticacheEngineVersions(t *testing.T, ctrl *gomock.Controller) client.Services {
+func buildElasticacheEngineVersions(t *testing.T, ctrl *gomock.Controller) *client.Services {
 	mockElasticache := mocks.NewMockElasticacheClient(ctrl)
 	output := elasticache.DescribeCacheEngineVersionsOutput{}
 	require.NoError(t, faker.FakeObject(&output))
@@ -19,7 +19,7 @@ func buildElasticacheEngineVersions(t *testing.T, ctrl *gomock.Controller) clien
 
 	mockElasticache.EXPECT().DescribeCacheEngineVersions(gomock.Any(), gomock.Any(), gomock.Any()).Return(&output, nil)
 
-	return client.Services{
+	return &client.Services{
 		Elasticache: mockElasticache,
 	}
 }

--- a/plugins/source/aws/resources/services/elasticache/events_mock_test.go
+++ b/plugins/source/aws/resources/services/elasticache/events_mock_test.go
@@ -12,14 +12,14 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func buildElasticacheEvents(t *testing.T, ctrl *gomock.Controller) client.Services {
+func buildElasticacheEvents(t *testing.T, ctrl *gomock.Controller) *client.Services {
 	mockElasticache := mocks.NewMockElasticacheClient(ctrl)
 	event := types.Event{}
 	require.NoError(t, faker.FakeObject(&event))
 
 	mockElasticache.EXPECT().DescribeEvents(gomock.Any(), gomock.Any(), gomock.Any()).Return(&elasticache.DescribeEventsOutput{Events: []types.Event{event}}, nil)
 
-	return client.Services{
+	return &client.Services{
 		Elasticache: mockElasticache,
 	}
 }

--- a/plugins/source/aws/resources/services/elasticache/global_replication_groups_mock_test.go
+++ b/plugins/source/aws/resources/services/elasticache/global_replication_groups_mock_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func buildElasticacheGlobalReplicationGroup(t *testing.T, ctrl *gomock.Controller) client.Services {
+func buildElasticacheGlobalReplicationGroup(t *testing.T, ctrl *gomock.Controller) *client.Services {
 	mockElasticache := mocks.NewMockElasticacheClient(ctrl)
 	output := elasticache.DescribeGlobalReplicationGroupsOutput{}
 	require.NoError(t, faker.FakeObject(&output))
@@ -19,7 +19,7 @@ func buildElasticacheGlobalReplicationGroup(t *testing.T, ctrl *gomock.Controlle
 
 	mockElasticache.EXPECT().DescribeGlobalReplicationGroups(gomock.Any(), gomock.Any(), gomock.Any()).Return(&output, nil)
 
-	return client.Services{
+	return &client.Services{
 		Elasticache: mockElasticache,
 	}
 }

--- a/plugins/source/aws/resources/services/elasticache/parameter_groups_mock_test.go
+++ b/plugins/source/aws/resources/services/elasticache/parameter_groups_mock_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func buildElasticacheParameterGroups(t *testing.T, ctrl *gomock.Controller) client.Services {
+func buildElasticacheParameterGroups(t *testing.T, ctrl *gomock.Controller) *client.Services {
 	mockElasticache := mocks.NewMockElasticacheClient(ctrl)
 	parameterGroupsOutput := elasticache.DescribeCacheParameterGroupsOutput{}
 	require.NoError(t, faker.FakeObject(&parameterGroupsOutput))
@@ -23,7 +23,7 @@ func buildElasticacheParameterGroups(t *testing.T, ctrl *gomock.Controller) clie
 
 	mockElasticache.EXPECT().DescribeCacheParameterGroups(gomock.Any(), gomock.Any(), gomock.Any()).Return(&parameterGroupsOutput, nil)
 
-	return client.Services{
+	return &client.Services{
 		Elasticache: mockElasticache,
 	}
 }

--- a/plugins/source/aws/resources/services/elasticache/replication_groups_mock_test.go
+++ b/plugins/source/aws/resources/services/elasticache/replication_groups_mock_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func buildElasticacheReplicationGroups(t *testing.T, ctrl *gomock.Controller) client.Services {
+func buildElasticacheReplicationGroups(t *testing.T, ctrl *gomock.Controller) *client.Services {
 	mockElasticache := mocks.NewMockElasticacheClient(ctrl)
 	output := elasticache.DescribeReplicationGroupsOutput{}
 	require.NoError(t, faker.FakeObject(&output))
@@ -25,7 +25,7 @@ func buildElasticacheReplicationGroups(t *testing.T, ctrl *gomock.Controller) cl
 
 	mockElasticache.EXPECT().ListTagsForResource(gomock.Any(), &elasticache.ListTagsForResourceInput{ResourceName: output.ReplicationGroups[0].ARN}, gomock.Any()).Return(&elasticache.ListTagsForResourceOutput{TagList: []types.Tag{ta}}, nil)
 
-	return client.Services{
+	return &client.Services{
 		Elasticache: mockElasticache,
 	}
 }

--- a/plugins/source/aws/resources/services/elasticache/reserved_cache_nodes_mock_test.go
+++ b/plugins/source/aws/resources/services/elasticache/reserved_cache_nodes_mock_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func buildElasticacheReservedCacheNodes(t *testing.T, ctrl *gomock.Controller) client.Services {
+func buildElasticacheReservedCacheNodes(t *testing.T, ctrl *gomock.Controller) *client.Services {
 	mockElasticache := mocks.NewMockElasticacheClient(ctrl)
 	output := elasticache.DescribeReservedCacheNodesOutput{}
 	require.NoError(t, faker.FakeObject(&output))
@@ -19,7 +19,7 @@ func buildElasticacheReservedCacheNodes(t *testing.T, ctrl *gomock.Controller) c
 
 	mockElasticache.EXPECT().DescribeReservedCacheNodes(gomock.Any(), gomock.Any(), gomock.Any()).Return(&output, nil)
 
-	return client.Services{
+	return &client.Services{
 		Elasticache: mockElasticache,
 	}
 }

--- a/plugins/source/aws/resources/services/elasticache/reserved_cache_nodes_offerings_mock_test.go
+++ b/plugins/source/aws/resources/services/elasticache/reserved_cache_nodes_offerings_mock_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func buildElasticacheReservedCacheNodesOfferings(t *testing.T, ctrl *gomock.Controller) client.Services {
+func buildElasticacheReservedCacheNodesOfferings(t *testing.T, ctrl *gomock.Controller) *client.Services {
 	mockElasticache := mocks.NewMockElasticacheClient(ctrl)
 	output := elasticache.DescribeReservedCacheNodesOfferingsOutput{}
 	require.NoError(t, faker.FakeObject(&output))
@@ -19,7 +19,7 @@ func buildElasticacheReservedCacheNodesOfferings(t *testing.T, ctrl *gomock.Cont
 
 	mockElasticache.EXPECT().DescribeReservedCacheNodesOfferings(gomock.Any(), gomock.Any(), gomock.Any()).Return(&output, nil)
 
-	return client.Services{
+	return &client.Services{
 		Elasticache: mockElasticache,
 	}
 }

--- a/plugins/source/aws/resources/services/elasticache/service_updates_mock_test.go
+++ b/plugins/source/aws/resources/services/elasticache/service_updates_mock_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func buildElasticacheServiceUpdates(t *testing.T, ctrl *gomock.Controller) client.Services {
+func buildElasticacheServiceUpdates(t *testing.T, ctrl *gomock.Controller) *client.Services {
 	mockElasticache := mocks.NewMockElasticacheClient(ctrl)
 	output := elasticache.DescribeServiceUpdatesOutput{}
 	require.NoError(t, faker.FakeObject(&output))
@@ -19,7 +19,7 @@ func buildElasticacheServiceUpdates(t *testing.T, ctrl *gomock.Controller) clien
 
 	mockElasticache.EXPECT().DescribeServiceUpdates(gomock.Any(), gomock.Any(), gomock.Any()).Return(&output, nil)
 
-	return client.Services{
+	return &client.Services{
 		Elasticache: mockElasticache,
 	}
 }

--- a/plugins/source/aws/resources/services/elasticache/snapshots_mock_test.go
+++ b/plugins/source/aws/resources/services/elasticache/snapshots_mock_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func buildElasticacheSnapshots(t *testing.T, ctrl *gomock.Controller) client.Services {
+func buildElasticacheSnapshots(t *testing.T, ctrl *gomock.Controller) *client.Services {
 	mockElasticache := mocks.NewMockElasticacheClient(ctrl)
 	output := elasticache.DescribeSnapshotsOutput{}
 	require.NoError(t, faker.FakeObject(&output))
@@ -19,7 +19,7 @@ func buildElasticacheSnapshots(t *testing.T, ctrl *gomock.Controller) client.Ser
 
 	mockElasticache.EXPECT().DescribeSnapshots(gomock.Any(), gomock.Any(), gomock.Any()).Return(&output, nil)
 
-	return client.Services{
+	return &client.Services{
 		Elasticache: mockElasticache,
 	}
 }

--- a/plugins/source/aws/resources/services/elasticache/subnet_groups_mock_test.go
+++ b/plugins/source/aws/resources/services/elasticache/subnet_groups_mock_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func buildElasticacheSubnetGroups(t *testing.T, ctrl *gomock.Controller) client.Services {
+func buildElasticacheSubnetGroups(t *testing.T, ctrl *gomock.Controller) *client.Services {
 	mockElasticache := mocks.NewMockElasticacheClient(ctrl)
 	output := elasticache.DescribeCacheSubnetGroupsOutput{}
 	require.NoError(t, faker.FakeObject(&output))
@@ -19,7 +19,7 @@ func buildElasticacheSubnetGroups(t *testing.T, ctrl *gomock.Controller) client.
 
 	mockElasticache.EXPECT().DescribeCacheSubnetGroups(gomock.Any(), gomock.Any(), gomock.Any()).Return(&output, nil)
 
-	return client.Services{
+	return &client.Services{
 		Elasticache: mockElasticache,
 	}
 }

--- a/plugins/source/aws/resources/services/elasticache/update_actions_mock_test.go
+++ b/plugins/source/aws/resources/services/elasticache/update_actions_mock_test.go
@@ -12,14 +12,14 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func buildElasticacheUpdateActions(t *testing.T, ctrl *gomock.Controller) client.Services {
+func buildElasticacheUpdateActions(t *testing.T, ctrl *gomock.Controller) *client.Services {
 	mockElasticache := mocks.NewMockElasticacheClient(ctrl)
 	action := types.UpdateAction{}
 	require.NoError(t, faker.FakeObject(&action))
 
 	mockElasticache.EXPECT().DescribeUpdateActions(gomock.Any(), gomock.Any(), gomock.Any()).Return(&elasticache.DescribeUpdateActionsOutput{UpdateActions: []types.UpdateAction{action}}, nil)
 
-	return client.Services{
+	return &client.Services{
 		Elasticache: mockElasticache,
 	}
 }

--- a/plugins/source/aws/resources/services/elasticache/user_groups_mock_test.go
+++ b/plugins/source/aws/resources/services/elasticache/user_groups_mock_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func buildElasticacheUserGroups(t *testing.T, ctrl *gomock.Controller) client.Services {
+func buildElasticacheUserGroups(t *testing.T, ctrl *gomock.Controller) *client.Services {
 	mockElasticache := mocks.NewMockElasticacheClient(ctrl)
 	output := elasticache.DescribeUserGroupsOutput{}
 	require.NoError(t, faker.FakeObject(&output))
@@ -19,7 +19,7 @@ func buildElasticacheUserGroups(t *testing.T, ctrl *gomock.Controller) client.Se
 
 	mockElasticache.EXPECT().DescribeUserGroups(gomock.Any(), gomock.Any(), gomock.Any()).Return(&output, nil)
 
-	return client.Services{
+	return &client.Services{
 		Elasticache: mockElasticache,
 	}
 }

--- a/plugins/source/aws/resources/services/elasticache/users_mock_test.go
+++ b/plugins/source/aws/resources/services/elasticache/users_mock_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func buildElasticacheUsers(t *testing.T, ctrl *gomock.Controller) client.Services {
+func buildElasticacheUsers(t *testing.T, ctrl *gomock.Controller) *client.Services {
 	mockElasticache := mocks.NewMockElasticacheClient(ctrl)
 	output := elasticache.DescribeUsersOutput{}
 	require.NoError(t, faker.FakeObject(&output))
@@ -19,7 +19,7 @@ func buildElasticacheUsers(t *testing.T, ctrl *gomock.Controller) client.Service
 
 	mockElasticache.EXPECT().DescribeUsers(gomock.Any(), gomock.Any(), gomock.Any()).Return(&output, nil)
 
-	return client.Services{
+	return &client.Services{
 		Elasticache: mockElasticache,
 	}
 }

--- a/plugins/source/aws/resources/services/elasticbeanstalk/application_versions_mock_test.go
+++ b/plugins/source/aws/resources/services/elasticbeanstalk/application_versions_mock_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func buildElasticbeanstalkApplicationVersions(t *testing.T, ctrl *gomock.Controller) client.Services {
+func buildElasticbeanstalkApplicationVersions(t *testing.T, ctrl *gomock.Controller) *client.Services {
 	m := mocks.NewMockElasticbeanstalkClient(ctrl)
 
 	la := elasticbeanstalkTypes.ApplicationVersionDescription{}
@@ -23,7 +23,7 @@ func buildElasticbeanstalkApplicationVersions(t *testing.T, ctrl *gomock.Control
 			ApplicationVersions: []elasticbeanstalkTypes.ApplicationVersionDescription{la},
 		}, nil)
 
-	return client.Services{
+	return &client.Services{
 		Elasticbeanstalk: m,
 	}
 }

--- a/plugins/source/aws/resources/services/elasticbeanstalk/applications_mock_test.go
+++ b/plugins/source/aws/resources/services/elasticbeanstalk/applications_mock_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func buildElasticbeanstalkApplications(t *testing.T, ctrl *gomock.Controller) client.Services {
+func buildElasticbeanstalkApplications(t *testing.T, ctrl *gomock.Controller) *client.Services {
 	m := mocks.NewMockElasticbeanstalkClient(ctrl)
 
 	la := elasticbeanstalkTypes.ApplicationDescription{}
@@ -32,7 +32,7 @@ func buildElasticbeanstalkApplications(t *testing.T, ctrl *gomock.Controller) cl
 			ResourceArn:  la.ApplicationArn,
 		}, nil)
 
-	return client.Services{
+	return &client.Services{
 		Elasticbeanstalk: m,
 	}
 }

--- a/plugins/source/aws/resources/services/elasticbeanstalk/envrionments_mock_test.go
+++ b/plugins/source/aws/resources/services/elasticbeanstalk/envrionments_mock_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func buildElasticbeanstalkEnvironments(t *testing.T, ctrl *gomock.Controller) client.Services {
+func buildElasticbeanstalkEnvironments(t *testing.T, ctrl *gomock.Controller) *client.Services {
 	m := mocks.NewMockElasticbeanstalkClient(ctrl)
 
 	la := elasticbeanstalkTypes.ApplicationDescription{}
@@ -42,7 +42,7 @@ func buildElasticbeanstalkEnvironments(t *testing.T, ctrl *gomock.Controller) cl
 	require.NoError(t, faker.FakeObject(&configOptsOutput))
 	m.EXPECT().DescribeConfigurationOptions(gomock.Any(), gomock.Any(), gomock.Any()).Return(&configOptsOutput, nil)
 
-	return client.Services{
+	return &client.Services{
 		Elasticbeanstalk: m,
 	}
 }

--- a/plugins/source/aws/resources/services/elasticsearch/domains_mock_test.go
+++ b/plugins/source/aws/resources/services/elasticsearch/domains_mock_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func buildElasticSearchDomains(t *testing.T, ctrl *gomock.Controller) client.Services {
+func buildElasticSearchDomains(t *testing.T, ctrl *gomock.Controller) *client.Services {
 	m := mocks.NewMockElasticsearchserviceClient(ctrl)
 
 	var info types.DomainInfo
@@ -50,7 +50,7 @@ func buildElasticSearchDomains(t *testing.T, ctrl *gomock.Controller) client.Ser
 
 	m.EXPECT().ListTags(gomock.Any(), gomock.Any(), gomock.Any()).Return(&tags, nil)
 
-	return client.Services{Elasticsearchservice: m}
+	return &client.Services{Elasticsearchservice: m}
 }
 
 func TestElasticSearchDomains(t *testing.T) {

--- a/plugins/source/aws/resources/services/elasticsearch/packages_mock_test.go
+++ b/plugins/source/aws/resources/services/elasticsearch/packages_mock_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func buildElasticSearchPackages(t *testing.T, ctrl *gomock.Controller) client.Services {
+func buildElasticSearchPackages(t *testing.T, ctrl *gomock.Controller) *client.Services {
 	m := mocks.NewMockElasticsearchserviceClient(ctrl)
 
 	var pkg types.PackageDetails
@@ -25,7 +25,7 @@ func buildElasticSearchPackages(t *testing.T, ctrl *gomock.Controller) client.Se
 		nil,
 	)
 
-	return client.Services{Elasticsearchservice: m}
+	return &client.Services{Elasticsearchservice: m}
 }
 
 func TestElasticSearchPackages(t *testing.T) {

--- a/plugins/source/aws/resources/services/elasticsearch/versions_mock_test.go
+++ b/plugins/source/aws/resources/services/elasticsearch/versions_mock_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func buildElasticSearchVersions(t *testing.T, ctrl *gomock.Controller) client.Services {
+func buildElasticSearchVersions(t *testing.T, ctrl *gomock.Controller) *client.Services {
 	m := mocks.NewMockElasticsearchserviceClient(ctrl)
 
 	var versions []string
@@ -35,7 +35,7 @@ func buildElasticSearchVersions(t *testing.T, ctrl *gomock.Controller) client.Se
 		nil,
 	)
 
-	return client.Services{Elasticsearchservice: m}
+	return &client.Services{Elasticsearchservice: m}
 }
 
 func TestElasticSearchVersions(t *testing.T) {

--- a/plugins/source/aws/resources/services/elasticsearch/vpc_endpoints_mock_test.go
+++ b/plugins/source/aws/resources/services/elasticsearch/vpc_endpoints_mock_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func buildElasticSearchVpcEndpoints(t *testing.T, ctrl *gomock.Controller) client.Services {
+func buildElasticSearchVpcEndpoints(t *testing.T, ctrl *gomock.Controller) *client.Services {
 	m := mocks.NewMockElasticsearchserviceClient(ctrl)
 
 	var summary types.VpcEndpointSummary
@@ -37,7 +37,7 @@ func buildElasticSearchVpcEndpoints(t *testing.T, ctrl *gomock.Controller) clien
 		nil,
 	)
 
-	return client.Services{Elasticsearchservice: m}
+	return &client.Services{Elasticsearchservice: m}
 }
 
 func TestElasticSearchVpcEndpoints(t *testing.T) {

--- a/plugins/source/aws/resources/services/elastictranscoder/pipelines_mock_test.go
+++ b/plugins/source/aws/resources/services/elastictranscoder/pipelines_mock_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func buildElastictranscoderPipelinesMock(t *testing.T, ctrl *gomock.Controller) client.Services {
+func buildElastictranscoderPipelinesMock(t *testing.T, ctrl *gomock.Controller) *client.Services {
 	m := mocks.NewMockElastictranscoderClient(ctrl)
 
 	pipeline := types.Pipeline{}
@@ -33,7 +33,7 @@ func buildElastictranscoderPipelinesMock(t *testing.T, ctrl *gomock.Controller) 
 		nil,
 	)
 
-	return client.Services{
+	return &client.Services{
 		Elastictranscoder: m,
 	}
 }

--- a/plugins/source/aws/resources/services/elastictranscoder/presets_mock_test.go
+++ b/plugins/source/aws/resources/services/elastictranscoder/presets_mock_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func buildElastictranscoderPresetsMock(t *testing.T, ctrl *gomock.Controller) client.Services {
+func buildElastictranscoderPresetsMock(t *testing.T, ctrl *gomock.Controller) *client.Services {
 	m := mocks.NewMockElastictranscoderClient(ctrl)
 	object := types.Preset{}
 	require.NoError(t, faker.FakeObject(&object))
@@ -22,7 +22,7 @@ func buildElastictranscoderPresetsMock(t *testing.T, ctrl *gomock.Controller) cl
 		nil,
 	)
 
-	return client.Services{
+	return &client.Services{
 		Elastictranscoder: m,
 	}
 }

--- a/plugins/source/aws/resources/services/elbv1/load_balancers_mock_test.go
+++ b/plugins/source/aws/resources/services/elbv1/load_balancers_mock_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func buildElbv1LoadBalancers(t *testing.T, ctrl *gomock.Controller) client.Services {
+func buildElbv1LoadBalancers(t *testing.T, ctrl *gomock.Controller) *client.Services {
 	m := mocks.NewMockElasticloadbalancingClient(ctrl)
 	l := elbv1Types.LoadBalancerDescription{}
 	require.NoError(t, faker.FakeObject(&l))
@@ -49,7 +49,7 @@ func buildElbv1LoadBalancers(t *testing.T, ctrl *gomock.Controller) client.Servi
 			PolicyDescriptions: []elbv1Types.PolicyDescription{p},
 		}, nil)
 
-	return client.Services{
+	return &client.Services{
 		Elasticloadbalancing: m,
 	}
 }

--- a/plugins/source/aws/resources/services/elbv2/load_balancers_mock_test.go
+++ b/plugins/source/aws/resources/services/elbv2/load_balancers_mock_test.go
@@ -14,7 +14,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func buildLoadBalancers(t *testing.T, ctrl *gomock.Controller) client.Services {
+func buildLoadBalancers(t *testing.T, ctrl *gomock.Controller) *client.Services {
 	m := mocks.NewMockElasticloadbalancingv2Client(ctrl)
 	w := mocks.NewMockWafv2Client(ctrl)
 	l := elbv2Types.LoadBalancer{}
@@ -72,7 +72,7 @@ func buildLoadBalancers(t *testing.T, ctrl *gomock.Controller) client.Services {
 		Rules: []elbv2Types.Rule{r},
 	}, nil)
 
-	return client.Services{
+	return &client.Services{
 		Elasticloadbalancingv2: m,
 		Wafv2:                  w,
 	}

--- a/plugins/source/aws/resources/services/elbv2/target_groups_mock_test.go
+++ b/plugins/source/aws/resources/services/elbv2/target_groups_mock_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func buildTargetGroups(t *testing.T, ctrl *gomock.Controller) client.Services {
+func buildTargetGroups(t *testing.T, ctrl *gomock.Controller) *client.Services {
 	m := mocks.NewMockElasticloadbalancingv2Client(ctrl)
 	l := elbv2Types.TargetGroup{}
 	require.NoError(t, faker.FakeObject(&l))
@@ -29,7 +29,7 @@ func buildTargetGroups(t *testing.T, ctrl *gomock.Controller) client.Services {
 	th := elasticloadbalancingv2.DescribeTargetHealthOutput{}
 	require.NoError(t, faker.FakeObject(&th))
 	m.EXPECT().DescribeTargetHealth(gomock.Any(), gomock.Any(), gomock.Any()).Return(&th, nil)
-	return client.Services{
+	return &client.Services{
 		Elasticloadbalancingv2: m,
 	}
 }

--- a/plugins/source/aws/resources/services/emr/block_public_access_configs_mock_test.go
+++ b/plugins/source/aws/resources/services/emr/block_public_access_configs_mock_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/golang/mock/gomock"
 )
 
-func buildEMRClient(t *testing.T, ctrl *gomock.Controller) client.Services {
+func buildEMRClient(t *testing.T, ctrl *gomock.Controller) *client.Services {
 	emrmock := mocks.NewMockEmrClient(ctrl)
 
 	out := &emr.GetBlockPublicAccessConfigurationOutput{
@@ -39,7 +39,7 @@ func buildEMRClient(t *testing.T, ctrl *gomock.Controller) client.Services {
 		&emr.GetBlockPublicAccessConfigurationInput{},
 		gomock.Any(),
 	).Return(out, nil)
-	return client.Services{Emr: emrmock}
+	return &client.Services{Emr: emrmock}
 }
 
 func TestEMRBlockPublicAccessConfigs(t *testing.T) {

--- a/plugins/source/aws/resources/services/emr/clusters_mock_test.go
+++ b/plugins/source/aws/resources/services/emr/clusters_mock_test.go
@@ -13,7 +13,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func buildEMRClusters(t *testing.T, ctrl *gomock.Controller) client.Services {
+func buildEMRClusters(t *testing.T, ctrl *gomock.Controller) *client.Services {
 	mock := mocks.NewMockEmrClient(ctrl)
 	var summary1 types.ClusterSummary
 	require.NoError(t, faker.FakeObject(&summary1))
@@ -130,7 +130,7 @@ func buildEMRClusters(t *testing.T, ctrl *gomock.Controller) client.Services {
 		nil,
 	)
 
-	return client.Services{Emr: mock}
+	return &client.Services{Emr: mock}
 }
 
 func TestEMRClusters(t *testing.T) {

--- a/plugins/source/aws/resources/services/emr/release_labels_test.go
+++ b/plugins/source/aws/resources/services/emr/release_labels_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func buildReleaseLabels(t *testing.T, ctrl *gomock.Controller) client.Services {
+func buildReleaseLabels(t *testing.T, ctrl *gomock.Controller) *client.Services {
 	mock := mocks.NewMockEmrClient(ctrl)
 
 	releaseLabels := []string{"emr-6.0.0", "emr-5.0.0"}
@@ -45,7 +45,7 @@ func buildReleaseLabels(t *testing.T, ctrl *gomock.Controller) client.Services {
 		)
 	}
 
-	return client.Services{Emr: mock}
+	return &client.Services{Emr: mock}
 }
 
 func TestReleaseLabels(t *testing.T) {

--- a/plugins/source/aws/resources/services/emr/security_configuration_test.go
+++ b/plugins/source/aws/resources/services/emr/security_configuration_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func buildSecurityConfigurations(t *testing.T, ctrl *gomock.Controller) client.Services {
+func buildSecurityConfigurations(t *testing.T, ctrl *gomock.Controller) *client.Services {
 	mock := mocks.NewMockEmrClient(ctrl)
 	var summary types.SecurityConfigurationSummary
 	require.NoError(t, faker.FakeObject(&summary))
@@ -27,7 +27,7 @@ func buildSecurityConfigurations(t *testing.T, ctrl *gomock.Controller) client.S
 		&emr.DescribeSecurityConfigurationOutput{CreationDateTime: summary.CreationDateTime, Name: summary.Name, SecurityConfiguration: &configString},
 		nil,
 	)
-	return client.Services{Emr: mock}
+	return &client.Services{Emr: mock}
 }
 
 func TestSecurityConfigurations(t *testing.T) {

--- a/plugins/source/aws/resources/services/emr/studios_test.go
+++ b/plugins/source/aws/resources/services/emr/studios_test.go
@@ -1,6 +1,8 @@
 package emr
 
 import (
+	"testing"
+
 	"github.com/aws/aws-sdk-go-v2/service/emr"
 	"github.com/aws/aws-sdk-go-v2/service/emr/types"
 	"github.com/cloudquery/cloudquery/plugins/source/aws/client"
@@ -8,10 +10,9 @@ import (
 	"github.com/cloudquery/plugin-sdk/v4/faker"
 	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/require"
-	"testing"
 )
 
-func buildStudios(t *testing.T, ctrl *gomock.Controller) client.Services {
+func buildStudios(t *testing.T, ctrl *gomock.Controller) *client.Services {
 	mock := mocks.NewMockEmrClient(ctrl)
 	var summary types.StudioSummary
 	require.NoError(t, faker.FakeObject(&summary))
@@ -48,7 +49,7 @@ func buildStudios(t *testing.T, ctrl *gomock.Controller) client.Services {
 		nil,
 	)
 
-	return client.Services{Emr: mock}
+	return &client.Services{Emr: mock}
 }
 
 func TestStudios(t *testing.T) {

--- a/plugins/source/aws/resources/services/eventbridge/api_destinations_mock_test.go
+++ b/plugins/source/aws/resources/services/eventbridge/api_destinations_mock_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func buildEventbridgeApiDestinationsMock(t *testing.T, ctrl *gomock.Controller) client.Services {
+func buildEventbridgeApiDestinationsMock(t *testing.T, ctrl *gomock.Controller) *client.Services {
 	m := mocks.NewMockEventbridgeClient(ctrl)
 	object := types.ApiDestination{}
 	require.NoError(t, faker.FakeObject(&object))
@@ -25,7 +25,7 @@ func buildEventbridgeApiDestinationsMock(t *testing.T, ctrl *gomock.Controller) 
 	tagsOutput := eventbridge.ListTagsForResourceOutput{}
 	require.NoError(t, faker.FakeObject(&tagsOutput))
 	m.EXPECT().ListTagsForResource(gomock.Any(), gomock.Any(), gomock.Any()).Return(&tagsOutput, nil).AnyTimes()
-	return client.Services{
+	return &client.Services{
 		Eventbridge: m,
 	}
 }

--- a/plugins/source/aws/resources/services/eventbridge/archives_mock_test.go
+++ b/plugins/source/aws/resources/services/eventbridge/archives_mock_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func buildEventbridgeArchivesMock(t *testing.T, ctrl *gomock.Controller) client.Services {
+func buildEventbridgeArchivesMock(t *testing.T, ctrl *gomock.Controller) *client.Services {
 	m := mocks.NewMockEventbridgeClient(ctrl)
 	object := types.Archive{}
 	require.NoError(t, faker.FakeObject(&object))
@@ -25,7 +25,7 @@ func buildEventbridgeArchivesMock(t *testing.T, ctrl *gomock.Controller) client.
 	tagsOutput := eventbridge.ListTagsForResourceOutput{}
 	require.NoError(t, faker.FakeObject(&tagsOutput))
 	m.EXPECT().ListTagsForResource(gomock.Any(), gomock.Any(), gomock.Any()).Return(&tagsOutput, nil).AnyTimes()
-	return client.Services{
+	return &client.Services{
 		Eventbridge: m,
 	}
 }

--- a/plugins/source/aws/resources/services/eventbridge/connections_mock_test.go
+++ b/plugins/source/aws/resources/services/eventbridge/connections_mock_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func buildEventbridgeConnectionsMock(t *testing.T, ctrl *gomock.Controller) client.Services {
+func buildEventbridgeConnectionsMock(t *testing.T, ctrl *gomock.Controller) *client.Services {
 	m := mocks.NewMockEventbridgeClient(ctrl)
 	object := types.Connection{}
 	require.NoError(t, faker.FakeObject(&object))
@@ -25,7 +25,7 @@ func buildEventbridgeConnectionsMock(t *testing.T, ctrl *gomock.Controller) clie
 	tagsOutput := eventbridge.ListTagsForResourceOutput{}
 	require.NoError(t, faker.FakeObject(&tagsOutput))
 	m.EXPECT().ListTagsForResource(gomock.Any(), gomock.Any(), gomock.Any()).Return(&tagsOutput, nil).AnyTimes()
-	return client.Services{
+	return &client.Services{
 		Eventbridge: m,
 	}
 }

--- a/plugins/source/aws/resources/services/eventbridge/endpoints_mock_test.go
+++ b/plugins/source/aws/resources/services/eventbridge/endpoints_mock_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func buildEventbridgeEndpointsMock(t *testing.T, ctrl *gomock.Controller) client.Services {
+func buildEventbridgeEndpointsMock(t *testing.T, ctrl *gomock.Controller) *client.Services {
 	m := mocks.NewMockEventbridgeClient(ctrl)
 	object := types.Endpoint{}
 	require.NoError(t, faker.FakeObject(&object))
@@ -25,7 +25,7 @@ func buildEventbridgeEndpointsMock(t *testing.T, ctrl *gomock.Controller) client
 	tagsOutput := eventbridge.ListTagsForResourceOutput{}
 	require.NoError(t, faker.FakeObject(&tagsOutput))
 	m.EXPECT().ListTagsForResource(gomock.Any(), gomock.Any(), gomock.Any()).Return(&tagsOutput, nil).AnyTimes()
-	return client.Services{
+	return &client.Services{
 		Eventbridge: m,
 	}
 }

--- a/plugins/source/aws/resources/services/eventbridge/event_buses_mock_test.go
+++ b/plugins/source/aws/resources/services/eventbridge/event_buses_mock_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func buildEventBridgeEventBusesMock(t *testing.T, ctrl *gomock.Controller) client.Services {
+func buildEventBridgeEventBusesMock(t *testing.T, ctrl *gomock.Controller) *client.Services {
 	m := mocks.NewMockEventbridgeClient(ctrl)
 
 	var bus types.EventBus
@@ -42,7 +42,7 @@ func buildEventBridgeEventBusesMock(t *testing.T, ctrl *gomock.Controller) clien
 			Targets: []types.Target{target},
 		}, nil)
 
-	return client.Services{
+	return &client.Services{
 		Eventbridge: m,
 	}
 }

--- a/plugins/source/aws/resources/services/eventbridge/event_sources_mock_test.go
+++ b/plugins/source/aws/resources/services/eventbridge/event_sources_mock_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func buildEventbridgeEventSourcesMock(t *testing.T, ctrl *gomock.Controller) client.Services {
+func buildEventbridgeEventSourcesMock(t *testing.T, ctrl *gomock.Controller) *client.Services {
 	m := mocks.NewMockEventbridgeClient(ctrl)
 	object := types.EventSource{}
 	require.NoError(t, faker.FakeObject(&object))
@@ -25,7 +25,7 @@ func buildEventbridgeEventSourcesMock(t *testing.T, ctrl *gomock.Controller) cli
 	tagsOutput := eventbridge.ListTagsForResourceOutput{}
 	require.NoError(t, faker.FakeObject(&tagsOutput))
 	m.EXPECT().ListTagsForResource(gomock.Any(), gomock.Any(), gomock.Any()).Return(&tagsOutput, nil).AnyTimes()
-	return client.Services{
+	return &client.Services{
 		Eventbridge: m,
 	}
 }

--- a/plugins/source/aws/resources/services/eventbridge/replays_mock_test.go
+++ b/plugins/source/aws/resources/services/eventbridge/replays_mock_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func buildEventbridgeReplaysMock(t *testing.T, ctrl *gomock.Controller) client.Services {
+func buildEventbridgeReplaysMock(t *testing.T, ctrl *gomock.Controller) *client.Services {
 	m := mocks.NewMockEventbridgeClient(ctrl)
 
 	var object types.Replay
@@ -32,7 +32,7 @@ func buildEventbridgeReplaysMock(t *testing.T, ctrl *gomock.Controller) client.S
 	require.NoError(t, faker.FakeObject(&tagsOutput))
 
 	m.EXPECT().ListTagsForResource(gomock.Any(), gomock.Any(), gomock.Any()).Return(&tagsOutput, nil).AnyTimes()
-	return client.Services{
+	return &client.Services{
 		Eventbridge: m,
 	}
 }

--- a/plugins/source/aws/resources/services/firehose/delivery_streams_mock_test.go
+++ b/plugins/source/aws/resources/services/firehose/delivery_streams_mock_test.go
@@ -13,7 +13,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func buildKinesisFirehoses(t *testing.T, ctrl *gomock.Controller) client.Services {
+func buildKinesisFirehoses(t *testing.T, ctrl *gomock.Controller) *client.Services {
 	f := mocks.NewMockFirehoseClient(ctrl)
 
 	streams := firehose.ListDeliveryStreamsOutput{}
@@ -34,7 +34,7 @@ func buildKinesisFirehoses(t *testing.T, ctrl *gomock.Controller) client.Service
 	tags.HasMoreTags = aws.Bool(false)
 	f.EXPECT().ListTagsForDeliveryStream(gomock.Any(), gomock.Any(), gomock.Any()).MinTimes(1).Return(&tags, nil)
 
-	return client.Services{
+	return &client.Services{
 		Firehose: f,
 	}
 }

--- a/plugins/source/aws/resources/services/frauddetector/batch_imports_mock_test.go
+++ b/plugins/source/aws/resources/services/frauddetector/batch_imports_mock_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func buildBatchImports(t *testing.T, ctrl *gomock.Controller) client.Services {
+func buildBatchImports(t *testing.T, ctrl *gomock.Controller) *client.Services {
 	fdClient := mocks.NewMockFrauddetectorClient(ctrl)
 
 	data := types.BatchImport{}
@@ -22,7 +22,7 @@ func buildBatchImports(t *testing.T, ctrl *gomock.Controller) client.Services {
 		&frauddetector.GetBatchImportJobsOutput{BatchImports: []types.BatchImport{data}}, nil,
 	)
 
-	return client.Services{
+	return &client.Services{
 		Frauddetector: fdClient,
 	}
 }

--- a/plugins/source/aws/resources/services/frauddetector/batch_predictions_mock_test.go
+++ b/plugins/source/aws/resources/services/frauddetector/batch_predictions_mock_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func buildBatchPredictions(t *testing.T, ctrl *gomock.Controller) client.Services {
+func buildBatchPredictions(t *testing.T, ctrl *gomock.Controller) *client.Services {
 	fdClient := mocks.NewMockFrauddetectorClient(ctrl)
 
 	data := types.BatchPrediction{}
@@ -22,7 +22,7 @@ func buildBatchPredictions(t *testing.T, ctrl *gomock.Controller) client.Service
 		&frauddetector.GetBatchPredictionJobsOutput{BatchPredictions: []types.BatchPrediction{data}}, nil,
 	)
 
-	return client.Services{
+	return &client.Services{
 		Frauddetector: fdClient,
 	}
 }

--- a/plugins/source/aws/resources/services/frauddetector/detectors_mock_test.go
+++ b/plugins/source/aws/resources/services/frauddetector/detectors_mock_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func buildDetectors(t *testing.T, ctrl *gomock.Controller) client.Services {
+func buildDetectors(t *testing.T, ctrl *gomock.Controller) *client.Services {
 	fdClient := mocks.NewMockFrauddetectorClient(ctrl)
 
 	data := types.Detector{}
@@ -25,7 +25,7 @@ func buildDetectors(t *testing.T, ctrl *gomock.Controller) client.Services {
 	buildRules(t, fdClient)
 	addTagsCall(t, fdClient)
 
-	return client.Services{
+	return &client.Services{
 		Frauddetector: fdClient,
 	}
 }

--- a/plugins/source/aws/resources/services/frauddetector/entity_types_mock_test.go
+++ b/plugins/source/aws/resources/services/frauddetector/entity_types_mock_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func buildEntityTypes(t *testing.T, ctrl *gomock.Controller) client.Services {
+func buildEntityTypes(t *testing.T, ctrl *gomock.Controller) *client.Services {
 	fdClient := mocks.NewMockFrauddetectorClient(ctrl)
 
 	data := types.EntityType{}
@@ -24,7 +24,7 @@ func buildEntityTypes(t *testing.T, ctrl *gomock.Controller) client.Services {
 
 	addTagsCall(t, fdClient)
 
-	return client.Services{
+	return &client.Services{
 		Frauddetector: fdClient,
 	}
 }

--- a/plugins/source/aws/resources/services/frauddetector/event_types_mock_test.go
+++ b/plugins/source/aws/resources/services/frauddetector/event_types_mock_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func buildEventTypes(t *testing.T, ctrl *gomock.Controller) client.Services {
+func buildEventTypes(t *testing.T, ctrl *gomock.Controller) *client.Services {
 	fdClient := mocks.NewMockFrauddetectorClient(ctrl)
 
 	data := types.EventType{}
@@ -24,7 +24,7 @@ func buildEventTypes(t *testing.T, ctrl *gomock.Controller) client.Services {
 
 	addTagsCall(t, fdClient)
 
-	return client.Services{
+	return &client.Services{
 		Frauddetector: fdClient,
 	}
 }

--- a/plugins/source/aws/resources/services/frauddetector/external_models_mock_test.go
+++ b/plugins/source/aws/resources/services/frauddetector/external_models_mock_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func buildExternalModels(t *testing.T, ctrl *gomock.Controller) client.Services {
+func buildExternalModels(t *testing.T, ctrl *gomock.Controller) *client.Services {
 	fdClient := mocks.NewMockFrauddetectorClient(ctrl)
 
 	data := types.ExternalModel{}
@@ -22,7 +22,7 @@ func buildExternalModels(t *testing.T, ctrl *gomock.Controller) client.Services 
 		&frauddetector.GetExternalModelsOutput{ExternalModels: []types.ExternalModel{data}}, nil,
 	)
 
-	return client.Services{
+	return &client.Services{
 		Frauddetector: fdClient,
 	}
 }

--- a/plugins/source/aws/resources/services/frauddetector/labels_mock_test.go
+++ b/plugins/source/aws/resources/services/frauddetector/labels_mock_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func buildLabels(t *testing.T, ctrl *gomock.Controller) client.Services {
+func buildLabels(t *testing.T, ctrl *gomock.Controller) *client.Services {
 	fdClient := mocks.NewMockFrauddetectorClient(ctrl)
 
 	data := types.Label{}
@@ -24,7 +24,7 @@ func buildLabels(t *testing.T, ctrl *gomock.Controller) client.Services {
 
 	addTagsCall(t, fdClient)
 
-	return client.Services{
+	return &client.Services{
 		Frauddetector: fdClient,
 	}
 }

--- a/plugins/source/aws/resources/services/frauddetector/models_mock_test.go
+++ b/plugins/source/aws/resources/services/frauddetector/models_mock_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func buildModels(t *testing.T, ctrl *gomock.Controller) client.Services {
+func buildModels(t *testing.T, ctrl *gomock.Controller) *client.Services {
 	fdClient := mocks.NewMockFrauddetectorClient(ctrl)
 
 	data := types.Model{}
@@ -24,7 +24,7 @@ func buildModels(t *testing.T, ctrl *gomock.Controller) client.Services {
 
 	buildModelVersions(t, fdClient)
 
-	return client.Services{
+	return &client.Services{
 		Frauddetector: fdClient,
 	}
 }

--- a/plugins/source/aws/resources/services/frauddetector/outcomes_mock_test.go
+++ b/plugins/source/aws/resources/services/frauddetector/outcomes_mock_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func buildOutcomes(t *testing.T, ctrl *gomock.Controller) client.Services {
+func buildOutcomes(t *testing.T, ctrl *gomock.Controller) *client.Services {
 	fdClient := mocks.NewMockFrauddetectorClient(ctrl)
 
 	data := types.Outcome{}
@@ -24,7 +24,7 @@ func buildOutcomes(t *testing.T, ctrl *gomock.Controller) client.Services {
 
 	addTagsCall(t, fdClient)
 
-	return client.Services{
+	return &client.Services{
 		Frauddetector: fdClient,
 	}
 }

--- a/plugins/source/aws/resources/services/frauddetector/variables_mock_test.go
+++ b/plugins/source/aws/resources/services/frauddetector/variables_mock_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func buildVariables(t *testing.T, ctrl *gomock.Controller) client.Services {
+func buildVariables(t *testing.T, ctrl *gomock.Controller) *client.Services {
 	fdClient := mocks.NewMockFrauddetectorClient(ctrl)
 
 	data := types.Variable{}
@@ -24,7 +24,7 @@ func buildVariables(t *testing.T, ctrl *gomock.Controller) client.Services {
 
 	addTagsCall(t, fdClient)
 
-	return client.Services{
+	return &client.Services{
 		Frauddetector: fdClient,
 	}
 }

--- a/plugins/source/aws/resources/services/fsx/data_repository_associations_test.go
+++ b/plugins/source/aws/resources/services/fsx/data_repository_associations_test.go
@@ -13,7 +13,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func buildDataRepoAssociationsMock(t *testing.T, ctrl *gomock.Controller) client.Services {
+func buildDataRepoAssociationsMock(t *testing.T, ctrl *gomock.Controller) *client.Services {
 	m := mocks.NewMockFsxClient(ctrl)
 
 	var a types.DataRepositoryAssociation
@@ -27,7 +27,7 @@ func buildDataRepoAssociationsMock(t *testing.T, ctrl *gomock.Controller) client
 		nil,
 	)
 
-	return client.Services{
+	return &client.Services{
 		Fsx: m,
 	}
 }

--- a/plugins/source/aws/resources/services/fsx/data_repository_tasks_test.go
+++ b/plugins/source/aws/resources/services/fsx/data_repository_tasks_test.go
@@ -13,7 +13,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func buildDataRepoTasksMock(t *testing.T, ctrl *gomock.Controller) client.Services {
+func buildDataRepoTasksMock(t *testing.T, ctrl *gomock.Controller) *client.Services {
 	m := mocks.NewMockFsxClient(ctrl)
 
 	var task types.DataRepositoryTask
@@ -27,7 +27,7 @@ func buildDataRepoTasksMock(t *testing.T, ctrl *gomock.Controller) client.Servic
 		nil,
 	)
 
-	return client.Services{
+	return &client.Services{
 		Fsx: m,
 	}
 }

--- a/plugins/source/aws/resources/services/fsx/file_caches_test.go
+++ b/plugins/source/aws/resources/services/fsx/file_caches_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func buildFileCachesMock(t *testing.T, ctrl *gomock.Controller) client.Services {
+func buildFileCachesMock(t *testing.T, ctrl *gomock.Controller) *client.Services {
 	m := mocks.NewMockFsxClient(ctrl)
 
 	var fc types.FileCache
@@ -38,7 +38,7 @@ func buildFileCachesMock(t *testing.T, ctrl *gomock.Controller) client.Services 
 		nil,
 	)
 
-	return client.Services{
+	return &client.Services{
 		Fsx: m,
 	}
 }

--- a/plugins/source/aws/resources/services/fsx/file_systems_test.go
+++ b/plugins/source/aws/resources/services/fsx/file_systems_test.go
@@ -13,7 +13,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func buildFilesystemsMock(t *testing.T, ctrl *gomock.Controller) client.Services {
+func buildFilesystemsMock(t *testing.T, ctrl *gomock.Controller) *client.Services {
 	m := mocks.NewMockFsxClient(ctrl)
 
 	var f types.FileSystem
@@ -31,7 +31,7 @@ func buildFilesystemsMock(t *testing.T, ctrl *gomock.Controller) client.Services
 		nil,
 	)
 
-	return client.Services{
+	return &client.Services{
 		Fsx: m,
 	}
 }

--- a/plugins/source/aws/resources/services/fsx/snapshots_test.go
+++ b/plugins/source/aws/resources/services/fsx/snapshots_test.go
@@ -13,7 +13,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func buildSnapshotsMock(t *testing.T, ctrl *gomock.Controller) client.Services {
+func buildSnapshotsMock(t *testing.T, ctrl *gomock.Controller) *client.Services {
 	m := mocks.NewMockFsxClient(ctrl)
 
 	var s types.Snapshot
@@ -29,7 +29,7 @@ func buildSnapshotsMock(t *testing.T, ctrl *gomock.Controller) client.Services {
 		nil,
 	)
 
-	return client.Services{
+	return &client.Services{
 		Fsx: m,
 	}
 }

--- a/plugins/source/aws/resources/services/fsx/storage_virtual_machines_test.go
+++ b/plugins/source/aws/resources/services/fsx/storage_virtual_machines_test.go
@@ -13,7 +13,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func buildStorageVmsMock(t *testing.T, ctrl *gomock.Controller) client.Services {
+func buildStorageVmsMock(t *testing.T, ctrl *gomock.Controller) *client.Services {
 	m := mocks.NewMockFsxClient(ctrl)
 
 	var vm types.StorageVirtualMachine
@@ -26,7 +26,7 @@ func buildStorageVmsMock(t *testing.T, ctrl *gomock.Controller) client.Services 
 		&fsx.DescribeStorageVirtualMachinesOutput{StorageVirtualMachines: []types.StorageVirtualMachine{vm}},
 		nil,
 	)
-	return client.Services{
+	return &client.Services{
 		Fsx: m,
 	}
 }

--- a/plugins/source/aws/resources/services/fsx/volumes_test.go
+++ b/plugins/source/aws/resources/services/fsx/volumes_test.go
@@ -13,7 +13,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func buildVolumesMock(t *testing.T, ctrl *gomock.Controller) client.Services {
+func buildVolumesMock(t *testing.T, ctrl *gomock.Controller) *client.Services {
 	m := mocks.NewMockFsxClient(ctrl)
 
 	var v types.Volume
@@ -30,7 +30,7 @@ func buildVolumesMock(t *testing.T, ctrl *gomock.Controller) client.Services {
 		nil,
 	)
 
-	return client.Services{
+	return &client.Services{
 		Fsx: m,
 	}
 }

--- a/plugins/source/aws/resources/services/glacier/data_retrieval_policies_mock_test.go
+++ b/plugins/source/aws/resources/services/glacier/data_retrieval_policies_mock_test.go
@@ -11,14 +11,14 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func buildDRPMock(t *testing.T, ctrl *gomock.Controller) client.Services {
+func buildDRPMock(t *testing.T, ctrl *gomock.Controller) *client.Services {
 	m := mocks.NewMockGlacierClient(ctrl)
 
 	p := glacier.GetDataRetrievalPolicyOutput{}
 	require.NoError(t, faker.FakeObject(&p))
 	m.EXPECT().GetDataRetrievalPolicy(gomock.Any(), gomock.Any(), gomock.Any()).Return(&p, nil)
 
-	return client.Services{
+	return &client.Services{
 		Glacier: m,
 	}
 }

--- a/plugins/source/aws/resources/services/glacier/vaults_mock_test.go
+++ b/plugins/source/aws/resources/services/glacier/vaults_mock_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func buildVaultsMock(t *testing.T, ctrl *gomock.Controller) client.Services {
+func buildVaultsMock(t *testing.T, ctrl *gomock.Controller) *client.Services {
 	m := mocks.NewMockGlacierClient(ctrl)
 
 	v := glacier.ListVaultsOutput{}
@@ -38,7 +38,7 @@ func buildVaultsMock(t *testing.T, ctrl *gomock.Controller) client.Services {
 	require.NoError(t, faker.FakeObject(&tags))
 	m.EXPECT().ListTagsForVault(gomock.Any(), gomock.Any(), gomock.Any()).Return(&tags, nil)
 
-	return client.Services{
+	return &client.Services{
 		Glacier: m,
 	}
 }

--- a/plugins/source/aws/resources/services/glue/classifiers_test.go
+++ b/plugins/source/aws/resources/services/glue/classifiers_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func buildClassifiers(t *testing.T, ctrl *gomock.Controller) client.Services {
+func buildClassifiers(t *testing.T, ctrl *gomock.Controller) *client.Services {
 	m := mocks.NewMockGlueClient(ctrl)
 
 	var c glue.GetClassifiersOutput
@@ -20,7 +20,7 @@ func buildClassifiers(t *testing.T, ctrl *gomock.Controller) client.Services {
 	c.NextToken = nil
 	m.EXPECT().GetClassifiers(gomock.Any(), gomock.Any(), gomock.Any()).Return(&c, nil)
 
-	return client.Services{
+	return &client.Services{
 		Glue: m,
 	}
 }

--- a/plugins/source/aws/resources/services/glue/connections_test.go
+++ b/plugins/source/aws/resources/services/glue/connections_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func buildConnections(t *testing.T, ctrl *gomock.Controller) client.Services {
+func buildConnections(t *testing.T, ctrl *gomock.Controller) *client.Services {
 	m := mocks.NewMockGlueClient(ctrl)
 
 	var connecions glue.GetConnectionsOutput
@@ -20,7 +20,7 @@ func buildConnections(t *testing.T, ctrl *gomock.Controller) client.Services {
 	connecions.NextToken = nil
 	m.EXPECT().GetConnections(gomock.Any(), gomock.Any(), gomock.Any()).Return(&connecions, nil)
 
-	return client.Services{
+	return &client.Services{
 		Glue: m,
 	}
 }

--- a/plugins/source/aws/resources/services/glue/crawlers_test.go
+++ b/plugins/source/aws/resources/services/glue/crawlers_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func buildCrawlers(t *testing.T, ctrl *gomock.Controller) client.Services {
+func buildCrawlers(t *testing.T, ctrl *gomock.Controller) *client.Services {
 	m := mocks.NewMockGlueClient(ctrl)
 
 	var crawler glue.GetCrawlersOutput
@@ -25,7 +25,7 @@ func buildCrawlers(t *testing.T, ctrl *gomock.Controller) client.Services {
 
 	m.EXPECT().GetTags(gomock.Any(), gomock.Any(), gomock.Any()).Return(&tags, nil)
 
-	return client.Services{
+	return &client.Services{
 		Glue: m,
 	}
 }

--- a/plugins/source/aws/resources/services/glue/databases_mock_test.go
+++ b/plugins/source/aws/resources/services/glue/databases_mock_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func buildDatabasesMock(t *testing.T, ctrl *gomock.Controller) client.Services {
+func buildDatabasesMock(t *testing.T, ctrl *gomock.Controller) *client.Services {
 	m := mocks.NewMockGlueClient(ctrl)
 
 	db := glue.GetDatabasesOutput{}
@@ -33,7 +33,7 @@ func buildDatabasesMock(t *testing.T, ctrl *gomock.Controller) client.Services {
 	require.NoError(t, faker.FakeObject(&tags))
 	m.EXPECT().GetTags(gomock.Any(), gomock.Any(), gomock.Any()).Return(&tags, nil)
 
-	return client.Services{
+	return &client.Services{
 		Glue: m,
 	}
 }

--- a/plugins/source/aws/resources/services/glue/datacatalog_encryption_settings_test.go
+++ b/plugins/source/aws/resources/services/glue/datacatalog_encryption_settings_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func buildDatacatalogEncryptionSettingsMock(t *testing.T, ctrl *gomock.Controller) client.Services {
+func buildDatacatalogEncryptionSettingsMock(t *testing.T, ctrl *gomock.Controller) *client.Services {
 	m := mocks.NewMockGlueClient(ctrl)
 
 	var s glue.GetDataCatalogEncryptionSettingsOutput
@@ -22,7 +22,7 @@ func buildDatacatalogEncryptionSettingsMock(t *testing.T, ctrl *gomock.Controlle
 		gomock.Any(),
 	).Return(&s, nil)
 
-	return client.Services{
+	return &client.Services{
 		Glue: m,
 	}
 }

--- a/plugins/source/aws/resources/services/glue/dev_endpoints_test.go
+++ b/plugins/source/aws/resources/services/glue/dev_endpoints_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func buildDevEndpointsMock(t *testing.T, ctrl *gomock.Controller) client.Services {
+func buildDevEndpointsMock(t *testing.T, ctrl *gomock.Controller) *client.Services {
 	m := mocks.NewMockGlueClient(ctrl)
 
 	var devEndpoint glue.GetDevEndpointsOutput
@@ -32,7 +32,7 @@ func buildDevEndpointsMock(t *testing.T, ctrl *gomock.Controller) client.Service
 		nil,
 	)
 
-	return client.Services{
+	return &client.Services{
 		Glue: m,
 	}
 }

--- a/plugins/source/aws/resources/services/glue/jobs_test.go
+++ b/plugins/source/aws/resources/services/glue/jobs_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func buildJobsMock(t *testing.T, ctrl *gomock.Controller) client.Services {
+func buildJobsMock(t *testing.T, ctrl *gomock.Controller) *client.Services {
 	m := mocks.NewMockGlueClient(ctrl)
 
 	node := types.CodeGenConfigurationNode{}
@@ -35,7 +35,7 @@ func buildJobsMock(t *testing.T, ctrl *gomock.Controller) client.Services {
 		nil,
 	)
 
-	return client.Services{
+	return &client.Services{
 		Glue: m,
 	}
 }

--- a/plugins/source/aws/resources/services/glue/ml_transforms_test.go
+++ b/plugins/source/aws/resources/services/glue/ml_transforms_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func buildMlTransformsMock(t *testing.T, ctrl *gomock.Controller) client.Services {
+func buildMlTransformsMock(t *testing.T, ctrl *gomock.Controller) *client.Services {
 	m := mocks.NewMockGlueClient(ctrl)
 
 	var transforms glue.GetMLTransformsOutput
@@ -41,7 +41,7 @@ func buildMlTransformsMock(t *testing.T, ctrl *gomock.Controller) client.Service
 		nil,
 	)
 
-	return client.Services{
+	return &client.Services{
 		Glue: m,
 	}
 }

--- a/plugins/source/aws/resources/services/glue/registries_test.go
+++ b/plugins/source/aws/resources/services/glue/registries_test.go
@@ -13,7 +13,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func buildRegistriesMock(t *testing.T, ctrl *gomock.Controller) client.Services {
+func buildRegistriesMock(t *testing.T, ctrl *gomock.Controller) *client.Services {
 	m := mocks.NewMockGlueClient(ctrl)
 
 	var r types.RegistryListItem
@@ -91,7 +91,7 @@ func buildRegistriesMock(t *testing.T, ctrl *gomock.Controller) client.Services 
 		gomock.Any(),
 	).Return(&sm, nil)
 
-	return client.Services{
+	return &client.Services{
 		Glue: m,
 	}
 }

--- a/plugins/source/aws/resources/services/glue/security_configurations_test.go
+++ b/plugins/source/aws/resources/services/glue/security_configurations_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func buildSecurityConfigurationsMock(t *testing.T, ctrl *gomock.Controller) client.Services {
+func buildSecurityConfigurationsMock(t *testing.T, ctrl *gomock.Controller) *client.Services {
 	m := mocks.NewMockGlueClient(ctrl)
 
 	var s glue.GetSecurityConfigurationsOutput
@@ -23,7 +23,7 @@ func buildSecurityConfigurationsMock(t *testing.T, ctrl *gomock.Controller) clie
 		gomock.Any(),
 	).Return(&s, nil)
 
-	return client.Services{
+	return &client.Services{
 		Glue: m,
 	}
 }

--- a/plugins/source/aws/resources/services/glue/triggers_test.go
+++ b/plugins/source/aws/resources/services/glue/triggers_test.go
@@ -13,7 +13,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func buildTriggersMock(t *testing.T, ctrl *gomock.Controller) client.Services {
+func buildTriggersMock(t *testing.T, ctrl *gomock.Controller) *client.Services {
 	m := mocks.NewMockGlueClient(ctrl)
 
 	var name string
@@ -48,7 +48,7 @@ func buildTriggersMock(t *testing.T, ctrl *gomock.Controller) client.Services {
 		nil,
 	)
 
-	return client.Services{
+	return &client.Services{
 		Glue: m,
 	}
 }

--- a/plugins/source/aws/resources/services/glue/workflows_test.go
+++ b/plugins/source/aws/resources/services/glue/workflows_test.go
@@ -13,7 +13,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func buildWorkflowsMock(t *testing.T, ctrl *gomock.Controller) client.Services {
+func buildWorkflowsMock(t *testing.T, ctrl *gomock.Controller) *client.Services {
 	m := mocks.NewMockGlueClient(ctrl)
 
 	var name string
@@ -48,7 +48,7 @@ func buildWorkflowsMock(t *testing.T, ctrl *gomock.Controller) client.Services {
 		nil,
 	)
 
-	return client.Services{
+	return &client.Services{
 		Glue: m,
 	}
 }

--- a/plugins/source/aws/resources/services/guardduty/detectors_mock_test.go
+++ b/plugins/source/aws/resources/services/guardduty/detectors_mock_test.go
@@ -14,7 +14,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func buildDetectors(t *testing.T, ctrl *gomock.Controller) client.Services {
+func buildDetectors(t *testing.T, ctrl *gomock.Controller) *client.Services {
 	m := mocks.NewMockGuarddutyClient(ctrl)
 
 	var d guardduty.GetDetectorOutput
@@ -86,7 +86,7 @@ func buildDetectors(t *testing.T, ctrl *gomock.Controller) client.Services {
 	m.EXPECT().ListMembers(gomock.Any(), gomock.Any(), gomock.Any()).Return(
 		&guardduty.ListMembersOutput{Members: []gdTypes.Member{member}}, nil,
 	)
-	return client.Services{
+	return &client.Services{
 		Guardduty: m,
 	}
 }

--- a/plugins/source/aws/resources/services/iam/account_authorization_details_mock_test.go
+++ b/plugins/source/aws/resources/services/iam/account_authorization_details_mock_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func buildIamAccountAuthDetails(t *testing.T, ctrl *gomock.Controller) client.Services {
+func buildIamAccountAuthDetails(t *testing.T, ctrl *gomock.Controller) *client.Services {
 	m := mocks.NewMockIamClient(ctrl)
 
 	details := &iam.GetAccountAuthorizationDetailsOutput{}
@@ -19,7 +19,7 @@ func buildIamAccountAuthDetails(t *testing.T, ctrl *gomock.Controller) client.Se
 	details.Marker = nil
 	details.IsTruncated = false
 	m.EXPECT().GetAccountAuthorizationDetails(gomock.Any(), gomock.Any(), gomock.Any()).Return(details, nil)
-	return client.Services{
+	return &client.Services{
 		Iam: m,
 	}
 }

--- a/plugins/source/aws/resources/services/iam/accounts_mock_test.go
+++ b/plugins/source/aws/resources/services/iam/accounts_mock_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func buildAccount(t *testing.T, ctrl *gomock.Controller) client.Services {
+func buildAccount(t *testing.T, ctrl *gomock.Controller) *client.Services {
 	m := mocks.NewMockIamClient(ctrl)
 
 	acc := struct {
@@ -58,7 +58,7 @@ func buildAccount(t *testing.T, ctrl *gomock.Controller) client.Services {
 	m.EXPECT().GetAccountSummary(gomock.Any(), gomock.Any(), gomock.Any()).Return(&iam.GetAccountSummaryOutput{SummaryMap: summaryData}, nil)
 	m.EXPECT().ListAccountAliases(gomock.Any(), gomock.Any(), gomock.Any()).Return(&iam.ListAccountAliasesOutput{AccountAliases: []string{"testAccount"}}, nil)
 
-	return client.Services{
+	return &client.Services{
 		Iam: m,
 	}
 }

--- a/plugins/source/aws/resources/services/iam/credential_reports_mock_test.go
+++ b/plugins/source/aws/resources/services/iam/credential_reports_mock_test.go
@@ -21,26 +21,26 @@ var exampleReportWithNilValues = `user,arn,user_creation_time,password_enabled,p
 user-cli,arn:aws:iam::123456789012:user/user-cli,2022-07-18T09:03:38+00:00,false,N/A,N/A,N/A,false,true,2022-08-01T13:51:50+00:00,2022-08-05T08:49:00+00:00,ap-northeast-3,glue,true,2022-08-29T08:39:55+00:00,2022-09-01T15:41:00+00:00,us-east-1,logs,false,N/A,false,N/A
 user-readonly,arn:aws:iam::123456789012:user/user-readonly,2022-08-31T11:10:33+00:00,false,N/A,N/A,N/A,false,true,2022-08-31T11:10:34+00:00,2022-08-31T11:23:00+00:00,us-east-1,iam,false,N/A,N/A,N/A,N/A,false,N/A,false,N/A`
 
-func buildCredentialReports(_ *testing.T, ctrl *gomock.Controller) client.Services {
+func buildCredentialReports(_ *testing.T, ctrl *gomock.Controller) *client.Services {
 	m := mocks.NewMockIamClient(ctrl)
 	m.EXPECT().GetCredentialReport(gomock.Any(), gomock.Any(), gomock.Any()).Return(
 		&iam.GetCredentialReportOutput{
 			Content: []byte(exampleReport),
 		}, nil)
 
-	return client.Services{
+	return &client.Services{
 		Iam: m,
 	}
 }
 
-func buildCredentialReportsWithNilValues(ctrl *gomock.Controller) client.Services {
+func buildCredentialReportsWithNilValues(ctrl *gomock.Controller) *client.Services {
 	m := mocks.NewMockIamClient(ctrl)
 	m.EXPECT().GetCredentialReport(gomock.Any(), gomock.Any(), gomock.Any()).Return(
 		&iam.GetCredentialReportOutput{
 			Content: []byte(exampleReportWithNilValues),
 		}, nil)
 
-	return client.Services{
+	return &client.Services{
 		Iam: m,
 	}
 }

--- a/plugins/source/aws/resources/services/iam/groups_mock_test.go
+++ b/plugins/source/aws/resources/services/iam/groups_mock_test.go
@@ -13,7 +13,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func buildIamGroups(t *testing.T, ctrl *gomock.Controller) client.Services {
+func buildIamGroups(t *testing.T, ctrl *gomock.Controller) *client.Services {
 	m := mocks.NewMockIamClient(ctrl)
 	g := iamTypes.Group{}
 	require.NoError(t, faker.FakeObject(&g))
@@ -53,7 +53,7 @@ func buildIamGroups(t *testing.T, ctrl *gomock.Controller) client.Services {
 		nil,
 	)
 
-	return client.Services{
+	return &client.Services{
 		Iam: m,
 	}
 }

--- a/plugins/source/aws/resources/services/iam/instance_profiles_mock_test.go
+++ b/plugins/source/aws/resources/services/iam/instance_profiles_mock_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func buildIamInstanceProfiles(t *testing.T, ctrl *gomock.Controller) client.Services {
+func buildIamInstanceProfiles(t *testing.T, ctrl *gomock.Controller) *client.Services {
 	m := mocks.NewMockIamClient(ctrl)
 	p := iamTypes.InstanceProfile{}
 	require.NoError(t, faker.FakeObject(&p))
@@ -31,7 +31,7 @@ func buildIamInstanceProfiles(t *testing.T, ctrl *gomock.Controller) client.Serv
 			},
 		}, nil)
 
-	return client.Services{
+	return &client.Services{
 		Iam: m,
 	}
 }

--- a/plugins/source/aws/resources/services/iam/openid_connect_identity_providers_mock_test.go
+++ b/plugins/source/aws/resources/services/iam/openid_connect_identity_providers_mock_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func buildIamOpenIDConnectProviders(t *testing.T, ctrl *gomock.Controller) client.Services {
+func buildIamOpenIDConnectProviders(t *testing.T, ctrl *gomock.Controller) *client.Services {
 	m := mocks.NewMockIamClient(ctrl)
 	l := iamTypes.OpenIDConnectProviderListEntry{}
 	require.NoError(t, faker.FakeObject(&l))
@@ -25,7 +25,7 @@ func buildIamOpenIDConnectProviders(t *testing.T, ctrl *gomock.Controller) clien
 	require.NoError(t, faker.FakeObject(&p))
 	m.EXPECT().GetOpenIDConnectProvider(gomock.Any(), gomock.Any(), gomock.Any()).Return(&p, nil)
 
-	return client.Services{
+	return &client.Services{
 		Iam: m,
 	}
 }

--- a/plugins/source/aws/resources/services/iam/password_policies_mock_test.go
+++ b/plugins/source/aws/resources/services/iam/password_policies_mock_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func buildIamPasswordPolicies(t *testing.T, ctrl *gomock.Controller) client.Services {
+func buildIamPasswordPolicies(t *testing.T, ctrl *gomock.Controller) *client.Services {
 	m := mocks.NewMockIamClient(ctrl)
 	g := iamTypes.PasswordPolicy{}
 	require.NoError(t, faker.FakeObject(&g))
@@ -21,7 +21,7 @@ func buildIamPasswordPolicies(t *testing.T, ctrl *gomock.Controller) client.Serv
 		&iam.GetAccountPasswordPolicyOutput{
 			PasswordPolicy: &g,
 		}, nil)
-	return client.Services{
+	return &client.Services{
 		Iam: m,
 	}
 }

--- a/plugins/source/aws/resources/services/iam/policies_mock_test.go
+++ b/plugins/source/aws/resources/services/iam/policies_mock_test.go
@@ -14,7 +14,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func buildIamPolicies(t *testing.T, ctrl *gomock.Controller) client.Services {
+func buildIamPolicies(t *testing.T, ctrl *gomock.Controller) *client.Services {
 	m := mocks.NewMockIamClient(ctrl)
 	g := iamTypes.Policy{}
 	require.NoError(t, faker.FakeObject(&g))
@@ -64,7 +64,7 @@ func buildIamPolicies(t *testing.T, ctrl *gomock.Controller) client.Services {
 		nil,
 	)
 
-	return client.Services{
+	return &client.Services{
 		Iam: m,
 	}
 }

--- a/plugins/source/aws/resources/services/iam/roles_mock_test.go
+++ b/plugins/source/aws/resources/services/iam/roles_mock_test.go
@@ -13,7 +13,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func buildRoles(t *testing.T, ctrl *gomock.Controller) client.Services {
+func buildRoles(t *testing.T, ctrl *gomock.Controller) *client.Services {
 	m := mocks.NewMockIamClient(ctrl)
 	r := iamTypes.Role{}
 	require.NoError(t, faker.FakeObject(&r))
@@ -64,7 +64,7 @@ func buildRoles(t *testing.T, ctrl *gomock.Controller) client.Services {
 		nil,
 	)
 
-	return client.Services{
+	return &client.Services{
 		Iam: m,
 	}
 }

--- a/plugins/source/aws/resources/services/iam/saml_identity_providers_mock_test.go
+++ b/plugins/source/aws/resources/services/iam/saml_identity_providers_mock_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func buildIamSAMLProviders(t *testing.T, ctrl *gomock.Controller) client.Services {
+func buildIamSAMLProviders(t *testing.T, ctrl *gomock.Controller) *client.Services {
 	m := mocks.NewMockIamClient(ctrl)
 	l := iamTypes.SAMLProviderListEntry{}
 	require.NoError(t, faker.FakeObject(&l))
@@ -25,7 +25,7 @@ func buildIamSAMLProviders(t *testing.T, ctrl *gomock.Controller) client.Service
 	require.NoError(t, faker.FakeObject(&p))
 	m.EXPECT().GetSAMLProvider(gomock.Any(), gomock.Any(), gomock.Any()).Return(&p, nil)
 
-	return client.Services{
+	return &client.Services{
 		Iam: m,
 	}
 }

--- a/plugins/source/aws/resources/services/iam/server_certificates_mock_test.go
+++ b/plugins/source/aws/resources/services/iam/server_certificates_mock_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func buildIamServerCerts(t *testing.T, ctrl *gomock.Controller) client.Services {
+func buildIamServerCerts(t *testing.T, ctrl *gomock.Controller) *client.Services {
 	m := mocks.NewMockIamClient(ctrl)
 	u := iamTypes.ServerCertificateMetadata{}
 	require.NoError(t, faker.FakeObject(&u))
@@ -22,7 +22,7 @@ func buildIamServerCerts(t *testing.T, ctrl *gomock.Controller) client.Services 
 			ServerCertificateMetadataList: []iamTypes.ServerCertificateMetadata{u},
 		}, nil)
 
-	return client.Services{
+	return &client.Services{
 		Iam: m,
 	}
 }

--- a/plugins/source/aws/resources/services/iam/users_mock_test.go
+++ b/plugins/source/aws/resources/services/iam/users_mock_test.go
@@ -13,7 +13,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func buildIamUsers(t *testing.T, ctrl *gomock.Controller) client.Services {
+func buildIamUsers(t *testing.T, ctrl *gomock.Controller) *client.Services {
 	m := mocks.NewMockIamClient(ctrl)
 	u := types.User{}
 	require.NoError(t, faker.FakeObject(&u))
@@ -90,7 +90,7 @@ func buildIamUsers(t *testing.T, ctrl *gomock.Controller) client.Services {
 		nil,
 	)
 
-	return client.Services{
+	return &client.Services{
 		Iam: m,
 	}
 }

--- a/plugins/source/aws/resources/services/iam/virtual_mfa_devices_mock_test.go
+++ b/plugins/source/aws/resources/services/iam/virtual_mfa_devices_mock_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func buildIamVirtualMfaDevices(t *testing.T, ctrl *gomock.Controller) client.Services {
+func buildIamVirtualMfaDevices(t *testing.T, ctrl *gomock.Controller) *client.Services {
 	m := mocks.NewMockIamClient(ctrl)
 	g := iamTypes.VirtualMFADevice{}
 	require.NoError(t, faker.FakeObject(&g))
@@ -21,7 +21,7 @@ func buildIamVirtualMfaDevices(t *testing.T, ctrl *gomock.Controller) client.Ser
 		&iam.ListVirtualMFADevicesOutput{
 			VirtualMFADevices: []iamTypes.VirtualMFADevice{g},
 		}, nil)
-	return client.Services{
+	return &client.Services{
 		Iam: m,
 	}
 }

--- a/plugins/source/aws/resources/services/identitystore/groups_mock_test.go
+++ b/plugins/source/aws/resources/services/identitystore/groups_mock_test.go
@@ -14,7 +14,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func buildGroups(t *testing.T, ctrl *gomock.Controller) client.Services {
+func buildGroups(t *testing.T, ctrl *gomock.Controller) *client.Services {
 	mIdentity := mocks.NewMockIdentitystoreClient(ctrl)
 	mSSOAdmin := mocks.NewMockSsoadminClient(ctrl)
 	im := types.InstanceMetadata{}
@@ -40,7 +40,7 @@ func buildGroups(t *testing.T, ctrl *gomock.Controller) client.Services {
 			GroupMemberships: []iTypes.GroupMembership{groupMembership},
 		}, nil)
 
-	return client.Services{
+	return &client.Services{
 		Ssoadmin:      mSSOAdmin,
 		Identitystore: mIdentity,
 	}

--- a/plugins/source/aws/resources/services/identitystore/users_mock_test.go
+++ b/plugins/source/aws/resources/services/identitystore/users_mock_test.go
@@ -14,7 +14,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func buildUsers(t *testing.T, ctrl *gomock.Controller) client.Services {
+func buildUsers(t *testing.T, ctrl *gomock.Controller) *client.Services {
 	mIdentity := mocks.NewMockIdentitystoreClient(ctrl)
 	mSSOAdmin := mocks.NewMockSsoadminClient(ctrl)
 	im := types.InstanceMetadata{}
@@ -31,7 +31,7 @@ func buildUsers(t *testing.T, ctrl *gomock.Controller) client.Services {
 			Users: []iTypes.User{users},
 		}, nil)
 
-	return client.Services{
+	return &client.Services{
 		Ssoadmin:      mSSOAdmin,
 		Identitystore: mIdentity,
 	}

--- a/plugins/source/aws/resources/services/inspector/findings_mock_test.go
+++ b/plugins/source/aws/resources/services/inspector/findings_mock_test.go
@@ -13,7 +13,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func buildInspectorFindings(t *testing.T, ctrl *gomock.Controller) client.Services {
+func buildInspectorFindings(t *testing.T, ctrl *gomock.Controller) *client.Services {
 	inspectorClient := mocks.NewMockInspectorClient(ctrl)
 
 	finding := types.Finding{}
@@ -28,7 +28,7 @@ func buildInspectorFindings(t *testing.T, ctrl *gomock.Controller) client.Servic
 		nil,
 	)
 
-	return client.Services{
+	return &client.Services{
 		Inspector: inspectorClient,
 	}
 }

--- a/plugins/source/aws/resources/services/inspector2/covered_resources_mock_test.go
+++ b/plugins/source/aws/resources/services/inspector2/covered_resources_mock_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func buildCoveredResources(t *testing.T, ctrl *gomock.Controller) client.Services {
+func buildCoveredResources(t *testing.T, ctrl *gomock.Controller) *client.Services {
 	inspectorClient := mocks.NewMockInspector2Client(ctrl)
 
 	coveredResource := types.CoveredResource{}
@@ -21,7 +21,7 @@ func buildCoveredResources(t *testing.T, ctrl *gomock.Controller) client.Service
 	inspectorClient.EXPECT().ListCoverage(gomock.Any(), gomock.Any(), gomock.Any()).
 		Return(&inspector2.ListCoverageOutput{CoveredResources: []types.CoveredResource{coveredResource}}, nil)
 
-	return client.Services{Inspector2: inspectorClient}
+	return &client.Services{Inspector2: inspectorClient}
 }
 
 func TestCoveredResources(t *testing.T) {

--- a/plugins/source/aws/resources/services/inspector2/findings_mock_test.go
+++ b/plugins/source/aws/resources/services/inspector2/findings_mock_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func buildFindings(t *testing.T, ctrl *gomock.Controller) client.Services {
+func buildFindings(t *testing.T, ctrl *gomock.Controller) *client.Services {
 	inspectorClient := mocks.NewMockInspector2Client(ctrl)
 
 	finding := types.Finding{}
@@ -21,7 +21,7 @@ func buildFindings(t *testing.T, ctrl *gomock.Controller) client.Services {
 	inspectorClient.EXPECT().ListFindings(gomock.Any(), gomock.Any(), gomock.Any()).
 		Return(&inspector2.ListFindingsOutput{Findings: []types.Finding{finding}}, nil)
 
-	return client.Services{Inspector2: inspectorClient}
+	return &client.Services{Inspector2: inspectorClient}
 }
 
 func TestFindings(t *testing.T) {

--- a/plugins/source/aws/resources/services/iot/billing_groups_mock_test.go
+++ b/plugins/source/aws/resources/services/iot/billing_groups_mock_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func buildIotBillingGroupsMock(t *testing.T, ctrl *gomock.Controller) client.Services {
+func buildIotBillingGroupsMock(t *testing.T, ctrl *gomock.Controller) *client.Services {
 	m := mocks.NewMockIotClient(ctrl)
 
 	groupsOutput := iot.ListBillingGroupsOutput{}
@@ -37,7 +37,7 @@ func buildIotBillingGroupsMock(t *testing.T, ctrl *gomock.Controller) client.Ser
 	m.EXPECT().ListTagsForResource(gomock.Any(), gomock.Any(), gomock.Any()).Return(
 		&tags, nil)
 
-	return client.Services{
+	return &client.Services{
 		Iot: m,
 	}
 }

--- a/plugins/source/aws/resources/services/iot/ca_certificates_mock_test.go
+++ b/plugins/source/aws/resources/services/iot/ca_certificates_mock_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func buildIotCaCertificatesMock(t *testing.T, ctrl *gomock.Controller) client.Services {
+func buildIotCaCertificatesMock(t *testing.T, ctrl *gomock.Controller) *client.Services {
 	m := mocks.NewMockIotClient(ctrl)
 
 	ca := iot.ListCACertificatesOutput{}
@@ -31,7 +31,7 @@ func buildIotCaCertificatesMock(t *testing.T, ctrl *gomock.Controller) client.Se
 	m.EXPECT().ListCertificatesByCA(gomock.Any(), gomock.Any(), gomock.Any()).Return(
 		&ct, nil)
 
-	return client.Services{
+	return &client.Services{
 		Iot: m,
 	}
 }

--- a/plugins/source/aws/resources/services/iot/certificates_mock_test.go
+++ b/plugins/source/aws/resources/services/iot/certificates_mock_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func buildIotCertificatesMock(t *testing.T, ctrl *gomock.Controller) client.Services {
+func buildIotCertificatesMock(t *testing.T, ctrl *gomock.Controller) *client.Services {
 	m := mocks.NewMockIotClient(ctrl)
 
 	certs := iot.ListCertificatesOutput{}
@@ -31,7 +31,7 @@ func buildIotCertificatesMock(t *testing.T, ctrl *gomock.Controller) client.Serv
 	m.EXPECT().ListAttachedPolicies(gomock.Any(), gomock.Any(), gomock.Any()).Return(
 		&p, nil)
 
-	return client.Services{
+	return &client.Services{
 		Iot: m,
 	}
 }

--- a/plugins/source/aws/resources/services/iot/jobs_mock_test.go
+++ b/plugins/source/aws/resources/services/iot/jobs_mock_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func buildIotJobs(t *testing.T, ctrl *gomock.Controller) client.Services {
+func buildIotJobs(t *testing.T, ctrl *gomock.Controller) *client.Services {
 	m := mocks.NewMockIotClient(ctrl)
 
 	lp := iot.ListJobsOutput{}
@@ -31,7 +31,7 @@ func buildIotJobs(t *testing.T, ctrl *gomock.Controller) client.Services {
 	m.EXPECT().ListTagsForResource(gomock.Any(), gomock.Any(), gomock.Any()).Return(
 		&tags, nil)
 
-	return client.Services{
+	return &client.Services{
 		Iot: m,
 	}
 }

--- a/plugins/source/aws/resources/services/iot/policies_mock_test.go
+++ b/plugins/source/aws/resources/services/iot/policies_mock_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func buildIotPolicies(t *testing.T, ctrl *gomock.Controller) client.Services {
+func buildIotPolicies(t *testing.T, ctrl *gomock.Controller) *client.Services {
 	m := mocks.NewMockIotClient(ctrl)
 
 	lp := iot.ListPoliciesOutput{}
@@ -34,7 +34,7 @@ func buildIotPolicies(t *testing.T, ctrl *gomock.Controller) client.Services {
 	m.EXPECT().ListTagsForResource(gomock.Any(), gomock.Any(), gomock.Any()).Return(
 		&tags, nil)
 
-	return client.Services{
+	return &client.Services{
 		Iot: m,
 	}
 }

--- a/plugins/source/aws/resources/services/iot/security_profiles_mock_test.go
+++ b/plugins/source/aws/resources/services/iot/security_profiles_mock_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func buildIotSecurityProfilesMock(t *testing.T, ctrl *gomock.Controller) client.Services {
+func buildIotSecurityProfilesMock(t *testing.T, ctrl *gomock.Controller) *client.Services {
 	m := mocks.NewMockIotClient(ctrl)
 
 	sp := iot.ListSecurityProfilesOutput{}
@@ -38,7 +38,7 @@ func buildIotSecurityProfilesMock(t *testing.T, ctrl *gomock.Controller) client.
 	m.EXPECT().ListTagsForResource(gomock.Any(), gomock.Any(), gomock.Any()).Return(
 		&tags, nil)
 
-	return client.Services{
+	return &client.Services{
 		Iot: m,
 	}
 }

--- a/plugins/source/aws/resources/services/iot/streams_mock_test.go
+++ b/plugins/source/aws/resources/services/iot/streams_mock_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func buildIotStreamsMock(t *testing.T, ctrl *gomock.Controller) client.Services {
+func buildIotStreamsMock(t *testing.T, ctrl *gomock.Controller) *client.Services {
 	m := mocks.NewMockIotClient(ctrl)
 
 	streams := iot.ListStreamsOutput{}
@@ -25,7 +25,7 @@ func buildIotStreamsMock(t *testing.T, ctrl *gomock.Controller) client.Services 
 	m.EXPECT().DescribeStream(gomock.Any(), gomock.Any(), gomock.Any()).Return(
 		&streamOutput, nil)
 
-	return client.Services{
+	return &client.Services{
 		Iot: m,
 	}
 }

--- a/plugins/source/aws/resources/services/iot/thing_groups_mock_test.go
+++ b/plugins/source/aws/resources/services/iot/thing_groups_mock_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func buildIotThingGroupsMock(t *testing.T, ctrl *gomock.Controller) client.Services {
+func buildIotThingGroupsMock(t *testing.T, ctrl *gomock.Controller) *client.Services {
 	m := mocks.NewMockIotClient(ctrl)
 
 	groupsOutput := iot.ListThingGroupsOutput{}
@@ -43,7 +43,7 @@ func buildIotThingGroupsMock(t *testing.T, ctrl *gomock.Controller) client.Servi
 	m.EXPECT().ListTagsForResource(gomock.Any(), gomock.Any(), gomock.Any()).Return(
 		&tags, nil)
 
-	return client.Services{
+	return &client.Services{
 		Iot: m,
 	}
 }

--- a/plugins/source/aws/resources/services/iot/thing_types_mock_test.go
+++ b/plugins/source/aws/resources/services/iot/thing_types_mock_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func buildIotThingTypesMock(t *testing.T, ctrl *gomock.Controller) client.Services {
+func buildIotThingTypesMock(t *testing.T, ctrl *gomock.Controller) *client.Services {
 	m := mocks.NewMockIotClient(ctrl)
 
 	groupsOutput := iot.ListThingTypesOutput{}
@@ -26,7 +26,7 @@ func buildIotThingTypesMock(t *testing.T, ctrl *gomock.Controller) client.Servic
 	m.EXPECT().ListTagsForResource(gomock.Any(), gomock.Any(), gomock.Any()).Return(
 		&tags, nil)
 
-	return client.Services{
+	return &client.Services{
 		Iot: m,
 	}
 }

--- a/plugins/source/aws/resources/services/iot/things_mock_test.go
+++ b/plugins/source/aws/resources/services/iot/things_mock_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func buildIotThingsMock(t *testing.T, ctrl *gomock.Controller) client.Services {
+func buildIotThingsMock(t *testing.T, ctrl *gomock.Controller) *client.Services {
 	m := mocks.NewMockIotClient(ctrl)
 
 	thing := types.ThingAttribute{}
@@ -26,7 +26,7 @@ func buildIotThingsMock(t *testing.T, ctrl *gomock.Controller) client.Services {
 	m.EXPECT().ListThingPrincipals(gomock.Any(), gomock.Any(), gomock.Any()).Return(
 		&lp, nil)
 
-	return client.Services{
+	return &client.Services{
 		Iot: m,
 	}
 }

--- a/plugins/source/aws/resources/services/iot/topic_rules_mock_test.go
+++ b/plugins/source/aws/resources/services/iot/topic_rules_mock_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func buildIotTopicRules(t *testing.T, ctrl *gomock.Controller) client.Services {
+func buildIotTopicRules(t *testing.T, ctrl *gomock.Controller) *client.Services {
 	m := mocks.NewMockIotClient(ctrl)
 
 	lp := iot.ListTopicRulesOutput{}
@@ -36,7 +36,7 @@ func buildIotTopicRules(t *testing.T, ctrl *gomock.Controller) client.Services {
 	m.EXPECT().ListTagsForResource(gomock.Any(), gomock.Any(), gomock.Any()).Return(
 		&tags, nil)
 
-	return client.Services{
+	return &client.Services{
 		Iot: m,
 	}
 }

--- a/plugins/source/aws/resources/services/kafka/clusters_mock_test.go
+++ b/plugins/source/aws/resources/services/kafka/clusters_mock_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func buildKafkaClustersMock(t *testing.T, ctrl *gomock.Controller) client.Services {
+func buildKafkaClustersMock(t *testing.T, ctrl *gomock.Controller) *client.Services {
 	m := mocks.NewMockKafkaClient(ctrl)
 	object := types.Cluster{}
 	require.NoError(t, faker.FakeObject(&object))
@@ -33,7 +33,7 @@ func buildKafkaClustersMock(t *testing.T, ctrl *gomock.Controller) client.Servic
 	require.NoError(t, faker.FakeObject(&tagsOutput))
 	m.EXPECT().ListTagsForResource(gomock.Any(), gomock.Any(), gomock.Any()).Return(&tagsOutput, nil).AnyTimes()
 
-	return client.Services{
+	return &client.Services{
 		Kafka: m,
 	}
 }

--- a/plugins/source/aws/resources/services/kafka/configurations_mock_test.go
+++ b/plugins/source/aws/resources/services/kafka/configurations_mock_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func buildKafkaConfigurationsMock(t *testing.T, ctrl *gomock.Controller) client.Services {
+func buildKafkaConfigurationsMock(t *testing.T, ctrl *gomock.Controller) *client.Services {
 	m := mocks.NewMockKafkaClient(ctrl)
 	object := types.Configuration{}
 	require.NoError(t, faker.FakeObject(&object))
@@ -25,7 +25,7 @@ func buildKafkaConfigurationsMock(t *testing.T, ctrl *gomock.Controller) client.
 	tagsOutput := kafka.ListTagsForResourceOutput{}
 	require.NoError(t, faker.FakeObject(&tagsOutput))
 	m.EXPECT().ListTagsForResource(gomock.Any(), gomock.Any(), gomock.Any()).Return(&tagsOutput, nil).AnyTimes()
-	return client.Services{
+	return &client.Services{
 		Kafka: m,
 	}
 }

--- a/plugins/source/aws/resources/services/kinesis/streams_mock_test.go
+++ b/plugins/source/aws/resources/services/kinesis/streams_mock_test.go
@@ -28,7 +28,7 @@ type customKinesisClient struct {
 	StreamStatus            types.StreamStatus
 }
 
-func buildKinesisStreams(t *testing.T, ctrl *gomock.Controller) client.Services {
+func buildKinesisStreams(t *testing.T, ctrl *gomock.Controller) *client.Services {
 	k := mocks.NewMockKinesisClient(ctrl)
 
 	streams := kinesis.ListStreamsOutput{}
@@ -62,7 +62,7 @@ func buildKinesisStreams(t *testing.T, ctrl *gomock.Controller) client.Services 
 	tags.HasMoreTags = aws.Bool(false)
 	k.EXPECT().ListTagsForStream(gomock.Any(), gomock.Any(), gomock.Any()).MinTimes(1).Return(&tags, nil)
 
-	return client.Services{
+	return &client.Services{
 		Kinesis: k,
 	}
 }

--- a/plugins/source/aws/resources/services/kms/aliases_mock_test.go
+++ b/plugins/source/aws/resources/services/kms/aliases_mock_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func buildKmsAliases(t *testing.T, ctrl *gomock.Controller) client.Services {
+func buildKmsAliases(t *testing.T, ctrl *gomock.Controller) *client.Services {
 	m := mocks.NewMockKmsClient(ctrl)
 
 	aliases := kms.ListAliasesOutput{}
@@ -20,7 +20,7 @@ func buildKmsAliases(t *testing.T, ctrl *gomock.Controller) client.Services {
 	m.EXPECT().ListAliases(gomock.Any(), gomock.Any(), gomock.Any()).Return(
 		&aliases, nil)
 
-	return client.Services{
+	return &client.Services{
 		Kms: m,
 	}
 }

--- a/plugins/source/aws/resources/services/kms/keys_mock_test.go
+++ b/plugins/source/aws/resources/services/kms/keys_mock_test.go
@@ -13,7 +13,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func buildKmsKeys(t *testing.T, ctrl *gomock.Controller) client.Services {
+func buildKmsKeys(t *testing.T, ctrl *gomock.Controller) *client.Services {
 	m := mocks.NewMockKmsClient(ctrl)
 
 	keyListEntry := types.KeyListEntry{}
@@ -49,7 +49,7 @@ func buildKmsKeys(t *testing.T, ctrl *gomock.Controller) client.Services {
 		PolicyName: aws.String("default"),
 	}, gomock.Any()).Return(&kms.GetKeyPolicyOutput{Policy: &pj}, nil)
 
-	return client.Services{
+	return &client.Services{
 		Kms: m,
 	}
 }

--- a/plugins/source/aws/resources/services/lambda/functions_mock_test.go
+++ b/plugins/source/aws/resources/services/lambda/functions_mock_test.go
@@ -15,7 +15,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func buildLambdaFunctionsMock(t *testing.T, ctrl *gomock.Controller) client.Services {
+func buildLambdaFunctionsMock(t *testing.T, ctrl *gomock.Controller) *client.Services {
 	m := mocks.NewMockLambdaClient(ctrl)
 
 	lastModified := "1994-11-05T08:15:30.000+0500"
@@ -109,7 +109,7 @@ func buildLambdaFunctionsMock(t *testing.T, ctrl *gomock.Controller) client.Serv
 	m.EXPECT().GetRuntimeManagementConfig(gomock.Any(), gomock.Any(), gomock.Any()).
 		Return(&runtimeManagementConfig, nil).AnyTimes()
 
-	return client.Services{
+	return &client.Services{
 		Lambda: m,
 	}
 }

--- a/plugins/source/aws/resources/services/lambda/layers_mock_test.go
+++ b/plugins/source/aws/resources/services/lambda/layers_mock_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func buildLambdaLayersMock(t *testing.T, ctrl *gomock.Controller) client.Services {
+func buildLambdaLayersMock(t *testing.T, ctrl *gomock.Controller) *client.Services {
 	m := mocks.NewMockLambdaClient(ctrl)
 
 	creationDate := "1994-11-05T08:15:30.000+0500"
@@ -40,7 +40,7 @@ func buildLambdaLayersMock(t *testing.T, ctrl *gomock.Controller) client.Service
 	m.EXPECT().GetLayerVersionPolicy(gomock.Any(), gomock.Any(), gomock.Any()).Return(
 		&lvp, nil)
 
-	return client.Services{
+	return &client.Services{
 		Lambda: m,
 	}
 }

--- a/plugins/source/aws/resources/services/lambda/runtimes_mock_test.go
+++ b/plugins/source/aws/resources/services/lambda/runtimes_mock_test.go
@@ -7,8 +7,8 @@ import (
 	"github.com/golang/mock/gomock"
 )
 
-func buildLambdaRuntimesMock(*testing.T, *gomock.Controller) client.Services {
-	return client.Services{}
+func buildLambdaRuntimesMock(*testing.T, *gomock.Controller) *client.Services {
+	return &client.Services{}
 }
 
 func TestLambdaRuntimes(t *testing.T) {

--- a/plugins/source/aws/resources/services/lightsail/alarms_mock_test.go
+++ b/plugins/source/aws/resources/services/lightsail/alarms_mock_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func buildAlarmsMock(t *testing.T, ctrl *gomock.Controller) client.Services {
+func buildAlarmsMock(t *testing.T, ctrl *gomock.Controller) *client.Services {
 	m := mocks.NewMockLightsailClient(ctrl)
 
 	b := lightsail.GetAlarmsOutput{}
@@ -20,7 +20,7 @@ func buildAlarmsMock(t *testing.T, ctrl *gomock.Controller) client.Services {
 	m.EXPECT().GetAlarms(gomock.Any(), gomock.Any(), gomock.Any()).Return(
 		&b, nil)
 
-	return client.Services{
+	return &client.Services{
 		Lightsail: m,
 	}
 }

--- a/plugins/source/aws/resources/services/lightsail/buckets_mock_test.go
+++ b/plugins/source/aws/resources/services/lightsail/buckets_mock_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func buildBucketsMock(t *testing.T, ctrl *gomock.Controller) client.Services {
+func buildBucketsMock(t *testing.T, ctrl *gomock.Controller) *client.Services {
 	m := mocks.NewMockLightsailClient(ctrl)
 
 	b := lightsail.GetBucketsOutput{}
@@ -26,7 +26,7 @@ func buildBucketsMock(t *testing.T, ctrl *gomock.Controller) client.Services {
 	m.EXPECT().GetBucketAccessKeys(gomock.Any(), gomock.Any(), gomock.Any()).Return(
 		&ac, nil)
 
-	return client.Services{
+	return &client.Services{
 		Lightsail: m,
 	}
 }

--- a/plugins/source/aws/resources/services/lightsail/certificates_mock_test.go
+++ b/plugins/source/aws/resources/services/lightsail/certificates_mock_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func buildCertificatesMock(t *testing.T, ctrl *gomock.Controller) client.Services {
+func buildCertificatesMock(t *testing.T, ctrl *gomock.Controller) *client.Services {
 	m := mocks.NewMockLightsailClient(ctrl)
 
 	b := lightsail.GetCertificatesOutput{}
@@ -19,7 +19,7 @@ func buildCertificatesMock(t *testing.T, ctrl *gomock.Controller) client.Service
 	m.EXPECT().GetCertificates(gomock.Any(), gomock.Any(), gomock.Any()).Return(
 		&b, nil)
 
-	return client.Services{
+	return &client.Services{
 		Lightsail: m,
 	}
 }

--- a/plugins/source/aws/resources/services/lightsail/container_services_mock_test.go
+++ b/plugins/source/aws/resources/services/lightsail/container_services_mock_test.go
@@ -13,7 +13,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func buildContainerServicesMock(t *testing.T, ctrl *gomock.Controller) client.Services {
+func buildContainerServicesMock(t *testing.T, ctrl *gomock.Controller) *client.Services {
 	m := mocks.NewMockLightsailClient(ctrl)
 
 	dep := types.ContainerServiceDeployment{State: "test", Containers: map[string]types.Container{"test": {Image: aws.String("test")}}}
@@ -30,7 +30,7 @@ func buildContainerServicesMock(t *testing.T, ctrl *gomock.Controller) client.Se
 	require.NoError(t, faker.FakeObject(&i))
 	m.EXPECT().GetContainerImages(gomock.Any(), gomock.Any(), gomock.Any()).Return(&i, nil)
 
-	return client.Services{
+	return &client.Services{
 		Lightsail: m,
 	}
 }

--- a/plugins/source/aws/resources/services/lightsail/database_snapshots_mock_test.go
+++ b/plugins/source/aws/resources/services/lightsail/database_snapshots_mock_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func buildDatabaseSnapshotsMock(t *testing.T, ctrl *gomock.Controller) client.Services {
+func buildDatabaseSnapshotsMock(t *testing.T, ctrl *gomock.Controller) *client.Services {
 	m := mocks.NewMockLightsailClient(ctrl)
 
 	s := lightsail.GetRelationalDatabaseSnapshotsOutput{}
@@ -20,7 +20,7 @@ func buildDatabaseSnapshotsMock(t *testing.T, ctrl *gomock.Controller) client.Se
 	m.EXPECT().GetRelationalDatabaseSnapshots(gomock.Any(), gomock.Any(), gomock.Any()).Return(
 		&s, nil)
 
-	return client.Services{
+	return &client.Services{
 		Lightsail: m,
 	}
 }

--- a/plugins/source/aws/resources/services/lightsail/databases_mock_test.go
+++ b/plugins/source/aws/resources/services/lightsail/databases_mock_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func buildDatabasesMock(t *testing.T, ctrl *gomock.Controller) client.Services {
+func buildDatabasesMock(t *testing.T, ctrl *gomock.Controller) *client.Services {
 	m := mocks.NewMockLightsailClient(ctrl)
 
 	b := lightsail.GetRelationalDatabasesOutput{}
@@ -44,7 +44,7 @@ func buildDatabasesMock(t *testing.T, ctrl *gomock.Controller) client.Services {
 	m.EXPECT().GetRelationalDatabaseLogEvents(gomock.Any(), gomock.Any(), gomock.Any()).Return(
 		&le, nil)
 
-	return client.Services{
+	return &client.Services{
 		Lightsail: m,
 	}
 }

--- a/plugins/source/aws/resources/services/lightsail/disks_mock_test.go
+++ b/plugins/source/aws/resources/services/lightsail/disks_mock_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func buildDisks(t *testing.T, ctrl *gomock.Controller) client.Services {
+func buildDisks(t *testing.T, ctrl *gomock.Controller) *client.Services {
 	mock := mocks.NewMockLightsailClient(ctrl)
 
 	var disks lightsail.GetDisksOutput
@@ -40,7 +40,7 @@ func buildDisks(t *testing.T, ctrl *gomock.Controller) client.Services {
 		nil,
 	)
 
-	return client.Services{Lightsail: mock}
+	return &client.Services{Lightsail: mock}
 }
 
 func TestLightsailDisks(t *testing.T) {

--- a/plugins/source/aws/resources/services/lightsail/distributions_mock_test.go
+++ b/plugins/source/aws/resources/services/lightsail/distributions_mock_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func buildDistributions(t *testing.T, ctrl *gomock.Controller) client.Services {
+func buildDistributions(t *testing.T, ctrl *gomock.Controller) *client.Services {
 	mock := mocks.NewMockLightsailClient(ctrl)
 
 	var d lightsail.GetDistributionsOutput
@@ -33,7 +33,7 @@ func buildDistributions(t *testing.T, ctrl *gomock.Controller) client.Services {
 		gomock.Any(),
 	).Return(&r, nil)
 
-	return client.Services{Lightsail: mock}
+	return &client.Services{Lightsail: mock}
 }
 
 func TestLightsailDistributions(t *testing.T) {

--- a/plugins/source/aws/resources/services/lightsail/instance_snapshots_mock_test.go
+++ b/plugins/source/aws/resources/services/lightsail/instance_snapshots_mock_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func buildInstanceSnapshots(t *testing.T, ctrl *gomock.Controller) client.Services {
+func buildInstanceSnapshots(t *testing.T, ctrl *gomock.Controller) *client.Services {
 	mock := mocks.NewMockLightsailClient(ctrl)
 
 	var is lightsail.GetInstanceSnapshotsOutput
@@ -25,7 +25,7 @@ func buildInstanceSnapshots(t *testing.T, ctrl *gomock.Controller) client.Servic
 		gomock.Any(),
 	).Return(&is, nil)
 
-	return client.Services{Lightsail: mock}
+	return &client.Services{Lightsail: mock}
 }
 
 func TestLightsailInstanceSnapshots(t *testing.T) {

--- a/plugins/source/aws/resources/services/lightsail/instances_mock_test.go
+++ b/plugins/source/aws/resources/services/lightsail/instances_mock_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func buildInstances(t *testing.T, ctrl *gomock.Controller) client.Services {
+func buildInstances(t *testing.T, ctrl *gomock.Controller) *client.Services {
 	mock := mocks.NewMockLightsailClient(ctrl)
 
 	var instances []types.Instance
@@ -47,7 +47,7 @@ func buildInstances(t *testing.T, ctrl *gomock.Controller) client.Services {
 		gomock.Any(),
 	).Return(&a, nil)
 
-	return client.Services{Lightsail: mock}
+	return &client.Services{Lightsail: mock}
 }
 
 func TestLightsailInstances(t *testing.T) {

--- a/plugins/source/aws/resources/services/lightsail/load_balancers_mock_test.go
+++ b/plugins/source/aws/resources/services/lightsail/load_balancers_mock_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func buildLoadBalancers(t *testing.T, ctrl *gomock.Controller) client.Services {
+func buildLoadBalancers(t *testing.T, ctrl *gomock.Controller) *client.Services {
 	mock := mocks.NewMockLightsailClient(ctrl)
 
 	var lb lightsail.GetLoadBalancersOutput
@@ -34,7 +34,7 @@ func buildLoadBalancers(t *testing.T, ctrl *gomock.Controller) client.Services {
 		gomock.Any(),
 	).Return(&lbc, nil)
 
-	return client.Services{Lightsail: mock}
+	return &client.Services{Lightsail: mock}
 }
 
 func TestLoadBalancers(t *testing.T) {

--- a/plugins/source/aws/resources/services/lightsail/static_ips_mock_test.go
+++ b/plugins/source/aws/resources/services/lightsail/static_ips_mock_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func buildStaticIps(t *testing.T, ctrl *gomock.Controller) client.Services {
+func buildStaticIps(t *testing.T, ctrl *gomock.Controller) *client.Services {
 	mock := mocks.NewMockLightsailClient(ctrl)
 
 	var ips lightsail.GetStaticIpsOutput
@@ -21,7 +21,7 @@ func buildStaticIps(t *testing.T, ctrl *gomock.Controller) client.Services {
 
 	mock.EXPECT().GetStaticIps(gomock.Any(), &lightsail.GetStaticIpsInput{}, gomock.Any()).Return(&ips, nil)
 
-	return client.Services{Lightsail: mock}
+	return &client.Services{Lightsail: mock}
 }
 
 func TestStaticIps(t *testing.T) {

--- a/plugins/source/aws/resources/services/mq/brokers_mock_test.go
+++ b/plugins/source/aws/resources/services/mq/brokers_mock_test.go
@@ -13,7 +13,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func buildMqBrokers(t *testing.T, ctrl *gomock.Controller) client.Services {
+func buildMqBrokers(t *testing.T, ctrl *gomock.Controller) *client.Services {
 	m := mocks.NewMockMqClient(ctrl)
 
 	bs := types.BrokerSummary{}
@@ -64,7 +64,7 @@ func buildMqBrokers(t *testing.T, ctrl *gomock.Controller) client.Services {
 	m.EXPECT().DescribeConfigurationRevision(gomock.Any(), gomock.Any(), gomock.Any()).Return(
 		&revision, nil)
 
-	return client.Services{Mq: m}
+	return &client.Services{Mq: m}
 }
 
 func TestMqBrokers(t *testing.T) {

--- a/plugins/source/aws/resources/services/mwaa/environments_mock_test.go
+++ b/plugins/source/aws/resources/services/mwaa/environments_mock_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func buildMwaaEnvironments(t *testing.T, ctrl *gomock.Controller) client.Services {
+func buildMwaaEnvironments(t *testing.T, ctrl *gomock.Controller) *client.Services {
 	m := mocks.NewMockMwaaClient(ctrl)
 	g := types.Environment{}
 	require.NoError(t, faker.FakeObject(&g))
@@ -25,7 +25,7 @@ func buildMwaaEnvironments(t *testing.T, ctrl *gomock.Controller) client.Service
 		&mwaa.GetEnvironmentOutput{
 			Environment: &g,
 		}, nil)
-	return client.Services{
+	return &client.Services{
 		Mwaa: m,
 	}
 }

--- a/plugins/source/aws/resources/services/neptune/cluster_parameter_groups_mock_test.go
+++ b/plugins/source/aws/resources/services/neptune/cluster_parameter_groups_mock_test.go
@@ -13,7 +13,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func buildNeptuneClusterParameterGroups(t *testing.T, ctrl *gomock.Controller) client.Services {
+func buildNeptuneClusterParameterGroups(t *testing.T, ctrl *gomock.Controller) *client.Services {
 	mock := mocks.NewMockNeptuneClient(ctrl)
 	var g types.DBClusterParameterGroup
 	require.NoError(t, faker.FakeObject(&g))
@@ -51,7 +51,7 @@ func buildNeptuneClusterParameterGroups(t *testing.T, ctrl *gomock.Controller) c
 		&neptune.DescribeDBClusterParametersOutput{Parameters: []types.Parameter{p}},
 		nil,
 	)
-	return client.Services{Neptune: mock}
+	return &client.Services{Neptune: mock}
 }
 
 func TestNeptuneClusterParameterGroups(t *testing.T) {

--- a/plugins/source/aws/resources/services/neptune/cluster_snapshots_mock_test.go
+++ b/plugins/source/aws/resources/services/neptune/cluster_snapshots_mock_test.go
@@ -13,7 +13,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func buildNeptuneClientForClusterSnapshots(t *testing.T, ctrl *gomock.Controller) client.Services {
+func buildNeptuneClientForClusterSnapshots(t *testing.T, ctrl *gomock.Controller) *client.Services {
 	mock := mocks.NewMockNeptuneClient(ctrl)
 
 	var s types.DBClusterSnapshot
@@ -55,7 +55,7 @@ func buildNeptuneClientForClusterSnapshots(t *testing.T, ctrl *gomock.Controller
 		nil,
 	)
 
-	return client.Services{Neptune: mock}
+	return &client.Services{Neptune: mock}
 }
 
 func TestNeptuneDBClusterSnapshots(t *testing.T) {

--- a/plugins/source/aws/resources/services/neptune/db_parameter_groups_mock_test.go
+++ b/plugins/source/aws/resources/services/neptune/db_parameter_groups_mock_test.go
@@ -13,7 +13,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func buildNeptuneDBParameterGroups(t *testing.T, ctrl *gomock.Controller) client.Services {
+func buildNeptuneDBParameterGroups(t *testing.T, ctrl *gomock.Controller) *client.Services {
 	mock := mocks.NewMockNeptuneClient(ctrl)
 	var g types.DBParameterGroup
 	require.NoError(t, faker.FakeObject(&g))
@@ -51,7 +51,7 @@ func buildNeptuneDBParameterGroups(t *testing.T, ctrl *gomock.Controller) client
 		&neptune.DescribeDBParametersOutput{Parameters: []types.Parameter{p}},
 		nil,
 	)
-	return client.Services{Neptune: mock}
+	return &client.Services{Neptune: mock}
 }
 
 func TestNeptuneDBParameterGroups(t *testing.T) {

--- a/plugins/source/aws/resources/services/neptune/event_subscriptions_mock_test.go
+++ b/plugins/source/aws/resources/services/neptune/event_subscriptions_mock_test.go
@@ -13,7 +13,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func buildNeptuneEventSubscriptions(t *testing.T, ctrl *gomock.Controller) client.Services {
+func buildNeptuneEventSubscriptions(t *testing.T, ctrl *gomock.Controller) *client.Services {
 	mock := mocks.NewMockNeptuneClient(ctrl)
 	var s types.EventSubscription
 	require.NoError(t, faker.FakeObject(&s))
@@ -35,7 +35,7 @@ func buildNeptuneEventSubscriptions(t *testing.T, ctrl *gomock.Controller) clien
 		},
 		nil,
 	)
-	return client.Services{Neptune: mock}
+	return &client.Services{Neptune: mock}
 }
 
 func TestNeptuneEventSubscriptions(t *testing.T) {

--- a/plugins/source/aws/resources/services/neptune/global_clusters_mock_test.go
+++ b/plugins/source/aws/resources/services/neptune/global_clusters_mock_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func buildNeptuneGlobalClusters(t *testing.T, ctrl *gomock.Controller) client.Services {
+func buildNeptuneGlobalClusters(t *testing.T, ctrl *gomock.Controller) *client.Services {
 	mock := mocks.NewMockNeptuneClient(ctrl)
 	var gc types.GlobalCluster
 	require.NoError(t, faker.FakeObject(&gc))
@@ -21,7 +21,7 @@ func buildNeptuneGlobalClusters(t *testing.T, ctrl *gomock.Controller) client.Se
 		&neptune.DescribeGlobalClustersOutput{GlobalClusters: []types.GlobalCluster{gc}},
 		nil,
 	)
-	return client.Services{Neptune: mock}
+	return &client.Services{Neptune: mock}
 }
 
 func TestNeptuneGlobalCluster(t *testing.T) {

--- a/plugins/source/aws/resources/services/neptune/mock_test.go
+++ b/plugins/source/aws/resources/services/neptune/mock_test.go
@@ -13,7 +13,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func buildNeptuneDBClusters(t *testing.T, ctrl *gomock.Controller) client.Services {
+func buildNeptuneDBClusters(t *testing.T, ctrl *gomock.Controller) *client.Services {
 	m := mocks.NewMockNeptuneClient(ctrl)
 	l := types.DBCluster{}
 	require.NoError(t, faker.FakeObject(&l))
@@ -32,12 +32,12 @@ func buildNeptuneDBClusters(t *testing.T, ctrl *gomock.Controller) client.Servic
 		},
 		nil,
 	)
-	return client.Services{
+	return &client.Services{
 		Neptune: m,
 	}
 }
 
-func buildNeptuneDBInstances(t *testing.T, ctrl *gomock.Controller) client.Services {
+func buildNeptuneDBInstances(t *testing.T, ctrl *gomock.Controller) *client.Services {
 	m := mocks.NewMockNeptuneClient(ctrl)
 	l := types.DBInstance{}
 	require.NoError(t, faker.FakeObject(&l))
@@ -57,12 +57,12 @@ func buildNeptuneDBInstances(t *testing.T, ctrl *gomock.Controller) client.Servi
 		nil,
 	)
 
-	return client.Services{
+	return &client.Services{
 		Neptune: m,
 	}
 }
 
-func buildNeptuneDBSubnetGroups(t *testing.T, ctrl *gomock.Controller) client.Services {
+func buildNeptuneDBSubnetGroups(t *testing.T, ctrl *gomock.Controller) *client.Services {
 	m := mocks.NewMockNeptuneClient(ctrl)
 	l := types.DBSubnetGroup{}
 	require.NoError(t, faker.FakeObject(&l))
@@ -82,7 +82,7 @@ func buildNeptuneDBSubnetGroups(t *testing.T, ctrl *gomock.Controller) client.Se
 		},
 		nil,
 	)
-	return client.Services{
+	return &client.Services{
 		Neptune: m,
 	}
 }

--- a/plugins/source/aws/resources/services/networkfirewall/firewall_policies_mock_test.go
+++ b/plugins/source/aws/resources/services/networkfirewall/firewall_policies_mock_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func buildFirewallPoliciesMock(t *testing.T, ctrl *gomock.Controller) client.Services {
+func buildFirewallPoliciesMock(t *testing.T, ctrl *gomock.Controller) *client.Services {
 	m := mocks.NewMockNetworkfirewallClient(ctrl)
 	fpm := types.FirewallPolicyMetadata{}
 	require.NoError(t, faker.FakeObject(&fpm))
@@ -27,7 +27,7 @@ func buildFirewallPoliciesMock(t *testing.T, ctrl *gomock.Controller) client.Ser
 
 	m.EXPECT().DescribeFirewallPolicy(gomock.Any(), gomock.Any(), gomock.Any()).Return(&fp, nil)
 
-	return client.Services{
+	return &client.Services{
 		Networkfirewall: m,
 	}
 }

--- a/plugins/source/aws/resources/services/networkfirewall/firewalls_mock_test.go
+++ b/plugins/source/aws/resources/services/networkfirewall/firewalls_mock_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func buildFirewallsMock(t *testing.T, ctrl *gomock.Controller) client.Services {
+func buildFirewallsMock(t *testing.T, ctrl *gomock.Controller) *client.Services {
 	m := mocks.NewMockNetworkfirewallClient(ctrl)
 	fm := types.FirewallMetadata{}
 	require.NoError(t, faker.FakeObject(&fm))
@@ -27,7 +27,7 @@ func buildFirewallsMock(t *testing.T, ctrl *gomock.Controller) client.Services {
 
 	m.EXPECT().DescribeFirewall(gomock.Any(), gomock.Any(), gomock.Any()).Return(&fo, nil)
 
-	return client.Services{
+	return &client.Services{
 		Networkfirewall: m,
 	}
 }

--- a/plugins/source/aws/resources/services/networkfirewall/rule_groups_mock_test.go
+++ b/plugins/source/aws/resources/services/networkfirewall/rule_groups_mock_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func buildRuleGroupsMock(t *testing.T, ctrl *gomock.Controller) client.Services {
+func buildRuleGroupsMock(t *testing.T, ctrl *gomock.Controller) *client.Services {
 	m := mocks.NewMockNetworkfirewallClient(ctrl)
 	rgm := types.RuleGroupMetadata{}
 	require.NoError(t, faker.FakeObject(&rgm))
@@ -27,7 +27,7 @@ func buildRuleGroupsMock(t *testing.T, ctrl *gomock.Controller) client.Services 
 
 	m.EXPECT().DescribeRuleGroup(gomock.Any(), gomock.Any(), gomock.Any()).Return(&rg, nil)
 
-	return client.Services{
+	return &client.Services{
 		Networkfirewall: m,
 	}
 }

--- a/plugins/source/aws/resources/services/networkfirewall/tls_inspection_configurations_mock_test.go
+++ b/plugins/source/aws/resources/services/networkfirewall/tls_inspection_configurations_mock_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func buildTLSInspectionConfigurationsMock(t *testing.T, ctrl *gomock.Controller) client.Services {
+func buildTLSInspectionConfigurationsMock(t *testing.T, ctrl *gomock.Controller) *client.Services {
 	m := mocks.NewMockNetworkfirewallClient(ctrl)
 	ticm := types.TLSInspectionConfigurationMetadata{}
 	require.NoError(t, faker.FakeObject(&ticm))
@@ -27,7 +27,7 @@ func buildTLSInspectionConfigurationsMock(t *testing.T, ctrl *gomock.Controller)
 
 	m.EXPECT().DescribeTLSInspectionConfiguration(gomock.Any(), gomock.Any(), gomock.Any()).Return(&tico, nil)
 
-	return client.Services{
+	return &client.Services{
 		Networkfirewall: m,
 	}
 }

--- a/plugins/source/aws/resources/services/networkmanager/global_networks_mock_test.go
+++ b/plugins/source/aws/resources/services/networkmanager/global_networks_mock_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func buildNetworksMock(t *testing.T, ctrl *gomock.Controller) client.Services {
+func buildNetworksMock(t *testing.T, ctrl *gomock.Controller) *client.Services {
 	m := mocks.NewMockNetworkmanagerClient(ctrl)
 
 	network := types.GlobalNetwork{}
@@ -45,7 +45,7 @@ func buildNetworksMock(t *testing.T, ctrl *gomock.Controller) client.Services {
 	}, gomock.Any()).Return(
 		&networkmanager.GetTransitGatewayRegistrationsOutput{TransitGatewayRegistrations: []types.TransitGatewayRegistration{registration}}, nil)
 
-	return client.Services{Networkmanager: m}
+	return &client.Services{Networkmanager: m}
 }
 
 func TestGlobalNetworks(t *testing.T) {

--- a/plugins/source/aws/resources/services/organizations/accounts_mock_test.go
+++ b/plugins/source/aws/resources/services/organizations/accounts_mock_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func buildOrganizationsAccounts(t *testing.T, ctrl *gomock.Controller) client.Services {
+func buildOrganizationsAccounts(t *testing.T, ctrl *gomock.Controller) *client.Services {
 	m := mocks.NewMockOrganizationsClient(ctrl)
 	g := organizationsTypes.Account{}
 	require.NoError(t, faker.FakeObject(&g))
@@ -37,7 +37,7 @@ func buildOrganizationsAccounts(t *testing.T, ctrl *gomock.Controller) client.Se
 		&organizations.ListParentsOutput{
 			Parents: []organizationsTypes.Parent{p},
 		}, nil)
-	return client.Services{
+	return &client.Services{
 		Organizations: m,
 	}
 }

--- a/plugins/source/aws/resources/services/organizations/delegated_admins_mock_test.go
+++ b/plugins/source/aws/resources/services/organizations/delegated_admins_mock_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func buildDelegatedAdministrators(t *testing.T, ctrl *gomock.Controller) client.Services {
+func buildDelegatedAdministrators(t *testing.T, ctrl *gomock.Controller) *client.Services {
 	m := mocks.NewMockOrganizationsClient(ctrl)
 	da := types.DelegatedAdministrator{}
 	require.NoError(t, faker.FakeObject(&da))
@@ -29,7 +29,7 @@ func buildDelegatedAdministrators(t *testing.T, ctrl *gomock.Controller) client.
 		&organizations.ListDelegatedServicesForAccountOutput{
 			DelegatedServices: []types.DelegatedService{ds},
 		}, nil)
-	return client.Services{
+	return &client.Services{
 		Organizations: m,
 	}
 }

--- a/plugins/source/aws/resources/services/organizations/organizational_units_mock_test.go
+++ b/plugins/source/aws/resources/services/organizations/organizational_units_mock_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func buildOrganizationalUnits(t *testing.T, ctrl *gomock.Controller) client.Services {
+func buildOrganizationalUnits(t *testing.T, ctrl *gomock.Controller) *client.Services {
 	m := mocks.NewMockOrganizationsClient(ctrl)
 	g := types.Root{}
 	require.NoError(t, faker.FakeObject(&g))
@@ -46,7 +46,7 @@ func buildOrganizationalUnits(t *testing.T, ctrl *gomock.Controller) client.Serv
 			Parents: []types.Parent{p},
 		}, nil)
 
-	return client.Services{
+	return &client.Services{
 		Organizations: m,
 	}
 }

--- a/plugins/source/aws/resources/services/organizations/organizations_mock_test.go
+++ b/plugins/source/aws/resources/services/organizations/organizations_mock_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func buildOrganizations(t *testing.T, ctrl *gomock.Controller) client.Services {
+func buildOrganizations(t *testing.T, ctrl *gomock.Controller) *client.Services {
 	m := mocks.NewMockOrganizationsClient(ctrl)
 
 	o := organizations.DescribeOrganizationOutput{}
@@ -19,7 +19,7 @@ func buildOrganizations(t *testing.T, ctrl *gomock.Controller) client.Services {
 
 	m.EXPECT().DescribeOrganization(gomock.Any(), gomock.Any(), gomock.Any()).Return(&o, nil)
 
-	return client.Services{
+	return &client.Services{
 		Organizations: m,
 	}
 }

--- a/plugins/source/aws/resources/services/organizations/resource_policies_mock_test.go
+++ b/plugins/source/aws/resources/services/organizations/resource_policies_mock_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func buildResourcePolicy(t *testing.T, ctrl *gomock.Controller) client.Services {
+func buildResourcePolicy(t *testing.T, ctrl *gomock.Controller) *client.Services {
 	m := mocks.NewMockOrganizationsClient(ctrl)
 
 	o := organizations.DescribeResourcePolicyOutput{}
@@ -19,7 +19,7 @@ func buildResourcePolicy(t *testing.T, ctrl *gomock.Controller) client.Services 
 
 	m.EXPECT().DescribeResourcePolicy(gomock.Any(), gomock.Any(), gomock.Any()).Return(&o, nil)
 
-	return client.Services{
+	return &client.Services{
 		Organizations: m,
 	}
 }

--- a/plugins/source/aws/resources/services/organizations/roots_mock_test.go
+++ b/plugins/source/aws/resources/services/organizations/roots_mock_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func buildOrganizationsRoots(t *testing.T, ctrl *gomock.Controller) client.Services {
+func buildOrganizationsRoots(t *testing.T, ctrl *gomock.Controller) *client.Services {
 	m := mocks.NewMockOrganizationsClient(ctrl)
 	g := types.Root{}
 	require.NoError(t, faker.FakeObject(&g))
@@ -29,7 +29,7 @@ func buildOrganizationsRoots(t *testing.T, ctrl *gomock.Controller) client.Servi
 		&organizations.ListTagsForResourceOutput{
 			Tags: tt,
 		}, nil)
-	return client.Services{
+	return &client.Services{
 		Organizations: m,
 	}
 }

--- a/plugins/source/aws/resources/services/qldb/ledgers_mock_test.go
+++ b/plugins/source/aws/resources/services/qldb/ledgers_mock_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func buildLedgersMock(t *testing.T, ctrl *gomock.Controller) client.Services {
+func buildLedgersMock(t *testing.T, ctrl *gomock.Controller) *client.Services {
 	m := mocks.NewMockQldbClient(ctrl)
 
 	ledger := types.LedgerSummary{}
@@ -57,7 +57,7 @@ func buildLedgersMock(t *testing.T, ctrl *gomock.Controller) client.Services {
 			Streams: []types.JournalKinesisStreamDescription{ke},
 		}, nil)
 
-	return client.Services{Qldb: m}
+	return &client.Services{Qldb: m}
 }
 
 func TestQldbLedgers(t *testing.T) {

--- a/plugins/source/aws/resources/services/quicksight/analyses_mock_test.go
+++ b/plugins/source/aws/resources/services/quicksight/analyses_mock_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func buildAnalysesMock(t *testing.T, ctrl *gomock.Controller) client.Services {
+func buildAnalysesMock(t *testing.T, ctrl *gomock.Controller) *client.Services {
 	m := mocks.NewMockQuicksightClient(ctrl)
 
 	var lo quicksight.ListAnalysesOutput
@@ -30,7 +30,7 @@ func buildAnalysesMock(t *testing.T, ctrl *gomock.Controller) client.Services {
 
 	m.EXPECT().ListTagsForResource(gomock.Any(), gomock.Any(), gomock.Any()).Return(&to, nil)
 
-	return client.Services{
+	return &client.Services{
 		Quicksight: m,
 	}
 }

--- a/plugins/source/aws/resources/services/quicksight/dashboards_mock_test.go
+++ b/plugins/source/aws/resources/services/quicksight/dashboards_mock_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func buildDashboardsMock(t *testing.T, ctrl *gomock.Controller) client.Services {
+func buildDashboardsMock(t *testing.T, ctrl *gomock.Controller) *client.Services {
 	m := mocks.NewMockQuicksightClient(ctrl)
 
 	var ld quicksight.ListDashboardsOutput
@@ -25,7 +25,7 @@ func buildDashboardsMock(t *testing.T, ctrl *gomock.Controller) client.Services 
 
 	m.EXPECT().ListTagsForResource(gomock.Any(), gomock.Any(), gomock.Any()).Return(&to, nil)
 
-	return client.Services{
+	return &client.Services{
 		Quicksight: m,
 	}
 }

--- a/plugins/source/aws/resources/services/quicksight/data_sets_mock_test.go
+++ b/plugins/source/aws/resources/services/quicksight/data_sets_mock_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func buildDataSetsMock(t *testing.T, ctrl *gomock.Controller) client.Services {
+func buildDataSetsMock(t *testing.T, ctrl *gomock.Controller) *client.Services {
 	m := mocks.NewMockQuicksightClient(ctrl)
 
 	var ld quicksight.ListDataSetsOutput
@@ -36,7 +36,7 @@ func buildDataSetsMock(t *testing.T, ctrl *gomock.Controller) client.Services {
 
 	m.EXPECT().ListTagsForResource(gomock.Any(), gomock.Any(), gomock.Any()).Return(&to2, nil)
 
-	return client.Services{
+	return &client.Services{
 		Quicksight: m,
 	}
 }

--- a/plugins/source/aws/resources/services/quicksight/data_sources_mock_test.go
+++ b/plugins/source/aws/resources/services/quicksight/data_sources_mock_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func buildDataSourcesMock(t *testing.T, ctrl *gomock.Controller) client.Services {
+func buildDataSourcesMock(t *testing.T, ctrl *gomock.Controller) *client.Services {
 	m := mocks.NewMockQuicksightClient(ctrl)
 
 	var ld quicksight.ListDataSourcesOutput
@@ -25,7 +25,7 @@ func buildDataSourcesMock(t *testing.T, ctrl *gomock.Controller) client.Services
 
 	m.EXPECT().ListTagsForResource(gomock.Any(), gomock.Any(), gomock.Any()).Return(&to, nil)
 
-	return client.Services{
+	return &client.Services{
 		Quicksight: m,
 	}
 }

--- a/plugins/source/aws/resources/services/quicksight/folders_mock_test.go
+++ b/plugins/source/aws/resources/services/quicksight/folders_mock_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func buildFoldersMock(t *testing.T, ctrl *gomock.Controller) client.Services {
+func buildFoldersMock(t *testing.T, ctrl *gomock.Controller) *client.Services {
 	m := mocks.NewMockQuicksightClient(ctrl)
 
 	var lo quicksight.ListFoldersOutput
@@ -30,7 +30,7 @@ func buildFoldersMock(t *testing.T, ctrl *gomock.Controller) client.Services {
 
 	m.EXPECT().ListTagsForResource(gomock.Any(), gomock.Any(), gomock.Any()).Return(&to, nil)
 
-	return client.Services{
+	return &client.Services{
 		Quicksight: m,
 	}
 }

--- a/plugins/source/aws/resources/services/quicksight/groups_mock_test.go
+++ b/plugins/source/aws/resources/services/quicksight/groups_mock_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func buildGroupsMock(t *testing.T, ctrl *gomock.Controller) client.Services {
+func buildGroupsMock(t *testing.T, ctrl *gomock.Controller) *client.Services {
 	m := mocks.NewMockQuicksightClient(ctrl)
 
 	var lo quicksight.ListGroupsOutput
@@ -31,7 +31,7 @@ func buildGroupsMock(t *testing.T, ctrl *gomock.Controller) client.Services {
 	gm.NextToken = nil
 	m.EXPECT().ListGroupMemberships(gomock.Any(), gomock.Any(), gomock.Any()).Return(&gm, nil)
 
-	return client.Services{
+	return &client.Services{
 		Quicksight: m,
 	}
 }

--- a/plugins/source/aws/resources/services/quicksight/templates_mock_test.go
+++ b/plugins/source/aws/resources/services/quicksight/templates_mock_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func buildTemplatesMock(t *testing.T, ctrl *gomock.Controller) client.Services {
+func buildTemplatesMock(t *testing.T, ctrl *gomock.Controller) *client.Services {
 	m := mocks.NewMockQuicksightClient(ctrl)
 
 	var lo quicksight.ListTemplatesOutput
@@ -25,7 +25,7 @@ func buildTemplatesMock(t *testing.T, ctrl *gomock.Controller) client.Services {
 
 	m.EXPECT().ListTagsForResource(gomock.Any(), gomock.Any(), gomock.Any()).Return(&to, nil)
 
-	return client.Services{
+	return &client.Services{
 		Quicksight: m,
 	}
 }

--- a/plugins/source/aws/resources/services/quicksight/users_mock_test.go
+++ b/plugins/source/aws/resources/services/quicksight/users_mock_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func buildUsersMock(t *testing.T, ctrl *gomock.Controller) client.Services {
+func buildUsersMock(t *testing.T, ctrl *gomock.Controller) *client.Services {
 	m := mocks.NewMockQuicksightClient(ctrl)
 
 	var lo quicksight.ListUsersOutput
@@ -25,7 +25,7 @@ func buildUsersMock(t *testing.T, ctrl *gomock.Controller) client.Services {
 
 	m.EXPECT().ListTagsForResource(gomock.Any(), gomock.Any(), gomock.Any()).Return(&to, nil)
 
-	return client.Services{
+	return &client.Services{
 		Quicksight: m,
 	}
 }

--- a/plugins/source/aws/resources/services/ram/principals_mock_test.go
+++ b/plugins/source/aws/resources/services/ram/principals_mock_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func buildRamPrincipalsMock(t *testing.T, ctrl *gomock.Controller) client.Services {
+func buildRamPrincipalsMock(t *testing.T, ctrl *gomock.Controller) *client.Services {
 	m := mocks.NewMockRamClient(ctrl)
 	object := types.Principal{}
 	require.NoError(t, faker.FakeObject(&object))
@@ -22,7 +22,7 @@ func buildRamPrincipalsMock(t *testing.T, ctrl *gomock.Controller) client.Servic
 			Principals: []types.Principal{object},
 		}, nil).MinTimes(1)
 
-	return client.Services{
+	return &client.Services{
 		Ram: m,
 	}
 }

--- a/plugins/source/aws/resources/services/ram/resource_share_associations_mock_test.go
+++ b/plugins/source/aws/resources/services/ram/resource_share_associations_mock_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func buildRamResourceShareAssociationsMock(t *testing.T, ctrl *gomock.Controller) client.Services {
+func buildRamResourceShareAssociationsMock(t *testing.T, ctrl *gomock.Controller) *client.Services {
 	m := mocks.NewMockRamClient(ctrl)
 
 	object := types.ResourceShareAssociation{}
@@ -20,7 +20,7 @@ func buildRamResourceShareAssociationsMock(t *testing.T, ctrl *gomock.Controller
 
 	m.EXPECT().GetResourceShareAssociations(gomock.Any(), gomock.Any(), gomock.Any()).Return(
 		&ram.GetResourceShareAssociationsOutput{ResourceShareAssociations: []types.ResourceShareAssociation{object}}, nil).MinTimes(1)
-	return client.Services{Ram: m}
+	return &client.Services{Ram: m}
 }
 
 func TestRamResourceShareAssociatedResources(t *testing.T) {

--- a/plugins/source/aws/resources/services/ram/resource_share_invitations_mock_test.go
+++ b/plugins/source/aws/resources/services/ram/resource_share_invitations_mock_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func buildRamResourceShareInvitationsMock(t *testing.T, ctrl *gomock.Controller) client.Services {
+func buildRamResourceShareInvitationsMock(t *testing.T, ctrl *gomock.Controller) *client.Services {
 	m := mocks.NewMockRamClient(ctrl)
 	object := types.ResourceShareInvitation{}
 	require.NoError(t, faker.FakeObject(&object))
@@ -22,7 +22,7 @@ func buildRamResourceShareInvitationsMock(t *testing.T, ctrl *gomock.Controller)
 			ResourceShareInvitations: []types.ResourceShareInvitation{object},
 		}, nil)
 
-	return client.Services{
+	return &client.Services{
 		Ram: m,
 	}
 }

--- a/plugins/source/aws/resources/services/ram/resource_shares_mock_test.go
+++ b/plugins/source/aws/resources/services/ram/resource_shares_mock_test.go
@@ -13,7 +13,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func buildRamResourceSharesMock(t *testing.T, ctrl *gomock.Controller) client.Services {
+func buildRamResourceSharesMock(t *testing.T, ctrl *gomock.Controller) *client.Services {
 	m := mocks.NewMockRamClient(ctrl)
 	object := types.ResourceShare{}
 	require.NoError(t, faker.FakeObject(&object))
@@ -38,7 +38,7 @@ func buildRamResourceSharesMock(t *testing.T, ctrl *gomock.Controller) client.Se
 	m.EXPECT().GetPermission(gomock.Any(), gomock.Any(), gomock.Any()).Return(
 		&ram.GetPermissionOutput{Permission: &types.ResourceSharePermissionDetail{Permission: &detail}}, nil).MinTimes(1)
 
-	return client.Services{Ram: m}
+	return &client.Services{Ram: m}
 }
 
 func TestRamResourceShares(t *testing.T) {

--- a/plugins/source/aws/resources/services/ram/resource_types_mock_test.go
+++ b/plugins/source/aws/resources/services/ram/resource_types_mock_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func buildRamResourceTypesMock(t *testing.T, ctrl *gomock.Controller) client.Services {
+func buildRamResourceTypesMock(t *testing.T, ctrl *gomock.Controller) *client.Services {
 	m := mocks.NewMockRamClient(ctrl)
 	object := types.ServiceNameAndResourceType{}
 	require.NoError(t, faker.FakeObject(&object))
@@ -20,7 +20,7 @@ func buildRamResourceTypesMock(t *testing.T, ctrl *gomock.Controller) client.Ser
 	m.EXPECT().ListResourceTypes(gomock.Any(), gomock.Any(), gomock.Any()).Return(
 		&ram.ListResourceTypesOutput{ResourceTypes: []types.ServiceNameAndResourceType{object}}, nil)
 
-	return client.Services{Ram: m}
+	return &client.Services{Ram: m}
 }
 
 func TestRamResourceTypes(t *testing.T) {

--- a/plugins/source/aws/resources/services/ram/resources_mock_test.go
+++ b/plugins/source/aws/resources/services/ram/resources_mock_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func buildRamResourcesMock(t *testing.T, ctrl *gomock.Controller) client.Services {
+func buildRamResourcesMock(t *testing.T, ctrl *gomock.Controller) *client.Services {
 	m := mocks.NewMockRamClient(ctrl)
 	object := types.Resource{}
 	require.NoError(t, faker.FakeObject(&object))
@@ -22,7 +22,7 @@ func buildRamResourcesMock(t *testing.T, ctrl *gomock.Controller) client.Service
 			Resources: []types.Resource{object},
 		}, nil).MinTimes(1)
 
-	return client.Services{
+	return &client.Services{
 		Ram: m,
 	}
 }

--- a/plugins/source/aws/resources/services/rds/cluster_parameter_groups_mock_test.go
+++ b/plugins/source/aws/resources/services/rds/cluster_parameter_groups_mock_test.go
@@ -13,7 +13,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func buildRdsClusterParameterGroups(t *testing.T, ctrl *gomock.Controller) client.Services {
+func buildRdsClusterParameterGroups(t *testing.T, ctrl *gomock.Controller) *client.Services {
 	mock := mocks.NewMockRdsClient(ctrl)
 	var g types.DBClusterParameterGroup
 	require.NoError(t, faker.FakeObject(&g))
@@ -49,7 +49,7 @@ func buildRdsClusterParameterGroups(t *testing.T, ctrl *gomock.Controller) clien
 		&rds.DescribeDBClusterParametersOutput{Parameters: []types.Parameter{p}},
 		nil,
 	)
-	return client.Services{Rds: mock}
+	return &client.Services{Rds: mock}
 }
 
 func TestRdsClusterParameterGroups(t *testing.T) {

--- a/plugins/source/aws/resources/services/rds/cluster_snapshots_mock_test.go
+++ b/plugins/source/aws/resources/services/rds/cluster_snapshots_mock_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func buildRDSClientForClusterSnapshots(t *testing.T, ctrl *gomock.Controller) client.Services {
+func buildRDSClientForClusterSnapshots(t *testing.T, ctrl *gomock.Controller) *client.Services {
 	mock := mocks.NewMockRdsClient(ctrl)
 
 	var s types.DBClusterSnapshot
@@ -40,7 +40,7 @@ func buildRDSClientForClusterSnapshots(t *testing.T, ctrl *gomock.Controller) cl
 		},
 		nil,
 	)
-	return client.Services{Rds: mock}
+	return &client.Services{Rds: mock}
 }
 
 func TestRDSDBClusterSnapshots(t *testing.T) {

--- a/plugins/source/aws/resources/services/rds/db_parameter_groups_mock_test.go
+++ b/plugins/source/aws/resources/services/rds/db_parameter_groups_mock_test.go
@@ -13,7 +13,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func buildRDSDBParameterGroups(t *testing.T, ctrl *gomock.Controller) client.Services {
+func buildRDSDBParameterGroups(t *testing.T, ctrl *gomock.Controller) *client.Services {
 	mock := mocks.NewMockRdsClient(ctrl)
 	var g types.DBParameterGroup
 	require.NoError(t, faker.FakeObject(&g))
@@ -49,7 +49,7 @@ func buildRDSDBParameterGroups(t *testing.T, ctrl *gomock.Controller) client.Ser
 		&rds.DescribeDBParametersOutput{Parameters: []types.Parameter{p}},
 		nil,
 	)
-	return client.Services{Rds: mock}
+	return &client.Services{Rds: mock}
 }
 
 func TestRDSDBParameterGroups(t *testing.T) {

--- a/plugins/source/aws/resources/services/rds/db_proxies_mock_test.go
+++ b/plugins/source/aws/resources/services/rds/db_proxies_mock_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func buildRdsDbProxiesMock(t *testing.T, ctrl *gomock.Controller) client.Services {
+func buildRdsDbProxiesMock(t *testing.T, ctrl *gomock.Controller) *client.Services {
 	m := mocks.NewMockRdsClient(ctrl)
 	proxy := types.DBProxy{}
 	require.NoError(t, faker.FakeObject(&proxy))
@@ -27,7 +27,7 @@ func buildRdsDbProxiesMock(t *testing.T, ctrl *gomock.Controller) client.Service
 	m.EXPECT().ListTagsForResource(gomock.Any(), gomock.Any(), gomock.Any()).Return(
 		&tags, nil)
 
-	return client.Services{
+	return &client.Services{
 		Rds: m,
 	}
 }

--- a/plugins/source/aws/resources/services/rds/db_security_groups_mock_test.go
+++ b/plugins/source/aws/resources/services/rds/db_security_groups_mock_test.go
@@ -13,7 +13,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func buildRdsDbSecurityGroups(t *testing.T, ctrl *gomock.Controller) client.Services {
+func buildRdsDbSecurityGroups(t *testing.T, ctrl *gomock.Controller) *client.Services {
 	mock := mocks.NewMockRdsClient(ctrl)
 	var g types.DBSecurityGroup
 	require.NoError(t, faker.FakeObject(&g))
@@ -38,7 +38,7 @@ func buildRdsDbSecurityGroups(t *testing.T, ctrl *gomock.Controller) client.Serv
 		nil,
 	)
 
-	return client.Services{Rds: mock}
+	return &client.Services{Rds: mock}
 }
 
 func TestRDSDBSecurityGroups(t *testing.T) {

--- a/plugins/source/aws/resources/services/rds/db_snapshots_mock_test.go
+++ b/plugins/source/aws/resources/services/rds/db_snapshots_mock_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func buildRDSClient(t *testing.T, ctrl *gomock.Controller) client.Services {
+func buildRDSClient(t *testing.T, ctrl *gomock.Controller) *client.Services {
 	mock := mocks.NewMockRdsClient(ctrl)
 
 	var s types.DBSnapshot
@@ -40,7 +40,7 @@ func buildRDSClient(t *testing.T, ctrl *gomock.Controller) client.Services {
 		},
 		nil,
 	)
-	return client.Services{Rds: mock}
+	return &client.Services{Rds: mock}
 }
 
 func TestRDSDBSnapshots(t *testing.T) {

--- a/plugins/source/aws/resources/services/rds/engine_versions_mock_test.go
+++ b/plugins/source/aws/resources/services/rds/engine_versions_mock_test.go
@@ -13,9 +13,9 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func buildEngineVersionsMock(t *testing.T, ctrl *gomock.Controller) client.Services {
+func buildEngineVersionsMock(t *testing.T, ctrl *gomock.Controller) *client.Services {
 	m := mocks.NewMockRdsClient(ctrl)
-	services := client.Services{
+	services := &client.Services{
 		Rds: m,
 	}
 	var ev rds.DescribeDBEngineVersionsOutput

--- a/plugins/source/aws/resources/services/rds/event_subscriptions_mock_test.go
+++ b/plugins/source/aws/resources/services/rds/event_subscriptions_mock_test.go
@@ -13,7 +13,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func buildRDSEventSubscriptions(t *testing.T, ctrl *gomock.Controller) client.Services {
+func buildRDSEventSubscriptions(t *testing.T, ctrl *gomock.Controller) *client.Services {
 	mock := mocks.NewMockRdsClient(ctrl)
 	var s types.EventSubscription
 	require.NoError(t, faker.FakeObject(&s))
@@ -33,7 +33,7 @@ func buildRDSEventSubscriptions(t *testing.T, ctrl *gomock.Controller) client.Se
 		},
 		nil,
 	)
-	return client.Services{Rds: mock}
+	return &client.Services{Rds: mock}
 }
 
 func TestRDSEventSubscriptions(t *testing.T) {

--- a/plugins/source/aws/resources/services/rds/events_mock_test.go
+++ b/plugins/source/aws/resources/services/rds/events_mock_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func buildRDSEvents(t *testing.T, ctrl *gomock.Controller) client.Services {
+func buildRDSEvents(t *testing.T, ctrl *gomock.Controller) *client.Services {
 	mock := mocks.NewMockRdsClient(ctrl)
 	var events []types.Event
 	require.NoError(t, faker.FakeObject(&events))
@@ -21,7 +21,7 @@ func buildRDSEvents(t *testing.T, ctrl *gomock.Controller) client.Services {
 		&rds.DescribeEventsOutput{Events: events},
 		nil,
 	)
-	return client.Services{Rds: mock}
+	return &client.Services{Rds: mock}
 }
 
 func TestRDSEvents(t *testing.T) {

--- a/plugins/source/aws/resources/services/rds/mock_test.go
+++ b/plugins/source/aws/resources/services/rds/mock_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func buildRdsCertificates(t *testing.T, ctrl *gomock.Controller) client.Services {
+func buildRdsCertificates(t *testing.T, ctrl *gomock.Controller) *client.Services {
 	m := mocks.NewMockRdsClient(ctrl)
 	l := rdsTypes.Certificate{}
 	require.NoError(t, faker.FakeObject(&l))
@@ -21,12 +21,12 @@ func buildRdsCertificates(t *testing.T, ctrl *gomock.Controller) client.Services
 		&rds.DescribeCertificatesOutput{
 			Certificates: []rdsTypes.Certificate{l},
 		}, nil)
-	return client.Services{
+	return &client.Services{
 		Rds: m,
 	}
 }
 
-func buildRdsDBClusters(t *testing.T, ctrl *gomock.Controller) client.Services {
+func buildRdsDBClusters(t *testing.T, ctrl *gomock.Controller) *client.Services {
 	m := mocks.NewMockRdsClient(ctrl)
 	l := rdsTypes.DBCluster{}
 	require.NoError(t, faker.FakeObject(&l))
@@ -37,12 +37,12 @@ func buildRdsDBClusters(t *testing.T, ctrl *gomock.Controller) client.Services {
 		&rds.DescribeDBClustersOutput{
 			DBClusters: []rdsTypes.DBCluster{l},
 		}, nil)
-	return client.Services{
+	return &client.Services{
 		Rds: m,
 	}
 }
 
-func buildRdsDBInstances(t *testing.T, ctrl *gomock.Controller) client.Services {
+func buildRdsDBInstances(t *testing.T, ctrl *gomock.Controller) *client.Services {
 	m := mocks.NewMockRdsClient(ctrl)
 	l := rdsTypes.DBInstance{}
 	require.NoError(t, faker.FakeObject(&l))
@@ -51,12 +51,12 @@ func buildRdsDBInstances(t *testing.T, ctrl *gomock.Controller) client.Services 
 		&rds.DescribeDBInstancesOutput{
 			DBInstances: []rdsTypes.DBInstance{l},
 		}, nil)
-	return client.Services{
+	return &client.Services{
 		Rds: m,
 	}
 }
 
-func buildRdsDBSubnetGroups(t *testing.T, ctrl *gomock.Controller) client.Services {
+func buildRdsDBSubnetGroups(t *testing.T, ctrl *gomock.Controller) *client.Services {
 	m := mocks.NewMockRdsClient(ctrl)
 	l := rdsTypes.DBSubnetGroup{}
 	require.NoError(t, faker.FakeObject(&l))
@@ -65,12 +65,12 @@ func buildRdsDBSubnetGroups(t *testing.T, ctrl *gomock.Controller) client.Servic
 		&rds.DescribeDBSubnetGroupsOutput{
 			DBSubnetGroups: []rdsTypes.DBSubnetGroup{l},
 		}, nil)
-	return client.Services{
+	return &client.Services{
 		Rds: m,
 	}
 }
 
-func buildRdsDBReservedInstances(t *testing.T, ctrl *gomock.Controller) client.Services {
+func buildRdsDBReservedInstances(t *testing.T, ctrl *gomock.Controller) *client.Services {
 	m := mocks.NewMockRdsClient(ctrl)
 	ri := rdsTypes.ReservedDBInstance{}
 	require.NoError(t, faker.FakeObject(&ri))
@@ -85,7 +85,7 @@ func buildRdsDBReservedInstances(t *testing.T, ctrl *gomock.Controller) client.S
 
 	m.EXPECT().ListTagsForResource(gomock.Any(), gomock.Any(), gomock.Any()).Return(&tagOutput, nil)
 
-	return client.Services{
+	return &client.Services{
 		Rds: m,
 	}
 }

--- a/plugins/source/aws/resources/services/rds/option_groups_mock_test.go
+++ b/plugins/source/aws/resources/services/rds/option_groups_mock_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func buildOptionGroups(t *testing.T, ctrl *gomock.Controller) client.Services {
+func buildOptionGroups(t *testing.T, ctrl *gomock.Controller) *client.Services {
 	mock := mocks.NewMockRdsClient(ctrl)
 	var s types.OptionGroup
 	require.NoError(t, faker.FakeObject(&s))
@@ -21,7 +21,7 @@ func buildOptionGroups(t *testing.T, ctrl *gomock.Controller) client.Services {
 		&rds.DescribeOptionGroupsOutput{OptionGroupsList: []types.OptionGroup{s}},
 		nil,
 	)
-	return client.Services{Rds: mock}
+	return &client.Services{Rds: mock}
 }
 
 func TestRDSOptionGroups(t *testing.T) {

--- a/plugins/source/aws/resources/services/redshift/clusters_mock_test.go
+++ b/plugins/source/aws/resources/services/redshift/clusters_mock_test.go
@@ -13,7 +13,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func buildClustersMock(t *testing.T, ctrl *gomock.Controller) client.Services {
+func buildClustersMock(t *testing.T, ctrl *gomock.Controller) *client.Services {
 	m := mocks.NewMockRedshiftClient(ctrl)
 	g := types.Cluster{}
 	require.NoError(t, faker.FakeObject(&g))
@@ -86,7 +86,7 @@ func buildClustersMock(t *testing.T, ctrl *gomock.Controller) client.Services {
 		nil,
 	)
 
-	return client.Services{
+	return &client.Services{
 		Redshift: m,
 	}
 }

--- a/plugins/source/aws/resources/services/redshift/data_shares_mock_test.go
+++ b/plugins/source/aws/resources/services/redshift/data_shares_mock_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func buildDataSharesMock(t *testing.T, ctrl *gomock.Controller) client.Services {
+func buildDataSharesMock(t *testing.T, ctrl *gomock.Controller) *client.Services {
 	m := mocks.NewMockRedshiftClient(ctrl)
 	ds := types.DataShare{}
 	require.NoError(t, faker.FakeObject(&ds))
@@ -22,7 +22,7 @@ func buildDataSharesMock(t *testing.T, ctrl *gomock.Controller) client.Services 
 			DataShares: []types.DataShare{ds},
 		}, nil)
 
-	return client.Services{
+	return &client.Services{
 		Redshift: m,
 	}
 }

--- a/plugins/source/aws/resources/services/redshift/event_subscriptions_mock_test.go
+++ b/plugins/source/aws/resources/services/redshift/event_subscriptions_mock_test.go
@@ -13,7 +13,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func buildEventSubscriptionsMock(t *testing.T, ctrl *gomock.Controller) client.Services {
+func buildEventSubscriptionsMock(t *testing.T, ctrl *gomock.Controller) *client.Services {
 	m := mocks.NewMockRedshiftClient(ctrl)
 
 	var s types.EventSubscription
@@ -30,7 +30,7 @@ func buildEventSubscriptionsMock(t *testing.T, ctrl *gomock.Controller) client.S
 		nil,
 	)
 
-	return client.Services{
+	return &client.Services{
 		Redshift: m,
 	}
 }

--- a/plugins/source/aws/resources/services/redshift/events_mock_test.go
+++ b/plugins/source/aws/resources/services/redshift/events_mock_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func buildEventsMock(t *testing.T, ctrl *gomock.Controller) client.Services {
+func buildEventsMock(t *testing.T, ctrl *gomock.Controller) *client.Services {
 	m := mocks.NewMockRedshiftClient(ctrl)
 	ev := types.Event{}
 	require.NoError(t, faker.FakeObject(&ev))
@@ -22,7 +22,7 @@ func buildEventsMock(t *testing.T, ctrl *gomock.Controller) client.Services {
 			Events: []types.Event{ev},
 		}, nil)
 
-	return client.Services{
+	return &client.Services{
 		Redshift: m,
 	}
 }

--- a/plugins/source/aws/resources/services/redshift/subnet_groups_mock_test.go
+++ b/plugins/source/aws/resources/services/redshift/subnet_groups_mock_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func buildSubnetGroupsMock(t *testing.T, ctrl *gomock.Controller) client.Services {
+func buildSubnetGroupsMock(t *testing.T, ctrl *gomock.Controller) *client.Services {
 	m := mocks.NewMockRedshiftClient(ctrl)
 
 	g := types.ClusterSubnetGroup{}
@@ -22,7 +22,7 @@ func buildSubnetGroupsMock(t *testing.T, ctrl *gomock.Controller) client.Service
 		&redshift.DescribeClusterSubnetGroupsOutput{
 			ClusterSubnetGroups: []types.ClusterSubnetGroup{g},
 		}, nil)
-	return client.Services{
+	return &client.Services{
 		Redshift: m,
 	}
 }

--- a/plugins/source/aws/resources/services/resiliencehub/apps_mock_test.go
+++ b/plugins/source/aws/resources/services/resiliencehub/apps_mock_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func buildApps(t *testing.T, ctrl *gomock.Controller) client.Services {
+func buildApps(t *testing.T, ctrl *gomock.Controller) *client.Services {
 	mock := mocks.NewMockResiliencehubClient(ctrl)
 	var l resiliencehub.ListAppsOutput
 	require.NoError(t, faker.FakeObject(&l))
@@ -34,7 +34,7 @@ func buildApps(t *testing.T, ctrl *gomock.Controller) client.Services {
 
 	buildAppAssessments(t, mock)
 	buildAppVersions(t, mock)
-	return client.Services{Resiliencehub: mock}
+	return &client.Services{Resiliencehub: mock}
 }
 
 func TestResiilencehubApps(t *testing.T) {

--- a/plugins/source/aws/resources/services/resiliencehub/resiliency_policies_mock_test.go
+++ b/plugins/source/aws/resources/services/resiliencehub/resiliency_policies_mock_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func buildResiliencyPolicies(t *testing.T, ctrl *gomock.Controller) client.Services {
+func buildResiliencyPolicies(t *testing.T, ctrl *gomock.Controller) *client.Services {
 	mock := mocks.NewMockResiliencehubClient(ctrl)
 	var l resiliencehub.ListResiliencyPoliciesOutput
 	require.NoError(t, faker.FakeObject(&l))
@@ -23,7 +23,7 @@ func buildResiliencyPolicies(t *testing.T, ctrl *gomock.Controller) client.Servi
 		gomock.Any(),
 	).Return(&l, nil)
 
-	return client.Services{Resiliencehub: mock}
+	return &client.Services{Resiliencehub: mock}
 }
 
 func TestResiilencehubResiliencyPolicies(t *testing.T) {

--- a/plugins/source/aws/resources/services/resiliencehub/suggested_resiliency_policies_mock_test.go
+++ b/plugins/source/aws/resources/services/resiliencehub/suggested_resiliency_policies_mock_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func buildSuggestedResiliencyPolicies(t *testing.T, ctrl *gomock.Controller) client.Services {
+func buildSuggestedResiliencyPolicies(t *testing.T, ctrl *gomock.Controller) *client.Services {
 	mock := mocks.NewMockResiliencehubClient(ctrl)
 	var l resiliencehub.ListSuggestedResiliencyPoliciesOutput
 	require.NoError(t, faker.FakeObject(&l))
@@ -23,7 +23,7 @@ func buildSuggestedResiliencyPolicies(t *testing.T, ctrl *gomock.Controller) cli
 		gomock.Any(),
 	).Return(&l, nil)
 
-	return client.Services{Resiliencehub: mock}
+	return &client.Services{Resiliencehub: mock}
 }
 
 func TestResiilencehubSuggestedResiliencyPolicies(t *testing.T) {

--- a/plugins/source/aws/resources/services/resourcegroups/resource_groups_mock_test.go
+++ b/plugins/source/aws/resources/services/resourcegroups/resource_groups_mock_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func buildResourceGroupsMock(t *testing.T, ctrl *gomock.Controller) client.Services {
+func buildResourceGroupsMock(t *testing.T, ctrl *gomock.Controller) *client.Services {
 	m := mocks.NewMockResourcegroupsClient(ctrl)
 	gId := types.GroupIdentifier{}
 	require.NoError(t, faker.FakeObject(&gId))
@@ -40,7 +40,7 @@ func buildResourceGroupsMock(t *testing.T, ctrl *gomock.Controller) client.Servi
 			GroupQuery: &query,
 		}, nil)
 
-	return client.Services{
+	return &client.Services{
 		Resourcegroups: m,
 	}
 }

--- a/plugins/source/aws/resources/services/route53/delegations_sets_mock_test.go
+++ b/plugins/source/aws/resources/services/route53/delegations_sets_mock_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func buildRoute53DelegationSetsMock(t *testing.T, ctrl *gomock.Controller) client.Services {
+func buildRoute53DelegationSetsMock(t *testing.T, ctrl *gomock.Controller) *client.Services {
 	m := mocks.NewMockRoute53Client(ctrl)
 	ds := route53Types.DelegationSet{}
 	require.NoError(t, faker.FakeObject(&ds))
@@ -21,7 +21,7 @@ func buildRoute53DelegationSetsMock(t *testing.T, ctrl *gomock.Controller) clien
 		&route53.ListReusableDelegationSetsOutput{
 			DelegationSets: []route53Types.DelegationSet{ds},
 		}, nil)
-	return client.Services{
+	return &client.Services{
 		Route53: m,
 	}
 }

--- a/plugins/source/aws/resources/services/route53/domains_mock_test.go
+++ b/plugins/source/aws/resources/services/route53/domains_mock_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func buildRoute53Domains(t *testing.T, ctrl *gomock.Controller) client.Services {
+func buildRoute53Domains(t *testing.T, ctrl *gomock.Controller) *client.Services {
 	mock := mocks.NewMockRoute53domainsClient(ctrl)
 
 	var ds types.DomainSummary
@@ -38,7 +38,7 @@ func buildRoute53Domains(t *testing.T, ctrl *gomock.Controller) client.Services 
 		&tagsOut, nil,
 	)
 
-	return client.Services{
+	return &client.Services{
 		Route53domains: mock,
 	}
 }

--- a/plugins/source/aws/resources/services/route53/health_check_mock_test.go
+++ b/plugins/source/aws/resources/services/route53/health_check_mock_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func buildRoute53HealthChecksMock(t *testing.T, ctrl *gomock.Controller) client.Services {
+func buildRoute53HealthChecksMock(t *testing.T, ctrl *gomock.Controller) *client.Services {
 	m := mocks.NewMockRoute53Client(ctrl)
 	hc := route53Types.HealthCheck{}
 	require.NoError(t, faker.FakeObject(&hc))
@@ -33,7 +33,7 @@ func buildRoute53HealthChecksMock(t *testing.T, ctrl *gomock.Controller) client.
 				},
 			},
 		}, nil)
-	return client.Services{
+	return &client.Services{
 		Route53: m,
 	}
 }

--- a/plugins/source/aws/resources/services/route53/hosted_zones_mock_test.go
+++ b/plugins/source/aws/resources/services/route53/hosted_zones_mock_test.go
@@ -13,7 +13,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func buildRoute53HostedZonesMock(t *testing.T, ctrl *gomock.Controller) client.Services {
+func buildRoute53HostedZonesMock(t *testing.T, ctrl *gomock.Controller) *client.Services {
 	m := mocks.NewMockRoute53Client(ctrl)
 	h := types.HostedZone{}
 	require.NoError(t, faker.FakeObject(&h))
@@ -70,7 +70,7 @@ func buildRoute53HostedZonesMock(t *testing.T, ctrl *gomock.Controller) client.S
 			DelegationSet: &ds,
 			VPCs:          []types.VPC{vpc},
 		}, nil)
-	return client.Services{
+	return &client.Services{
 		Route53: m,
 	}
 }

--- a/plugins/source/aws/resources/services/route53/operations_mock_test.go
+++ b/plugins/source/aws/resources/services/route53/operations_mock_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func buildRoute53Operations(t *testing.T, ctrl *gomock.Controller) client.Services {
+func buildRoute53Operations(t *testing.T, ctrl *gomock.Controller) *client.Services {
 	mock := mocks.NewMockRoute53domainsClient(ctrl)
 
 	var os types.OperationSummary
@@ -31,7 +31,7 @@ func buildRoute53Operations(t *testing.T, ctrl *gomock.Controller) client.Servic
 		&detail, nil,
 	)
 
-	return client.Services{
+	return &client.Services{
 		Route53domains: mock,
 	}
 }

--- a/plugins/source/aws/resources/services/route53/traffic_policies_mock_test.go
+++ b/plugins/source/aws/resources/services/route53/traffic_policies_mock_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func buildRoute53TrafficPoliciesMock(t *testing.T, ctrl *gomock.Controller) client.Services {
+func buildRoute53TrafficPoliciesMock(t *testing.T, ctrl *gomock.Controller) *client.Services {
 	m := mocks.NewMockRoute53Client(ctrl)
 	tps := route53Types.TrafficPolicySummary{}
 	require.NoError(t, faker.FakeObject(&tps))
@@ -31,7 +31,7 @@ func buildRoute53TrafficPoliciesMock(t *testing.T, ctrl *gomock.Controller) clie
 		&route53.ListTrafficPolicyVersionsOutput{
 			TrafficPolicies: []route53Types.TrafficPolicy{tp},
 		}, nil)
-	return client.Services{
+	return &client.Services{
 		Route53: m,
 	}
 }

--- a/plugins/source/aws/resources/services/route53recoverycontrolconfig/clusters_mock_test.go
+++ b/plugins/source/aws/resources/services/route53recoverycontrolconfig/clusters_mock_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func buildClusters(t *testing.T, ctrl *gomock.Controller) client.Services {
+func buildClusters(t *testing.T, ctrl *gomock.Controller) *client.Services {
 	m := mocks.NewMockRoute53recoverycontrolconfigClient(ctrl)
 
 	var c types.Cluster
@@ -29,7 +29,7 @@ func buildClusters(t *testing.T, ctrl *gomock.Controller) client.Services {
 		nil,
 	)
 
-	return client.Services{
+	return &client.Services{
 		Route53recoverycontrolconfig: m,
 	}
 }

--- a/plugins/source/aws/resources/services/route53recoverycontrolconfig/control_panel_mock_test.go
+++ b/plugins/source/aws/resources/services/route53recoverycontrolconfig/control_panel_mock_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func buildControlPanels(t *testing.T, ctrl *gomock.Controller) client.Services {
+func buildControlPanels(t *testing.T, ctrl *gomock.Controller) *client.Services {
 	m := mocks.NewMockRoute53recoverycontrolconfigClient(ctrl)
 
 	var c types.ControlPanel
@@ -63,7 +63,7 @@ func buildControlPanels(t *testing.T, ctrl *gomock.Controller) client.Services {
 		nil,
 	)
 
-	return client.Services{
+	return &client.Services{
 		Route53recoverycontrolconfig: m,
 	}
 }

--- a/plugins/source/aws/resources/services/route53recoveryreadiness/cells_mock_test.go
+++ b/plugins/source/aws/resources/services/route53recoveryreadiness/cells_mock_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func buildCells(t *testing.T, ctrl *gomock.Controller) client.Services {
+func buildCells(t *testing.T, ctrl *gomock.Controller) *client.Services {
 	m := mocks.NewMockRoute53recoveryreadinessClient(ctrl)
 	co := types.CellOutput{}
 	require.NoError(t, faker.FakeObject(&co))
@@ -22,7 +22,7 @@ func buildCells(t *testing.T, ctrl *gomock.Controller) client.Services {
 			Cells: []types.CellOutput{co},
 		}, nil)
 
-	return client.Services{
+	return &client.Services{
 		Route53recoveryreadiness: m,
 	}
 }

--- a/plugins/source/aws/resources/services/route53recoveryreadiness/readiness_checks_mock_test.go
+++ b/plugins/source/aws/resources/services/route53recoveryreadiness/readiness_checks_mock_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func buildReadinessChecks(t *testing.T, ctrl *gomock.Controller) client.Services {
+func buildReadinessChecks(t *testing.T, ctrl *gomock.Controller) *client.Services {
 	m := mocks.NewMockRoute53recoveryreadinessClient(ctrl)
 	rco := types.ReadinessCheckOutput{}
 	require.NoError(t, faker.FakeObject(&rco))
@@ -22,7 +22,7 @@ func buildReadinessChecks(t *testing.T, ctrl *gomock.Controller) client.Services
 			ReadinessChecks: []types.ReadinessCheckOutput{rco},
 		}, nil)
 
-	return client.Services{
+	return &client.Services{
 		Route53recoveryreadiness: m,
 	}
 }

--- a/plugins/source/aws/resources/services/route53recoveryreadiness/recovery_groups_mock_test.go
+++ b/plugins/source/aws/resources/services/route53recoveryreadiness/recovery_groups_mock_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func buildRecoveryGroups(t *testing.T, ctrl *gomock.Controller) client.Services {
+func buildRecoveryGroups(t *testing.T, ctrl *gomock.Controller) *client.Services {
 	m := mocks.NewMockRoute53recoveryreadinessClient(ctrl)
 	rco := types.RecoveryGroupOutput{}
 	require.NoError(t, faker.FakeObject(&rco))
@@ -22,7 +22,7 @@ func buildRecoveryGroups(t *testing.T, ctrl *gomock.Controller) client.Services 
 			RecoveryGroups: []types.RecoveryGroupOutput{rco},
 		}, nil)
 
-	return client.Services{
+	return &client.Services{
 		Route53recoveryreadiness: m,
 	}
 }

--- a/plugins/source/aws/resources/services/route53recoveryreadiness/resource_sets_mock_test.go
+++ b/plugins/source/aws/resources/services/route53recoveryreadiness/resource_sets_mock_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func buildResourceSets(t *testing.T, ctrl *gomock.Controller) client.Services {
+func buildResourceSets(t *testing.T, ctrl *gomock.Controller) *client.Services {
 	m := mocks.NewMockRoute53recoveryreadinessClient(ctrl)
 	rs := types.ResourceSetOutput{}
 	require.NoError(t, faker.FakeObject(&rs))
@@ -22,7 +22,7 @@ func buildResourceSets(t *testing.T, ctrl *gomock.Controller) client.Services {
 			ResourceSets: []types.ResourceSetOutput{rs},
 		}, nil)
 
-	return client.Services{
+	return &client.Services{
 		Route53recoveryreadiness: m,
 	}
 }

--- a/plugins/source/aws/resources/services/route53resolver/firewall_configs_mock_test.go
+++ b/plugins/source/aws/resources/services/route53resolver/firewall_configs_mock_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func buildFirewallConfigsMock(t *testing.T, ctrl *gomock.Controller) client.Services {
+func buildFirewallConfigsMock(t *testing.T, ctrl *gomock.Controller) *client.Services {
 	m := mocks.NewMockRoute53resolverClient(ctrl)
 	fc := types.FirewallConfig{}
 	require.NoError(t, faker.FakeObject(&fc))
@@ -22,7 +22,7 @@ func buildFirewallConfigsMock(t *testing.T, ctrl *gomock.Controller) client.Serv
 			FirewallConfigs: []types.FirewallConfig{fc},
 		}, nil)
 
-	return client.Services{
+	return &client.Services{
 		Route53resolver: m,
 	}
 }

--- a/plugins/source/aws/resources/services/route53resolver/firewall_domain_list_mock_test.go
+++ b/plugins/source/aws/resources/services/route53resolver/firewall_domain_list_mock_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func buildFirewallDomainListMock(t *testing.T, ctrl *gomock.Controller) client.Services {
+func buildFirewallDomainListMock(t *testing.T, ctrl *gomock.Controller) *client.Services {
 	m := mocks.NewMockRoute53resolverClient(ctrl)
 	fdlm := types.FirewallDomainListMetadata{}
 	require.NoError(t, faker.FakeObject(&fdlm))
@@ -30,7 +30,7 @@ func buildFirewallDomainListMock(t *testing.T, ctrl *gomock.Controller) client.S
 			FirewallDomainList: &fdl,
 		}, nil)
 
-	return client.Services{
+	return &client.Services{
 		Route53resolver: m,
 	}
 }

--- a/plugins/source/aws/resources/services/route53resolver/firewall_rule_group_associations_mock_test.go
+++ b/plugins/source/aws/resources/services/route53resolver/firewall_rule_group_associations_mock_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func buildFirewallRuleGroupAssociationsMock(t *testing.T, ctrl *gomock.Controller) client.Services {
+func buildFirewallRuleGroupAssociationsMock(t *testing.T, ctrl *gomock.Controller) *client.Services {
 	m := mocks.NewMockRoute53resolverClient(ctrl)
 	frga := types.FirewallRuleGroupAssociation{}
 	require.NoError(t, faker.FakeObject(&frga))
@@ -25,7 +25,7 @@ func buildFirewallRuleGroupAssociationsMock(t *testing.T, ctrl *gomock.Controlle
 	fdl := types.FirewallDomainList{}
 	require.NoError(t, faker.FakeObject(&fdl))
 
-	return client.Services{
+	return &client.Services{
 		Route53resolver: m,
 	}
 }

--- a/plugins/source/aws/resources/services/route53resolver/firewall_rule_group_mock_test.go
+++ b/plugins/source/aws/resources/services/route53resolver/firewall_rule_group_mock_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func buildFirewallRuleGroupsMock(t *testing.T, ctrl *gomock.Controller) client.Services {
+func buildFirewallRuleGroupsMock(t *testing.T, ctrl *gomock.Controller) *client.Services {
 	m := mocks.NewMockRoute53resolverClient(ctrl)
 	frgm := types.FirewallRuleGroupMetadata{}
 	require.NoError(t, faker.FakeObject(&frgm))
@@ -30,7 +30,7 @@ func buildFirewallRuleGroupsMock(t *testing.T, ctrl *gomock.Controller) client.S
 			FirewallRuleGroup: &frg,
 		}, nil)
 
-	return client.Services{
+	return &client.Services{
 		Route53resolver: m,
 	}
 }

--- a/plugins/source/aws/resources/services/route53resolver/resolver_endpoints_mock_test.go
+++ b/plugins/source/aws/resources/services/route53resolver/resolver_endpoints_mock_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func buildEndpointsMock(t *testing.T, ctrl *gomock.Controller) client.Services {
+func buildEndpointsMock(t *testing.T, ctrl *gomock.Controller) *client.Services {
 	m := mocks.NewMockRoute53resolverClient(ctrl)
 	re := types.ResolverEndpoint{}
 	require.NoError(t, faker.FakeObject(&re))
@@ -22,7 +22,7 @@ func buildEndpointsMock(t *testing.T, ctrl *gomock.Controller) client.Services {
 			ResolverEndpoints: []types.ResolverEndpoint{re},
 		}, nil)
 
-	return client.Services{
+	return &client.Services{
 		Route53resolver: m,
 	}
 }

--- a/plugins/source/aws/resources/services/route53resolver/resolver_query_log_config_associations_mock_test.go
+++ b/plugins/source/aws/resources/services/route53resolver/resolver_query_log_config_associations_mock_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func buildResolverQueryLogConfigAssociationsMock(t *testing.T, ctrl *gomock.Controller) client.Services {
+func buildResolverQueryLogConfigAssociationsMock(t *testing.T, ctrl *gomock.Controller) *client.Services {
 	m := mocks.NewMockRoute53resolverClient(ctrl)
 	rqlca := types.ResolverQueryLogConfigAssociation{}
 	require.NoError(t, faker.FakeObject(&rqlca))
@@ -22,7 +22,7 @@ func buildResolverQueryLogConfigAssociationsMock(t *testing.T, ctrl *gomock.Cont
 			ResolverQueryLogConfigAssociations: []types.ResolverQueryLogConfigAssociation{rqlca},
 		}, nil)
 
-	return client.Services{
+	return &client.Services{
 		Route53resolver: m,
 	}
 }

--- a/plugins/source/aws/resources/services/route53resolver/resolver_query_log_configs_mock_test.go
+++ b/plugins/source/aws/resources/services/route53resolver/resolver_query_log_configs_mock_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func buildResolverQueryLogConfigsMock(t *testing.T, ctrl *gomock.Controller) client.Services {
+func buildResolverQueryLogConfigsMock(t *testing.T, ctrl *gomock.Controller) *client.Services {
 	m := mocks.NewMockRoute53resolverClient(ctrl)
 	rqlc := types.ResolverQueryLogConfig{}
 	require.NoError(t, faker.FakeObject(&rqlc))
@@ -22,7 +22,7 @@ func buildResolverQueryLogConfigsMock(t *testing.T, ctrl *gomock.Controller) cli
 			ResolverQueryLogConfigs: []types.ResolverQueryLogConfig{rqlc},
 		}, nil)
 
-	return client.Services{
+	return &client.Services{
 		Route53resolver: m,
 	}
 }

--- a/plugins/source/aws/resources/services/route53resolver/resolver_rule_associations_mock_test.go
+++ b/plugins/source/aws/resources/services/route53resolver/resolver_rule_associations_mock_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func buildResolverRuleAssociationsMock(t *testing.T, ctrl *gomock.Controller) client.Services {
+func buildResolverRuleAssociationsMock(t *testing.T, ctrl *gomock.Controller) *client.Services {
 	m := mocks.NewMockRoute53resolverClient(ctrl)
 	rra := types.ResolverRuleAssociation{}
 	require.NoError(t, faker.FakeObject(&rra))
@@ -22,7 +22,7 @@ func buildResolverRuleAssociationsMock(t *testing.T, ctrl *gomock.Controller) cl
 			ResolverRuleAssociations: []types.ResolverRuleAssociation{rra},
 		}, nil)
 
-	return client.Services{
+	return &client.Services{
 		Route53resolver: m,
 	}
 }

--- a/plugins/source/aws/resources/services/route53resolver/resolver_rules_mock_test.go
+++ b/plugins/source/aws/resources/services/route53resolver/resolver_rules_mock_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func buildResolverRulesMock(t *testing.T, ctrl *gomock.Controller) client.Services {
+func buildResolverRulesMock(t *testing.T, ctrl *gomock.Controller) *client.Services {
 	m := mocks.NewMockRoute53resolverClient(ctrl)
 	rr := types.ResolverRule{}
 	require.NoError(t, faker.FakeObject(&rr))
@@ -22,7 +22,7 @@ func buildResolverRulesMock(t *testing.T, ctrl *gomock.Controller) client.Servic
 			ResolverRules: []types.ResolverRule{rr},
 		}, nil)
 
-	return client.Services{
+	return &client.Services{
 		Route53resolver: m,
 	}
 }

--- a/plugins/source/aws/resources/services/s3/access_points_mock_test.go
+++ b/plugins/source/aws/resources/services/s3/access_points_mock_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func buildS3AccessPoints(t *testing.T, ctrl *gomock.Controller) client.Services {
+func buildS3AccessPoints(t *testing.T, ctrl *gomock.Controller) *client.Services {
 	m := mocks.NewMockS3controlClient(ctrl)
 	ap := types.AccessPoint{}
 	require.NoError(t, faker.FakeObject(&ap))
@@ -22,7 +22,7 @@ func buildS3AccessPoints(t *testing.T, ctrl *gomock.Controller) client.Services 
 			AccessPointList: []types.AccessPoint{ap},
 		}, nil)
 
-	return client.Services{
+	return &client.Services{
 		S3control: m,
 	}
 }

--- a/plugins/source/aws/resources/services/s3/buckets_mock_test.go
+++ b/plugins/source/aws/resources/services/s3/buckets_mock_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func buildS3Buckets(t *testing.T, ctrl *gomock.Controller) client.Services {
+func buildS3Buckets(t *testing.T, ctrl *gomock.Controller) *client.Services {
 	m := mocks.NewMockS3Client(ctrl)
 	b := s3Types.Bucket{}
 	require.NoError(t, faker.FakeObject(&b))
@@ -80,7 +80,7 @@ func buildS3Buckets(t *testing.T, ctrl *gomock.Controller) client.Services {
 	m.EXPECT().GetBucketNotificationConfiguration(gomock.Any(), gomock.Any(), gomock.Any()).Return(&gbnco, nil)
 	m.EXPECT().GetObjectLockConfiguration(gomock.Any(), gomock.Any(), gomock.Any()).Return(&golco, nil)
 
-	return client.Services{S3: m}
+	return &client.Services{S3: m}
 }
 
 func TestS3Buckets(t *testing.T) {

--- a/plugins/source/aws/resources/services/s3/multi_region_access_points_mock_test.go
+++ b/plugins/source/aws/resources/services/s3/multi_region_access_points_mock_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func buildS3MultiRegionAccessPoints(t *testing.T, ctrl *gomock.Controller) client.Services {
+func buildS3MultiRegionAccessPoints(t *testing.T, ctrl *gomock.Controller) *client.Services {
 	m := mocks.NewMockS3controlClient(ctrl)
 	mrap := types.MultiRegionAccessPointReport{}
 	require.NoError(t, faker.FakeObject(&mrap))
@@ -22,7 +22,7 @@ func buildS3MultiRegionAccessPoints(t *testing.T, ctrl *gomock.Controller) clien
 			AccessPoints: []types.MultiRegionAccessPointReport{mrap},
 		}, nil)
 
-	return client.Services{
+	return &client.Services{
 		S3control: m,
 	}
 }

--- a/plugins/source/aws/resources/services/sagemaker/apps_mock_test.go
+++ b/plugins/source/aws/resources/services/sagemaker/apps_mock_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func buildSageMakerApps(t *testing.T, ctrl *gomock.Controller) client.Services {
+func buildSageMakerApps(t *testing.T, ctrl *gomock.Controller) *client.Services {
 	m := mocks.NewMockSagemakerClient(ctrl)
 
 	appDets := types.AppDetails{}
@@ -38,7 +38,7 @@ func buildSageMakerApps(t *testing.T, ctrl *gomock.Controller) client.Services {
 		&tagsOut, nil,
 	)
 
-	return client.Services{
+	return &client.Services{
 		Sagemaker: m,
 	}
 }

--- a/plugins/source/aws/resources/services/sagemaker/endpoint_configurations_mock_test.go
+++ b/plugins/source/aws/resources/services/sagemaker/endpoint_configurations_mock_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func buildSageMakerEndpointConfigs(t *testing.T, ctrl *gomock.Controller) client.Services {
+func buildSageMakerEndpointConfigs(t *testing.T, ctrl *gomock.Controller) *client.Services {
 	m := mocks.NewMockSagemakerClient(ctrl)
 
 	summ := types.EndpointConfigSummary{}
@@ -39,7 +39,7 @@ func buildSageMakerEndpointConfigs(t *testing.T, ctrl *gomock.Controller) client
 		&tagsOut, nil,
 	)
 
-	return client.Services{
+	return &client.Services{
 		Sagemaker: m,
 	}
 }

--- a/plugins/source/aws/resources/services/sagemaker/models_mock_test.go
+++ b/plugins/source/aws/resources/services/sagemaker/models_mock_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func buildSageMakerModels(t *testing.T, ctrl *gomock.Controller) client.Services {
+func buildSageMakerModels(t *testing.T, ctrl *gomock.Controller) *client.Services {
 	m := mocks.NewMockSagemakerClient(ctrl)
 
 	summ := types.ModelSummary{}
@@ -39,7 +39,7 @@ func buildSageMakerModels(t *testing.T, ctrl *gomock.Controller) client.Services
 		&tagsOut, nil,
 	)
 
-	return client.Services{
+	return &client.Services{
 		Sagemaker: m,
 	}
 }

--- a/plugins/source/aws/resources/services/sagemaker/notebook_instances_mock_test.go
+++ b/plugins/source/aws/resources/services/sagemaker/notebook_instances_mock_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func buildSageMakerNotebookInstances(t *testing.T, ctrl *gomock.Controller) client.Services {
+func buildSageMakerNotebookInstances(t *testing.T, ctrl *gomock.Controller) *client.Services {
 	m := mocks.NewMockSagemakerClient(ctrl)
 
 	summ := types.NotebookInstanceSummary{}
@@ -39,7 +39,7 @@ func buildSageMakerNotebookInstances(t *testing.T, ctrl *gomock.Controller) clie
 		&tagsOut, nil,
 	)
 
-	return client.Services{
+	return &client.Services{
 		Sagemaker: m,
 	}
 }

--- a/plugins/source/aws/resources/services/sagemaker/training_jobs_mock_test.go
+++ b/plugins/source/aws/resources/services/sagemaker/training_jobs_mock_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func buildSageMakerTrainingJobs(t *testing.T, ctrl *gomock.Controller) client.Services {
+func buildSageMakerTrainingJobs(t *testing.T, ctrl *gomock.Controller) *client.Services {
 	m := mocks.NewMockSagemakerClient(ctrl)
 
 	summ := types.TrainingJobSummary{}
@@ -39,7 +39,7 @@ func buildSageMakerTrainingJobs(t *testing.T, ctrl *gomock.Controller) client.Se
 		&tagsOut, nil,
 	)
 
-	return client.Services{
+	return &client.Services{
 		Sagemaker: m,
 	}
 }

--- a/plugins/source/aws/resources/services/savingsplans/savingsplans_mock_test.go
+++ b/plugins/source/aws/resources/services/savingsplans/savingsplans_mock_test.go
@@ -13,7 +13,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func buildSavingPlansPlans(t *testing.T, ctrl *gomock.Controller) client.Services {
+func buildSavingPlansPlans(t *testing.T, ctrl *gomock.Controller) *client.Services {
 	m := mocks.NewMockSavingsplansClient(ctrl)
 
 	var s types.SavingsPlan
@@ -30,7 +30,7 @@ func buildSavingPlansPlans(t *testing.T, ctrl *gomock.Controller) client.Service
 		nil,
 	)
 
-	return client.Services{
+	return &client.Services{
 		Savingsplans: m,
 	}
 }

--- a/plugins/source/aws/resources/services/scheduler/schedule_groups_mock_test.go
+++ b/plugins/source/aws/resources/services/scheduler/schedule_groups_mock_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func buildSchedulerScheduleGroupsMock(t *testing.T, ctrl *gomock.Controller) client.Services {
+func buildSchedulerScheduleGroupsMock(t *testing.T, ctrl *gomock.Controller) *client.Services {
 	m := mocks.NewMockSchedulerClient(ctrl)
 	object := types.ScheduleGroupSummary{}
 	require.NoError(t, faker.FakeObject(&object))
@@ -25,7 +25,7 @@ func buildSchedulerScheduleGroupsMock(t *testing.T, ctrl *gomock.Controller) cli
 	tagsOutput := scheduler.ListTagsForResourceOutput{}
 	require.NoError(t, faker.FakeObject(&tagsOutput))
 	m.EXPECT().ListTagsForResource(gomock.Any(), gomock.Any(), gomock.Any()).Return(&tagsOutput, nil).AnyTimes()
-	return client.Services{
+	return &client.Services{
 		Scheduler: m,
 	}
 }

--- a/plugins/source/aws/resources/services/scheduler/schedules_mock_test.go
+++ b/plugins/source/aws/resources/services/scheduler/schedules_mock_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func buildSchedulerSchedulesMock(t *testing.T, ctrl *gomock.Controller) client.Services {
+func buildSchedulerSchedulesMock(t *testing.T, ctrl *gomock.Controller) *client.Services {
 	m := mocks.NewMockSchedulerClient(ctrl)
 	object := types.ScheduleSummary{}
 	require.NoError(t, faker.FakeObject(&object))
@@ -30,7 +30,7 @@ func buildSchedulerSchedulesMock(t *testing.T, ctrl *gomock.Controller) client.S
 	tagsOutput := scheduler.ListTagsForResourceOutput{}
 	require.NoError(t, faker.FakeObject(&tagsOutput))
 	m.EXPECT().ListTagsForResource(gomock.Any(), gomock.Any(), gomock.Any()).Return(&tagsOutput, nil).AnyTimes()
-	return client.Services{
+	return &client.Services{
 		Scheduler: m,
 	}
 }

--- a/plugins/source/aws/resources/services/secretsmanager/secrets_mock_test.go
+++ b/plugins/source/aws/resources/services/secretsmanager/secrets_mock_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func buildSecretsmanagerModels(t *testing.T, ctrl *gomock.Controller) client.Services {
+func buildSecretsmanagerModels(t *testing.T, ctrl *gomock.Controller) *client.Services {
 	m := mocks.NewMockSecretsmanagerClient(ctrl)
 
 	secret := types.SecretListEntry{}
@@ -50,7 +50,7 @@ func buildSecretsmanagerModels(t *testing.T, ctrl *gomock.Controller) client.Ser
 		nil,
 	)
 
-	return client.Services{
+	return &client.Services{
 		Secretsmanager: m,
 	}
 }

--- a/plugins/source/aws/resources/services/securityhub/enabled_standards_mock_test.go
+++ b/plugins/source/aws/resources/services/securityhub/enabled_standards_mock_test.go
@@ -13,7 +13,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func buildEnabledStandards(t *testing.T, ctrl *gomock.Controller) client.Services {
+func buildEnabledStandards(t *testing.T, ctrl *gomock.Controller) *client.Services {
 	shMock := mocks.NewMockSecurityhubClient(ctrl)
 	standardsSubscription := types.StandardsSubscription{}
 	require.NoError(t, faker.FakeObject(&standardsSubscription))
@@ -27,7 +27,7 @@ func buildEnabledStandards(t *testing.T, ctrl *gomock.Controller) client.Service
 		nil,
 	)
 
-	return client.Services{Securityhub: shMock}
+	return &client.Services{Securityhub: shMock}
 }
 
 func TestEnabledStandards(t *testing.T) {

--- a/plugins/source/aws/resources/services/securityhub/findings_mock_test.go
+++ b/plugins/source/aws/resources/services/securityhub/findings_mock_test.go
@@ -14,7 +14,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func buildFindings(t *testing.T, ctrl *gomock.Controller) client.Services {
+func buildFindings(t *testing.T, ctrl *gomock.Controller) *client.Services {
 	shMock := mocks.NewMockSecurityhubClient(ctrl)
 	findings := types.AwsSecurityFinding{}
 	require.NoError(t, faker.FakeObject(&findings))
@@ -37,7 +37,7 @@ func buildFindings(t *testing.T, ctrl *gomock.Controller) client.Services {
 		nil,
 	)
 
-	return client.Services{Securityhub: shMock}
+	return &client.Services{Securityhub: shMock}
 }
 
 func TestFindings(t *testing.T) {

--- a/plugins/source/aws/resources/services/securityhub/hubs_mock_test.go
+++ b/plugins/source/aws/resources/services/securityhub/hubs_mock_test.go
@@ -13,7 +13,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func buildHubs(t *testing.T, ctrl *gomock.Controller) client.Services {
+func buildHubs(t *testing.T, ctrl *gomock.Controller) *client.Services {
 	shMock := mocks.NewMockSecurityhubClient(ctrl)
 	hub := securityhub.DescribeHubOutput{}
 	require.NoError(t, faker.FakeObject(&hub))
@@ -33,7 +33,7 @@ func buildHubs(t *testing.T, ctrl *gomock.Controller) client.Services {
 		gomock.Any(),
 	).Return(&securityhub.ListTagsForResourceOutput{Tags: tags}, nil)
 
-	return client.Services{Securityhub: shMock}
+	return &client.Services{Securityhub: shMock}
 }
 
 func TestHubs(t *testing.T) {

--- a/plugins/source/aws/resources/services/servicecatalog/portfolios_mock_test.go
+++ b/plugins/source/aws/resources/services/servicecatalog/portfolios_mock_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func buildPortfolios(t *testing.T, ctrl *gomock.Controller) client.Services {
+func buildPortfolios(t *testing.T, ctrl *gomock.Controller) *client.Services {
 	mk := mocks.NewMockServicecatalogClient(ctrl)
 
 	o := servicecatalog.ListPortfoliosOutput{}
@@ -32,7 +32,7 @@ func buildPortfolios(t *testing.T, ctrl *gomock.Controller) client.Services {
 		nil,
 	)
 
-	return client.Services{
+	return &client.Services{
 		Servicecatalog: mk,
 	}
 }

--- a/plugins/source/aws/resources/services/servicecatalog/products_mock_test.go
+++ b/plugins/source/aws/resources/services/servicecatalog/products_mock_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func buildProducts(t *testing.T, ctrl *gomock.Controller) client.Services {
+func buildProducts(t *testing.T, ctrl *gomock.Controller) *client.Services {
 	mk := mocks.NewMockServicecatalogClient(ctrl)
 
 	o := servicecatalog.SearchProductsAsAdminOutput{}
@@ -31,7 +31,7 @@ func buildProducts(t *testing.T, ctrl *gomock.Controller) client.Services {
 		nil,
 	)
 
-	return client.Services{
+	return &client.Services{
 		Servicecatalog: mk,
 	}
 }

--- a/plugins/source/aws/resources/services/servicecatalog/provisioned_products_mock_test.go
+++ b/plugins/source/aws/resources/services/servicecatalog/provisioned_products_mock_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func buildProvisionedProducts(t *testing.T, ctrl *gomock.Controller) client.Services {
+func buildProvisionedProducts(t *testing.T, ctrl *gomock.Controller) *client.Services {
 	mk := mocks.NewMockServicecatalogClient(ctrl)
 
 	o := servicecatalog.SearchProvisionedProductsOutput{}
@@ -34,7 +34,7 @@ func buildProvisionedProducts(t *testing.T, ctrl *gomock.Controller) client.Serv
 	llpo.NextPageToken = nil
 	mk.EXPECT().ListLaunchPaths(gomock.Any(), gomock.Any(), gomock.Any()).Return(&llpo, nil).MinTimes(1)
 
-	return client.Services{
+	return &client.Services{
 		Servicecatalog: mk,
 	}
 }

--- a/plugins/source/aws/resources/services/servicediscovery/namespaces_test.go
+++ b/plugins/source/aws/resources/services/servicediscovery/namespaces_test.go
@@ -13,7 +13,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func buildNamespaces(t *testing.T, ctrl *gomock.Controller) client.Services {
+func buildNamespaces(t *testing.T, ctrl *gomock.Controller) *client.Services {
 	m := mocks.NewMockServicediscoveryClient(ctrl)
 
 	var ns types.NamespaceSummary
@@ -50,7 +50,7 @@ func buildNamespaces(t *testing.T, ctrl *gomock.Controller) client.Services {
 		nil,
 	)
 
-	return client.Services{
+	return &client.Services{
 		Servicediscovery: m,
 	}
 }

--- a/plugins/source/aws/resources/services/servicediscovery/services_test.go
+++ b/plugins/source/aws/resources/services/servicediscovery/services_test.go
@@ -13,7 +13,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func buildServices(t *testing.T, ctrl *gomock.Controller) client.Services {
+func buildServices(t *testing.T, ctrl *gomock.Controller) *client.Services {
 	m := mocks.NewMockServicediscoveryClient(ctrl)
 
 	var ss types.ServiceSummary
@@ -74,7 +74,7 @@ func buildServices(t *testing.T, ctrl *gomock.Controller) client.Services {
 		nil,
 	)
 
-	return client.Services{
+	return &client.Services{
 		Servicediscovery: m,
 	}
 }

--- a/plugins/source/aws/resources/services/servicequotas/services_mock_test.go
+++ b/plugins/source/aws/resources/services/servicequotas/services_mock_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func buildServices(t *testing.T, ctrl *gomock.Controller) client.Services {
+func buildServices(t *testing.T, ctrl *gomock.Controller) *client.Services {
 	m := mocks.NewMockServicequotasClient(ctrl)
 
 	services := servicequotas.ListServicesOutput{}
@@ -25,7 +25,7 @@ func buildServices(t *testing.T, ctrl *gomock.Controller) client.Services {
 	quotas.NextToken = nil
 	m.EXPECT().ListServiceQuotas(gomock.Any(), gomock.Any(), gomock.Any()).Return(&quotas, nil).AnyTimes()
 
-	return client.Services{
+	return &client.Services{
 		Servicequotas: m,
 	}
 }

--- a/plugins/source/aws/resources/services/ses/active_receipt_rule_sets_mock_test.go
+++ b/plugins/source/aws/resources/services/ses/active_receipt_rule_sets_mock_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func buildActiveReceiptRuleSets(t *testing.T, ctrl *gomock.Controller) client.Services {
+func buildActiveReceiptRuleSets(t *testing.T, ctrl *gomock.Controller) *client.Services {
 	sesClient := mocks.NewMockSesClient(ctrl)
 
 	data := new(ses.DescribeActiveReceiptRuleSetOutput)
@@ -19,7 +19,7 @@ func buildActiveReceiptRuleSets(t *testing.T, ctrl *gomock.Controller) client.Se
 
 	sesClient.EXPECT().DescribeActiveReceiptRuleSet(gomock.Any(), gomock.Any(), gomock.Any()).Return(data, nil)
 
-	return client.Services{
+	return &client.Services{
 		Ses: sesClient,
 	}
 }

--- a/plugins/source/aws/resources/services/ses/configuration_sets_mock_test.go
+++ b/plugins/source/aws/resources/services/ses/configuration_sets_mock_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func buildConfigurationSets(t *testing.T, ctrl *gomock.Controller) client.Services {
+func buildConfigurationSets(t *testing.T, ctrl *gomock.Controller) *client.Services {
 	sesClient := mocks.NewMockSesv2Client(ctrl)
 
 	cs := sesv2.GetConfigurationSetOutput{}
@@ -35,7 +35,7 @@ func buildConfigurationSets(t *testing.T, ctrl *gomock.Controller) client.Servic
 		nil,
 	)
 
-	return client.Services{
+	return &client.Services{
 		Sesv2: sesClient,
 	}
 }

--- a/plugins/source/aws/resources/services/ses/contact_lists_mock_test.go
+++ b/plugins/source/aws/resources/services/ses/contact_lists_mock_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func buildContactLists(t *testing.T, ctrl *gomock.Controller) client.Services {
+func buildContactLists(t *testing.T, ctrl *gomock.Controller) *client.Services {
 	sesClient := mocks.NewMockSesv2Client(ctrl)
 
 	cs := sesv2.GetContactListOutput{}
@@ -27,7 +27,7 @@ func buildContactLists(t *testing.T, ctrl *gomock.Controller) client.Services {
 		nil,
 	)
 
-	return client.Services{
+	return &client.Services{
 		Sesv2: sesClient,
 	}
 }

--- a/plugins/source/aws/resources/services/ses/custom_verification_email_templates_mock_test.go
+++ b/plugins/source/aws/resources/services/ses/custom_verification_email_templates_mock_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func buildCustomVerificationEmailTemplates(t *testing.T, ctrl *gomock.Controller) client.Services {
+func buildCustomVerificationEmailTemplates(t *testing.T, ctrl *gomock.Controller) *client.Services {
 	sesClient := mocks.NewMockSesv2Client(ctrl)
 
 	metadata := types.CustomVerificationEmailTemplateMetadata{}
@@ -34,7 +34,7 @@ func buildCustomVerificationEmailTemplates(t *testing.T, ctrl *gomock.Controller
 		nil,
 	)
 
-	return client.Services{
+	return &client.Services{
 		Sesv2: sesClient,
 	}
 }

--- a/plugins/source/aws/resources/services/ses/identities_mock_test.go
+++ b/plugins/source/aws/resources/services/ses/identities_mock_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func buildIdentities(t *testing.T, ctrl *gomock.Controller) client.Services {
+func buildIdentities(t *testing.T, ctrl *gomock.Controller) *client.Services {
 	sesClient := mocks.NewMockSesv2Client(ctrl)
 
 	ei := types.IdentityInfo{}
@@ -32,7 +32,7 @@ func buildIdentities(t *testing.T, ctrl *gomock.Controller) client.Services {
 		nil,
 	)
 
-	return client.Services{
+	return &client.Services{
 		Sesv2: sesClient,
 	}
 }

--- a/plugins/source/aws/resources/services/ses/templates_mock_test.go
+++ b/plugins/source/aws/resources/services/ses/templates_mock_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func buildSESTemplates(t *testing.T, ctrl *gomock.Controller) client.Services {
+func buildSESTemplates(t *testing.T, ctrl *gomock.Controller) *client.Services {
 	sesClient := mocks.NewMockSesv2Client(ctrl)
 
 	tplMeta := types.EmailTemplateMetadata{}
@@ -32,7 +32,7 @@ func buildSESTemplates(t *testing.T, ctrl *gomock.Controller) client.Services {
 		}, nil,
 	)
 
-	return client.Services{
+	return &client.Services{
 		Sesv2: sesClient,
 	}
 }

--- a/plugins/source/aws/resources/services/shield/attacks_mock_test.go
+++ b/plugins/source/aws/resources/services/shield/attacks_mock_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func buildAttacks(t *testing.T, ctrl *gomock.Controller) client.Services {
+func buildAttacks(t *testing.T, ctrl *gomock.Controller) *client.Services {
 	m := mocks.NewMockShieldClient(ctrl)
 	protection := shield.ListAttacksOutput{}
 	require.NoError(t, faker.FakeObject(&protection))
@@ -21,7 +21,7 @@ func buildAttacks(t *testing.T, ctrl *gomock.Controller) client.Services {
 	tags := shield.DescribeAttackOutput{}
 	require.NoError(t, faker.FakeObject(&tags))
 	m.EXPECT().DescribeAttack(gomock.Any(), gomock.Any(), gomock.Any()).Return(&tags, nil)
-	return client.Services{
+	return &client.Services{
 		Shield: m,
 	}
 }

--- a/plugins/source/aws/resources/services/shield/protection_groups_mock_test.go
+++ b/plugins/source/aws/resources/services/shield/protection_groups_mock_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func buildProtectionGroups(t *testing.T, ctrl *gomock.Controller) client.Services {
+func buildProtectionGroups(t *testing.T, ctrl *gomock.Controller) *client.Services {
 	m := mocks.NewMockShieldClient(ctrl)
 	pp := shield.ListProtectionGroupsOutput{}
 	require.NoError(t, faker.FakeObject(&pp))
@@ -22,7 +22,7 @@ func buildProtectionGroups(t *testing.T, ctrl *gomock.Controller) client.Service
 	require.NoError(t, faker.FakeObject(&tags))
 	m.EXPECT().ListTagsForResource(gomock.Any(), gomock.Any(), gomock.Any()).Return(&tags, nil)
 
-	return client.Services{
+	return &client.Services{
 		Shield: m,
 	}
 }

--- a/plugins/source/aws/resources/services/shield/protections_mock_test.go
+++ b/plugins/source/aws/resources/services/shield/protections_mock_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func buildProtections(t *testing.T, ctrl *gomock.Controller) client.Services {
+func buildProtections(t *testing.T, ctrl *gomock.Controller) *client.Services {
 	m := mocks.NewMockShieldClient(ctrl)
 	protection := shield.ListProtectionsOutput{}
 	require.NoError(t, faker.FakeObject(&protection))
@@ -21,7 +21,7 @@ func buildProtections(t *testing.T, ctrl *gomock.Controller) client.Services {
 	tags := shield.ListTagsForResourceOutput{}
 	require.NoError(t, faker.FakeObject(&tags))
 	m.EXPECT().ListTagsForResource(gomock.Any(), gomock.Any(), gomock.Any()).Return(&tags, nil)
-	return client.Services{
+	return &client.Services{
 		Shield: m,
 	}
 }

--- a/plugins/source/aws/resources/services/shield/subscriptions_mock_test.go
+++ b/plugins/source/aws/resources/services/shield/subscriptions_mock_test.go
@@ -11,13 +11,13 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func buildSubscriptions(t *testing.T, ctrl *gomock.Controller) client.Services {
+func buildSubscriptions(t *testing.T, ctrl *gomock.Controller) *client.Services {
 	m := mocks.NewMockShieldClient(ctrl)
 	subscription := shield.DescribeSubscriptionOutput{}
 	require.NoError(t, faker.FakeObject(&subscription))
 	m.EXPECT().DescribeSubscription(gomock.Any(), gomock.Any(), gomock.Any()).Return(&subscription, nil)
 
-	return client.Services{
+	return &client.Services{
 		Shield: m,
 	}
 }

--- a/plugins/source/aws/resources/services/signer/profiles_mock_test.go
+++ b/plugins/source/aws/resources/services/signer/profiles_mock_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func buildProfiles(t *testing.T, ctrl *gomock.Controller) client.Services {
+func buildProfiles(t *testing.T, ctrl *gomock.Controller) *client.Services {
 	m := mocks.NewMockSignerClient(ctrl)
 	profileList := types.SigningProfile{}
 	require.NoError(t, faker.FakeObject(&profileList))
@@ -26,7 +26,7 @@ func buildProfiles(t *testing.T, ctrl *gomock.Controller) client.Services {
 	m.EXPECT().GetSigningProfile(gomock.Any(), gomock.Any(), gomock.Any()).Return(
 		&profile, nil)
 
-	return client.Services{
+	return &client.Services{
 		Signer: m,
 	}
 }

--- a/plugins/source/aws/resources/services/sns/subscriptions_mock_test.go
+++ b/plugins/source/aws/resources/services/sns/subscriptions_mock_test.go
@@ -14,7 +14,7 @@ import (
 	"github.com/golang/mock/gomock"
 )
 
-func buildSnsSubscriptions(t *testing.T, ctrl *gomock.Controller) client.Services {
+func buildSnsSubscriptions(t *testing.T, ctrl *gomock.Controller) *client.Services {
 	m := mocks.NewMockSnsClient(ctrl)
 	sub := types.Subscription{}
 	require.NoError(t, faker.FakeObject(&sub))
@@ -57,7 +57,7 @@ func buildSnsSubscriptions(t *testing.T, ctrl *gomock.Controller) client.Service
 		nil,
 	)
 
-	return client.Services{
+	return &client.Services{
 		Sns: m,
 	}
 }

--- a/plugins/source/aws/resources/services/sns/topics_mock_test.go
+++ b/plugins/source/aws/resources/services/sns/topics_mock_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func buildSnsTopics(t *testing.T, ctrl *gomock.Controller) client.Services {
+func buildSnsTopics(t *testing.T, ctrl *gomock.Controller) *client.Services {
 	m := mocks.NewMockSnsClient(ctrl)
 	topic := types.Topic{}
 	require.NoError(t, faker.FakeObject(&topic))
@@ -45,7 +45,7 @@ func buildSnsTopics(t *testing.T, ctrl *gomock.Controller) client.Services {
 		&sns.ListTagsForResourceOutput{
 			Tags: []types.Tag{tag},
 		}, nil)
-	return client.Services{
+	return &client.Services{
 		Sns: m,
 	}
 }

--- a/plugins/source/aws/resources/services/sqs/queues_mock_test.go
+++ b/plugins/source/aws/resources/services/sqs/queues_mock_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/golang/mock/gomock"
 )
 
-func buildSQSQueues(t *testing.T, ctrl *gomock.Controller) client.Services {
+func buildSQSQueues(t *testing.T, ctrl *gomock.Controller) *client.Services {
 	sqsMock := mocks.NewMockSqsClient(ctrl)
 
 	var queueURL = "https://url1"
@@ -66,7 +66,7 @@ func buildSQSQueues(t *testing.T, ctrl *gomock.Controller) client.Services {
 		&sqs.ListQueueTagsOutput{Tags: map[string]string{"tag": "value"}},
 		nil,
 	)
-	return client.Services{Sqs: sqsMock}
+	return &client.Services{Sqs: sqsMock}
 }
 
 func TestQueues(t *testing.T) {

--- a/plugins/source/aws/resources/services/ssm/associations_mock_test.go
+++ b/plugins/source/aws/resources/services/ssm/associations_mock_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func buildAssociations(t *testing.T, ctrl *gomock.Controller) client.Services {
+func buildAssociations(t *testing.T, ctrl *gomock.Controller) *client.Services {
 	mock := mocks.NewMockSsmClient(ctrl)
 
 	var i types.Association
@@ -27,7 +27,7 @@ func buildAssociations(t *testing.T, ctrl *gomock.Controller) client.Services {
 		nil,
 	)
 
-	return client.Services{Ssm: mock}
+	return &client.Services{Ssm: mock}
 }
 
 func TestAssociations(t *testing.T) {

--- a/plugins/source/aws/resources/services/ssm/compliance_summary_items_mock_test.go
+++ b/plugins/source/aws/resources/services/ssm/compliance_summary_items_mock_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func buildComplianceSummaryItems(t *testing.T, ctrl *gomock.Controller) client.Services {
+func buildComplianceSummaryItems(t *testing.T, ctrl *gomock.Controller) *client.Services {
 	mock := mocks.NewMockSsmClient(ctrl)
 
 	var i types.ComplianceSummaryItem
@@ -27,7 +27,7 @@ func buildComplianceSummaryItems(t *testing.T, ctrl *gomock.Controller) client.S
 		nil,
 	)
 
-	return client.Services{Ssm: mock}
+	return &client.Services{Ssm: mock}
 }
 
 func TestComplianceSummaryItems(t *testing.T) {

--- a/plugins/source/aws/resources/services/ssm/documents_mock_test.go
+++ b/plugins/source/aws/resources/services/ssm/documents_mock_test.go
@@ -13,7 +13,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func buildSSMDocuments(t *testing.T, ctrl *gomock.Controller) client.Services {
+func buildSSMDocuments(t *testing.T, ctrl *gomock.Controller) *client.Services {
 	mock := mocks.NewMockSsmClient(ctrl)
 
 	docName := "testDocName"
@@ -69,7 +69,7 @@ func buildSSMDocuments(t *testing.T, ctrl *gomock.Controller) client.Services {
 		nil,
 	)
 
-	return client.Services{Ssm: mock}
+	return &client.Services{Ssm: mock}
 }
 
 func TestSSMDocuments(t *testing.T) {

--- a/plugins/source/aws/resources/services/ssm/instances_mock_test.go
+++ b/plugins/source/aws/resources/services/ssm/instances_mock_test.go
@@ -13,7 +13,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func buildSSMInstances(t *testing.T, ctrl *gomock.Controller) client.Services {
+func buildSSMInstances(t *testing.T, ctrl *gomock.Controller) *client.Services {
 	mock := mocks.NewMockSsmClient(ctrl)
 
 	var i types.InstanceInformation
@@ -51,7 +51,7 @@ func buildSSMInstances(t *testing.T, ctrl *gomock.Controller) client.Services {
 		nil,
 	)
 
-	return client.Services{Ssm: mock}
+	return &client.Services{Ssm: mock}
 }
 
 func TestSSMInstances(t *testing.T) {

--- a/plugins/source/aws/resources/services/ssm/inventories_mock_test.go
+++ b/plugins/source/aws/resources/services/ssm/inventories_mock_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func buildInventories(t *testing.T, ctrl *gomock.Controller) client.Services {
+func buildInventories(t *testing.T, ctrl *gomock.Controller) *client.Services {
 	mock := mocks.NewMockSsmClient(ctrl)
 
 	var i types.InventoryResultEntity
@@ -27,7 +27,7 @@ func buildInventories(t *testing.T, ctrl *gomock.Controller) client.Services {
 		nil,
 	)
 
-	return client.Services{Ssm: mock}
+	return &client.Services{Ssm: mock}
 }
 
 func TestInventories(t *testing.T) {

--- a/plugins/source/aws/resources/services/ssm/inventory_schemas_mock_test.go
+++ b/plugins/source/aws/resources/services/ssm/inventory_schemas_mock_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func buildInventorySchemas(t *testing.T, ctrl *gomock.Controller) client.Services {
+func buildInventorySchemas(t *testing.T, ctrl *gomock.Controller) *client.Services {
 	mock := mocks.NewMockSsmClient(ctrl)
 
 	var i types.InventoryItemSchema
@@ -27,7 +27,7 @@ func buildInventorySchemas(t *testing.T, ctrl *gomock.Controller) client.Service
 		nil,
 	)
 
-	return client.Services{Ssm: mock}
+	return &client.Services{Ssm: mock}
 }
 
 func TestInventorySchemas(t *testing.T) {

--- a/plugins/source/aws/resources/services/ssm/parameters_mock_test.go
+++ b/plugins/source/aws/resources/services/ssm/parameters_mock_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func buildParameters(t *testing.T, ctrl *gomock.Controller) client.Services {
+func buildParameters(t *testing.T, ctrl *gomock.Controller) *client.Services {
 	mock := mocks.NewMockSsmClient(ctrl)
 	var pm types.ParameterMetadata
 	require.NoError(t, faker.FakeObject(&pm))
@@ -25,7 +25,7 @@ func buildParameters(t *testing.T, ctrl *gomock.Controller) client.Services {
 		&ssm.DescribeParametersOutput{Parameters: []types.ParameterMetadata{pm}},
 		nil,
 	)
-	return client.Services{Ssm: mock}
+	return &client.Services{Ssm: mock}
 }
 
 func TestParameters(t *testing.T) {

--- a/plugins/source/aws/resources/services/ssm/patch_baselines_mock_test.go
+++ b/plugins/source/aws/resources/services/ssm/patch_baselines_mock_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func buildPatchBaselines(t *testing.T, ctrl *gomock.Controller) client.Services {
+func buildPatchBaselines(t *testing.T, ctrl *gomock.Controller) *client.Services {
 	mock := mocks.NewMockSsmClient(ctrl)
 
 	var i types.PatchBaselineIdentity
@@ -27,7 +27,7 @@ func buildPatchBaselines(t *testing.T, ctrl *gomock.Controller) client.Services 
 		nil,
 	)
 
-	return client.Services{Ssm: mock}
+	return &client.Services{Ssm: mock}
 }
 
 func TestPatchBaselines(t *testing.T) {

--- a/plugins/source/aws/resources/services/ssm/sessions_mock_test.go
+++ b/plugins/source/aws/resources/services/ssm/sessions_mock_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func buildSessions(t *testing.T, ctrl *gomock.Controller) client.Services {
+func buildSessions(t *testing.T, ctrl *gomock.Controller) *client.Services {
 	mock := mocks.NewMockSsmClient(ctrl)
 
 	var s types.Session
@@ -27,7 +27,7 @@ func buildSessions(t *testing.T, ctrl *gomock.Controller) client.Services {
 		nil,
 	)
 
-	return client.Services{Ssm: mock}
+	return &client.Services{Ssm: mock}
 }
 
 func TestSessions(t *testing.T) {

--- a/plugins/source/aws/resources/services/ssoadmin/instances_mock_test.go
+++ b/plugins/source/aws/resources/services/ssoadmin/instances_mock_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func buildInstances(t *testing.T, ctrl *gomock.Controller) client.Services {
+func buildInstances(t *testing.T, ctrl *gomock.Controller) *client.Services {
 	mSSOAdmin := mocks.NewMockSsoadminClient(ctrl)
 	im := types.InstanceMetadata{}
 	ps := types.PermissionSet{}
@@ -75,7 +75,7 @@ func buildInstances(t *testing.T, ctrl *gomock.Controller) client.Services {
 			AttachedManagedPolicies: []types.AttachedManagedPolicy{amp},
 		}, nil)
 
-	return client.Services{
+	return &client.Services{
 		Ssoadmin: mSSOAdmin,
 	}
 }

--- a/plugins/source/aws/resources/services/stepfunctions/activities_test.go
+++ b/plugins/source/aws/resources/services/stepfunctions/activities_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func buildActivities(t *testing.T, ctrl *gomock.Controller) client.Services {
+func buildActivities(t *testing.T, ctrl *gomock.Controller) *client.Services {
 	m := mocks.NewMockSfnClient(ctrl)
 	ali := types.ActivityListItem{}
 	require.NoError(t, faker.FakeObject(&ali))
@@ -22,7 +22,7 @@ func buildActivities(t *testing.T, ctrl *gomock.Controller) client.Services {
 			Activities: []types.ActivityListItem{ali},
 		}, nil)
 
-	return client.Services{
+	return &client.Services{
 		Sfn: m,
 	}
 }

--- a/plugins/source/aws/resources/services/stepfunctions/state_machines_test.go
+++ b/plugins/source/aws/resources/services/stepfunctions/state_machines_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func buildStateMachines(t *testing.T, ctrl *gomock.Controller) client.Services {
+func buildStateMachines(t *testing.T, ctrl *gomock.Controller) *client.Services {
 	m := mocks.NewMockSfnClient(ctrl)
 	im := types.StateMachineListItem{}
 	require.NoError(t, faker.FakeObject(&im))
@@ -59,7 +59,7 @@ func buildStateMachines(t *testing.T, ctrl *gomock.Controller) client.Services {
 	require.NoError(t, faker.FakeObject(&mapRunOut))
 
 	m.EXPECT().DescribeMapRun(gomock.Any(), gomock.Any(), gomock.Any()).Return(&mapRunOut, nil)
-	return client.Services{
+	return &client.Services{
 		Sfn: m,
 	}
 }

--- a/plugins/source/aws/resources/services/support/cases_test.go
+++ b/plugins/source/aws/resources/services/support/cases_test.go
@@ -13,7 +13,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func buildCases(t *testing.T, ctrl *gomock.Controller) client.Services {
+func buildCases(t *testing.T, ctrl *gomock.Controller) *client.Services {
 	m := mocks.NewMockSupportClient(ctrl)
 	details := []types.CaseDetails{}
 	require.NoError(t, faker.FakeObject(&details))
@@ -23,7 +23,7 @@ func buildCases(t *testing.T, ctrl *gomock.Controller) client.Services {
 
 	require.NoError(t, mockCommunications(details[0], m))
 
-	return client.Services{
+	return &client.Services{
 		Support: m,
 	}
 }

--- a/plugins/source/aws/resources/services/support/services_test.go
+++ b/plugins/source/aws/resources/services/support/services_test.go
@@ -13,7 +13,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func buildServices(t *testing.T, ctrl *gomock.Controller) client.Services {
+func buildServices(t *testing.T, ctrl *gomock.Controller) *client.Services {
 	m := mocks.NewMockSupportClient(ctrl)
 	services := []types.Service{}
 	require.NoError(t, faker.FakeObject(&services))
@@ -22,7 +22,7 @@ func buildServices(t *testing.T, ctrl *gomock.Controller) client.Services {
 		m.EXPECT().DescribeServices(gomock.Any(), &support.DescribeServicesInput{Language: aws.String(languageCode)}, gomock.Any()).Return(&support.DescribeServicesOutput{Services: services}, nil)
 	}
 
-	return client.Services{
+	return &client.Services{
 		Support: m,
 	}
 }

--- a/plugins/source/aws/resources/services/support/severity_levels_test.go
+++ b/plugins/source/aws/resources/services/support/severity_levels_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/golang/mock/gomock"
 )
 
-func buildSeverityLevels(t *testing.T, ctrl *gomock.Controller) client.Services {
+func buildSeverityLevels(t *testing.T, ctrl *gomock.Controller) *client.Services {
 	m := mocks.NewMockSupportClient(ctrl)
 	levels := []types.SeverityLevel{}
 	err := faker.FakeObject(&levels)
@@ -24,7 +24,7 @@ func buildSeverityLevels(t *testing.T, ctrl *gomock.Controller) client.Services 
 		m.EXPECT().DescribeSeverityLevels(gomock.Any(), &support.DescribeSeverityLevelsInput{Language: aws.String(languageCode)}, gomock.Any()).Return(&support.DescribeSeverityLevelsOutput{SeverityLevels: levels}, nil)
 	}
 
-	return client.Services{
+	return &client.Services{
 		Support: m,
 	}
 }

--- a/plugins/source/aws/resources/services/support/trusted_advisor_checks_test.go
+++ b/plugins/source/aws/resources/services/support/trusted_advisor_checks_test.go
@@ -13,7 +13,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func buildTrustedAdvisorChecks(t *testing.T, ctrl *gomock.Controller) client.Services {
+func buildTrustedAdvisorChecks(t *testing.T, ctrl *gomock.Controller) *client.Services {
 	m := mocks.NewMockSupportClient(ctrl)
 	checks := []types.TrustedAdvisorCheckDescription{}
 	require.NoError(t, faker.FakeObject(&checks))
@@ -33,7 +33,7 @@ func buildTrustedAdvisorChecks(t *testing.T, ctrl *gomock.Controller) client.Ser
 		t.Fatal(err)
 	}
 
-	return client.Services{
+	return &client.Services{
 		Support: m,
 	}
 }

--- a/plugins/source/aws/resources/services/timestream/databases_mock_test.go
+++ b/plugins/source/aws/resources/services/timestream/databases_mock_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func buildTimestreamDatabasesMock(t *testing.T, ctrl *gomock.Controller) client.Services {
+func buildTimestreamDatabasesMock(t *testing.T, ctrl *gomock.Controller) *client.Services {
 	m := mocks.NewMockTimestreamwriteClient(ctrl)
 	database := types.Database{}
 	require.NoError(t, faker.FakeObject(&database))
@@ -32,7 +32,7 @@ func buildTimestreamDatabasesMock(t *testing.T, ctrl *gomock.Controller) client.
 	m.EXPECT().ListTagsForResource(gomock.Any(), gomock.Any(), gomock.Any()).Return(
 		&timestreamwrite.ListTagsForResourceOutput{Tags: tags}, nil)
 
-	return client.Services{Timestreamwrite: m}
+	return &client.Services{Timestreamwrite: m}
 }
 
 func TestTimestreamDatabases(t *testing.T) {

--- a/plugins/source/aws/resources/services/transfer/servers_test.go
+++ b/plugins/source/aws/resources/services/transfer/servers_test.go
@@ -13,7 +13,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func buildServersMock(t *testing.T, ctrl *gomock.Controller) client.Services {
+func buildServersMock(t *testing.T, ctrl *gomock.Controller) *client.Services {
 	m := mocks.NewMockTransferClient(ctrl)
 
 	var ls types.ListedServer
@@ -49,7 +49,7 @@ func buildServersMock(t *testing.T, ctrl *gomock.Controller) client.Services {
 		nil,
 	)
 
-	return client.Services{
+	return &client.Services{
 		Transfer: m,
 	}
 }

--- a/plugins/source/aws/resources/services/waf/rule_groups_mock_test.go
+++ b/plugins/source/aws/resources/services/waf/rule_groups_mock_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func buildWAFRuleGroupsMock(t *testing.T, ctrl *gomock.Controller) client.Services {
+func buildWAFRuleGroupsMock(t *testing.T, ctrl *gomock.Controller) *client.Services {
 	m := mocks.NewMockWafClient(ctrl)
 	tempRuleGroupSum := types.RuleGroupSummary{}
 	require.NoError(t, faker.FakeObject(&tempRuleGroupSum))
@@ -39,7 +39,7 @@ func buildWAFRuleGroupsMock(t *testing.T, ctrl *gomock.Controller) client.Servic
 		TagInfoForResource: &types.TagInfoForResource{TagList: tempTags},
 	}, nil)
 
-	return client.Services{Waf: m}
+	return &client.Services{Waf: m}
 }
 
 func TestWafRuleGroups(t *testing.T) {

--- a/plugins/source/aws/resources/services/waf/rules_mock_test.go
+++ b/plugins/source/aws/resources/services/waf/rules_mock_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func buildWAFRulesMock(t *testing.T, ctrl *gomock.Controller) client.Services {
+func buildWAFRulesMock(t *testing.T, ctrl *gomock.Controller) *client.Services {
 	m := mocks.NewMockWafClient(ctrl)
 	tempRuleSum := types.RuleSummary{}
 	require.NoError(t, faker.FakeObject(&tempRuleSum))
@@ -33,7 +33,7 @@ func buildWAFRulesMock(t *testing.T, ctrl *gomock.Controller) client.Services {
 		TagInfoForResource: &types.TagInfoForResource{TagList: tempTags},
 	}, nil)
 
-	return client.Services{Waf: m}
+	return &client.Services{Waf: m}
 }
 
 func TestWafRules(t *testing.T) {

--- a/plugins/source/aws/resources/services/waf/subscribed_rule_groups_mock_test.go
+++ b/plugins/source/aws/resources/services/waf/subscribed_rule_groups_mock_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func buildWAFSubscribedRuleGroupsMock(t *testing.T, ctrl *gomock.Controller) client.Services {
+func buildWAFSubscribedRuleGroupsMock(t *testing.T, ctrl *gomock.Controller) *client.Services {
 	m := mocks.NewMockWafClient(ctrl)
 	tempSubscrRuleGroupSum := types.SubscribedRuleGroupSummary{}
 	require.NoError(t, faker.FakeObject(&tempSubscrRuleGroupSum))
@@ -21,7 +21,7 @@ func buildWAFSubscribedRuleGroupsMock(t *testing.T, ctrl *gomock.Controller) cli
 		RuleGroups: []types.SubscribedRuleGroupSummary{tempSubscrRuleGroupSum},
 	}, nil)
 
-	return client.Services{Waf: m}
+	return &client.Services{Waf: m}
 }
 
 func TestWafSubscribedRuleGroups(t *testing.T) {

--- a/plugins/source/aws/resources/services/waf/web_acls_mock_test.go
+++ b/plugins/source/aws/resources/services/waf/web_acls_mock_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func buildWAFWebACLMock(t *testing.T, ctrl *gomock.Controller) client.Services {
+func buildWAFWebACLMock(t *testing.T, ctrl *gomock.Controller) *client.Services {
 	m := mocks.NewMockWafClient(ctrl)
 	tempWebACLSum := types.WebACLSummary{}
 	require.NoError(t, faker.FakeObject(&tempWebACLSum))
@@ -39,7 +39,7 @@ func buildWAFWebACLMock(t *testing.T, ctrl *gomock.Controller) client.Services {
 		LoggingConfiguration: &loggingConfiguration,
 	}, nil)
 
-	return client.Services{Waf: m}
+	return &client.Services{Waf: m}
 }
 
 func TestWafWebACL(t *testing.T) {

--- a/plugins/source/aws/resources/services/wafregional/rate_based_rules_mock_test.go
+++ b/plugins/source/aws/resources/services/wafregional/rate_based_rules_mock_test.go
@@ -14,7 +14,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func buildRateBasedRulesMock(t *testing.T, ctrl *gomock.Controller) client.Services {
+func buildRateBasedRulesMock(t *testing.T, ctrl *gomock.Controller) *client.Services {
 	m := mocks.NewMockWafregionalClient(ctrl)
 
 	var rule types.RateBasedRule
@@ -56,7 +56,7 @@ func buildRateBasedRulesMock(t *testing.T, ctrl *gomock.Controller) client.Servi
 		nil,
 	)
 
-	return client.Services{Wafregional: m}
+	return &client.Services{Wafregional: m}
 }
 
 func TestRateBasedRules(t *testing.T) {

--- a/plugins/source/aws/resources/services/wafregional/rule_groups_mock_test.go
+++ b/plugins/source/aws/resources/services/wafregional/rule_groups_mock_test.go
@@ -14,7 +14,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func buildRuleGroupsMock(t *testing.T, ctrl *gomock.Controller) client.Services {
+func buildRuleGroupsMock(t *testing.T, ctrl *gomock.Controller) *client.Services {
 	m := mocks.NewMockWafregionalClient(ctrl)
 
 	tempRuleGroup := types.RuleGroup{}
@@ -69,7 +69,7 @@ func buildRuleGroupsMock(t *testing.T, ctrl *gomock.Controller) client.Services 
 		nil,
 	)
 
-	return client.Services{Wafregional: m}
+	return &client.Services{Wafregional: m}
 }
 
 func TestRuleGroups(t *testing.T) {

--- a/plugins/source/aws/resources/services/wafregional/rules_mock_test.go
+++ b/plugins/source/aws/resources/services/wafregional/rules_mock_test.go
@@ -14,7 +14,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func buildRulesMock(t *testing.T, ctrl *gomock.Controller) client.Services {
+func buildRulesMock(t *testing.T, ctrl *gomock.Controller) *client.Services {
 	m := mocks.NewMockWafregionalClient(ctrl)
 
 	var r types.Rule
@@ -56,7 +56,7 @@ func buildRulesMock(t *testing.T, ctrl *gomock.Controller) client.Services {
 		nil,
 	)
 
-	return client.Services{Wafregional: m}
+	return &client.Services{Wafregional: m}
 }
 
 func TestRules(t *testing.T) {

--- a/plugins/source/aws/resources/services/wafregional/web_acls_mock_test.go
+++ b/plugins/source/aws/resources/services/wafregional/web_acls_mock_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func buildWebACLsMock(t *testing.T, ctrl *gomock.Controller) client.Services {
+func buildWebACLsMock(t *testing.T, ctrl *gomock.Controller) *client.Services {
 	m := mocks.NewMockWafregionalClient(ctrl)
 
 	var acl types.WebACL
@@ -66,7 +66,7 @@ func buildWebACLsMock(t *testing.T, ctrl *gomock.Controller) client.Services {
 		nil,
 	)
 
-	return client.Services{Wafregional: m}
+	return &client.Services{Wafregional: m}
 }
 
 func TestWebACLs(t *testing.T) {

--- a/plugins/source/aws/resources/services/wafv2/ipsets_mock_test.go
+++ b/plugins/source/aws/resources/services/wafv2/ipsets_mock_test.go
@@ -13,7 +13,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func buildIpsetsMock(t *testing.T, ctrl *gomock.Controller) client.Services {
+func buildIpsetsMock(t *testing.T, ctrl *gomock.Controller) *client.Services {
 	m := mocks.NewMockWafv2Client(ctrl)
 
 	for _, scope := range []types.Scope{types.ScopeCloudfront, types.ScopeRegional} {
@@ -54,7 +54,7 @@ func buildIpsetsMock(t *testing.T, ctrl *gomock.Controller) client.Services {
 		)
 	}
 
-	return client.Services{Wafv2: m}
+	return &client.Services{Wafv2: m}
 }
 
 func TestWafV2IPSets(t *testing.T) {

--- a/plugins/source/aws/resources/services/wafv2/managed_rule_groups_mock_test.go
+++ b/plugins/source/aws/resources/services/wafv2/managed_rule_groups_mock_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func buildWAFV2ManagedRuleGroupsMock(t *testing.T, ctrl *gomock.Controller) client.Services {
+func buildWAFV2ManagedRuleGroupsMock(t *testing.T, ctrl *gomock.Controller) *client.Services {
 	m := mocks.NewMockWafv2Client(ctrl)
 	var tempDescribeManagedRuleGroup wafv2.DescribeManagedRuleGroupOutput
 	require.NoError(t, faker.FakeObject(&tempDescribeManagedRuleGroup))
@@ -28,7 +28,7 @@ func buildWAFV2ManagedRuleGroupsMock(t *testing.T, ctrl *gomock.Controller) clie
 		m.EXPECT().DescribeManagedRuleGroup(gomock.Any(), gomock.Any(), gomock.Any()).Return(&tempDescribeManagedRuleGroup, nil)
 	}
 
-	return client.Services{Wafv2: m}
+	return &client.Services{Wafv2: m}
 }
 
 func TestWafV2ManagedRuleGroups(t *testing.T) {

--- a/plugins/source/aws/resources/services/wafv2/regex_pattern_sets_mock_test.go
+++ b/plugins/source/aws/resources/services/wafv2/regex_pattern_sets_mock_test.go
@@ -13,7 +13,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func buildRegexPatternSetsMock(t *testing.T, ctrl *gomock.Controller) client.Services {
+func buildRegexPatternSetsMock(t *testing.T, ctrl *gomock.Controller) *client.Services {
 	m := mocks.NewMockWafv2Client(ctrl)
 
 	for _, scope := range []types.Scope{types.ScopeCloudfront, types.ScopeRegional} {
@@ -53,7 +53,7 @@ func buildRegexPatternSetsMock(t *testing.T, ctrl *gomock.Controller) client.Ser
 		)
 	}
 
-	return client.Services{Wafv2: m}
+	return &client.Services{Wafv2: m}
 }
 
 func TestWafV2RegexPatternSets(t *testing.T) {

--- a/plugins/source/aws/resources/services/wafv2/rule_groups_mock_test.go
+++ b/plugins/source/aws/resources/services/wafv2/rule_groups_mock_test.go
@@ -13,7 +13,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func buildWAFV2RuleGroupsMock(t *testing.T, ctrl *gomock.Controller) client.Services {
+func buildWAFV2RuleGroupsMock(t *testing.T, ctrl *gomock.Controller) *client.Services {
 	m := mocks.NewMockWafv2Client(ctrl)
 	visibilityConfig := types.VisibilityConfig{}
 	require.NoError(t, faker.FakeObject(&visibilityConfig))
@@ -65,7 +65,7 @@ func buildWAFV2RuleGroupsMock(t *testing.T, ctrl *gomock.Controller) client.Serv
 		}, nil)
 	}
 
-	return client.Services{Wafv2: m}
+	return &client.Services{Wafv2: m}
 }
 
 func TestWafV2RuleGroups(t *testing.T) {

--- a/plugins/source/aws/resources/services/wafv2/web_acls_mock_test.go
+++ b/plugins/source/aws/resources/services/wafv2/web_acls_mock_test.go
@@ -15,7 +15,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func buildWAFV2WebACLMock(t *testing.T, ctrl *gomock.Controller) client.Services {
+func buildWAFV2WebACLMock(t *testing.T, ctrl *gomock.Controller) *client.Services {
 	m := mocks.NewMockWafv2Client(ctrl)
 	cfm := mocks.NewMockCloudfrontClient(ctrl)
 
@@ -69,7 +69,7 @@ func buildWAFV2WebACLMock(t *testing.T, ctrl *gomock.Controller) client.Services
 		DistributionList: &distributionList,
 	}, nil)
 
-	return client.Services{Wafv2: m, Cloudfront: cfm}
+	return &client.Services{Wafv2: m, Cloudfront: cfm}
 }
 
 func TestWafV2WebACL(t *testing.T) {

--- a/plugins/source/aws/resources/services/wellarchitected/lenses_mock_test.go
+++ b/plugins/source/aws/resources/services/wellarchitected/lenses_mock_test.go
@@ -13,7 +13,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func buildLensesMock(t *testing.T, ctrl *gomock.Controller) client.Services {
+func buildLensesMock(t *testing.T, ctrl *gomock.Controller) *client.Services {
 	m := mocks.NewMockWellarchitectedClient(ctrl)
 	for _, lensType := range types.LensType("").Values() {
 		var summary types.LensSummary
@@ -43,7 +43,7 @@ func buildLensesMock(t *testing.T, ctrl *gomock.Controller) client.Services {
 		m.EXPECT().GetLens(gomock.Any(), getInput, gomock.Any()).
 			Return(&wellarchitected.GetLensOutput{Lens: &lens}, nil)
 	}
-	return client.Services{Wellarchitected: m}
+	return &client.Services{Wellarchitected: m}
 }
 
 func TestLenses(t *testing.T) {

--- a/plugins/source/aws/resources/services/wellarchitected/share_invitations_mock_test.go
+++ b/plugins/source/aws/resources/services/wellarchitected/share_invitations_mock_test.go
@@ -13,7 +13,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func buildShareInvitationsMock(t *testing.T, ctrl *gomock.Controller) client.Services {
+func buildShareInvitationsMock(t *testing.T, ctrl *gomock.Controller) *client.Services {
 	m := mocks.NewMockWellarchitectedClient(ctrl)
 	for _, shareResourceType := range types.ShareResourceType("").Values() {
 		var summary types.ShareInvitationSummary
@@ -32,7 +32,7 @@ func buildShareInvitationsMock(t *testing.T, ctrl *gomock.Controller) client.Ser
 				nil,
 			)
 	}
-	return client.Services{Wellarchitected: m}
+	return &client.Services{Wellarchitected: m}
 }
 
 func TestShareInvitations(t *testing.T) {

--- a/plugins/source/aws/resources/services/wellarchitected/workloads_mock_test.go
+++ b/plugins/source/aws/resources/services/wellarchitected/workloads_mock_test.go
@@ -13,7 +13,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func buildWorkloadsMock(t *testing.T, ctrl *gomock.Controller) client.Services {
+func buildWorkloadsMock(t *testing.T, ctrl *gomock.Controller) *client.Services {
 	m := mocks.NewMockWellarchitectedClient(ctrl)
 
 	var summary types.WorkloadSummary
@@ -33,7 +33,7 @@ func buildWorkloadsMock(t *testing.T, ctrl *gomock.Controller) client.Services {
 	buildWorkloadMilestones(t, m, &workload)
 	buildWorkloadShares(t, m, &workload)
 
-	return client.Services{Wellarchitected: m}
+	return &client.Services{Wellarchitected: m}
 }
 
 func TestWorkloads(t *testing.T) {

--- a/plugins/source/aws/resources/services/workspaces/directories_mock_test.go
+++ b/plugins/source/aws/resources/services/workspaces/directories_mock_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func buildDirectories(t *testing.T, ctrl *gomock.Controller) client.Services {
+func buildDirectories(t *testing.T, ctrl *gomock.Controller) *client.Services {
 	mock := mocks.NewMockWorkspacesClient(ctrl)
 
 	var directory types.WorkspaceDirectory
@@ -27,7 +27,7 @@ func buildDirectories(t *testing.T, ctrl *gomock.Controller) client.Services {
 		nil,
 	)
 
-	return client.Services{Workspaces: mock}
+	return &client.Services{Workspaces: mock}
 }
 
 func TestWorkspacesDirectories(t *testing.T) {

--- a/plugins/source/aws/resources/services/workspaces/workspaces_mock_test.go
+++ b/plugins/source/aws/resources/services/workspaces/workspaces_mock_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func buildWorkspaces(t *testing.T, ctrl *gomock.Controller) client.Services {
+func buildWorkspaces(t *testing.T, ctrl *gomock.Controller) *client.Services {
 	mock := mocks.NewMockWorkspacesClient(ctrl)
 
 	var workspace types.Workspace
@@ -27,7 +27,7 @@ func buildWorkspaces(t *testing.T, ctrl *gomock.Controller) client.Services {
 		nil,
 	)
 
-	return client.Services{Workspaces: mock}
+	return &client.Services{Workspaces: mock}
 }
 
 func TestWorkspacesWorkspaces(t *testing.T) {

--- a/plugins/source/aws/resources/services/xray/encryption_config_mock_test.go
+++ b/plugins/source/aws/resources/services/xray/encryption_config_mock_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func buildEncryptionConfig(t *testing.T, ctrl *gomock.Controller) client.Services {
+func buildEncryptionConfig(t *testing.T, ctrl *gomock.Controller) *client.Services {
 	mock := mocks.NewMockXrayClient(ctrl)
 
 	var config types.EncryptionConfig
@@ -29,7 +29,7 @@ func buildEncryptionConfig(t *testing.T, ctrl *gomock.Controller) client.Service
 		nil,
 	)
 
-	return client.Services{Xray: mock}
+	return &client.Services{Xray: mock}
 }
 
 func TestXrayEncryptionConfig(t *testing.T) {

--- a/plugins/source/aws/resources/services/xray/groups_mock_test.go
+++ b/plugins/source/aws/resources/services/xray/groups_mock_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func buildGroups(t *testing.T, ctrl *gomock.Controller) client.Services {
+func buildGroups(t *testing.T, ctrl *gomock.Controller) *client.Services {
 	mock := mocks.NewMockXrayClient(ctrl)
 
 	test := "test"
@@ -49,7 +49,7 @@ func buildGroups(t *testing.T, ctrl *gomock.Controller) client.Services {
 		nil,
 	)
 
-	return client.Services{Xray: mock}
+	return &client.Services{Xray: mock}
 }
 
 func TestXrayGroups(t *testing.T) {

--- a/plugins/source/aws/resources/services/xray/resource_policies_mock_test.go
+++ b/plugins/source/aws/resources/services/xray/resource_policies_mock_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func buildResourcePolicies(t *testing.T, ctrl *gomock.Controller) client.Services {
+func buildResourcePolicies(t *testing.T, ctrl *gomock.Controller) *client.Services {
 	mock := mocks.NewMockXrayClient(ctrl)
 
 	var pols types.ResourcePolicy
@@ -31,7 +31,7 @@ func buildResourcePolicies(t *testing.T, ctrl *gomock.Controller) client.Service
 		nil,
 	)
 
-	return client.Services{Xray: mock}
+	return &client.Services{Xray: mock}
 }
 
 func TestResourcePolicies(t *testing.T) {

--- a/plugins/source/aws/resources/services/xray/sampling_rules_mock_test.go
+++ b/plugins/source/aws/resources/services/xray/sampling_rules_mock_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func buildSamplingRules(t *testing.T, ctrl *gomock.Controller) client.Services {
+func buildSamplingRules(t *testing.T, ctrl *gomock.Controller) *client.Services {
 	mock := mocks.NewMockXrayClient(ctrl)
 
 	test := "test"
@@ -49,7 +49,7 @@ func buildSamplingRules(t *testing.T, ctrl *gomock.Controller) client.Services {
 		nil,
 	)
 
-	return client.Services{Xray: mock}
+	return &client.Services{Xray: mock}
 }
 
 func TestXraySamplingRules(t *testing.T) {


### PR DESCRIPTION
Overtakes https://github.com/cloudquery/cloudquery/pull/16066