### PR TITLE
feat: Handle All types of Schema Changes

### DIFF
--- a/plugins/destination/mysql/client/migrate.go
+++ b/plugins/destination/mysql/client/migrate.go
@@ -68,10 +68,8 @@ func (*Client) canAutoMigrate(changes []schema.TableColumnChange) bool {
 			if change.Previous.PrimaryKey || change.Previous.NotNull {
 				return false
 			}
-		case schema.TableColumnChangeTypeUpdate:
-			return false
 		default:
-			panic("unknown change type")
+			return false
 		}
 	}
 	return true


### PR DESCRIPTION
<!-- 🎉 Thank you for making CloudQuery awesome by submitting a PR 🎉 -->

#### Summary

This will mark unsupported schema changes as non-automigratable rather than panicing