### PR TITLE
fix: Extract `HUBSPOT_APP_TOKEN` to spec

### DIFF
--- a/plugins/source/hubspot/client/client.go
+++ b/plugins/source/hubspot/client/client.go
@@ -54,7 +54,7 @@ func New(_ context.Context, logger zerolog.Logger, s spec.Spec) (schema.ClientMe
 		Authorizer: hubspot.NewTokenAuthorizer(authToken),
 		Spec:       s,
 		RateLimiter: rate.NewLimiter(
-			/* r= */ rate.Limit(*s.MaxRequestsPerSecond),
+			/* r= */ rate.Limit(s.MaxRequestsPerSecond),
 			/* b= */ 1,
 		),
 	}, nil

--- a/plugins/source/hubspot/client/spec/schema.json
+++ b/plugins/source/hubspot/client/spec/schema.json
@@ -5,18 +5,16 @@
   "$defs": {
     "Spec": {
       "properties": {
+        "app_token": {
+          "type": "string",
+          "minLength": 1,
+          "description": "In order for CloudQuery to sync resources from your HubSpot setup, you will need to authenticate with your HubSpot account. You will need to create a [HubSpot Private App](https://developers.hubspot.com/docs/api/private-apps), and copy the App Token here.\nIf not specified `HUBSPOT_APP_TOKEN` environment variable will be used instead."
+        },
         "max_requests_per_second": {
-          "oneOf": [
-            {
-              "type": "integer",
-              "minimum": 1,
-              "description": "Max number of requests per second to perform against the Hubspot API.",
-              "default": 5
-            },
-            {
-              "type": "null"
-            }
-          ]
+          "type": "integer",
+          "minimum": 1,
+          "description": "Max number of requests per second to perform against the Hubspot API.",
+          "default": 5
         },
         "table_options": {
           "oneOf": [

--- a/plugins/source/hubspot/client/spec/spec_test.go
+++ b/plugins/source/hubspot/client/spec/spec_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/cloudquery/codegen/jsonschema"
+	"github.com/stretchr/testify/require"
 )
 
 func TestJSONSchema(t *testing.T) {
@@ -13,57 +14,70 @@ func TestJSONSchema(t *testing.T) {
 			Spec: `{}`,
 		},
 		{
-			Name: "null max_requests_per_second",
-			Spec: `{"max_requests_per_second": null}`,
+			Name: "app_token",
+			Spec: `{"app_token": "token"}`,
+		},
+		{
+			Name: "empty app_token",
+			Spec: `{"app_token": ""}`,
+			Err:  true,
 		},
 		{
 			Name: "max_requests_per_second == -1 is invalid",
-			Spec: `{"max_requests_per_second": -1}`,
+			Spec: `{"app_token": "token", "max_requests_per_second": -1}`,
 			Err:  true,
 		},
 		{
 			Name: "max_requests_per_second == 0 is invalid",
-			Spec: `{"max_requests_per_second": 0}`,
+			Spec: `{"app_token": "token", "max_requests_per_second": 0}`,
 			Err:  true,
 		},
 		{
 			Name: "max_requests_per_second == 1 is valid",
-			Spec: `{"max_requests_per_second": 1}`,
+			Spec: `{"app_token": "token", "max_requests_per_second": 1}`,
 		},
 		{
 			Name: "concurrency == -1 is invalid",
-			Spec: `{"concurrency": -1}`,
+			Spec: `{"app_token": "token", "concurrency": -1}`,
 			Err:  true,
 		},
 		{
 			Name: "concurrency == 0 is invalid",
-			Spec: `{"concurrency": 0}`,
+			Spec: `{"app_token": "token", "concurrency": 0}`,
 			Err:  true,
 		},
 		{
 			Name: "concurrency == 1 is valid",
-			Spec: `{"concurrency": 1}`,
+			Spec: `{"app_token": "token", "concurrency": 1}`,
 		},
 		{
 			Name: "table_options == null is valid",
-			Spec: `{"table_options": null}`,
+			Spec: `{"app_token": "token", "table_options": null}`,
+		},
+	})
+}
+
+func TestTableOptionsJSONSchema(t *testing.T) {
+	schema, err := jsonschema.Generate(TableOptions{})
+
+	require.NoError(t, err)
+	jsonschema.TestJSONSchema(t, string(schema), []jsonschema.TestCase{
+		{
+			Name: "empty table options",
+			Spec: `{}`,
 		},
 		{
-			Name: "table_options == {} is valid",
-			Spec: `{"table_options": {}}`,
+			Name: "hubspot_crm_companies = null is invalid",
+			Spec: `{"hubspot_crm_companies": null}`,
 		},
 		{
-			Name: "spec with table options = null is invalid",
-			Spec: `{"table_options": {"hubspot_crm_companies": null}}`,
-		},
-		{
-			Name: "spec with table options = [] is invalid",
-			Spec: `{"table_options": {"hubspot_crm_companies": []}}`,
+			Name: "hubspot_crm_companiess = [] is invalid",
+			Spec: `{"hubspot_crm_companies": []}`,
 			Err:  true,
 		},
 		{
-			Name: "spec with table options = {} is valid",
-			Spec: `{"table_options": {"hubspot_crm_companies": {}}}`,
+			Name: "hubspot_crm_companies = {} is valid",
+			Spec: `{"hubspot_crm_companies": {}}`,
 		},
 	})
 }

--- a/plugins/source/hubspot/client/spec/table_options.go
+++ b/plugins/source/hubspot/client/spec/table_options.go
@@ -5,9 +5,9 @@ type TableOptions map[string]*TableOptionsSpec
 // Table options spec.
 type TableOptionsSpec struct {
 	// List of properties to sync. If empty, everything is synced.
-	Properties []string `yaml:"properties,omitempty" json:"properties,omitempty" jsonschema:"minLength=1"`
+	Properties []string `json:"properties,omitempty" jsonschema:"minLength=1"`
 	// List of associations to sync. If empty, everything is synced.
-	Associations []string `yaml:"associations,omitempty" json:"associations,omitempty" jsonschema:"minLength=1"`
+	Associations []string `json:"associations,omitempty" jsonschema:"minLength=1"`
 }
 
 func (ts TableOptions) ForTable(name string) *TableOptionsSpec {

--- a/plugins/source/hubspot/docs/_authentication.md
+++ b/plugins/source/hubspot/docs/_authentication.md
@@ -1,5 +1,6 @@
-In Order for CloudQuery to sync resources from your HubSpot setup, you will need to authenticate with your HubSpot account. You will need to create a [HubSpot Private App](https://developers.hubspot.com/docs/api/private-apps), and export the App Token in `HUBSPOT_APP_TOKEN` environment variable.
+In Order for CloudQuery to sync resources from your HubSpot setup, you will need to authenticate with your HubSpot account. You will need to create a [HubSpot Private App](https://developers.hubspot.com/docs/api/private-apps), and copy the App Token to the spec.
+If not specified `HUBSPOT_APP_TOKEN` environment variable will be used instead.
 
 ```bash copy
-export HUBSPOT_APP_TOKEN=<your_app_token>
+export HUBSPOT_APP_TOKEN=<your_app_token> # optional, if not using spec configuration
 ```

--- a/plugins/source/hubspot/docs/overview.md
+++ b/plugins/source/hubspot/docs/overview.md
@@ -31,7 +31,11 @@ The following example sets up the HubSpot plugin, and connects it to a postgresq
 
 This is the specs that can be used by the HubSpot source Plugin.
 
+- `app_token` (`string`, optional, default: `HUBSPOT_APP_TOKEN` environment variable)
+  The HubSpot App Token to use for authentication. This can also be set with the `HUBSPOT_APP_TOKEN` environment variable. 
+
 - `concurrency` (int, optional, default: `1000`):
+
   A best effort maximum number of Go routines to use. Lower this number to reduce memory usage.
 
 - `max_requests_per_second` (`int`, optional. Default: `5`)

--- a/plugins/source/hubspot/resources/plugin/plugin.go
+++ b/plugins/source/hubspot/resources/plugin/plugin.go
@@ -65,6 +65,9 @@ func newClient(ctx context.Context, logger zerolog.Logger, specBytes []byte, opt
 		return nil, err
 	}
 	s.SetDefaults()
+	if err := s.Validate(); err != nil {
+		return nil, err
+	}
 	syncClient, err := client.New(ctx, logger, *s)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
Since this is token's first appearance on the spec I don't think we should remove the env var yet.