### PR TITLE
chore: Use `ubuntu-latest` instead of `large-ubuntu-monorepo`

### DIFF
--- a/.github/workflows/publish_plugin_to_hub.yml
+++ b/.github/workflows/publish_plugin_to_hub.yml
@@ -62,7 +62,7 @@ jobs:
           result-encoding: string
   publish-plugin-to-hub-python:
     timeout-minutes: 60
-    runs-on: large-ubuntu-monorepo
+    runs-on: ubuntu-latest
     needs: prepare
     if: needs.prepare.outputs.plugin_releaser == 'python'
     steps:
@@ -142,7 +142,7 @@ jobs:
           cloudquery plugin publish --finalize
   publish-plugin-to-hub-node:
     timeout-minutes: 60
-    runs-on: large-ubuntu-monorepo
+    runs-on: ubuntu-latest
     needs: prepare
     if: needs.prepare.outputs.plugin_releaser == 'node'
     steps:
@@ -217,7 +217,7 @@ jobs:
 
   publish-plugin-to-hub-go:
     timeout-minutes: 60
-    runs-on: large-ubuntu-monorepo
+    runs-on: ubuntu-latest
     needs: prepare
     if: needs.prepare.outputs.plugin_releaser == 'go'
     steps:

--- a/.github/workflows/publish_plugin_to_hub_duckdb.yml
+++ b/.github/workflows/publish_plugin_to_hub_duckdb.yml
@@ -35,7 +35,7 @@ jobs:
           input_string: ${{steps.split.outputs.plugin_version}}
   publish-plugin-to-hub:
     timeout-minutes: 60
-    runs-on: large-ubuntu-monorepo
+    runs-on: ubuntu-latest
     container:
       image: ghcr.io/cloudquery/golang-cross:v10.0.0
       env:

--- a/.github/workflows/publish_plugin_to_hub_snowflake.yml
+++ b/.github/workflows/publish_plugin_to_hub_snowflake.yml
@@ -35,7 +35,7 @@ jobs:
           input_string: ${{steps.split.outputs.plugin_version}}
   publish-plugin-to-hub:
     timeout-minutes: 60
-    runs-on: large-ubuntu-monorepo
+    runs-on: ubuntu-latest
     container:
       image: ghcr.io/cloudquery/golang-cross:v10.0.0
       env:

--- a/.github/workflows/publish_plugin_to_hub_sqlite.yml
+++ b/.github/workflows/publish_plugin_to_hub_sqlite.yml
@@ -35,7 +35,7 @@ jobs:
           input_string: ${{steps.split.outputs.plugin_version}}
   publish-plugin-to-hub:
     timeout-minutes: 60
-    runs-on: large-ubuntu-monorepo
+    runs-on: ubuntu-latest
     container:
       image: ghcr.io/cloudquery/golang-cross:v10.0.0
       env:

--- a/.github/workflows/release_cli.yml
+++ b/.github/workflows/release_cli.yml
@@ -9,7 +9,7 @@ env:
 jobs:
   release-cli:
     timeout-minutes: 30
-    runs-on: large-ubuntu-monorepo
+    runs-on: ubuntu-latest
     steps:
       # Tag format is cli-<version>
       - name: Split tag

--- a/.github/workflows/release_plugin.yml
+++ b/.github/workflows/release_plugin.yml
@@ -61,7 +61,7 @@ jobs:
       contents: read
       packages: write
     timeout-minutes: 60
-    runs-on: large-ubuntu-monorepo
+    runs-on: ubuntu-latest
     needs: prepare
     if: needs.prepare.outputs.plugin_releaser == 'docker'
     env:
@@ -125,7 +125,7 @@ jobs:
 
   release-plugin-go:
     timeout-minutes: 60
-    runs-on: large-ubuntu-monorepo
+    runs-on: ubuntu-latest
     needs: prepare
     if: needs.prepare.outputs.plugin_releaser == 'go'
     env:

--- a/.github/workflows/release_plugin_dest_duckdb.yml
+++ b/.github/workflows/release_plugin_dest_duckdb.yml
@@ -6,7 +6,7 @@ on:
 jobs:
   release-plugin-binary-destination-duckdb:
     timeout-minutes: 30
-    runs-on: large-ubuntu-monorepo
+    runs-on: ubuntu-latest
     container:
       image: ghcr.io/cloudquery/golang-cross:v10.0.0
       env:

--- a/.github/workflows/release_plugin_dest_snowflake.yml
+++ b/.github/workflows/release_plugin_dest_snowflake.yml
@@ -6,7 +6,7 @@ on:
 jobs:
   release-plugin-binary-destination-snowflake:
     timeout-minutes: 30
