### PR TITLE
fix: Ensure all writers have a logger

### DIFF
--- a/plugins/destination/azblob/client/client.go
+++ b/plugins/destination/azblob/client/client.go
@@ -65,6 +65,7 @@ func New(ctx context.Context, logger zerolog.Logger, s []byte, opts plugin.NewCl
 	}
 
 	c.writer, err = streamingbatchwriter.New(c,
+		streamingbatchwriter.WithLogger(c.logger),
 		streamingbatchwriter.WithBatchSizeRows(*c.spec.BatchSize),
 		streamingbatchwriter.WithBatchSizeBytes(*c.spec.BatchSizeBytes),
 		streamingbatchwriter.WithBatchTimeout(c.spec.BatchTimeout.Duration()),

--- a/plugins/destination/duckdb/client/client.go
+++ b/plugins/destination/duckdb/client/client.go
@@ -40,7 +40,7 @@ func New(ctx context.Context, logger zerolog.Logger, spec []byte, _ plugin.NewCl
 		return nil, fmt.Errorf("failed to unmarshal spec: %w", err)
 	}
 	c.spec.SetDefaults()
-	c.writer, err = batchwriter.New(c, batchwriter.WithBatchSize(c.spec.BatchSize), batchwriter.WithBatchSizeBytes(c.spec.BatchSizeBytes))
+	c.writer, err = batchwriter.New(c, batchwriter.WithBatchSize(c.spec.BatchSize), batchwriter.WithBatchSizeBytes(c.spec.BatchSizeBytes), batchwriter.WithLogger(c.logger))
 	if err != nil {
 		return nil, fmt.Errorf("failed to create batch writer: %w", err)
 	}

--- a/plugins/destination/elasticsearch/client/client.go
+++ b/plugins/destination/elasticsearch/client/client.go
@@ -40,7 +40,7 @@ func New(ctx context.Context, logger zerolog.Logger, specBytes []byte, _ plugin.
 	if err := c.spec.Validate(); err != nil {
 		return nil, err
 	}
-	c.writer, err = batchwriter.New(c, batchwriter.WithBatchSize(c.spec.BatchSize), batchwriter.WithBatchSizeBytes(c.spec.BatchSizeBytes))
+	c.writer, err = batchwriter.New(c, batchwriter.WithBatchSize(c.spec.BatchSize), batchwriter.WithBatchSizeBytes(c.spec.BatchSizeBytes), batchwriter.WithLogger(c.logger))
 	if err != nil {
 		return nil, fmt.Errorf("failed to create batch writer: %w", err)
 	}

--- a/plugins/destination/file/client/client.go
+++ b/plugins/destination/file/client/client.go
@@ -51,6 +51,7 @@ func New(_ context.Context, logger zerolog.Logger, s []byte, opts plugin.NewClie
 		streamingbatchwriter.WithBatchSizeRows(*c.spec.BatchSize),
 		streamingbatchwriter.WithBatchSizeBytes(*c.spec.BatchSizeBytes),
 		streamingbatchwriter.WithBatchTimeout(c.spec.BatchTimeout.Duration()),
+		streamingbatchwriter.WithLogger(c.logger),
 	)
 	if err != nil {
 		return nil, err

--- a/plugins/destination/gcs/client/client.go
+++ b/plugins/destination/gcs/client/client.go
@@ -68,6 +68,7 @@ func New(ctx context.Context, logger zerolog.Logger, s []byte, _ plugin.NewClien
 		streamingbatchwriter.WithBatchSizeRows(*c.spec.BatchSize),
 		streamingbatchwriter.WithBatchSizeBytes(*c.spec.BatchSizeBytes),
 		streamingbatchwriter.WithBatchTimeout(c.spec.BatchTimeout.Duration()),
+		streamingbatchwriter.WithLogger(c.logger),
 	)
 	if err != nil {
 		return nil, err

--- a/plugins/destination/gremlin/client/client.go
+++ b/plugins/destination/gremlin/client/client.go
@@ -69,7 +69,7 @@ func New(ctx context.Context, logger zerolog.Logger, spec []byte, _ plugin.NewCl
 		return nil, err
 	}
 
-	c.writer, err = batchwriter.New(c, batchwriter.WithBatchSize(c.spec.BatchSize), batchwriter.WithBatchSizeBytes(c.spec.BatchSizeBytes))
+	c.writer, err = batchwriter.New(c, batchwriter.WithBatchSize(c.spec.BatchSize), batchwriter.WithBatchSizeBytes(c.spec.BatchSizeBytes), batchwriter.WithLogger(c.logger))
 	if err != nil {
 		return nil, err
 	}

--- a/plugins/destination/meilisearch/client/client.go
+++ b/plugins/destination/meilisearch/client/client.go
@@ -98,6 +98,7 @@ func New(_ context.Context, logger zerolog.Logger, specBytes []byte, _ plugin.Ne
 		batchwriter.WithBatchSize(spec.BatchSize),
 		batchwriter.WithBatchSizeBytes(spec.BatchSizeBytes),
 		batchwriter.WithBatchTimeout(spec.BatchTimeout.Duration()),
+		batchwriter.WithLogger(client.logger),
 	)
 	if err != nil {
 		return nil, err

--- a/plugins/destination/mongodb/client/client.go
+++ b/plugins/destination/mongodb/client/client.go
@@ -36,7 +36,7 @@ func New(ctx context.Context, logger zerolog.Logger, spec []byte, _ plugin.NewCl
 	if err != nil {
 		return nil, err
 	}
-	c.writer, err = batchwriter.New(c, batchwriter.WithBatchSize(c.spec.BatchSize), batchwriter.WithBatchSizeBytes(c.spec.BatchSizeBytes))
+	c.writer, err = batchwriter.New(c, batchwriter.WithBatchSize(c.spec.BatchSize), batchwriter.WithBatchSizeBytes(c.spec.BatchSizeBytes), batchwriter.WithLogger(c.logger))
 	if err != nil {
 		return nil, err
 	}

--- a/plugins/destination/neo4j/client/client.go
+++ b/plugins/destination/neo4j/client/client.go
@@ -43,7 +43,7 @@ func New(ctx context.Context, logger zerolog.Logger, spec []byte, _ plugin.NewCl
 		return nil, err
 	}
 
-	c.writer, err = batchwriter.New(c, batchwriter.WithBatchSize(c.spec.BatchSize), batchwriter.WithBatchSizeBytes(c.spec.BatchSizeBytes))
+	c.writer, err = batchwriter.New(c, batchwriter.WithBatchSize(c.spec.BatchSize), batchwriter.WithBatchSizeBytes(c.spec.BatchSizeBytes), batchwriter.WithLogger(c.logger))
 	if err != nil {
 		return nil, err
 	}

--- a/plugins/destination/s3/client/client.go
+++ b/plugins/destination/s3/client/client.go
@@ -99,6 +99,7 @@ func New(ctx context.Context, logger zerolog.Logger, s []byte, opts plugin.NewCl
 		streamingbatchwriter.WithBatchSizeRows(*c.spec.BatchSize),
 		streamingbatchwriter.WithBatchSizeBytes(*c.spec.BatchSizeBytes),
 		streamingbatchwriter.WithBatchTimeout(c.spec.BatchTimeout.Duration()),
+		streamingbatchwriter.WithLogger(c.logger),
 	)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
<!-- 🎉 Thank you for making CloudQuery awesome by submitting a PR 🎉 -->

#### Summary

Ensure that write errors are captured by passing a logger object to each writer