### PR TITLE
fix: Remove Unique Constraints in Append Mode

### DIFF
--- a/cli/cmd/migrate_v3.go
+++ b/cli/cmd/migrate_v3.go
@@ -33,7 +33,7 @@ func migrateConnectionV3(ctx context.Context, sourceClient *managedplugin.Client
 			transformer.WithSyncTimeColumn(migrateStart),
 		}
 		if destinationSpecs[i].WriteMode == specs.WriteModeAppend {
-			opts = append(opts, transformer.WithRemovePKs())
+			opts = append(opts, transformer.WithRemovePKs(), transformer.WithRemoveUniqueConstraints())
 		} else if destinationSpecs[i].PKMode == specs.PKModeCQID {
 			opts = append(opts, transformer.WithRemovePKs())
 			opts = append(opts, transformer.WithCQIDPrimaryKey())

--- a/cli/cmd/sync_v2.go
+++ b/cli/cmd/sync_v2.go
@@ -32,7 +32,7 @@ func getSourceV2DestV3DestinationsTransformers(destinationSpecs []specs.Destinat
 		}
 		opts := []transformer.RecordTransformerOption{}
 		if destinationSpecs[i].WriteMode == specs.WriteModeAppend {
-			opts = append(opts, transformer.WithRemovePKs())
+			opts = append(opts, transformer.WithRemovePKs(), transformer.WithRemoveUniqueConstraints())
 		} else if destinationSpecs[i].PKMode == specs.PKModeCQID {
 			opts = append(opts, transformer.WithRemovePKs())
 			opts = append(opts, transformer.WithCQIDPrimaryKey())

--- a/cli/cmd/sync_v3.go
+++ b/cli/cmd/sync_v3.go
@@ -77,7 +77,7 @@ func syncConnectionV3(ctx context.Context, source v3source, destinations []v3des
 			transformer.WithSyncTimeColumn(syncTime),
 		}
 		if destinationSpecs[i].WriteMode == specs.WriteModeAppend {
-			opts = append(opts, transformer.WithRemovePKs())
+			opts = append(opts, transformer.WithRemovePKs(), transformer.WithRemoveUniqueConstraints())
 		} else if destinationSpecs[i].PKMode == specs.PKModeCQID {
 			opts = append(opts, transformer.WithRemovePKs())
 			opts = append(opts, transformer.WithCQIDPrimaryKey())

--- a/cli/internal/transformer/transformer_test.go
+++ b/cli/internal/transformer/transformer_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/apache/arrow/go/v15/arrow"
 	"github.com/apache/arrow/go/v15/arrow/array"
 	"github.com/apache/arrow/go/v15/arrow/memory"
+	"github.com/cloudquery/plugin-sdk/v4/schema"
 )
 
 var transformTestCases = []struct {
@@ -92,13 +93,45 @@ var transformTestCases = []struct {
 			return NewRecordTransformer(WithRemovePKs(), WithCQIDPrimaryKey())
 		},
 		originalSchema: arrow.NewSchema([]arrow.Field{
-			{Name: "id", Type: arrow.PrimitiveTypes.Int64, Metadata: arrow.MetadataFrom(map[string]string{"cq:extension:primary_key": "true"})},
+			{Name: "id", Type: arrow.PrimitiveTypes.Int64, Metadata: arrow.MetadataFrom(map[string]string{schema.MetadataPrimaryKey: "true"})},
 			{Name: "_cq_id", Type: arrow.PrimitiveTypes.Int64},
 		}, nil),
 		originalJSONRecord: []byte(`{"id": 1, "_cq_id": 2}`),
 		expectedSchema: arrow.NewSchema([]arrow.Field{
 			{Name: "id", Type: arrow.PrimitiveTypes.Int64, Metadata: arrow.MetadataFrom(map[string]string{})},
-			{Name: "_cq_id", Type: arrow.PrimitiveTypes.Int64, Metadata: arrow.MetadataFrom(map[string]string{"cq:extension:primary_key": "true"})},
+			{Name: "_cq_id", Type: arrow.PrimitiveTypes.Int64, Metadata: arrow.MetadataFrom(map[string]string{schema.MetadataPrimaryKey: "true"})},
+		}, nil),
+		expectedJSONRecord: []byte(`{"id": 1, "_cq_id": 2}`),
+	},
+	{
+		name: "use_cq_id_primary_key_with_remove_unique",
+		transformer: func() *RecordTransformer {
+			return NewRecordTransformer(WithRemovePKs(), WithCQIDPrimaryKey(), WithRemoveUniqueConstraints())
+		},
+		originalSchema: arrow.NewSchema([]arrow.Field{
+			{Name: "id", Type: arrow.PrimitiveTypes.Int64, Metadata: arrow.MetadataFrom(map[string]string{schema.MetadataPrimaryKey: "true", schema.MetadataUnique: "true"})},
+			{Name: "_cq_id", Type: arrow.PrimitiveTypes.Int64},
+		}, nil),
+		originalJSONRecord: []byte(`{"id": 1, "_cq_id": 2}`),
+		expectedSchema: arrow.NewSchema([]arrow.Field{
+			{Name: "id", Type: arrow.PrimitiveTypes.Int64, Metadata: arrow.MetadataFrom(map[string]string{})},
+			{Name: "_cq_id", Type: arrow.PrimitiveTypes.Int64, Metadata: arrow.MetadataFrom(map[string]string{schema.MetadataPrimaryKey: "true"})},
+		}, nil),
+		expectedJSONRecord: []byte(`{"id": 1, "_cq_id": 2}`),
+	},
+	{
+		name: "use_with_remove_unique",
+		transformer: func() *RecordTransformer {
+			return NewRecordTransformer(WithRemovePKs(), WithRemoveUniqueConstraints())
+		},
+		originalSchema: arrow.NewSchema([]arrow.Field{
+			{Name: "id", Type: arrow.PrimitiveTypes.Int64, Metadata: arrow.MetadataFrom(map[string]string{schema.MetadataPrimaryKey: "true", schema.MetadataUnique: "true"})},
+			{Name: "_cq_id", Type: arrow.PrimitiveTypes.Int64},
+		}, nil),
+		originalJSONRecord: []byte(`{"id": 1, "_cq_id": 2}`),
+		expectedSchema: arrow.NewSchema([]arrow.Field{
+			{Name: "id", Type: arrow.PrimitiveTypes.Int64, Metadata: arrow.MetadataFrom(map[string]string{})},
+			{Name: "_cq_id", Type: arrow.PrimitiveTypes.Int64},
 		}, nil),
 		expectedJSONRecord: []byte(`{"id": 1, "_cq_id": 2}`),
 	},


### PR DESCRIPTION
<!-- 🎉 Thank you for making CloudQuery awesome by submitting a PR 🎉 -->

#### Summary

In append mode there should be no table constraints on the data. This has historically worked because all `_cq_ids` were random, but as we transition to deterministic `_cq_id` this is not the case anymore