### PR TITLE
chore: Switch to API key from `cloudquery login` token

### DIFF
--- a/.github/workflows/publish_plugin_to_hub.yml
+++ b/.github/workflows/publish_plugin_to_hub.yml
@@ -136,9 +136,9 @@ jobs:
 
       - name: Publish plugin to hub
         working-directory: ${{ needs.prepare.outputs.plugin_dir }}
+        env:
+          CLOUDQUERY_API_KEY: ${{ secrets.CLOUDQUERY_API_KEY }}
         run: |
-          mkdir -p ~/.local/share/cloudquery
-          echo ${{ secrets.CQ_CI_CLOUDQUERY_HUB_TOKEN }} > ~/.local/share/cloudquery/token
           cloudquery plugin publish --finalize
   publish-plugin-to-hub-node:
     timeout-minutes: 60
@@ -210,9 +210,9 @@ jobs:
 
       - name: Publish plugin to hub
         working-directory: ${{ needs.prepare.outputs.plugin_dir }}
+        env:
+          CLOUDQUERY_API_KEY: ${{ secrets.CLOUDQUERY_API_KEY }}
         run: |
-          mkdir -p ~/.local/share/cloudquery
-          echo ${{ secrets.CQ_CI_CLOUDQUERY_HUB_TOKEN }} > ~/.local/share/cloudquery/token
           cloudquery plugin publish --finalize
 
   publish-plugin-to-hub-go:
@@ -291,7 +291,7 @@ jobs:
 
       - name: Publish plugin to hub
         working-directory: ${{ needs.prepare.outputs.plugin_dir }}
+        env:
+          CLOUDQUERY_API_KEY: ${{ secrets.CLOUDQUERY_API_KEY }}
         run: |
-          mkdir -p ~/.local/share/cloudquery
-          echo ${{ secrets.CQ_CI_CLOUDQUERY_HUB_TOKEN }} > ~/.local/share/cloudquery/token
           cloudquery plugin publish --finalize

--- a/.github/workflows/publish_plugin_to_hub_duckdb.yml
+++ b/.github/workflows/publish_plugin_to_hub_duckdb.yml
@@ -111,7 +111,7 @@ jobs:
 
       - name: Publish plugin to hub
         working-directory: ${{ needs.prepare.outputs.plugin_dir }}
+        env:
+          CLOUDQUERY_API_KEY: ${{ secrets.CLOUDQUERY_API_KEY }}
         run: |
-          mkdir -p ~/.local/share/cloudquery
-          echo ${{ secrets.CQ_CI_CLOUDQUERY_HUB_TOKEN }} > ~/.local/share/cloudquery/token
           cloudquery plugin publish --finalize

--- a/.github/workflows/publish_plugin_to_hub_snowflake.yml
+++ b/.github/workflows/publish_plugin_to_hub_snowflake.yml
@@ -112,7 +112,7 @@ jobs:
 
       - name: Publish plugin to hub
         working-directory: ${{ needs.prepare.outputs.plugin_dir }}
+        env:
+          CLOUDQUERY_API_KEY: ${{ secrets.CLOUDQUERY_API_KEY }}
         run: |
-          mkdir -p ~/.local/share/cloudquery
-          echo ${{ secrets.CQ_CI_CLOUDQUERY_HUB_TOKEN }} > ~/.local/share/cloudquery/token
           cloudquery plugin publish --finalize

--- a/.github/workflows/publish_plugin_to_hub_sqlite.yml
+++ b/.github/workflows/publish_plugin_to_hub_sqlite.yml
@@ -111,7 +111,7 @@ jobs:
 
       - name: Publish plugin to hub
         working-directory: ${{ needs.prepare.outputs.plugin_dir }}
+        env:
+          CLOUDQUERY_API_KEY: ${{ secrets.CLOUDQUERY_API_KEY }}
         run: |
-          mkdir -p ~/.local/share/cloudquery
-          echo ${{ secrets.CQ_CI_CLOUDQUERY_HUB_TOKEN }} > ~/.local/share/cloudquery/token
           cloudquery plugin publish --finalize


### PR DESCRIPTION
<!-- 🎉 Thank you for making CloudQuery awesome by submitting a PR 🎉 -->

#### Summary

Publishing to the Hub CI was set up before the backend supported API keys so I used a CLI token. Now that we support API keys this PR switches to use one

<!--
Use the following steps to ensure your PR is ready to be reviewed

- [ ] Read the [contribution guidelines](https://github.com/cloudquery/cloudquery/blob/main/CONTRIBUTING.md) 🧑‍🎓
- [ ] Run `make lint` to ensure the proposed changes follow the coding style 🚨 (install golangci-lint [here](https://golangci-lint.run/usage/install/#local-installation))
- [ ] Run `make test` to ensure the proposed changes pass the tests 🧪
- [ ] If changing a source plugin run `make gen` to ensure docs are up to date 📝
- [ ] Ensure the status checks below are successful ✅
--->
