### PR TITLE
feat: Add mfa_devices for AWS IAM users

### DIFF
--- a/plugins/source/aws/docs/tables/README.md
+++ b/plugins/source/aws/docs/tables/README.md
@@ -402,6 +402,7 @@
 - [aws_iam_saml_identity_providers](aws_iam_saml_identity_providers.md)
 - [aws_iam_server_certificates](aws_iam_server_certificates.md)
 - [aws_iam_users](aws_iam_users.md)
+  - [aws_iam_mfa_devices](aws_iam_mfa_devices.md)
   - [aws_iam_signing_certificates](aws_iam_signing_certificates.md)
   - [aws_iam_ssh_public_keys](aws_iam_ssh_public_keys.md)
   - [aws_iam_user_access_keys](aws_iam_user_access_keys.md)

--- a/plugins/source/aws/docs/tables/aws_iam_mfa_devices.md
+++ b/plugins/source/aws/docs/tables/aws_iam_mfa_devices.md
@@ -1,0 +1,22 @@
+# Table: aws_iam_mfa_devices
+
+This table shows data for IAM MFA Devices.
+
+https://docs.aws.amazon.com/IAM/latest/APIReference/API_MFADevice.html
+
+The primary key for this table is **serial_number**.
+
+## Relations
+
+This table depends on [aws_iam_users](aws_iam_users.md).
+
+## Columns
+
+| Name          | Type          |
+| ------------- | ------------- |
+|_cq_id|`uuid`|
+|_cq_parent_id|`uuid`|
+|account_id|`utf8`|
+|serial_number (PK)|`utf8`|
+|enable_date|`timestamp[us, tz=UTC]`|
+|user_name|`utf8`|

--- a/plugins/source/aws/docs/tables/aws_iam_users.md
+++ b/plugins/source/aws/docs/tables/aws_iam_users.md
@@ -9,6 +9,7 @@ The composite primary key for this table is (**account_id**, **arn**).
 ## Relations
 
 The following tables depend on aws_iam_users:
+  - [aws_iam_mfa_devices](aws_iam_mfa_devices.md)
   - [aws_iam_signing_certificates](aws_iam_signing_certificates.md)
   - [aws_iam_ssh_public_keys](aws_iam_ssh_public_keys.md)
   - [aws_iam_user_access_keys](aws_iam_user_access_keys.md)

--- a/plugins/source/aws/resources/services/iam/mfa_devices.go
+++ b/plugins/source/aws/resources/services/iam/mfa_devices.go
@@ -1,0 +1,50 @@
+package iam
+
+import (
+	"context"
+
+	"github.com/apache/arrow/go/v15/arrow"
+	"github.com/aws/aws-sdk-go-v2/service/iam"
+	"github.com/aws/aws-sdk-go-v2/service/iam/types"
+	"github.com/cloudquery/cloudquery/plugins/source/aws/client"
+	"github.com/cloudquery/plugin-sdk/v4/schema"
+	"github.com/cloudquery/plugin-sdk/v4/transformers"
+)
+
+func mfaDevices() *schema.Table {
+	tableName := "aws_iam_mfa_devices"
+	return &schema.Table{
+		Name:        tableName,
+		Description: `https://docs.aws.amazon.com/IAM/latest/APIReference/API_MFADevice.html`,
+		Resolver:    fetchIamMfaDevices,
+		Transform:   transformers.TransformWithStruct(&types.MFADevice{}),
+		Columns: []schema.Column{
+			client.DefaultAccountIDColumn(false),
+			{
+				Name:       "serial_number",
+				Type:       arrow.BinaryTypes.String,
+				PrimaryKey: true,
+			},
+		},
+	}
+}
+
+func fetchIamMfaDevices(ctx context.Context, meta schema.ClientMeta, parent *schema.Resource, res chan<- any) error {
+	r := parent.Item.(*types.User)
+	cl := meta.(*client.Client)
+	svc := cl.Services(client.AWSServiceIam).Iam
+	paginator := iam.NewListMFADevicesPaginator(svc, &iam.ListMFADevicesInput{
+		UserName: r.UserName,
+	})
+	for paginator.HasMorePages() {
+		page, err := paginator.NextPage(ctx, func(options *iam.Options) {
+			options.Region = cl.Region
+		})
+		if err != nil {
+			return err
+		}
+		res <- page.MFADevices
+	}
+
+	return nil
+}

--- a/plugins/source/aws/resources/services/iam/users.go
+++ b/plugins/source/aws/resources/services/iam/users.go
@@ -45,6 +45,7 @@ func Users() *schema.Table {
 			sshPublicKeys(),
 			signingCertificates(),
 			userLastAccessedDetails(),
+			mfaDevices(),
 		},
 	}
 }

--- a/plugins/source/aws/resources/services/iam/users_mock_test.go
+++ b/plugins/source/aws/resources/services/iam/users_mock_test.go
@@ -25,6 +25,8 @@ func buildIamUsers(t *testing.T, ctrl *gomock.Controller) client.Services {
 	require.NoError(t, faker.FakeObject(&aup))
 	akl := iam.GetAccessKeyLastUsedOutput{}
 	require.NoError(t, faker.FakeObject(&akl))
+	mfaDevice := types.MFADevice{}
+	require.NoError(t, faker.FakeObject(&mfaDevice))
 
 	sshPublicKey := types.SSHPublicKeyMetadata{}
 	require.NoError(t, faker.FakeObject(&sshPublicKey))
@@ -54,6 +56,10 @@ func buildIamUsers(t *testing.T, ctrl *gomock.Controller) client.Services {
 		}, nil)
 	m.EXPECT().GetAccessKeyLastUsed(gomock.Any(), gomock.Any(), gomock.Any()).Return(
 		&akl, nil)
+	m.EXPECT().ListMFADevices(gomock.Any(), gomock.Any(), gomock.Any()).Return(
+		&iam.ListMFADevicesOutput{
+			MFADevices: []types.MFADevice{mfaDevice},
+		}, nil)
 
 	var l []string
 	require.NoError(t, faker.FakeObject(&l))


### PR DESCRIPTION
#### Summary

Resolves https://github.com/cloudquery/cloudquery/issues/16199

Add all `mfa_devices` listing for AWS IAM users.
Those ressources need to be fetch per user as the physical MFA devices cannot be retrieved via a list endpoint.

