### PR TITLE
feat: Handle All types of Schema Changes

### DIFF
--- a/plugins/destination/postgresql/client/migrate.go
+++ b/plugins/destination/postgresql/client/migrate.go
@@ -2,6 +2,7 @@ package client
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"strings"
 
@@ -100,10 +101,8 @@ func (c *Client) autoMigrateTable(ctx context.Context, table *schema.Table, chan
 			if err := c.addColumn(ctx, tableName, change.Current); err != nil {
 				return err
 			}
-		case schema.TableColumnChangeTypeRemove:
-			continue
 		default:
-			panic("unknown change type")
+			return errors.New("unsupported column change type: %s for column: %v from %v", change.Type.String(), change.Current, change.Previous)
 		}
 	}
 	return nil
@@ -125,10 +124,8 @@ func (*Client) canAutoMigrate(changes []schema.TableColumnChange) bool {
 				}
 				return false
 			}
-		case schema.TableColumnChangeTypeUpdate:
-			return false
 		default:
-			panic("unknown change type")
+			return false
 		}
 	}
 	return true

--- a/plugins/destination/postgresql/client/migrate.go
+++ b/plugins/destination/postgresql/client/migrate.go
@@ -100,6 +100,8 @@ func (c *Client) autoMigrateTable(ctx context.Context, table *schema.Table, chan
 			if err := c.addColumn(ctx, tableName, change.Current); err != nil {
 				return err
 			}
+		case schema.TableColumnChangeTypeRemove:
+			continue
 		default:
 			return fmt.Errorf("unsupported column change type: %s for column: %v from %v", change.Type.String(), change.Current, change.Previous)
 		}

--- a/plugins/destination/postgresql/client/migrate.go
+++ b/plugins/destination/postgresql/client/migrate.go
@@ -2,7 +2,6 @@ package client
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"strings"
 
@@ -102,7 +101,7 @@ func (c *Client) autoMigrateTable(ctx context.Context, table *schema.Table, chan
 				return err
 			}
 		default:
-			return errors.New("unsupported column change type: %s for column: %v from %v", change.Type.String(), change.Current, change.Previous)
+			return fmt.Errorf("unsupported column change type: %s for column: %v from %v", change.Type.String(), change.Current, change.Previous)
 		}
 	}
 	return nil


### PR DESCRIPTION
<!-- 🎉 Thank you for making CloudQuery awesome by submitting a PR 🎉 -->

#### Summary

This will mark unsupported schema changes as non-automigratable rather than panicing