### PR TITLE
fix: Use `write_mode` instead of `write-mode` in docs

### DIFF
--- a/plugins/destination/file/docs/_configuration.md
+++ b/plugins/destination/file/docs/_configuration.md
@@ -7,6 +7,7 @@ spec:
   path: "cloudquery/file"
   registry: "cloudquery"
   version: "VERSION_DESTINATION_FILE"
+  write_mode: "append"
   spec:
     path: "path/to/files/{{TABLE}}/{{UUID}}.{{FORMAT}}"
     format: "csv" # options: parquet, json, csv
@@ -22,4 +23,4 @@ spec:
     # batch_timeout: 30s
 ```
 
-Note that the file plugin only supports `append` write-mode. The (top level) spec section is described in the [Destination Spec Reference](/docs/reference/destination-spec).
+Note that the file plugin only supports `append` `write_mode`. The (top level) spec section is described in the [Destination Spec Reference](/docs/reference/destination-spec).

--- a/plugins/destination/gcs/docs/_configuration.md
+++ b/plugins/destination/gcs/docs/_configuration.md
@@ -7,6 +7,7 @@ spec:
   path: "cloudquery/gcs"
   registry: "cloudquery"
   version: "VERSION_DESTINATION_GCS"
+  write_mode: "append"
   spec:
     bucket: "bucket_name"
     path: "path/to/files"
@@ -24,4 +25,4 @@ spec:
     # batch_timeout: 30s
 ```
 
-Note that the GCS plugin only supports `append` write-mode. The (top level) spec section is described in the [Destination Spec Reference](/docs/reference/destination-spec).
+Note that the GCS plugin only supports `append` `write_mode`. The (top level) spec section is described in the [Destination Spec Reference](/docs/reference/destination-spec).

--- a/plugins/destination/kafka/docs/_configuration.md
+++ b/plugins/destination/kafka/docs/_configuration.md
@@ -9,6 +9,7 @@ spec:
   path: "cloudquery/kafka"
   registry: "cloudquery"
   version: "VERSION_DESTINATION_KAFKA"
+  write_mode: "append"
   spec:
     brokers: ["<broker-host>:<broker-port>"]
     format: "csv" # options: parquet, json, csv
@@ -26,4 +27,4 @@ spec:
     # batch_size: 1000
 ```
 
-Note that the Kafka plugin only supports `append` write-mode. The (top level) spec section is described in the [Destination Spec Reference](/docs/reference/destination-spec).
+Note that the Kafka plugin only supports `append` `write_mode`. The (top level) spec section is described in the [Destination Spec Reference](/docs/reference/destination-spec).

--- a/plugins/destination/s3/docs/_configuration.md
+++ b/plugins/destination/s3/docs/_configuration.md
@@ -41,4 +41,4 @@ path: "path/to/files/{{TABLE}}/dt={{YEAR}}-{{MONTH}}-{{DAY}}/{{UUID}}.parquet"
 
 Other supported formats are `json` and `csv`.
 
-Note that the S3 plugin only supports `append` write-mode. The (top level) spec section is described in the [Destination Spec Reference](/docs/reference/destination-spec).
+Note that the S3 plugin only supports `append` `write_mode`. The (top level) spec section is described in the [Destination Spec Reference](/docs/reference/destination-spec).


### PR DESCRIPTION
<!-- 🎉 Thank you for making CloudQuery awesome by submitting a PR 🎉 -->

#### Summary

Fixes some typos in the docs

<!--
Use the following steps to ensure your PR is ready to be reviewed

- [ ] Read the [contribution guidelines](https://github.com/cloudquery/cloudquery/blob/main/CONTRIBUTING.md) 🧑‍🎓
- [ ] Run `make lint` to ensure the proposed changes follow the coding style 🚨 (install golangci-lint [here](https://golangci-lint.run/usage/install/#local-installation))
- [ ] Run `make test` to ensure the proposed changes pass the tests 🧪
- [ ] If changing a source plugin run `make gen` to ensure docs are up to date 📝
- [ ] Ensure the status checks below are successful ✅
--->
