### PR TITLE
chore: Add `cloudquery:latest` to manifest to support arm64

### DIFF
--- a/cli/.goreleaser.yaml
+++ b/cli/.goreleaser.yaml
@@ -16,7 +16,6 @@ dockers:
     goarch: amd64
     dockerfile: Dockerfile.goreleaser
     image_templates:
-      - "ghcr.io/cloudquery/cloudquery:latest"
       - "ghcr.io/cloudquery/cloudquery:latest-linux-amd64"
       - "ghcr.io/cloudquery/cloudquery:{{.Version}}-linux-amd64"
       - "ghcr.io/cloudquery/cloudquery:{{ .Major }}.{{ .Minor }}-linux-amd64"
@@ -44,6 +43,11 @@ docker_manifests:
   image_templates:
   - "ghcr.io/cloudquery/cloudquery:{{.Version}}-linux-amd64"
   - "ghcr.io/cloudquery/cloudquery:{{.Version}}-linux-arm64"
+
+- name_template: "ghcr.io/cloudquery/cloudquery:latest"
+  image_templates:
+  - "ghcr.io/cloudquery/cloudquery:latest-linux-amd64"
+  - "ghcr.io/cloudquery/cloudquery:latest-linux-arm64"
 
 - name_template: "ghcr.io/cloudquery/cloudquery:{{ .Major }}.{{ .Minor }}"
   image_templates:


### PR DESCRIPTION
Reverts the last commit from https://github.com/cloudquery/cloudquery/pull/16231