### PR TITLE
doc: Fix broken hub link

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,11 +34,11 @@ See the **[Quickstart guide](https://www.cloudquery.io/docs/quickstart)** for in
 
 ### Links
 
-- Homepage: https://www.cloudquery.io
-- Documentation: https://www.cloudquery.io/docs
-- Integrations: https://www.hub.cloudquery.io
-- Releases: https://github.com/cloudquery/cloudquery/releases
-- Plugin SDK: https://github.com/cloudquery/plugin-sdk
+- Homepage: [https://www.cloudquery.io](https://www.cloudquery.io)
+- Documentation: [https://www.cloudquery.io/docs](https://www.cloudquery.io/docs)
+- Integrations: [https://hub.cloudquery.io](https://hub.cloudquery.io)
+- Releases: [https://github.com/cloudquery/cloudquery/releases](https://github.com/cloudquery/cloudquery/releases)
+- Plugin SDK: [https://github.com/cloudquery/plugin-sdk](https://github.com/cloudquery/plugin-sdk)
 
 ## License
 


### PR DESCRIPTION
<!-- 🎉 Thank you for making CloudQuery awesome by submitting a PR 🎉 -->

#### Summary

Fix the broken hub link in the docs (The www prefix was problematic). Took the liberty to actually mark them as links in markdown.