### PR TITLE
fix: Update `scheduler` doc & JSON schema

### DIFF
--- a/plugins/source/aws/client/spec/schema.json
+++ b/plugins/source/aws/client/spec/schema.json
@@ -344,7 +344,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "default": "shuffle"
         }
       },
       "additionalProperties": false,

--- a/plugins/source/aws/client/spec/spec.go
+++ b/plugins/source/aws/client/spec/spec.go
@@ -121,6 +121,9 @@ func (Spec) JSONSchemaExtend(sc *jsonschema.Schema) {
 			},
 		},
 	}
+
+	// additionally, as we want to outline non-sdk-default for scheduler strategy
+	sc.Properties.Value("scheduler").Default = (&[]scheduler.Strategy{scheduler.StrategyShuffle}[0]).String()
 }
 
 func (s *Spec) Validate() error {

--- a/plugins/source/aws/docs/_configuration.md
+++ b/plugins/source/aws/docs/_configuration.md
@@ -23,5 +23,5 @@ spec:
     # custom_endpoint_partition_id: "" # required when custom_endpoint_url is set
     # custom_endpoint_signing_region: "" # required when custom_endpoint_url is set
     # use_paid_apis: false
-    # scheduler: dfs # options are: dfs, round-robin or shuffle
+    # scheduler: shuffle # options are: dfs, round-robin or shuffle
 ```

--- a/plugins/source/aws/docs/configuration.md
+++ b/plugins/source/aws/docs/configuration.md
@@ -78,9 +78,12 @@ This is the (nested) spec used by the AWS source plugin.
   During initialization the AWS source plugin fetches information about each account and region. This setting controls how many accounts can be initialized concurrently.
   Only configurations with many accounts (either hardcoded or discovered via Organizations) should require modifying this setting, to either lower it to avoid rate limit errors, or to increase it to speed up the initialization process.
 
-- `scheduler` (string) (default: `dfs`):
+- `scheduler` (`string`) (default: `shuffle`):
 
-  The scheduler to use when determining the priority of resources to sync. Currently, the only supported values are `dfs` (depth-first search), `round-robin` and `shuffle`. For more information about this, see [performance tuning](/docs/advanced-topics/performance-tuning).
+  The scheduler to use when determining the priority of resources to sync.
+
+  Currently, the only supported values are `dfs` (depth-first search), `round-robin` and `shuffle`.
+  For more information about this, see [performance tuning](/docs/advanced-topics/performance-tuning).
 
 - `aws_debug` (`bool`) (default: `false`)
 

--- a/website/pages/docs/advanced-topics/performance-tuning.mdx
+++ b/website/pages/docs/advanced-topics/performance-tuning.mdx
@@ -105,18 +105,23 @@ spec:
     project_ids: ...
 ```
 
-Finally, the `shuffle` strategy aims to provide a balance between `dfs` and `round-robin` by randomizing the order in which table-client pairs are chosen. The following example enables `shuffle` for the AWS plugin, which can help reduce the likelihood of hitting rate limits by randomly mixing the underlying services to which API calls that are made concurrently, rather than hitting a single API with all calls at once:
+Finally, the `shuffle` strategy aims to provide a balance between `dfs` and `round-robin` by randomizing the order in which table-client pairs are chosen. The following example enables `shuffle` for the GCP plugin, which can help reduce the likelihood of hitting rate limits by randomly mixing the underlying services to which API calls that are made concurrently, rather than hitting a single API with all calls at once:
 
 ```yaml
 kind: source
 spec:
-  name: "aws"
-  path: "cloudquery/aws"
+  name: "gcp"
+  path: "cloudquery/gcp"
   registry: "cloudquery"
-  version: "VERSION_SOURCE_AWS"
-  tables: ["aws_account_*", "aws_s3_*", "aws_ec2_*"]
+  version: "VERSION_SOURCE_GCP"
+  tables: ["gcp_storage_*", "gcp_compute_*"]
   destinations: ["postgresql"]
   spec:
+    project_ids: ...
     scheduler: "shuffle"
     # ...
 ```
+
+:::callout{type="info"}
+The `shuffle` scheduler is the **default** for the AWS source plugin.
+:::


### PR DESCRIPTION
The AWS team pointed out that our documentation has not been updated after the default scheduler was set to `shuffle`. This should correct it.

Instead of https://github.com/cloudquery/cloudquery-private/pull/1039
