### PR TITLE
fix: Use team name instead of kind for team

### DIFF
--- a/plugins/destination/mssql/main.go
+++ b/plugins/destination/mssql/main.go
@@ -15,7 +15,7 @@ const (
 )
 
 func main() {
-	p := plugin.NewPlugin(internalPlugin.Name, internalPlugin.Version, client.New, plugin.WithKind(internalPlugin.Kind), plugin.WithTeam(internalPlugin.Kind))
+	p := plugin.NewPlugin(internalPlugin.Name, internalPlugin.Version, client.New, plugin.WithKind(internalPlugin.Kind), plugin.WithTeam(internalPlugin.Team))
 	if err := serve.Plugin(p,
 		serve.WithPluginSentryDSN(sentryDSN),
 		serve.WithDestinationV0V1Server(),


### PR DESCRIPTION
<!-- 🎉 Thank you for making CloudQuery awesome by submitting a PR 🎉 -->

#### Summary

This prevents this plugin from being published to the Hub.

Not sure when this broke since we have a few versions https://hub.cloudquery.io/plugins/destination/cloudquery/mssql/v4.3.15/versions?search=ms.

I added the wrong metadata in https://github.com/cloudquery/cloudquery/pull/15025/files (I think before it wasn't required and we got it from the CLI)

<!--
Use the following steps to ensure your PR is ready to be reviewed

- [ ] Read the [contribution guidelines](https://github.com/cloudquery/cloudquery/blob/main/CONTRIBUTING.md) 🧑‍🎓
- [ ] Run `make lint` to ensure the proposed changes follow the coding style 🚨 (install golangci-lint [here](https://golangci-lint.run/usage/install/#local-installation))
- [ ] Run `make test` to ensure the proposed changes pass the tests 🧪
- [ ] If changing a source plugin run `make gen` to ensure docs are up to date 📝
- [ ] Ensure the status checks below are successful ✅
--->
