### PR TITLE
fix: Handle 404 Error for read

### DIFF
--- a/plugins/destination/elasticsearch/client/read.go
+++ b/plugins/destination/elasticsearch/client/read.go
@@ -40,6 +40,9 @@ func (c *Client) Read(ctx context.Context, table *schema.Table, res chan<- arrow
 
 	defer resp.Body.Close()
 	if resp.StatusCode > 299 {
+		if resp.StatusCode == 404 {
+			return nil
+		}
 		data, _ := io.ReadAll(resp.Body)
 		return fmt.Errorf("failed to read: %s: %s", resp.Status, string(data))
 	}


### PR DESCRIPTION
<!-- 🎉 Thank you for making CloudQuery awesome by submitting a PR 🎉 -->

#### Summary

If an index has never had data written to it, it will not exist. So if we read from a non-existant index we will get a 404. 
Rather than returning an error when hitting a 404 the `Read` command should just return `nil`. 