### PR TITLE
fix: Properly set team on login

### DIFF
--- a/cli/cmd/login.go
+++ b/cli/cmd/login.go
@@ -250,5 +250,6 @@ func setTeamOnLogin(ctx context.Context, cmd *cobra.Command, token string) error
 	cmd.Printf("Your current team is not set.\n\n")
 	cmd.Printf("Teams available to you: " + strings.Join(teams, ", ") + "\n\n")
 	cmd.Printf("To set your current team, run `cloudquery switch <team>`\n\n")
-	return fmt.Errorf("team not set. Available teams: [" + strings.Join(teams, ", ") + "]")
+	// we don't fail here immediately, as there are some additional commands the user can run in this state
+	return nil
 }

--- a/cli/cmd/login.go
+++ b/cli/cmd/login.go
@@ -211,7 +211,7 @@ func setTeamOnLogin(ctx context.Context, cmd *cobra.Command, token string) error
 	}
 
 	if cmd.Flags().Changed("team") {
-		// don't care about the current value
+		// don't care about the current cached config value as the user explicitly passes the `team` flag
 		currentTeam := cmd.Flag("team").Value.String()
 		err = cl.ValidateTeamAgainstTeams(currentTeam, teams)
 		if err != nil {

--- a/cli/internal/team/team.go
+++ b/cli/internal/team/team.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"net/http"
+	"slices"
 	"strings"
 
 	cloudquery_api "github.com/cloudquery/cloudquery-api-go"
@@ -30,17 +31,19 @@ func NewClientFromAPI(apiClient *cloudquery_api.ClientWithResponses) *Client {
 	}
 }
 
-func (c *Client) ValidateTeam(ctx context.Context, teamName string) error {
+func (c *Client) ValidateTeam(ctx context.Context, name string) error {
 	teams, err := c.ListAllTeams(ctx)
 	if err != nil {
 		return err
 	}
-	for _, team := range teams {
-		if team == teamName {
-			return nil
-		}
+	return c.ValidateTeamAgainstTeams(name, teams)
+}
+
+func (*Client) ValidateTeamAgainstTeams(name string, teams []string) error {
+	if slices.Contains(teams, name) {
+		return nil
 	}
-	return fmt.Errorf("team %q not found. Teams available to you: %v", teamName, strings.Join(teams, ", "))
+	return fmt.Errorf("team %q not found. Teams available to you: %v", name, strings.Join(teams, ", "))
 }
 
 func (c *Client) ListAllTeams(ctx context.Context) ([]string, error) {


### PR DESCRIPTION
Closes https://github.com/cloudquery/cloudquery/issues/16298

The following scenarios have to be taken care of:
1. The user explicitly selects team via `--team` flag
2. The user has previously selected team
   1. The team is available after login – use it
   2. The team is unavailable – use the opt 3
3. Check that 1 & only 1 team is available for the user – & use it