### PR TITLE
fix: Use Logger for Client rather than the one that is passed in

### DIFF
--- a/plugins/destination/bigquery/client/client.go
+++ b/plugins/destination/bigquery/client/client.go
@@ -42,7 +42,7 @@ func New(_ context.Context, logger zerolog.Logger, specBytes []byte, opts plugin
 		return nil, err
 	}
 	c.writer, err = batchwriter.New(c,
-		batchwriter.WithLogger(logger),
+		batchwriter.WithLogger(c.logger),
 		batchwriter.WithBatchSize(c.spec.BatchSize),
 		batchwriter.WithBatchSizeBytes(c.spec.BatchSizeBytes),
 		batchwriter.WithBatchTimeout(c.spec.BatchTimeout.Duration()),

--- a/plugins/destination/clickhouse/client/client.go
+++ b/plugins/destination/clickhouse/client/client.go
@@ -85,7 +85,7 @@ func New(_ context.Context, logger zerolog.Logger, specBytes []byte, _ plugin.Ne
 		logger:   l,
 	}
 	c.writer, err = batchwriter.New(c,
-		batchwriter.WithLogger(l),
+		batchwriter.WithLogger(c.l),
 		batchwriter.WithBatchSize(s.BatchSize),
 		batchwriter.WithBatchSizeBytes(s.BatchSizeBytes),
 		batchwriter.WithBatchTimeout(s.BatchTimeout.Duration()),

--- a/plugins/destination/clickhouse/client/client.go
+++ b/plugins/destination/clickhouse/client/client.go
@@ -85,7 +85,7 @@ func New(_ context.Context, logger zerolog.Logger, specBytes []byte, _ plugin.Ne
 		logger:   l,
 	}
 	c.writer, err = batchwriter.New(c,
-		batchwriter.WithLogger(c.l),
+		batchwriter.WithLogger(c.logger),
 		batchwriter.WithBatchSize(s.BatchSize),
 		batchwriter.WithBatchSizeBytes(s.BatchSizeBytes),
 		batchwriter.WithBatchTimeout(s.BatchTimeout.Duration()),

--- a/plugins/destination/mysql/client/client.go
+++ b/plugins/destination/mysql/client/client.go
@@ -49,7 +49,7 @@ func New(ctx context.Context, logger zerolog.Logger, spec []byte, _ plugin.NewCl
 	if err := c.spec.Validate(); err != nil {
 		return nil, err
 	}
-	c.writer, err = batchwriter.New(c, batchwriter.WithLogger(logger), batchwriter.WithBatchSize(c.spec.BatchSize), batchwriter.WithBatchSizeBytes(c.spec.BatchSizeBytes))
+	c.writer, err = batchwriter.New(c, batchwriter.WithLogger(c.logger), batchwriter.WithBatchSize(c.spec.BatchSize), batchwriter.WithBatchSizeBytes(c.spec.BatchSizeBytes))
 	if err != nil {
 		return nil, fmt.Errorf("failed to create batch writer: %w", err)
 	}

--- a/plugins/destination/snowflake/client/client.go
+++ b/plugins/destination/snowflake/client/client.go
@@ -35,7 +35,7 @@ func New(_ context.Context, logger zerolog.Logger, spec []byte, _ plugin.NewClie
 		return nil, fmt.Errorf("failed to unmarshal snowflake spec: %w", err)
 	}
 	c.spec.SetDefaults()
-	c.writer, err = batchwriter.New(c, batchwriter.WithLogger(logger), batchwriter.WithBatchSize(c.spec.BatchSize), batchwriter.WithBatchSizeBytes(c.spec.BatchSizeBytes))
+	c.writer, err = batchwriter.New(c, batchwriter.WithLogger(c.logger), batchwriter.WithBatchSize(c.spec.BatchSize), batchwriter.WithBatchSizeBytes(c.spec.BatchSizeBytes))
 	if err != nil {
 		return nil, err
 	}

--- a/plugins/destination/sqlite/client/client.go
+++ b/plugins/destination/sqlite/client/client.go
@@ -34,7 +34,7 @@ func New(ctx context.Context, logger zerolog.Logger, spec []byte, _ plugin.NewCl
 	}
 	c.spec.SetDefaults()
 	var err error
-	c.writer, err = batchwriter.New(c, batchwriter.WithLogger(logger), batchwriter.WithBatchSize(c.spec.BatchSize), batchwriter.WithBatchSizeBytes(c.spec.BatchSizeBytes))
+	c.writer, err = batchwriter.New(c, batchwriter.WithLogger(c.logger), batchwriter.WithBatchSize(c.spec.BatchSize), batchwriter.WithBatchSizeBytes(c.spec.BatchSizeBytes))
 	if err != nil {
 		return nil, fmt.Errorf("failed to create batch writer: %w", err)
 	}


### PR DESCRIPTION
<!-- 🎉 Thank you for making CloudQuery awesome by submitting a PR 🎉 -->

#### Summary

Prior to this PR, these destinations used the logger that was passed in to the function, this meant that it had the wrong `module` name