### PR TITLE
feat: Validate plugin spec before init

### DIFF
--- a/cli/cmd/specs.go
+++ b/cli/cmd/specs.go
@@ -169,7 +169,7 @@ func parseJSONSchema(jsonSchema string) (*jsonschema.Schema, error) {
 			// We add resource as `file`, but there's none, actually.
 			// So, we need to prettify message a bit.
 			return nil, fmt.Errorf("jsonschema compilation failed: %w",
-				errors.New(strings.Replace(se.Err.Error(), "jsonschema: '' ", "jsonschema: ", 1)))
+				errors.New(strings.Replace(se.Err.Error(), "jsonschema: '' ", "", 1)))
 		}
 		return nil, err
 	}

--- a/cli/cmd/specs.go
+++ b/cli/cmd/specs.go
@@ -168,7 +168,6 @@ func parseJSONSchema(jsonSchema string) (*jsonschema.Schema, error) {
 		if errors.As(err, &se); se != nil && se.Err != nil {
 			// We add resource as `file`, but there's none, actually.
 			// So, we need to prettify message a bit.
-
 			return nil, fmt.Errorf("jsonschema compilation failed: %w",
 				errors.New(strings.Replace(se.Err.Error(), "jsonschema: '' ", "jsonschema: ", 1)))
 		}

--- a/cli/cmd/tables_v3.go
+++ b/cli/cmd/tables_v3.go
@@ -20,9 +20,7 @@ func tablesV3(ctx context.Context, sourceClient *managedplugin.Client, path stri
 		return err
 	}
 	sourcePbClient := pluginPb.NewPluginClient(sourceClient.Conn)
-	if _, err := sourcePbClient.Init(ctx, &pluginPb.Init_Request{
-		NoConnection: true,
-	}); err != nil {
+	if err := initPlugin(ctx, sourcePbClient, nil, true); err != nil {
 		return fmt.Errorf("failed to init source: %w", err)
 	}
 	getTablesResp, err := sourcePbClient.GetTables(ctx, &pluginPb.GetTables_Request{

--- a/cli/go.mod
+++ b/cli/go.mod
@@ -23,6 +23,7 @@ require (
 	github.com/opencontainers/go-digest v1.0.0
 	github.com/pkg/browser v0.0.0-20240102092130-5ac0b6a4141c
 	github.com/rs/zerolog v1.31.0
+	github.com/santhosh-tekuri/jsonschema/v5 v5.3.1
 	github.com/schollz/progressbar/v3 v3.13.1
 	github.com/spf13/cobra v1.6.1
 	github.com/stretchr/testify v1.8.4
@@ -118,7 +119,6 @@ require (
 	github.com/prometheus/procfs v0.6.0 // indirect
 	github.com/rivo/uniseg v0.4.4 // indirect
 	github.com/russross/blackfriday/v2 v2.1.0 // indirect
-	github.com/santhosh-tekuri/jsonschema/v5 v5.3.1 // indirect
 	github.com/schollz/closestmatch v2.1.0+incompatible // indirect
 	github.com/sirupsen/logrus v1.9.3 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect


### PR DESCRIPTION
This PR adds spec validation before passing it to the plugin.

It also extracts the init logic into a handy `initPlugin` func.

The decision structure is the following (we allow a bit of leeway here if the schema provided isn't a correct JSON schema: the CLI will **skip validation** _instead of_ failing the sync/init)

```mermaid
flowchart TD
    A{No Connection?} ----> |true| S
    A{No Connection?} --> |false| G[Get spec schema]
    subgraph validate
    G --> |non-empty schema| P[parse schema]
    G --> |failed call| E[error-out]
    P --> |OK| V[validate spec]
    V --> |failed| E
    end
    P --> |failed| S
    G --> |unimplemented| S
    G --> |empty schema| S
    V --> |OK| I[init]
    S[Skip validation] --> I  
```