### PR TITLE
fix: Clarify that `aws_debug: true` needs debug log level

### DIFF
--- a/plugins/source/aws/client/spec/schema.json
+++ b/plugins/source/aws/client/spec/schema.json
@@ -269,7 +269,7 @@
         },
         "aws_debug": {
           "type": "boolean",
-          "description": "If `true`, will log AWS debug logs, including retries and other request/response metadata."
+          "description": "If `true`, will log AWS debug logs, including retries and other request/response metadata. Requires passing `--log-level debug` to the CloudQuery CLI."
         },
         "max_retries": {
           "oneOf": [

--- a/plugins/source/aws/client/spec/spec.go
+++ b/plugins/source/aws/client/spec/spec.go
@@ -21,7 +21,7 @@ type Spec struct {
 	// In AWS organization mode, CloudQuery will source all accounts underneath automatically.
 	Organization *Organization `json:"org"`
 
-	// If `true`, will log AWS debug logs, including retries and other request/response metadata.
+	// If `true`, will log AWS debug logs, including retries and other request/response metadata. Requires passing `--log-level debug` to the CloudQuery CLI.
 	AWSDebug bool `json:"aws_debug,omitempty"`
 
 	// Defines the maximum number of times an API request will be retried.


### PR DESCRIPTION
<!-- 🎉 Thank you for making CloudQuery awesome by submitting a PR 🎉 -->

#### Summary

Tried to enable AWS debug logs during working on auth related issues and didn't understand why I didn't see them

<!--
Use the following steps to ensure your PR is ready to be reviewed

- [ ] Read the [contribution guidelines](https://github.com/cloudquery/cloudquery/blob/main/CONTRIBUTING.md) 🧑‍🎓
- [ ] Run `make lint` to ensure the proposed changes follow the coding style 🚨 (install golangci-lint [here](https://golangci-lint.run/usage/install/#local-installation))
- [ ] Run `make test` to ensure the proposed changes pass the tests 🧪
- [ ] If changing a source plugin run `make gen` to ensure docs are up to date 📝
- [ ] Ensure the status checks below are successful ✅
--->
