### PR TITLE
fix!: Remove deprecated `directory` option

### DIFF
--- a/plugins/destination/file/client/client.go
+++ b/plugins/destination/file/client/client.go
@@ -38,12 +38,9 @@ func New(_ context.Context, logger zerolog.Logger, spec []byte, opts plugin.NewC
 	if err := c.spec.Validate(); err != nil {
 		return nil, err
 	}
-	if c.spec.Directory != "" {
-		c.logger.Warn().Msg("deprecated: the `directory` configuration option will be removed in a future version, please use `path` instead")
-	}
 	c.spec.SetDefaults()
 
-	filetypesClient, err := filetypes.NewClient(c.spec.FileSpec)
+	filetypesClient, err := filetypes.NewClient(&c.spec.FileSpec)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create filetypes client: %w", err)
 	}

--- a/plugins/destination/file/client/client_test.go
+++ b/plugins/destination/file/client/client_test.go
@@ -60,15 +60,6 @@ func testSpecsWithoutFormat() []testSpec {
 	})
 
 	ret = append(ret, testSpec{
-		testName: "DirectoryWithTable",
-		Spec: Spec{
-			Directory:      filepath.Join("{{TABLE}}", "data.{{FORMAT}}"),
-			BatchSize:      &zero,
-			BatchSizeBytes: &zero,
-		},
-	})
-
-	ret = append(ret, testSpec{
 		testName: "Path",
 		Spec: Spec{
 			Path:           filepath.Join("{{TABLE}}.{{FORMAT}}"),
@@ -98,14 +89,14 @@ func testSpecs(t *testing.T) []testSpec {
 		for i := range formats {
 			s2 := s
 			s2.testName += ":" + string(formats[i].Format)
-			s2.FileSpec = &formats[i]
+			s2.FileSpec = formats[i]
 			ret = append(ret, s2)
 
 			if formats[i].Format != filetypes.FormatTypeParquet {
 				s2.testName += ":gzip"
-				fs := *s2.FileSpec
+				fs := s2.FileSpec
 				fs.Compression = filetypes.CompressionTypeGZip
-				s2.FileSpec = &fs
+				s2.FileSpec = fs
 				ret = append(ret, s2)
 			}
 		}
@@ -114,11 +105,7 @@ func testSpecs(t *testing.T) []testSpec {
 	for i := range ret {
 		bd := t.TempDir()
 		ret[i].baseDir = bd
-		if ret[i].Spec.Path == "" {
-			ret[i].Spec.Directory = filepath.Join(bd, ret[i].Spec.Directory)
-		} else {
-			ret[i].Spec.Path = filepath.Join(bd, ret[i].Spec.Path)
-		}
+		ret[i].Spec.Path = filepath.Join(bd, ret[i].Spec.Path)
 	}
 
 	return ret

--- a/plugins/destination/file/client/spec_test.go
+++ b/plugins/destination/file/client/spec_test.go
@@ -21,8 +21,8 @@ func TestSpec_SetDefaults(t *testing.T) {
 	}{
 
 		{
-			Give: Spec{Path: "test/path/{{TABLE}}.json", FileSpec: &filetypes.FileSpec{Format: "json", FormatSpec: map[string]any{"delimiter": ","}}},
-			Want: Spec{Path: "test/path/{{TABLE}}.json", FileSpec: &filetypes.FileSpec{Format: "json", FormatSpec: map[string]any{"delimiter": ","}}, BatchSize: int64Ptr(10000), BatchSizeBytes: int64Ptr(50 * 1024 * 1024), BatchTimeout: &dur30},
+			Give: Spec{Path: "test/path/{{TABLE}}.json", FileSpec: filetypes.FileSpec{Format: "json", FormatSpec: map[string]any{"delimiter": ","}}},
+			Want: Spec{Path: "test/path/{{TABLE}}.json", FileSpec: filetypes.FileSpec{Format: "json", FormatSpec: map[string]any{"delimiter": ","}}, BatchSize: int64Ptr(10000), BatchSizeBytes: int64Ptr(50 * 1024 * 1024), BatchTimeout: &dur30},
 		},
 	}
 	for _, tc := range cases {
@@ -41,13 +41,13 @@ func TestSpec_Validate(t *testing.T) {
 		Give    Spec
 		WantErr bool
 	}{
-		{Give: Spec{Path: "test/path", FileSpec: &filetypes.FileSpec{Format: "json"}, BatchSize: &zero, BatchSizeBytes: &zero, BatchTimeout: &dur0}, WantErr: false},
-		{Give: Spec{Path: "test/path/{{TABLE}}.{{UUID}}", FileSpec: &filetypes.FileSpec{Format: "json"}, NoRotate: false, BatchSize: &zero, BatchSizeBytes: &zero, BatchTimeout: &dur0}, WantErr: false},
-		{Give: Spec{Path: "test/path/{{TABLE}}.{{UUID}}", FileSpec: &filetypes.FileSpec{Format: "json"}, NoRotate: true, BatchSize: &zero, BatchSizeBytes: &zero, BatchTimeout: &dur0}, WantErr: true}, // can't have no_rotate and {{UUID}}
-		{Give: Spec{Path: "test/path/{{TABLE}}", FileSpec: &filetypes.FileSpec{Format: "json"}, NoRotate: true, BatchSize: &zero, BatchSizeBytes: &zero, BatchTimeout: &dur0}, WantErr: false},         // norotate with zero batchsize
-		{Give: Spec{Path: "test/path/{{TABLE}}", FileSpec: &filetypes.FileSpec{Format: "json"}, NoRotate: true}, WantErr: false},                                                                       // norotate with default batchsize
-		{Give: Spec{Path: "test/path/{{TABLE}}", FileSpec: &filetypes.FileSpec{Format: "json"}, NoRotate: true, BatchSize: &one}, WantErr: true},                                                       // norotate with non zero batchsize
-		{Give: Spec{Path: "test/path/{{TABLE}}", FileSpec: &filetypes.FileSpec{Format: "json"}, NoRotate: false, BatchSize: &one, BatchSizeBytes: &zero, BatchTimeout: &dur0}, WantErr: true},          // can't have nonzero batch size and no {{UUID}}
+		{Give: Spec{Path: "test/path", FileSpec: filetypes.FileSpec{Format: "json"}, BatchSize: &zero, BatchSizeBytes: &zero, BatchTimeout: &dur0}, WantErr: false},
+		{Give: Spec{Path: "test/path/{{TABLE}}.{{UUID}}", FileSpec: filetypes.FileSpec{Format: "json"}, NoRotate: false, BatchSize: &zero, BatchSizeBytes: &zero, BatchTimeout: &dur0}, WantErr: false},
+		{Give: Spec{Path: "test/path/{{TABLE}}.{{UUID}}", FileSpec: filetypes.FileSpec{Format: "json"}, NoRotate: true, BatchSize: &zero, BatchSizeBytes: &zero, BatchTimeout: &dur0}, WantErr: true}, // can't have no_rotate and {{UUID}}
+		{Give: Spec{Path: "test/path/{{TABLE}}", FileSpec: filetypes.FileSpec{Format: "json"}, NoRotate: true, BatchSize: &zero, BatchSizeBytes: &zero, BatchTimeout: &dur0}, WantErr: false},         // norotate with zero batchsize
+		{Give: Spec{Path: "test/path/{{TABLE}}", FileSpec: filetypes.FileSpec{Format: "json"}, NoRotate: true}, WantErr: false},                                                                       // norotate with default batchsize
+		{Give: Spec{Path: "test/path/{{TABLE}}", FileSpec: filetypes.FileSpec{Format: "json"}, NoRotate: true, BatchSize: &one}, WantErr: true},                                                       // norotate with non zero batchsize
+		{Give: Spec{Path: "test/path/{{TABLE}}", FileSpec: filetypes.FileSpec{Format: "json"}, NoRotate: false, BatchSize: &one, BatchSizeBytes: &zero, BatchTimeout: &dur0}, WantErr: true},          // can't have nonzero batch size and no {{UUID}}
 	}
 	for i, tc := range cases {
 		tc := tc

--- a/plugins/destination/file/docs/_configuration.md
+++ b/plugins/destination/file/docs/_configuration.md
@@ -11,7 +11,6 @@ spec:
     path: "path/to/files/{{TABLE}}/{{UUID}}.{{FORMAT}}"
     format: "csv" # options: parquet, json, csv
     # Optional parameters
-    # directory: "" # required if path is not present
     # format_spec:
       # CSV-specific parameters:
       # delimiter: ","

--- a/plugins/destination/file/docs/overview.md
+++ b/plugins/destination/file/docs/overview.md
@@ -20,7 +20,7 @@ This plugin is useful in local environments, but also in production environments
 
 This is the (nested) spec used by the file destination Plugin.
 
-- `path` (string) (required)
+- `path` (`string`) (**required**)
 
   Path template string that determines where files will be written. The path supports the following placeholder variables:
 
@@ -35,11 +35,7 @@ This is the (nested) spec used by the file destination Plugin.
 
   Note that timestamps are in UTC and will be the current time at the time the file is written, not when the sync started.
 
-- `directory` (`string`) (required if `path` is not set) (**deprecated**)
-
-  Directory where all files will be written. One file will be created per table. This is now deprecated in favor of `path` which allows more flexibility, and the `directory` option will be removed in a future version.
-
-- `format` (`string`) (required)
+- `format` (`string`) (**required**)
 
   Format of the output file.  Supported values are `csv`, `json` and `parquet`.
 
@@ -52,9 +48,9 @@ This is the (nested) spec used by the file destination Plugin.
   If set to `true`, the plugin will write to one file per table.
   Otherwise, for every batch a new file will be created with a different `.<UUID>` suffix.
 
-- `compression` (`string`) (optional) (default: empty)
+- `compression` (`string`) (optional) (default: `""`)
 
-  Compression algorithm to use. Supported values are empty or `gzip`. Not supported for `parquet` format.
+  Compression algorithm to use. Supported values are `""` and `gzip`. Not supported for `parquet` format.
 
 - `batch_size` (`integer`) (optional) (default: `10000`)
 


### PR DESCRIPTION
Additional changes:
1. Use direct embedding instead of pointer for file spec
2. Validate via file spec as well