### PR TITLE
fix: Proper JSON marshaling for `LogLevel`

### DIFF
--- a/plugins/destination/postgresql/client/spec/pgx_log_level.go
+++ b/plugins/destination/postgresql/client/spec/pgx_log_level.go
@@ -43,7 +43,7 @@ func (r LogLevel) LogLevel() tracelog.LogLevel {
 	return tracelog.LogLevel(r)
 }
 
-func (r *LogLevel) MarshalJSON() ([]byte, error) {
+func (r LogLevel) MarshalJSON() ([]byte, error) {
 	buffer := bytes.NewBufferString(`"`)
 	buffer.WriteString(r.String())
 	buffer.WriteString(`"`)

--- a/plugins/destination/postgresql/client/spec/pgx_log_level_test.go
+++ b/plugins/destination/postgresql/client/spec/pgx_log_level_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/cloudquery/codegen/jsonschema"
+	"github.com/jackc/pgx/v5/tracelog"
 	"github.com/stretchr/testify/require"
 )
 
@@ -27,4 +28,33 @@ func TestLogLevel_JSONSchema(t *testing.T) {
 			jsonschema.TestCase{Name: "bad value", Spec: `"some_extra_value"`, Err: true},
 		),
 	)
+}
+
+func TestLogLevel_MarshalJSON(t *testing.T) {
+	type spec struct {
+		LogLevel LogLevel `json:"log_level"`
+	}
+	for l := tracelog.LogLevelNone; l <= tracelog.LogLevelTrace; l++ {
+		level := LogLevel(l)
+		t.Run(level.String(), func(t *testing.T) {
+			data, err := json.Marshal(spec{LogLevel: level})
+			require.NoError(t, err)
+			require.Exactly(t, `{"log_level":"`+level.String()+`"}`, string(data))
+		})
+	}
+}
+
+func TestLogLevel_UnmarshalJSON(t *testing.T) {
+	type spec struct {
+		LogLevel LogLevel `json:"log_level"`
+	}
+	for l := tracelog.LogLevelNone; l <= tracelog.LogLevelTrace; l++ {
+		level := LogLevel(l)
+		t.Run(level.String(), func(t *testing.T) {
+			var s spec
+			err := json.Unmarshal([]byte(`{"log_level":"`+level.String()+`"}`), &s)
+			require.NoError(t, err)
+			require.Exactly(t, level, s.LogLevel)
+		})
+	}
 }


### PR DESCRIPTION
Follow-up for https://github.com/cloudquery/cloudquery/pull/16479