### PR TITLE
feat: Ensure all insert queries can be cached

### DIFF
--- a/plugins/destination/postgresql/client/insert.go
+++ b/plugins/destination/postgresql/client/insert.go
@@ -27,8 +27,8 @@ func (c *Client) InsertBatch(ctx context.Context, messages message.WriteInserts)
 	batch := new(pgx.Batch)
 
 	// Queries cache.
-	// We may consider LRU cache in the future, but even for 10K records it may be OK to just save.
-	queries := make(map[string]string, 100)
+	// Each table has a single query that is repeated for each record
+	queries := make(map[string]string, len(c.pgTablesToPKConstraints))
 
 	for _, msg := range messages {
 		r := msg.Record


### PR DESCRIPTION
<!-- 🎉 Thank you for making CloudQuery awesome by submitting a PR 🎉 -->

#### Summary

Currently we only preallocate for the first 100 sql queries. This PR changes it so that the cache can hold the SQL statement for all tables by using the number of tables present in the DB as the upper limit 