### PR TITLE
fix!: Remove support for deprecated `OKTA_API_TOKEN` environment variable

### DIFF
--- a/plugins/source/okta/README.md
+++ b/plugins/source/okta/README.md
@@ -8,7 +8,7 @@ The CloudQuery Okta plugin extracts Okta resources configurations and loads them
 
 ## Authentication
 
-To [authenticate](https://developer.okta.com/docs/guides/create-an-api-token/overview/) CloudQuery with your Okta account you need to set an `OKTA_API_TOKEN` environment variable or add it the configuration.
+To [authenticate](https://developer.okta.com/docs/guides/create-an-api-token/overview/) CloudQuery with your Okta account you need to add Okta API token to the configuration.
 
 ## Configuration
 
@@ -29,10 +29,9 @@ spec:
     # Required. Your Okta domain name
     domain: "https://<YOUR_OKTA_DOMAIN>.okta.com/"
 
-    # Optional. Okta Token to access API, you can set this with OKTA_API_TOKEN environment variable
-    # ⚠️ Warning - Your token should be kept secret and not committed to source control
-    # token: "<YOUR_OKTA_TOKEN>"
+    # Optional. Okta Token to access API
+    token: "<YOUR_OKTA_TOKEN>"
 ```
 
 - `domain` (Required) - Specify the Okta domain you are fetching from. [Visit this link](https://developer.okta.com/docs/guides/find-your-domain/findorg/) to find your Okta domain
-- `token` (Optional) - Okta Token to access the API. You can set this with an `OKTA_API_TOKEN` environment variable
+- `token` (Required) - Okta Token to access the API.

--- a/plugins/source/okta/client/spec.go
+++ b/plugins/source/okta/client/spec.go
@@ -1,8 +1,7 @@
 package client
 
 import (
-	"fmt"
-	"os"
+	"errors"
 	"time"
 
 	"github.com/rs/zerolog"
@@ -20,10 +19,6 @@ type (
 		MaxBackoff time.Duration `json:"max_backoff,omitempty"`
 		MaxRetries int32         `json:"max_retries,omitempty"`
 	}
-)
-
-const (
-	OktaAPIToken = "OKTA_API_TOKEN"
 )
 
 func (s *Spec) SetDefaults(logger *zerolog.Logger) {
@@ -44,11 +39,6 @@ func (s *Spec) SetDefaults(logger *zerolog.Logger) {
 		s.RateLimit.MaxBackoff = minBackOff
 	}
 
-	if len(s.Token) == 0 {
-		logger.Warn().Msgf("usage of %q environment variable value is deprecated and will be dropped in a future release", OktaAPIToken)
-		s.Token = os.Getenv(OktaAPIToken)
-	}
-
 	if s.Concurrency < 1 {
 		s.Concurrency = 10000
 	}
@@ -56,13 +46,13 @@ func (s *Spec) SetDefaults(logger *zerolog.Logger) {
 
 func (s Spec) Validate() error {
 	if len(s.Token) == 0 {
-		return fmt.Errorf("missing API token (should be set in the configuration or as %q environment variable)", OktaAPIToken)
+		return errors.New("missing \"token\" in plugin configuration")
 	}
 
 	const exampleDomain = "https://<CHANGE_THIS_TO_YOUR_OKTA_DOMAIN>.okta.com"
 	switch s.Domain {
 	case "", exampleDomain:
-		return fmt.Errorf("missing \"domain\" in plugin configuration")
+		return errors.New("missing \"domain\" in plugin configuration")
 	}
 
 	return nil

--- a/plugins/source/okta/docs/_authentication.md
+++ b/plugins/source/okta/docs/_authentication.md
@@ -1,1 +1,1 @@
-To [authenticate](https://developer.okta.com/docs/guides/create-an-api-token/overview/) CloudQuery with your Okta account you need to set an `OKTA_API_TOKEN` environment variable or add it the configuration.
+To [authenticate](https://developer.okta.com/docs/guides/create-an-api-token/overview/) CloudQuery with your Okta account you need to add Okta API token to the configuration.

--- a/plugins/source/okta/docs/_configuration.md
+++ b/plugins/source/okta/docs/_configuration.md
@@ -9,13 +9,10 @@ spec:
   tables: ["*"]
   destinations: ["DESTINATION_NAME"]
   spec:
-    # Required. Your Okta domain name
+    # Okta domain name
     domain: "https://<YOUR_OKTA_DOMAIN>.okta.com/"
-
-    # Optional. Okta Token to access API
-    # ⚠️ Warning - Your token should be kept secret and not committed to source control.
-    # ⚠️ Warning - In the future versions token parameter will become required.
-    # token: "<YOUR_OKTA_TOKEN>"
+    # Okta Token to access API
+    token: "<YOUR_OKTA_TOKEN>"
 
     # Optional. Rate limiter settings
     # rate_limit:

--- a/plugins/source/okta/docs/overview.md
+++ b/plugins/source/okta/docs/overview.md
@@ -24,43 +24,38 @@ The following example sets up the Okta plugin, and connects it to a postgresql d
 Make sure you use [environment variable expansion](/docs/advanced-topics/environment-variable-substitution) in production instead of committing the credentials to the configuration file directly.
 :::
 
-- `domain` (`string`, required)
+- `domain` (`string`) (required)
 
   Specify the Okta domain you are fetching from.
   [Visit this link](https://developer.okta.com/docs/guides/find-your-domain/findorg/) to find your Okta domain.
 
-- `token` (`string`, optional)
+- `token` (`string`) (required)
 
   Token for Okta API access.
-  You can set this with an `OKTA_API_TOKEN` environment variable.
-  :::callout{type="warning"}
-  Using `OKTA_API_TOKEN` environment variable will be deprecated in the future versions.
-  You can use [environment variable expansion](/docs/advanced-topics/environment-variable-substitution) and `"${OKTA_API_TOKEN}"` value in the configuration instead.
-  :::
 
-- `debug` (`bool`, optional. Default: `false`)
+- `debug` (`bool`) (optional) (default: `false`)
 
   Enables debug logs within the Okta SDK.
   :::callout{type="warning"}
   This feature will result in sensitive information being logged!
   :::
 
-- `concurrency` (`integer`, optional. default: `10000`)
+- `concurrency` (`integer`) (optional) (default: `10000`)
 
   Number of concurrent requests to be made to Okta API.
 
-- `rate_limit` ([Rate limit](#rate-limit-spec) spec, optional. Default: see [rate limit](#rate-limit-spec) spec defaults)
+- `rate_limit` ([Rate limit](#rate-limit-spec) spec) (optional) (default: see [rate limit](#rate-limit-spec) spec defaults)
 
   Rate limit configuration.
 
 ### Rate limit spec
 
-- `max_backoff` (`duration`, optional. Default: `5s`)
+- `max_backoff` (`duration`) (optional) (default: `5s`)
 
   Max backoff interval to be used.
   If the value specified is less than the default one, the default one is used.
 
-- `max_retries` (`int32`, optional. Default: `3`)
+- `max_retries` (`integer`) (optional) (default: `3`)
 
   Max retries to be performed.
   If the value specified is less than the default one, the default one is used.


### PR DESCRIPTION
Should be merged prior to https://github.com/cloudquery/cloudquery/pull/16493