### PR TITLE
feat!: Deterministic `_cq_id` Only

### DIFF
--- a/cli/cmd/migrate_test.go
+++ b/cli/cmd/migrate_test.go
@@ -37,6 +37,14 @@ func TestMigrate(t *testing.T) {
 			config: "sync-missing-path-error.yml",
 			err:    "Error: failed to validate destination test: path is required",
 		},
+		{
+			config: "removed-options.yml",
+			err:    "failed to migrate v3 source test: `deterministic_cqid` is no longer a valid option in your source spec. It is enabled by default and cannot be overridden",
+		},
+		{
+			config: "removed-options-dest.yml",
+			err:    "`pk_mode` is no longer a valid option in your destination spec",
+		},
 	}
 	_, filename, _, _ := runtime.Caller(0)
 	currentDir := path.Dir(filename)

--- a/cli/cmd/migrate_v3.go
+++ b/cli/cmd/migrate_v3.go
@@ -26,7 +26,6 @@ func migrateConnectionV3(ctx context.Context, sourceClient *managedplugin.Client
 		if destinationSpecs[i].PKMode != nil {
 			return errors.New("`pk_mode` is no longer a valid option in your destination spec")
 		}
-
 	}
 	migrateStart := time.Now().UTC()
 	log.Info().Str("source", sourceSpec.Name).Strs("destinations", destinationStrings).Time("migrate_time", migrateStart).Msg("Start migration")
@@ -36,7 +35,6 @@ func migrateConnectionV3(ctx context.Context, sourceClient *managedplugin.Client
 	destinationsPbClients := make([]plugin.PluginClient, len(destinationsClients))
 	destinationTransformers := make([]*transformer.RecordTransformer, len(destinationsClients))
 	for i := range destinationsClients {
-
 		destinationsPbClients[i] = plugin.NewPluginClient(destinationsClients[i].Conn)
 		opts := []transformer.RecordTransformerOption{
 			transformer.WithSourceNameColumn(sourceSpec.Name),

--- a/cli/cmd/specs.go
+++ b/cli/cmd/specs.go
@@ -35,7 +35,7 @@ func CLISourceSpecToPbSpec(spec specs.Source) pbSpecs.Source {
 		SkipDependentTables: spec.SkipDependentTables,
 		Destinations:        spec.Destinations,
 		Spec:                spec.Spec,
-		DeterministicCQID:   spec.DeterministicCQID,
+		DeterministicCQID:   spec.DeterministicCQID != nil && *spec.DeterministicCQID,
 	}
 }
 
@@ -63,8 +63,11 @@ func CLIMigrateModeToPbMigrateMode(migrateMode specs.MigrateMode) pbSpecs.Migrat
 	}
 }
 
