### PR TITLE
feat: Persist KMS Key data even if AccessDenied on `kms:DescribeKey`

### DIFF
--- a/plugins/source/aws/resources/services/kms/keys.go
+++ b/plugins/source/aws/resources/services/kms/keys.go
@@ -81,6 +81,15 @@ func getKey(ctx context.Context, meta schema.ClientMeta, resource *schema.Resour
 		options.Region = cl.Region
 	})
 	if err != nil {
+		if client.IsAWSError(err, "AccessDenied") || client.IsAWSError(err, "AccessDeniedException") {
+			resource.Item = &types.KeyMetadata{
+				Arn:   item.KeyArn,
+				KeyId: item.KeyId,
+			}
+			cl.Logger().Warn().Err(err).Msg("metadata retrieved from ListKeys will still be persisted")
+			return nil
+		}
+
 		return err
 	}
 	resource.Item = d.KeyMetadata


### PR DESCRIPTION
<!-- 🎉 Thank you for making CloudQuery awesome by submitting a PR 🎉 -->

#### Summary

⚠️ **If you're contributing to a plugin please read this section of the [contribution guidelines](https://github.com/cloudquery/cloudquery/blob/main/CONTRIBUTING.md#open-core-vs-open-source) 🧑‍🎓 before submitting this PR** ⚠️

<!--
Explain what problem this PR addresses
-->

<!--
Use the following steps to ensure your PR is ready to be reviewed

- [ ] Read the [contribution guidelines](https://github.com/cloudquery/cloudquery/blob/main/CONTRIBUTING.md) 🧑‍🎓
- [ ] Run `make lint` to ensure the proposed changes follow the coding style 🚨 (install golangci-lint [here](https://golangci-lint.run/usage/install/#local-installation))
- [ ] Run `make test` to ensure the proposed changes pass the tests 🧪
- [ ] If changing a source plugin run `make gen` to ensure docs are up to date 📝
- [ ] Ensure the status checks below are successful ✅
--->
