### PR TITLE
fix: Always pass _CQ_TEAM_NAME to plugins

### DIFF
--- a/cli/cmd/sync.go
+++ b/cli/cmd/sync.go
@@ -302,7 +302,7 @@ func filterPluginEnv(environ []string, pluginName, kind string) []string {
 	env := make([]string, 0)
 	prefix := "__" + kind + "_" + pluginName + "__"
 	for _, v := range environ {
-		if strings.HasPrefix(v, "CLOUDQUERY_API_KEY=") {
+		if strings.HasPrefix(v, "CLOUDQUERY_API_KEY=") || strings.HasPrefix(v, "_CQ_TEAM_NAME=") {
 			env = append(env, v)
 		} else if strings.HasPrefix(v, prefix) {
 			env = append(env, strings.TrimPrefix(v, prefix))


### PR DESCRIPTION
<!-- 🎉 Thank you for making CloudQuery awesome by submitting a PR 🎉 -->

#### Summary

Also needed for plugins that track usage (see error in https://github.com/cloudquery/cloudquery-issues/issues/1343 - internal issue)

<!--
Use the following steps to ensure your PR is ready to be reviewed

- [ ] Read the [contribution guidelines](https://github.com/cloudquery/cloudquery/blob/main/CONTRIBUTING.md) 🧑‍🎓
- [ ] Run `make lint` to ensure the proposed changes follow the coding style 🚨 (install golangci-lint [here](https://golangci-lint.run/usage/install/#local-installation))
- [ ] Run `make test` to ensure the proposed changes pass the tests 🧪
- [ ] If changing a source plugin run `make gen` to ensure docs are up to date 📝
- [ ] Ensure the status checks below are successful ✅
--->