-    runs-on: large-ubuntu-monorepo
+    runs-on: ubuntu-latest
     container:
       image: ghcr.io/cloudquery/golang-cross:v10.0.0
       env:

--- a/.github/workflows/release_plugin_dest_sqlite.yml
+++ b/.github/workflows/release_plugin_dest_sqlite.yml
@@ -6,7 +6,7 @@ on:
 jobs:
   release-plugin-binary-destination-sqlite:
     timeout-minutes: 30
-    runs-on: large-ubuntu-monorepo
+    runs-on: ubuntu-latest
     container:
       image: ghcr.io/cloudquery/golang-cross:v10.0.0
       env:

--- a/.github/workflows/release_plugin_source_test.yml
+++ b/.github/workflows/release_plugin_source_test.yml
@@ -9,7 +9,7 @@ env:
 jobs:
   release-plugin-binary-source-test:
     timeout-minutes: 60
-    runs-on: large-ubuntu-monorepo
+    runs-on: ubuntu-latest
     steps:
       # Tag format is plugins-<type>-<name>-<version>
       - name: Split tag

--- a/.github/workflows/release_scaffold.yml
+++ b/.github/workflows/release_scaffold.yml
@@ -9,7 +9,7 @@ env:
 jobs:
   release-scaffold:
     timeout-minutes: 30
-    runs-on: large-ubuntu-monorepo
+    runs-on: ubuntu-latest
     steps:
       # Tag format is scaffold-<version>
       - name: Split tag

--- a/.github/workflows/source_aws.yml
+++ b/.github/workflows/source_aws.yml
@@ -23,7 +23,7 @@ jobs:
     permissions:
       id-token: write
       contents: read
-    runs-on: large-ubuntu-monorepo
+    runs-on: ubuntu-latest
     defaults:
       run:
         working-directory: ./plugins/source/aws
@@ -72,7 +72,7 @@ jobs:
         run: cloudquery sync test/sanity.yml --log-console
   validate-release:
     timeout-minutes: 60
-    runs-on: large-ubuntu-monorepo
+    runs-on: ubuntu-latest
     env:
       CGO_ENABLED: 0
     steps:

--- a/.github/workflows/source_azure.yml
+++ b/.github/workflows/source_azure.yml
@@ -20,7 +20,7 @@ jobs:
   plugins-source-azure:
     timeout-minutes: 30
     name: "plugins/source/azure"
-    runs-on: large-ubuntu-monorepo
+    runs-on: ubuntu-latest
     defaults:
       run:
         working-directory: ./plugins/source/azure
@@ -60,7 +60,7 @@ jobs:
         run: make test
   validate-release:
     timeout-minutes: 30
-    runs-on: large-ubuntu-monorepo
+    runs-on: ubuntu-latest
     env:
       CGO_ENABLED: 0
     steps:

--- a/.github/workflows/source_gcp.yml
+++ b/.github/workflows/source_gcp.yml
@@ -20,7 +20,7 @@ jobs:
   plugins-source-gcp:
     timeout-minutes: 30
     name: "plugins/source/gcp"
-    runs-on: large-ubuntu-monorepo
+    runs-on: ubuntu-latest
     defaults:
       run:
         working-directory: ./plugins/source/gcp
@@ -60,7 +60,7 @@ jobs:
         run: make test
   validate-release:
     timeout-minutes: 30
-    runs-on: large-ubuntu-monorepo
+    runs-on: ubuntu-latest
     env:
       CGO_ENABLED: 0
     steps:
@@ -96,7 +96,7 @@ jobs:
           GORELEASER_KEY: ${{ secrets.GORELEASER_KEY }}
   test-policies:
     timeout-minutes: 30
-    runs-on: large-ubuntu-monorepo
+    runs-on: ubuntu-latest
     defaults:
       run:
         working-directory: ./plugins/source/gcp


### PR DESCRIPTION
<!-- 🎉 Thank you for making CloudQuery awesome by submitting a PR 🎉 -->

#### Summary

Our large runner `large-ubuntu-monorepo` has the same specs as the new default (see https://github.blog/2024-01-17-github-hosted-runners-double-the-power-for-open-source/)

<!--
Use the following steps to ensure your PR is ready to be reviewed

- [ ] Read the [contribution guidelines](https://github.com/cloudquery/cloudquery/blob/main/CONTRIBUTING.md) 🧑‍🎓
- [ ] Run `make lint` to ensure the proposed changes follow the coding style 🚨 (install golangci-lint [here](https://golangci-lint.run/usage/install/#local-installation))
- [ ] Run `make test` to ensure the proposed changes pass the tests 🧪
- [ ] If changing a source plugin run `make gen` to ensure docs are up to date 📝
- [ ] Ensure the status checks below are successful ✅
--->
