### PR TITLE
chore: Fix detection of Go Plugins

### DIFF
--- a/.github/workflows/publish_plugin_to_hub.yml
+++ b/.github/workflows/publish_plugin_to_hub.yml
@@ -52,7 +52,7 @@ jobs:
             if (pluginFiles.includes('package.json')) {
               return 'node';
             }
-            if (pluginFiles.includes('.goreleaser.yaml')) {
+            if (pluginFiles.includes('main.go')) {
               return 'go';
             }
             if (pluginFiles.includes('main.py')) {


### PR DESCRIPTION
<!-- 🎉 Thank you for making CloudQuery awesome by submitting a PR 🎉 -->

#### Summary

Now that we're publishing to the Hub we shouldn't use the Go Releaser file to detect if this is a Go plugin

<!--
Use the following steps to ensure your PR is ready to be reviewed

- [ ] Read the [contribution guidelines](https://github.com/cloudquery/cloudquery/blob/main/CONTRIBUTING.md) 🧑‍🎓
- [ ] Run `make lint` to ensure the proposed changes follow the coding style 🚨 (install golangci-lint [here](https://golangci-lint.run/usage/install/#local-installation))
- [ ] Run `make test` to ensure the proposed changes pass the tests 🧪
- [ ] If changing a source plugin run `make gen` to ensure docs are up to date 📝
- [ ] Ensure the status checks below are successful ✅
--->
