### PR TITLE
chore: Use shared Column definition

### DIFF
--- a/plugins/source/aws/resources/services/appmesh/meshes.go
+++ b/plugins/source/aws/resources/services/appmesh/meshes.go
@@ -23,18 +23,8 @@ The 'request_account_id' and 'request_region' columns are added to show the acco
 		Multiplex:           client.ServiceAccountRegionMultiplexer(tableName, "appmesh"),
 		Transform:           transformers.TransformWithStruct(&types.MeshData{}),
 		Columns: []schema.Column{
-			{
-				Name:                "request_account_id",
-				Type:                arrow.BinaryTypes.String,
-				Resolver:            client.ResolveAWSAccount,
-				PrimaryKeyComponent: true,
-			},
-			{
-				Name:                "request_region",
-				Type:                arrow.BinaryTypes.String,
-				Resolver:            client.ResolveAWSRegion,
-				PrimaryKeyComponent: true,
-			},
+			client.RequestAccountIDColumn(true),
+			client.RequestRegionColumn(true),
 			{
 				Name:                "arn",
 				Type:                arrow.BinaryTypes.String,

--- a/plugins/source/aws/resources/services/appmesh/virtual_gateways.go
+++ b/plugins/source/aws/resources/services/appmesh/virtual_gateways.go
@@ -19,18 +19,8 @@ func virtualGateways() *schema.Table {
 		PreResourceResolver: getVirtualGateway,
 		Transform:           transformers.TransformWithStruct(&types.VirtualGatewayData{}),
 		Columns: []schema.Column{
-			{
-				Name:                "request_account_id",
-				Type:                arrow.BinaryTypes.String,
-				Resolver:            client.ResolveAWSAccount,
-				PrimaryKeyComponent: true,
-			},
-			{
-				Name:                "request_region",
-				Type:                arrow.BinaryTypes.String,
-				Resolver:            client.ResolveAWSRegion,
-				PrimaryKeyComponent: true,
-			},
+			client.RequestAccountIDColumn(true),
+			client.RequestRegionColumn(true),
 			{
 				Name:                "arn",
 				Type:                arrow.BinaryTypes.String,

--- a/plugins/source/aws/resources/services/appmesh/virtual_nodes.go
+++ b/plugins/source/aws/resources/services/appmesh/virtual_nodes.go
@@ -19,18 +19,8 @@ func virtualNodes() *schema.Table {
 		PreResourceResolver: getVirtualNode,
 		Transform:           transformers.TransformWithStruct(&types.VirtualNodeData{}),
 		Columns: []schema.Column{
-			{
-				Name:                "request_account_id",
-				Type:                arrow.BinaryTypes.String,
-				Resolver:            client.ResolveAWSAccount,
-				PrimaryKeyComponent: true,
-			},
-			{
-				Name:                "request_region",
-				Type:                arrow.BinaryTypes.String,
-				Resolver:            client.ResolveAWSRegion,
-				PrimaryKeyComponent: true,
-			},
+			client.RequestAccountIDColumn(true),
+			client.RequestRegionColumn(true),
 			{
 				Name:                "arn",
 				Type:                arrow.BinaryTypes.String,

--- a/plugins/source/aws/resources/services/appmesh/virtual_routers.go
+++ b/plugins/source/aws/resources/services/appmesh/virtual_routers.go
@@ -19,18 +19,8 @@ func virtualRouters() *schema.Table {
 		PreResourceResolver: getVirtualRouter,
 		Transform:           transformers.TransformWithStruct(&types.VirtualRouterData{}),
 		Columns: []schema.Column{
-			{
-				Name:                "request_account_id",
-				Type:                arrow.BinaryTypes.String,
-				Resolver:            client.ResolveAWSAccount,
-				PrimaryKeyComponent: true,
-			},
-			{
-				Name:                "request_region",
-				Type:                arrow.BinaryTypes.String,
-				Resolver:            client.ResolveAWSRegion,
-				PrimaryKeyComponent: true,
-			},
+			client.RequestAccountIDColumn(true),
+			client.RequestRegionColumn(true),
 			{
 				Name:                "arn",
 				Type:                arrow.BinaryTypes.String,

--- a/plugins/source/aws/resources/services/appmesh/virtual_services.go
+++ b/plugins/source/aws/resources/services/appmesh/virtual_services.go
@@ -19,18 +19,8 @@ func virtualServices() *schema.Table {
 		PreResourceResolver: getVirtualService,
 		Transform:           transformers.TransformWithStruct(&types.VirtualServiceData{}),
 		Columns: []schema.Column{
-			{
-				Name:                "request_account_id",
-				Type:                arrow.BinaryTypes.String,
-				Resolver:            client.ResolveAWSAccount,
-				PrimaryKeyComponent: true,
-			},
-			{
-				Name:                "request_region",
-				Type:                arrow.BinaryTypes.String,
-				Resolver:            client.ResolveAWSRegion,
-				PrimaryKeyComponent: true,
-			},
+			client.RequestAccountIDColumn(true),
+			client.RequestRegionColumn(true),
 			{
 				Name:                "arn",
 				Type:                arrow.BinaryTypes.String,

--- a/plugins/source/aws/resources/services/cloudformation/stack_instance_resource_drifts.go
+++ b/plugins/source/aws/resources/services/cloudformation/stack_instance_resource_drifts.go
@@ -22,16 +22,8 @@ The 'request_account_id' and 'request_region' columns are added to show the acco
 		Resolver:  fetchStackInstanceResourceDrifts,
 		Transform: transformers.TransformWithStruct(&types.StackInstanceResourceDriftsSummary{}, transformers.WithPrimaryKeyComponents("StackId", "LogicalResourceId", "PhysicalResourceId")),
 		Columns: []schema.Column{
-			{
-				Name:     "request_account_id",
-				Type:     arrow.BinaryTypes.String,
-				Resolver: client.ResolveAWSAccount,
-			},
-			{
-				Name:     "request_region",
-				Type:     arrow.BinaryTypes.String,
-				Resolver: client.ResolveAWSRegion,
-			},
+			client.RequestAccountIDColumn(false),
+			client.RequestRegionColumn(false),
 			{
 				Name:                "stack_set_arn",
 				Type:                arrow.BinaryTypes.String,

--- a/plugins/source/aws/resources/services/cloudformation/stackset_operation_results.go
+++ b/plugins/source/aws/resources/services/cloudformation/stackset_operation_results.go
@@ -22,18 +22,8 @@ The 'request_account_id' and 'request_region' columns are added to show the acco
 		Resolver:  fetchCloudformationStackSetOperationResults,
 		Transform: transformers.TransformWithStruct(&types.StackSetOperationResultSummary{}, transformers.WithPrimaryKeyComponents("Account", "Region")),
 		Columns: []schema.Column{
-			{
-				Name:                "request_account_id",
-				Type:                arrow.BinaryTypes.String,
-				Resolver:            client.ResolveAWSAccount,
-				PrimaryKeyComponent: true,
-			},
-			{
-				Name:                "request_region",
-				Type:                arrow.BinaryTypes.String,
-				Resolver:            client.ResolveAWSRegion,
-				PrimaryKeyComponent: true,
-			},
+			client.RequestAccountIDColumn(true),
+			client.RequestRegionColumn(true),
 			{
 				Name:                "stack_set_arn",
 				Type:                arrow.BinaryTypes.String,

--- a/plugins/source/aws/resources/services/codeartifact/domains.go
+++ b/plugins/source/aws/resources/services/codeartifact/domains.go
@@ -3,7 +3,6 @@ package codeartifact
 import (
 	"context"
 
-	"github.com/apache/arrow/go/v15/arrow"
 	"github.com/aws/aws-sdk-go-v2/service/codeartifact"
 	"github.com/aws/aws-sdk-go-v2/service/codeartifact/types"
 	"github.com/cloudquery/cloudquery/plugins/source/aws/client"
@@ -23,18 +22,8 @@ The 'request_account_id' and 'request_region' columns are added to show the acco
 		Multiplex:           client.ServiceAccountRegionMultiplexer(tableName, "codeartifact"),
 		Transform:           transformers.TransformWithStruct(&types.DomainDescription{}, transformers.WithPrimaryKeyComponents("Arn")),
 		Columns: []schema.Column{
-			{
-				Name:                "request_account_id",
-				Type:                arrow.BinaryTypes.String,
-				Resolver:            client.ResolveAWSAccount,
-				PrimaryKeyComponent: true,
-			},
-			{
-				Name:                "request_region",
-				Type:                arrow.BinaryTypes.String,
-				Resolver:            client.ResolveAWSRegion,
-				PrimaryKeyComponent: true,
-			},
+			client.RequestAccountIDColumn(true),
+			client.RequestRegionColumn(true),
 			{
 				Name:     "tags",
 				Type:     sdkTypes.ExtensionTypes.JSON,

--- a/plugins/source/aws/resources/services/codeartifact/repositories.go
+++ b/plugins/source/aws/resources/services/codeartifact/repositories.go
@@ -3,7 +3,6 @@ package codeartifact
 import (
 	"context"
 
-	"github.com/apache/arrow/go/v15/arrow"
 	"github.com/aws/aws-sdk-go-v2/service/codeartifact"
 	"github.com/aws/aws-sdk-go-v2/service/codeartifact/types"
 	"github.com/cloudquery/cloudquery/plugins/source/aws/client"
@@ -23,18 +22,8 @@ The 'request_account_id' and 'request_region' columns are added to show the acco
 		Multiplex:           client.ServiceAccountRegionMultiplexer(tableName, "codeartifact"),
 		Transform:           transformers.TransformWithStruct(&types.RepositoryDescription{}, transformers.WithPrimaryKeyComponents("Arn")),
 		Columns: []schema.Column{
-			{
-				Name:                "request_account_id",
-				Type:                arrow.BinaryTypes.String,
-				Resolver:            client.ResolveAWSAccount,
-				PrimaryKeyComponent: true,
-			},
-			{
-				Name:                "request_region",
-				Type:                arrow.BinaryTypes.String,
-				Resolver:            client.ResolveAWSRegion,
-				PrimaryKeyComponent: true,
-			},
+			client.RequestAccountIDColumn(true),
+			client.RequestRegionColumn(true),
 			{
 				Name:     "tags",
 				Type:     sdkTypes.ExtensionTypes.JSON,

--- a/plugins/source/aws/resources/services/detective/members.go
+++ b/plugins/source/aws/resources/services/detective/members.go
@@ -3,8 +3,6 @@ package detective
 import (
 	"context"
 
-	"github.com/apache/arrow/go/v15/arrow"
-
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/detective"
 	"github.com/aws/aws-sdk-go-v2/service/detective/types"
@@ -22,17 +20,8 @@ The 'request_account_id' and 'request_region' columns are added to show the acco
 		Resolver:  fetchMembers,
 		Transform: transformers.TransformWithStruct(&types.MemberDetail{}, transformers.WithPrimaryKeyComponents("AccountId", "GraphArn")),
 		Columns: []schema.Column{
-			{
-				Name:     "request_account_id",
-				Type:     arrow.BinaryTypes.String,
-				Resolver: client.ResolveAWSAccount,
-			},
-			{
-				Name:                "request_region",
-				Type:                arrow.BinaryTypes.String,
-				Resolver:            client.ResolveAWSRegion,
-				PrimaryKeyComponent: true,
-			},
+			client.RequestAccountIDColumn(false),
+			client.RequestRegionColumn(true),
 		},
 	}
 }

--- a/plugins/source/aws/resources/services/directconnect/connections.go
+++ b/plugins/source/aws/resources/services/directconnect/connections.go
@@ -21,17 +21,8 @@ func Connections() *schema.Table {
 		Multiplex:   client.ServiceAccountRegionMultiplexer(tableName, "directconnect"),
 		Transform:   transformers.TransformWithStruct(&types.Connection{}),
 		Columns: []schema.Column{
-			{
-				Name:                "request_account_id",
-				Type:                arrow.BinaryTypes.String,
-				Resolver:            client.ResolveAWSAccount,
-				PrimaryKeyComponent: true,
-			},
-			{
-				Name:     "request_region",
-				Type:     arrow.BinaryTypes.String,
-				Resolver: client.ResolveAWSRegion,
-			},
+			client.RequestAccountIDColumn(true),
+			client.RequestRegionColumn(false),
 			{
 				Name:                "arn",
 				Type:                arrow.BinaryTypes.String,

--- a/plugins/source/aws/resources/services/directconnect/gateway_associations.go
+++ b/plugins/source/aws/resources/services/directconnect/gateway_associations.go
@@ -20,17 +20,8 @@ func gatewayAssociations() *schema.Table {
 		Resolver:    fetchDirectconnectGatewayAssociations,
 		Transform:   transformers.TransformWithStruct(&types.DirectConnectGatewayAssociation{}, transformers.WithPrimaryKeyComponents("AssociationId")),
 		Columns: []schema.Column{
-			{
-				Name:                "request_account_id",
-				Type:                arrow.BinaryTypes.String,
-				Resolver:            client.ResolveAWSAccount,
-				PrimaryKeyComponent: true,
-			},
-			{
-				Name:     "request_region",
-				Type:     arrow.BinaryTypes.String,
-				Resolver: client.ResolveAWSRegion,
-			},
+			client.RequestAccountIDColumn(true),
+			client.RequestRegionColumn(false),
 			{
 				Name:                "gateway_arn",
 				Type:                arrow.BinaryTypes.String,

--- a/plugins/source/aws/resources/services/directconnect/gateway_attachments.go
+++ b/plugins/source/aws/resources/services/directconnect/gateway_attachments.go
@@ -22,17 +22,8 @@ func gatewayAttachments() *schema.Table {
 			transformers.WithPrimaryKeyComponents("VirtualInterfaceOwnerAccount", "VirtualInterfaceRegion", "VirtualInterfaceId"),
 		),
 		Columns: []schema.Column{
-			{
-				Name:                "request_account_id",
-				Type:                arrow.BinaryTypes.String,
-				Resolver:            client.ResolveAWSAccount,
-				PrimaryKeyComponent: true,
-			},
-			{
-				Name:     "request_region",
-				Type:     arrow.BinaryTypes.String,
-				Resolver: client.ResolveAWSRegion,
-			},
+			client.RequestAccountIDColumn(true),
+			client.RequestRegionColumn(false),
 			{
 				Name:                "gateway_arn",
 				Type:                arrow.BinaryTypes.String,

--- a/plugins/source/aws/resources/services/directconnect/gateways.go
+++ b/plugins/source/aws/resources/services/directconnect/gateways.go
@@ -23,17 +23,8 @@ func Gateways() *schema.Table {
 		Multiplex:   client.AccountMultiplex(tableName),
 		Transform:   transformers.TransformWithStruct(&types.DirectConnectGateway{}),
 		Columns: []schema.Column{
-			{
-				Name:                "request_account_id",
-				Type:                arrow.BinaryTypes.String,
-				Resolver:            client.ResolveAWSAccount,
-				PrimaryKeyComponent: true,
-			},
-			{
-				Name:     "request_region",
-				Type:     arrow.BinaryTypes.String,
-				Resolver: client.ResolveAWSRegion,
-			},
+			client.RequestAccountIDColumn(true),
+			client.RequestRegionColumn(false),
 			{
 				Name:                "arn",
 				Type:                arrow.BinaryTypes.String,

--- a/plugins/source/aws/resources/services/directconnect/lags.go
+++ b/plugins/source/aws/resources/services/directconnect/lags.go
@@ -21,17 +21,8 @@ func Lags() *schema.Table {
 		Multiplex:   client.ServiceAccountRegionMultiplexer(tableName, "directconnect"),
 		Transform:   transformers.TransformWithStruct(&types.Lag{}),
 		Columns: []schema.Column{
-			{
-				Name:                "request_account_id",
-				Type:                arrow.BinaryTypes.String,
-				Resolver:            client.ResolveAWSAccount,
-				PrimaryKeyComponent: true,
-			},
-			{
-				Name:     "request_region",
-				Type:     arrow.BinaryTypes.String,
-				Resolver: client.ResolveAWSRegion,
-			},
+			client.RequestAccountIDColumn(true),
+			client.RequestRegionColumn(false),
 			{
 				Name:                "arn",
 				Type:                arrow.BinaryTypes.String,

--- a/plugins/source/aws/resources/services/directconnect/locations.go
+++ b/plugins/source/aws/resources/services/directconnect/locations.go
@@ -3,7 +3,6 @@ package directconnect
 import (
 	"context"
 
-	"github.com/apache/arrow/go/v15/arrow"
 	"github.com/aws/aws-sdk-go-v2/service/directconnect"
 	"github.com/aws/aws-sdk-go-v2/service/directconnect/types"
 	"github.com/cloudquery/cloudquery/plugins/source/aws/client"
@@ -20,18 +19,8 @@ func Locations() *schema.Table {
 		Multiplex:   client.ServiceAccountRegionMultiplexer(tableName, "directconnect"),
 		Transform:   transformers.TransformWithStruct(&types.Location{}, transformers.WithPrimaryKeyComponents("LocationCode")),
 		Columns: []schema.Column{
-			{
-				Name:                "request_account_id",
-				Type:                arrow.BinaryTypes.String,
-				Resolver:            client.ResolveAWSAccount,
-				PrimaryKeyComponent: true,
-			},
-			{
-				Name:                "request_region",
-				Type:                arrow.BinaryTypes.String,
-				Resolver:            client.ResolveAWSRegion,
-				PrimaryKeyComponent: true,
-			},
+			client.RequestAccountIDColumn(true),
+			client.RequestRegionColumn(true),
 		},
 	}
 }

--- a/plugins/source/aws/resources/services/directconnect/virtual_gateways.go
+++ b/plugins/source/aws/resources/services/directconnect/virtual_gateways.go
@@ -20,18 +20,8 @@ func VirtualGateways() *schema.Table {
 		Multiplex:   client.ServiceAccountRegionMultiplexer(tableName, "directconnect"),
 		Transform:   transformers.TransformWithStruct(&types.VirtualGateway{}),
 		Columns: []schema.Column{
-			{
-				Name:                "request_account_id",
-				Type:                arrow.BinaryTypes.String,
-				Resolver:            client.ResolveAWSAccount,
-				PrimaryKeyComponent: true,
-			},
-			{
-				Name:                "request_region",
-				Type:                arrow.BinaryTypes.String,
-				Resolver:            client.ResolveAWSRegion,
-				PrimaryKeyComponent: true,
-			},
+			client.RequestAccountIDColumn(true),
+			client.RequestRegionColumn(true),
 			{
 				Name:                "id",
 				Type:                arrow.BinaryTypes.String,

--- a/plugins/source/aws/resources/services/directconnect/virtual_interfaces.go
+++ b/plugins/source/aws/resources/services/directconnect/virtual_interfaces.go
@@ -21,18 +21,8 @@ func VirtualInterfaces() *schema.Table {
 		Multiplex:   client.ServiceAccountRegionMultiplexer(tableName, "directconnect"),
 		Transform:   transformers.TransformWithStruct(&types.VirtualInterface{}),
 		Columns: []schema.Column{
-			{
-				Name:                "request_account_id",
-				Type:                arrow.BinaryTypes.String,
-				Resolver:            client.ResolveAWSAccount,
-				PrimaryKeyComponent: true,
-			},
-			{
-				Name:                "request_region",
-				Type:                arrow.BinaryTypes.String,
-				Resolver:            client.ResolveAWSRegion,
-				PrimaryKeyComponent: true,
-			},
+			client.RequestAccountIDColumn(true),
+			client.RequestRegionColumn(true),
 			{
 				Name:                "arn",
 				Type:                arrow.BinaryTypes.String,

--- a/plugins/source/aws/resources/services/ec2/instance_connect.go
+++ b/plugins/source/aws/resources/services/ec2/instance_connect.go
@@ -22,18 +22,8 @@ The 'request_account_id' and 'request_region' columns are added to show from whe
 		Multiplex: client.ServiceAccountRegionMultiplexer(tableName, "ec2"),
 		Transform: transformers.TransformWithStruct(&types.Ec2InstanceConnectEndpoint{}),
 		Columns: []schema.Column{
-			{
-				Name:                "request_account_id",
-				Type:                arrow.BinaryTypes.String,
-				Resolver:            client.ResolveAWSAccount,
-				PrimaryKeyComponent: true,
-			},
-			{
-				Name:                "request_region",
-				Type:                arrow.BinaryTypes.String,
-				Resolver:            client.ResolveAWSRegion,
-				PrimaryKeyComponent: true,
-			},
+			client.RequestAccountIDColumn(true),
+			client.RequestRegionColumn(true),
 			{
 				Name:                "arn",
 				Type:                arrow.BinaryTypes.String,

--- a/plugins/source/aws/resources/services/ec2/managed_prefix_lists.go
+++ b/plugins/source/aws/resources/services/ec2/managed_prefix_lists.go
@@ -22,18 +22,8 @@ The 'request_account_id' and 'request_region' columns are added to show the acco
 		Multiplex: client.ServiceAccountRegionMultiplexer(tableName, "ec2"),
 		Transform: transformers.TransformWithStruct(&types.ManagedPrefixList{}),
 		Columns: []schema.Column{
-			{
-				Name:                "request_account_id",
-				Type:                arrow.BinaryTypes.String,
-				Resolver:            client.ResolveAWSAccount,
-				PrimaryKeyComponent: true,
-			},
-			{
-				Name:                "request_region",
-				Type:                arrow.BinaryTypes.String,
-				Resolver:            client.ResolveAWSRegion,
-				PrimaryKeyComponent: true,
-			},
+			client.RequestAccountIDColumn(true),
+			client.RequestRegionColumn(true),
 			{
 				Name:                "arn",
 				Type:                arrow.BinaryTypes.String,

--- a/plugins/source/aws/resources/services/ec2/subnets.go
+++ b/plugins/source/aws/resources/services/ec2/subnets.go
@@ -22,18 +22,8 @@ The 'request_account_id' and 'request_region' columns are added to show from whe
 		Multiplex: client.ServiceAccountRegionMultiplexer(tableName, "ec2"),
 		Transform: transformers.TransformWithStruct(&types.Subnet{}),
 		Columns: []schema.Column{
-			{
-				Name:                "request_account_id",
-				Type:                arrow.BinaryTypes.String,
-				Resolver:            client.ResolveAWSAccount,
-				PrimaryKeyComponent: true,
-			},
-			{
-				Name:                "request_region",
-				Type:                arrow.BinaryTypes.String,
-				Resolver:            client.ResolveAWSRegion,
-				PrimaryKeyComponent: true,
-			},
+			client.RequestAccountIDColumn(true),
+			client.RequestRegionColumn(true),
 			{
 				Name:                "arn",
 				Type:                arrow.BinaryTypes.String,

--- a/plugins/source/aws/resources/services/guardduty/detector_filters.go
+++ b/plugins/source/aws/resources/services/guardduty/detector_filters.go
@@ -23,18 +23,8 @@ func detectorFilters() *schema.Table {
 			transformers.WithSkipFields("ResultMetadata"),
 		),
 		Columns: schema.ColumnList{
-			{
-				Name:                "request_account_id",
-				Type:                arrow.BinaryTypes.String,
-				Resolver:            client.ResolveAWSAccount,
-				PrimaryKeyComponent: true,
-			},
-			{
-				Name:                "request_region",
-				Type:                arrow.BinaryTypes.String,
-				Resolver:            client.ResolveAWSRegion,
-				PrimaryKeyComponent: true,
-			},
+			client.RequestAccountIDColumn(true),
+			client.RequestRegionColumn(true),
 			{
 				Name:                "detector_arn",
 				Type:                arrow.BinaryTypes.String,

--- a/plugins/source/aws/resources/services/guardduty/detector_findings.go
+++ b/plugins/source/aws/resources/services/guardduty/detector_findings.go
@@ -24,18 +24,8 @@ func detectorFindings() *schema.Table {
 			transformers.WithResolverTransformer(client.TimestampResolverTransformer),
 		),
 		Columns: schema.ColumnList{
-			{
-				Name:                "request_account_id",
-				Type:                arrow.BinaryTypes.String,
-				Resolver:            client.ResolveAWSAccount,
-				PrimaryKeyComponent: true,
-			},
-			{
-				Name:                "request_region",
-				Type:                arrow.BinaryTypes.String,
-				Resolver:            client.ResolveAWSRegion,
-				PrimaryKeyComponent: true,
-			},
+			client.RequestAccountIDColumn(true),
+			client.RequestRegionColumn(true),
 			{
 				Name:                "detector_arn",
 				Type:                arrow.BinaryTypes.String,

--- a/plugins/source/aws/resources/services/guardduty/detector_ipsets.go
+++ b/plugins/source/aws/resources/services/guardduty/detector_ipsets.go
@@ -23,18 +23,8 @@ func detectorIPSets() *schema.Table {
 			transformers.WithSkipFields("ResultMetadata"),
 		),
 		Columns: schema.ColumnList{
-			{
-				Name:                "request_account_id",
-				Type:                arrow.BinaryTypes.String,
-				Resolver:            client.ResolveAWSAccount,
-				PrimaryKeyComponent: true,
-			},
-			{
-				Name:                "request_region",
-				Type:                arrow.BinaryTypes.String,
-				Resolver:            client.ResolveAWSRegion,
-				PrimaryKeyComponent: true,
-			},
+			client.RequestAccountIDColumn(true),
+			client.RequestRegionColumn(true),
 			{
 				Name:                "detector_arn",
 				Type:                arrow.BinaryTypes.String,

--- a/plugins/source/aws/resources/services/guardduty/detector_members.go
+++ b/plugins/source/aws/resources/services/guardduty/detector_members.go
@@ -25,18 +25,8 @@ func detectorMembers() *schema.Table {
 			transformers.WithResolverTransformer(client.TimestampResolverTransformer),
 		),
 		Columns: schema.ColumnList{
-			{
-				Name:                "request_account_id",
-				Type:                arrow.BinaryTypes.String,
-				Resolver:            client.ResolveAWSAccount,
-				PrimaryKeyComponent: true,
-			},
-			{
-				Name:                "request_region",
-				Type:                arrow.BinaryTypes.String,
-				Resolver:            client.ResolveAWSRegion,
-				PrimaryKeyComponent: true,
-			},
+			client.RequestAccountIDColumn(true),
+			client.RequestRegionColumn(true),
 			{
 				Name:                "detector_arn",
 				Type:                arrow.BinaryTypes.String,

--- a/plugins/source/aws/resources/services/guardduty/detector_publishing_destinations.go
+++ b/plugins/source/aws/resources/services/guardduty/detector_publishing_destinations.go
@@ -21,18 +21,8 @@ func detectorPublishingDestinations() *schema.Table {
 		Resolver:    fetchGuarddutyDetectorPublishingDestinations,
 		Transform:   transformers.TransformWithStruct(&types.Destination{}, transformers.WithPrimaryKeyComponents("DestinationId")),
 		Columns: schema.ColumnList{
-			{
-				Name:                "request_account_id",
-				Type:                arrow.BinaryTypes.String,
-				Resolver:            client.ResolveAWSAccount,
-				PrimaryKeyComponent: true,
-			},
-			{
-				Name:                "request_region",
-				Type:                arrow.BinaryTypes.String,
-				Resolver:            client.ResolveAWSRegion,
-				PrimaryKeyComponent: true,
-			},
+			client.RequestAccountIDColumn(true),
+			client.RequestRegionColumn(true),
 			{
 				Name:                "detector_arn",
 				Type:                arrow.BinaryTypes.String,

--- a/plugins/source/aws/resources/services/guardduty/detector_threat_intel_sets.go
+++ b/plugins/source/aws/resources/services/guardduty/detector_threat_intel_sets.go
@@ -21,18 +21,8 @@ func detectorThreatIntelSets() *schema.Table {
 		PreResourceResolver: getDetectorThreatIntelSet,
 		Transform:           transformers.TransformWithStruct(&guardduty.GetThreatIntelSetOutput{}, transformers.WithPrimaryKeyComponents("Name"), transformers.WithSkipFields("ResultMetadata")),
 		Columns: schema.ColumnList{
-			{
-				Name:                "request_account_id",
-				Type:                arrow.BinaryTypes.String,
-				Resolver:            client.ResolveAWSAccount,
-				PrimaryKeyComponent: true,
-			},
-			{
-				Name:                "request_region",
-				Type:                arrow.BinaryTypes.String,
-				Resolver:            client.ResolveAWSRegion,
-				PrimaryKeyComponent: true,
-			},
+			client.RequestAccountIDColumn(true),
+			client.RequestRegionColumn(true),
 			{
 				Name:                "detector_arn",
 				Type:                arrow.BinaryTypes.String,

--- a/plugins/source/aws/resources/services/guardduty/detectors.go
+++ b/plugins/source/aws/resources/services/guardduty/detectors.go
@@ -26,18 +26,8 @@ func Detectors() *schema.Table {
 		),
 		Multiplex: client.ServiceAccountRegionMultiplexer(tableName, "guardduty"),
 		Columns: schema.ColumnList{
-			{
-				Name:                "request_account_id",
-				Type:                arrow.BinaryTypes.String,
-				Resolver:            client.ResolveAWSAccount,
-				PrimaryKeyComponent: true,
-			},
-			{
-				Name:                "request_region",
-				Type:                arrow.BinaryTypes.String,
-				Resolver:            client.ResolveAWSRegion,
-				PrimaryKeyComponent: true,
-			},
+			client.RequestAccountIDColumn(true),
+			client.RequestRegionColumn(true),
 			{
 				Name:     "arn",
 				Type:     arrow.BinaryTypes.String,

--- a/plugins/source/aws/resources/services/networkmanager/global_networks.go
+++ b/plugins/source/aws/resources/services/networkmanager/global_networks.go
@@ -24,12 +24,7 @@ The  'request_region' column is added to show region of where the request was ma
 		Columns: []schema.Column{
 			client.DefaultAccountIDColumn(false),
 			// Only including the request_region in the PK because the ARN doesn't include it as it is a global resource
-			{
-				Name:                "request_region",
-				Type:                arrow.BinaryTypes.String,
-				Resolver:            client.ResolveAWSRegion,
-				PrimaryKeyComponent: true,
-			},
+			client.RequestRegionColumn(true),
 			{
 				Name:                "arn",
 				Type:                arrow.BinaryTypes.String,

--- a/plugins/source/aws/resources/services/networkmanager/link.go
+++ b/plugins/source/aws/resources/services/networkmanager/link.go
@@ -22,12 +22,7 @@ The  'request_region' column is added to show region of where the request was ma
 		Transform: transformers.TransformWithStruct(&types.Link{}, transformers.WithPrimaryKeyComponents("GlobalNetworkId")),
 		Columns: []schema.Column{
 			client.DefaultAccountIDColumn(false),
-			{
-				Name:                "request_region",
-				Type:                arrow.BinaryTypes.String,
-				Resolver:            client.ResolveAWSRegion,
-				PrimaryKeyComponent: true,
-			}, {
+			client.RequestRegionColumn(true), {
 				Name:                "arn",
 				Type:                arrow.BinaryTypes.String,
 				Resolver:            schema.PathResolver("LinkArn"),

--- a/plugins/source/aws/resources/services/networkmanager/sites.go
+++ b/plugins/source/aws/resources/services/networkmanager/sites.go
@@ -22,12 +22,7 @@ The  'request_region' column is added to show region of where the request was ma
 		Transform: transformers.TransformWithStruct(&types.Site{}, transformers.WithPrimaryKeyComponents("GlobalNetworkId")),
 		Columns: []schema.Column{
 			client.DefaultAccountIDColumn(false),
-			{
-				Name:                "request_region",
-				Type:                arrow.BinaryTypes.String,
-				Resolver:            client.ResolveAWSRegion,
-				PrimaryKeyComponent: true,
-			},
+			client.RequestRegionColumn(true),
 			{
 				Name:                "arn",
 				Type:                arrow.BinaryTypes.String,

--- a/plugins/source/aws/resources/services/networkmanager/transit_gateway_registrations.go
+++ b/plugins/source/aws/resources/services/networkmanager/transit_gateway_registrations.go
@@ -3,7 +3,6 @@ package networkmanager
 import (
 	"context"
 
-	"github.com/apache/arrow/go/v15/arrow"
 	"github.com/aws/aws-sdk-go-v2/service/networkmanager"
 	"github.com/aws/aws-sdk-go-v2/service/networkmanager/types"
 	"github.com/cloudquery/cloudquery/plugins/source/aws/client"
@@ -21,12 +20,8 @@ The  'request_region' column is added to show region of where the request was ma
 		Transform: transformers.TransformWithStruct(&types.TransitGatewayRegistration{}, transformers.WithPrimaryKeyComponents("GlobalNetworkId", "TransitGatewayArn")),
 		Columns: []schema.Column{
 			client.DefaultAccountIDColumn(false),
-			{
-				Name:                "request_region",
-				Type:                arrow.BinaryTypes.String,
-				Resolver:            client.ResolveAWSRegion,
-				PrimaryKeyComponent: true,
-			}},
+			client.RequestRegionColumn(true),
+		},
 		Relations: schema.Tables{},
 	}
 }

--- a/plugins/source/aws/resources/services/organizations/account_parents.go
+++ b/plugins/source/aws/resources/services/organizations/account_parents.go
@@ -20,12 +20,7 @@ The 'request_account_id' column is added to show from where the request was made
 		Resolver:  fetchParents,
 		Transform: transformers.TransformWithStruct(&types.Parent{}, transformers.WithPrimaryKeyComponents("Type")),
 		Columns: []schema.Column{
-			{
-				Name:                "request_account_id",
-				Type:                arrow.BinaryTypes.String,
-				Resolver:            client.ResolveAWSAccount,
-				PrimaryKeyComponent: true,
-			},
+			client.RequestAccountIDColumn(true),
 			{
 				Name:                "id",
 				Type:                arrow.BinaryTypes.String,

--- a/plugins/source/aws/resources/services/organizations/accounts.go
+++ b/plugins/source/aws/resources/services/organizations/accounts.go
@@ -3,7 +3,6 @@ package organizations
 import (
 	"context"
 
-	"github.com/apache/arrow/go/v15/arrow"
 	"github.com/aws/aws-sdk-go-v2/service/organizations"
 	"github.com/aws/aws-sdk-go-v2/service/organizations/types"
 	"github.com/cloudquery/cloudquery/plugins/source/aws/client"
@@ -22,12 +21,7 @@ The 'request_account_id' column is added to show from where the request was made
 		Transform: transformers.TransformWithStruct(&types.Account{}, transformers.WithPrimaryKeyComponents("Arn")),
 		Multiplex: client.ServiceAccountRegionMultiplexer(tableName, "organizations"),
 		Columns: []schema.Column{
-			{
-				Name:                "request_account_id",
-				Type:                arrow.BinaryTypes.String,
-				Resolver:            client.ResolveAWSAccount,
-				PrimaryKeyComponent: true,
-			},
+			client.RequestAccountIDColumn(true),
 			{
 				Name:     "tags",
 				Type:     sdkTypes.ExtensionTypes.JSON,

--- a/plugins/source/aws/resources/services/organizations/organizational_unit_parents.go
+++ b/plugins/source/aws/resources/services/organizations/organizational_unit_parents.go
@@ -20,12 +20,7 @@ The 'request_account_id' column is added to show from where the request was made
 		Resolver:  fetchOUParents,
 		Transform: transformers.TransformWithStruct(&types.Parent{}, transformers.WithPrimaryKeyComponents("Type")),
 		Columns: []schema.Column{
-			{
-				Name:                "request_account_id",
-				Type:                arrow.BinaryTypes.String,
-				Resolver:            client.ResolveAWSAccount,
-				PrimaryKeyComponent: true,
-			},
+			client.RequestAccountIDColumn(true),
 			{
 				Name:                "id",
 				Type:                arrow.BinaryTypes.String,

--- a/plugins/source/aws/resources/services/organizations/organizational_units.go
+++ b/plugins/source/aws/resources/services/organizations/organizational_units.go
@@ -3,7 +3,6 @@ package organizations
 import (
 	"context"
 
-	"github.com/apache/arrow/go/v15/arrow"
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/organizations"
 	"github.com/aws/aws-sdk-go-v2/service/organizations/types"
@@ -27,12 +26,7 @@ The 'request_account_id' column is added to show from where the request was made
 		),
 		Multiplex: client.ServiceAccountRegionMultiplexer(tableName, "organizations"),
 		Columns: []schema.Column{
-			{
-				Name:                "request_account_id",
-				Type:                arrow.BinaryTypes.String,
-				Resolver:            client.ResolveAWSAccount,
-				PrimaryKeyComponent: true,
-			},
+			client.RequestAccountIDColumn(true),
 		},
 		Relations: []*schema.Table{
 			organizationalUnitParents(),

--- a/plugins/source/aws/resources/services/organizations/organizations.go
+++ b/plugins/source/aws/resources/services/organizations/organizations.go
@@ -3,7 +3,6 @@ package organizations
 import (
 	"context"
 
-	"github.com/apache/arrow/go/v15/arrow"
 	"github.com/aws/aws-sdk-go-v2/service/organizations"
 	"github.com/aws/aws-sdk-go-v2/service/organizations/types"
 	"github.com/cloudquery/cloudquery/plugins/source/aws/client"
@@ -27,12 +26,7 @@ The 'request_account_id' column is added to show from where the request was made
 		),
 		Multiplex: client.ServiceAccountRegionMultiplexer(tableName, "organizations"),
 		Columns: []schema.Column{
-			{
-				Name:                "request_account_id",
-				Type:                arrow.BinaryTypes.String,
-				Resolver:            client.ResolveAWSAccount,
-				PrimaryKeyComponent: true,
-			},
+			client.RequestAccountIDColumn(true),
 		},
 	}
 }

--- a/plugins/source/aws/resources/services/organizations/roots.go
+++ b/plugins/source/aws/resources/services/organizations/roots.go
@@ -3,7 +3,6 @@ package organizations
 import (
 	"context"
 
-	"github.com/apache/arrow/go/v15/arrow"
 	"github.com/aws/aws-sdk-go-v2/service/organizations"
 	"github.com/aws/aws-sdk-go-v2/service/organizations/types"
 	"github.com/cloudquery/cloudquery/plugins/source/aws/client"
@@ -22,12 +21,7 @@ The 'request_account_id' column is added to show from where the request was made
 		Transform: transformers.TransformWithStruct(&types.Root{}, transformers.WithPrimaryKeyComponents("Arn")),
 		Multiplex: client.ServiceAccountRegionMultiplexer(tableName, "organizations"),
 		Columns: []schema.Column{
-			{
-				Name:                "request_account_id",
-				Type:                arrow.BinaryTypes.String,
-				Resolver:            client.ResolveAWSAccount,
-				PrimaryKeyComponent: true,
-			},
+			client.RequestAccountIDColumn(true),
 			{
 				Name:     "tags",
 				Type:     sdkTypes.ExtensionTypes.JSON,

--- a/plugins/source/aws/resources/services/securityhub/findings.go
+++ b/plugins/source/aws/resources/services/securityhub/findings.go
@@ -3,7 +3,6 @@ package securityhub
 import (
 	"context"
 
-	"github.com/apache/arrow/go/v15/arrow"
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/securityhub"
 	"github.com/aws/aws-sdk-go-v2/service/securityhub/types"
@@ -27,18 +26,8 @@ This is useful when multi region and account aggregation is enabled.`,
 		),
 		Multiplex: client.ServiceAccountRegionMultiplexer(tableName, "securityhub"),
 		Columns: []schema.Column{
-			{
-				Name:                "request_account_id",
-				Type:                arrow.BinaryTypes.String,
-				Resolver:            client.ResolveAWSAccount,
-				PrimaryKeyComponent: true,
-			},
-			{
-				Name:                "request_region",
-				Type:                arrow.BinaryTypes.String,
-				Resolver:            client.ResolveAWSRegion,
-				PrimaryKeyComponent: true,
-			},
+			client.RequestAccountIDColumn(true),
+			client.RequestRegionColumn(true),
 		},
 	}
 }

--- a/plugins/source/aws/resources/services/ssoadmin/account_assignments.go
+++ b/plugins/source/aws/resources/services/ssoadmin/account_assignments.go
@@ -21,16 +21,8 @@ The 'request_account_id' and 'request_region' columns are added to show the acco
 		Resolver:  fetchSsoadminAccountAssignments,
 		Transform: transformers.TransformWithStruct(&types.AccountAssignment{}, transformers.WithPrimaryKeyComponents("PermissionSetArn", "PrincipalId", "PrincipalType", "AccountId")),
 		Columns: schema.ColumnList{
-			{
-				Name:     "request_account_id",
-				Type:     arrow.BinaryTypes.String,
-				Resolver: client.ResolveAWSAccount,
-			},
-			{
-				Name:     "request_region",
-				Type:     arrow.BinaryTypes.String,
-				Resolver: client.ResolveAWSRegion,
-			},
+			client.RequestAccountIDColumn(false),
+			client.RequestRegionColumn(false),
 			{
 				Name:                "instance_arn",
 				Type:                arrow.BinaryTypes.String,

--- a/plugins/source/aws/resources/services/ssoadmin/permission_sets.go
+++ b/plugins/source/aws/resources/services/ssoadmin/permission_sets.go
@@ -22,16 +22,8 @@ The 'request_account_id' and 'request_region' columns are added to show the acco
 		PreResourceResolver: getSsoadminPermissionSet,
 		Transform:           transformers.TransformWithStruct(&types.PermissionSet{}, transformers.WithPrimaryKeyComponents("PermissionSetArn")),
 		Columns: []schema.Column{
-			{
-				Name:     "request_account_id",
-				Type:     arrow.BinaryTypes.String,
-				Resolver: client.ResolveAWSAccount,
-			},
-			{
-				Name:     "request_region",
-				Type:     arrow.BinaryTypes.String,
-				Resolver: client.ResolveAWSRegion,
-			},
+			client.RequestAccountIDColumn(false),
+			client.RequestRegionColumn(false),
 			{
 				Name:                "instance_arn",
 				Type:                arrow.BinaryTypes.String,


### PR DESCRIPTION
<!-- 🎉 Thank you for making CloudQuery awesome by submitting a PR 🎉 -->

#### Summary

This PR has no functional  changes for the user. It swaps out hard coded column definition for a single shared definition in the client