### PR TITLE
fix(deps): Update module github.com/cloudquery/cloudquery-api-go to v1.6.5

### DIFF
--- a/cli/cmd/plugin_publish.go
+++ b/cli/cmd/plugin_publish.go
@@ -155,7 +155,7 @@ func runPluginPublish(ctx context.Context, cmd *cobra.Command, args []string) er
 }
 
 func publishPluginAssets(ctx context.Context, c *cloudquery_api.ClientWithResponses, token, distDir string, pkgJSON publish.PackageJSONV1) error {
-	if pkgJSON.PackageType == string(cloudquery_api.PluginVersionPackageTypeDocker) {
+	if pkgJSON.PackageType == string(cloudquery_api.Docker) {
 		return publish.PublishToDockerRegistry(ctx, token, distDir, pkgJSON)
 	}
 

--- a/cli/go.mod
+++ b/cli/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/apache/arrow/go/v15 v15.0.0-20240114144300-7e703aae55c1
 	github.com/bradleyjkemp/cupaloy/v2 v2.8.0
 	github.com/cenkalti/backoff/v4 v4.2.1
-	github.com/cloudquery/cloudquery-api-go v1.6.4
+	github.com/cloudquery/cloudquery-api-go v1.6.5
 	github.com/cloudquery/codegen v0.3.12
 	github.com/cloudquery/plugin-pb-go v1.16.4
 	github.com/cloudquery/plugin-sdk/v4 v4.25.2

--- a/cli/go.sum
+++ b/cli/go.sum
@@ -62,8 +62,8 @@ github.com/chenzhuoyu/base64x v0.0.0-20230717121745-296ad89f973d/go.mod h1:8EPpV
 github.com/chenzhuoyu/iasm v0.9.0/go.mod h1:Xjy2NpN3h7aUqeqM+woSuuvxmIe6+DDsiNLIrkAmYog=
 github.com/chenzhuoyu/iasm v0.9.1 h1:tUHQJXo3NhBqw6s33wkGn9SP3bvrWLdlVIJ3hQBL7P0=
 github.com/chenzhuoyu/iasm v0.9.1/go.mod h1:Xjy2NpN3h7aUqeqM+woSuuvxmIe6+DDsiNLIrkAmYog=
-github.com/cloudquery/cloudquery-api-go v1.6.4 h1:75S5WdQirq8hR2ZSVPZ2Mrn+nz8DlHUZgj5gwQnoS/Y=
-github.com/cloudquery/cloudquery-api-go v1.6.4/go.mod h1:03fojQg0UpdgqXZ9tzZ5gF5CPad/F0sok66bsX6u4RA=
+github.com/cloudquery/cloudquery-api-go v1.6.5 h1:mnbn80T8q5RrnFMiuRrY5BvSI2DOSCwLCxh7Kd5bhV0=
+github.com/cloudquery/cloudquery-api-go v1.6.5/go.mod h1:03fojQg0UpdgqXZ9tzZ5gF5CPad/F0sok66bsX6u4RA=
 github.com/cloudquery/codegen v0.3.12 h1:9BaYdwbMJU1HVT/BHI+ykhOhBGeXt8AjpvBiXN1KhKE=
 github.com/cloudquery/codegen v0.3.12/go.mod h1:utqjurr58U8uqcPJe0rZjh06i0Eq9uAPGOmyIjq/1w8=
 github.com/cloudquery/jsonschema v0.0.0-20231018073309-6c617a23d42f h1:vmYGxIGDVpmhk0QVeDwXXbAt+SwQcOn4xH1G25pmKP8=

--- a/cli/internal/publish/plugins.go
+++ b/cli/internal/publish/plugins.go
@@ -245,7 +245,7 @@ func CreateNewPluginDraftVersion(ctx context.Context, c *cloudquery_api.ClientWi
 
 	body := cloudquery_api.CreatePluginVersionJSONRequestBody{
 		Message:          pkgJSON.Message,
-		PackageType:      cloudquery_api.CreatePluginVersionJSONBodyPackageType(pkgJSON.PackageType),
+		PackageType:      cloudquery_api.PluginPackageType(pkgJSON.PackageType),
 		Protocols:        pkgJSON.Protocols,
 		SupportedTargets: targets,
 		Checksums:        checksums,


### PR DESCRIPTION
Replaces https://github.com/cloudquery/cloudquery/pull/16191