-func CLIPkModeToPbPKMode(pkMode specs.PKMode) pbSpecs.PKMode {
-	switch pkMode {
+func CLIPkModeToPbPKMode(pkMode *specs.PKMode) pbSpecs.PKMode {
+	if pkMode == nil {
+		return pbSpecs.PKModeDefaultKeys
+	}
+	switch *pkMode {
 	case specs.PKModeCQID:
 		return pbSpecs.PKModeCQID
 	case specs.PKModeDefaultKeys:

--- a/cli/cmd/sync_test.go
+++ b/cli/cmd/sync_test.go
@@ -41,6 +41,14 @@ func TestSync(t *testing.T) {
 			config: "sync-missing-path-error.yml",
 			err:    "Error: failed to validate destination test: path is required",
 		},
+		{
+			config: "removed-options.yml",
+			err:    "failed to sync v3 source test: `deterministic_cqid` is no longer a valid option in your source spec. It is enabled by default and cannot be overridden",
+		},
+		{
+			config: "removed-options-dest.yml",
+			err:    "`pk_mode` is no longer a valid option in your destination spec",
+		},
 	}
 	_, filename, _, _ := runtime.Caller(0)
 	currentDir := path.Dir(filename)

--- a/cli/cmd/sync_v2.go
+++ b/cli/cmd/sync_v2.go
@@ -33,10 +33,10 @@ func getSourceV2DestV3DestinationsTransformers(destinationSpecs []specs.Destinat
 		opts := []transformer.RecordTransformerOption{}
 		if destinationSpecs[i].WriteMode == specs.WriteModeAppend {
 			opts = append(opts, transformer.WithRemovePKs(), transformer.WithRemovePKs())
-			if sourceSpec.DeterministicCQID {
+			if sourceSpec.DeterministicCQID != nil && *sourceSpec.DeterministicCQID {
 				opts = append(opts, transformer.WithRemoveUniqueConstraints())
 			}
-		} else if destinationSpecs[i].PKMode == specs.PKModeCQID {
+		} else if destinationSpecs[i].PKMode != nil && *destinationSpecs[i].PKMode == specs.PKModeCQID {
 			opts = append(opts, transformer.WithRemovePKs())
 			opts = append(opts, transformer.WithCQIDPrimaryKey())
 		}

--- a/cli/cmd/testdata/removed-options-dest.yml
+++ b/cli/cmd/testdata/removed-options-dest.yml
@@ -1,0 +1,16 @@
+kind: "source"
+spec:
+  name: "test"
+  path: "cloudquery/test"
+  registry: "github"
+  destinations: [test]
+  version: "v3.1.15" # latest version of source test plugin
+  tables: ["*"]
+---
+kind: "destination"
+spec:
+  name: "test"
+  path: "cloudquery/test"
+  registry: "github"
+  version: "v2.2.14" # latest version of destination test plugin
+  pk_mode: cq-id-only

--- a/cli/cmd/testdata/removed-options.yml
+++ b/cli/cmd/testdata/removed-options.yml
@@ -1,0 +1,16 @@
+kind: "source"
+spec:
+  name: "test"
+  path: "cloudquery/test"
+  registry: "github"
+  destinations: [test]
+  version: "v3.1.15" # latest version of source test plugin
+  tables: ["*"]
+  deterministic_cq_id: true
+---
+kind: "destination"
+spec:
+  name: "test"
+  path: "cloudquery/test"
+  registry: "github"
+  version: "v2.2.14" # latest version of destination test plugin

--- a/cli/internal/specs/v0/destination.go
+++ b/cli/internal/specs/v0/destination.go
@@ -17,9 +17,6 @@ type Destination struct {
 	// Destination plugin migrate mode
 	MigrateMode MigrateMode `json:"migrate_mode,omitempty" jsonschema:"default=safe"`
 
-	// Destination plugin PK mode
-	PKMode PKMode `json:"pk_mode,omitempty" jsonschema:"default=default"`
-
 	// Destination plugin own (nested) spec
 	Spec map[string]any `json:"spec,omitempty"`
 }

--- a/cli/internal/specs/v0/destination.go
+++ b/cli/internal/specs/v0/destination.go
@@ -18,7 +18,7 @@ type Destination struct {
 	MigrateMode MigrateMode `json:"migrate_mode,omitempty" jsonschema:"default=safe"`
 
 	// Destination plugin PK mode
-	PKMode PKMode `json:"pk_mode,omitempty" jsonschema:"default=default"`
+	PKMode *PKMode `json:"pk_mode,omitempty" jsonschema:"default=default"`
 
 	// Destination plugin own (nested) spec
 	Spec map[string]any `json:"spec,omitempty"`

--- a/cli/internal/specs/v0/destination.go
+++ b/cli/internal/specs/v0/destination.go
@@ -17,6 +17,9 @@ type Destination struct {
 	// Destination plugin migrate mode
 	MigrateMode MigrateMode `json:"migrate_mode,omitempty" jsonschema:"default=safe"`
 
+	// Destination plugin PK mode
+	PKMode PKMode `json:"pk_mode,omitempty" jsonschema:"default=default"`
+
 	// Destination plugin own (nested) spec
 	Spec map[string]any `json:"spec,omitempty"`
 }

--- a/cli/internal/specs/v0/source.go
+++ b/cli/internal/specs/v0/source.go
@@ -42,7 +42,7 @@ type Source struct {
 
 	// DeterministicCQID is a flag that indicates whether the source plugin should generate a random UUID as the value of `_cq_id`
 	// or whether it should calculate a UUID that is a hash of the primary keys (if they exist) or the entire resource.
-	DeterministicCQID bool `json:"deterministic_cq_id,omitempty" jsonschema:"default=false"`
+	DeterministicCQID *bool `json:"deterministic_cq_id" jsonschema:"default=false"`
 
 	// If specified this will spawn the plugin with `--otel-endpoint`
 	OtelEndpoint string `json:"otel_endpoint,omitempty" jsonschema:"default="`

--- a/cli/internal/specs/v0/source.go
+++ b/cli/internal/specs/v0/source.go
@@ -40,10 +40,6 @@ type Source struct {
 	// Source plugin own (nested) spec
 	Spec map[string]any `json:"spec,omitempty"`
 
-	// DeterministicCQID is a flag that indicates whether the source plugin should generate a random UUID as the value of `_cq_id`
-	// or whether it should calculate a UUID that is a hash of the primary keys (if they exist) or the entire resource.
-	DeterministicCQID bool `json:"deterministic_cq_id,omitempty" jsonschema:"default=false"`
-
 	// If specified this will spawn the plugin with `--otel-endpoint`
 	OtelEndpoint string `json:"otel_endpoint,omitempty" jsonschema:"default="`
 	// If specified this will spawn the plugin with `--otel-endpoint-insecure`

--- a/cli/internal/specs/v0/source.go
+++ b/cli/internal/specs/v0/source.go
@@ -40,6 +40,10 @@ type Source struct {
 	// Source plugin own (nested) spec
 	Spec map[string]any `json:"spec,omitempty"`
 
+	// DeterministicCQID is a flag that indicates whether the source plugin should generate a random UUID as the value of `_cq_id`
+	// or whether it should calculate a UUID that is a hash of the primary keys (if they exist) or the entire resource.
+	DeterministicCQID bool `json:"deterministic_cq_id,omitempty" jsonschema:"default=false"`
+
 	// If specified this will spawn the plugin with `--otel-endpoint`
 	OtelEndpoint string `json:"otel_endpoint,omitempty" jsonschema:"default="`
 	// If specified this will spawn the plugin with `--otel-endpoint-insecure`

--- a/cli/internal/specs/v0/source_test.go
+++ b/cli/internal/specs/v0/source_test.go
@@ -565,7 +565,6 @@ func TestSource_JSONSchemaExtend(t *testing.T) {
 		},
 		{
 			Name: "null deterministic_cq_id",
-			Err:  true,
 			Spec: `{"name":"a","path":"b","registry":"local","tables":["*"],"destinations":["a"],
 "deterministic_cq_id":null
 }`,

--- a/website/pages/docs/reference/destination-spec.md
+++ b/website/pages/docs/reference/destination-spec.md
@@ -87,19 +87,6 @@ Read more about how CloudQuery handles migrations [here](/docs/advanced-topics/m
 
 <!-- vale off -->
 
-### pk_mode
-
-<!-- vale on -->
-
-(`string`, optional, default: `default`, Available: `default`, `cq-id-only` introduced in CLI `v2.5.2`)
-
-Specifies the Primary Keys that the destination will configure when using the `overwrite` or `overwrite-delete-stale` mode.
-
-- `default`: The default primary keys are used.
-- `cq-id-only`: The `_cq_id` field is used as the only primary key for each table. This is useful when you don't want breaking changes to primary keys to impact your schema. It is highly recommended that if you are using this feature you should also use the [`deterministic_cq_id` feature in the source](/docs/reference/source-spec#deterministic_cq_id). If you are using `overwrite` mode and a source updates a primary key, this will result in a new row being inserted. If you are using `overwrite-delete-stale` mode, a new row will be inserted and the old row will be deleted as a stale resource. Note: using this parameter might result in changes to query performance as CloudQuery will not be creating indexes for the default primary key columns.
-
-Supported by destination plugins released on 2023-03-21 and later
-
 ### spec
 
 (`object`, optional)

--- a/website/pages/docs/reference/source-spec.md
+++ b/website/pages/docs/reference/source-spec.md
@@ -95,18 +95,6 @@ Specify the names of the destinations to sync the data of the source plugin to.
 
 <!-- vale off -->
 
-### deterministic_cq_id
-
-<!-- vale on -->
-
-(`bool`, optional, default: `false`, introduced in CLI `v2.4.1`)
-
-A flag that indicates whether the value of `_cq_id` should be a UUID that is a hash of the primary keys or a random UUID. If a resource has no primary keys defined the value will always be a random UUID. This option cannot be used when you are using a destination that enforces primary keys in `append` write mode as the `_cq_id` needs to be unique for each row.
-
-Supported by source plugins released on 2023-03-08 and later
-
-<!-- vale off -->
-
 ### otel_endpoint (preview)
 
 <!-- vale on -->
@@ -131,20 +119,3 @@ If set to `true`, the exporter will not verify the server will connect via `http
 
 Plugin-specific configurations. Visit [source plugins](https://hub.cloudquery.io/plugins/source) documentation for more information.
 
-## Top level deprecated options
-
-### concurrency
-
-This option was deprecated in CLI `v3.6.0` in favor of plugin level concurrency, as each plugin as its own concurrency requirements. See more in each plugin documentation.
-
-### scheduler
-
-This option was deprecated in CLI `v3.6.0` in favor of plugin level scheduler, as each plugin as its own scheduler requirements. See more in each plugin documentation.
-
-### backend
-
-This option was deprecated in CLI `v3.6.0` in favor of `backend_options`. See [Managing Incremental Tables](/docs/advanced-topics/managing-incremental-tables) for more information.
-
-### backend_spec
-
-This option was deprecated in CLI `v3.6.0` in favor of `backend_options`. See [Managing Incremental Tables](/docs/advanced-topics/managing-incremental-tables) for more information.


### PR DESCRIPTION
<!-- 🎉 Thank you for making CloudQuery awesome by submitting a PR 🎉 -->

#### Summary

Initial work to enable `_cq_id` by default and remove the option to set it