### PR TITLE
fix: Fix Multiple PKs

### DIFF
--- a/plugins/source/aws/docs/tables/aws_route53resolver_resolver_rules.md
+++ b/plugins/source/aws/docs/tables/aws_route53resolver_resolver_rules.md
@@ -5,7 +5,7 @@ This table shows data for Amazon Route 53 Resolver Resolver Rules.
 https://docs.aws.amazon.com/Route53/latest/APIReference/API_route53resolver_ResolverRule.html
 
 The primary key for this table is **_cq_id**.
-The following field is used to calculate the value of `_cq_id`: **arn**.
+The following fields are used to calculate the value of `_cq_id`: (**request_account_id**, **request_region**, **arn**).
 
 ## Columns
 
@@ -15,6 +15,8 @@ The following field is used to calculate the value of `_cq_id`: **arn**.
 |_cq_parent_id|`uuid`|
 |account_id|`utf8`|
 |region|`utf8`|
+|request_account_id|`utf8`|
+|request_region|`utf8`|
 |arn|`utf8`|
 |creation_time|`utf8`|
 |creator_request_id|`utf8`|

--- a/plugins/source/aws/docs/tables/aws_s3_bucket_cors_rules.md
+++ b/plugins/source/aws/docs/tables/aws_s3_bucket_cors_rules.md
@@ -5,7 +5,7 @@ This table shows data for S3 Bucket Cors Rules.
 https://docs.aws.amazon.com/AmazonS3/latest/API/API_CORSRule.html
 
 The primary key for this table is **_cq_id**.
-The following fields are used to calculate the value of `_cq_id`: (**bucket_arn**, **id**).
+The following fields are used to calculate the value of `_cq_id`: (**bucket_arn**, **allowed_methods**, **allowed_origins**, **allowed_headers**, **expose_headers**, **id**, **max_age_seconds**).
 ## Relations
 
 This table depends on [aws_s3_buckets](aws_s3_buckets.md).

--- a/plugins/source/aws/resources/services/route53resolver/resolver_rules.go
+++ b/plugins/source/aws/resources/services/route53resolver/resolver_rules.go
@@ -21,6 +21,8 @@ func ResolverRules() *schema.Table {
 		Columns: []schema.Column{
 			client.DefaultAccountIDColumn(false),
 			client.DefaultRegionColumn(false),
+			client.RequestAccountIDColumn(true),
+			client.RequestRegionColumn(true),
 		},
 	}
 }

--- a/plugins/source/aws/resources/services/s3/bucket_cors_rules.go
+++ b/plugins/source/aws/resources/services/s3/bucket_cors_rules.go
@@ -18,7 +18,7 @@ func bucketCorsRules() *schema.Table {
 		Name:        "aws_s3_bucket_cors_rules",
 		Description: `https://docs.aws.amazon.com/AmazonS3/latest/API/API_CORSRule.html`,
 		Resolver:    fetchS3BucketCorsRules,
-		Transform:   transformers.TransformWithStruct(&types.CORSRule{}, transformers.WithPrimaryKeyComponents("ID")),
+		Transform:   transformers.TransformWithStruct(&types.CORSRule{}, transformers.WithPrimaryKeyComponents("AllowedMethods", "AllowedOrigins", "AllowedHeaders", "ExposeHeaders", "ID", "MaxAgeSeconds")),
 		Columns: []schema.Column{
 			client.DefaultAccountIDColumn(false),
 			{


### PR DESCRIPTION
<!-- 🎉 Thank you for making CloudQuery awesome by submitting a PR 🎉 -->

#### Summary

BEGIN_COMMIT_OVERRIDE
fix: Fix PrimaryKey component for `aws_route53resolver_resolver_rules ` to account for cross account and region sharing

fix: Fix PrimaryKey component for `aws_s3_bucket_cors_rules`
END_COMMIT_OVERRIDE