### PR TITLE
feat!: Bump `go-github` to v59 in Github plugin

### DIFF
--- a/plugins/source/github/client/client.go
+++ b/plugins/source/github/client/client.go
@@ -13,7 +13,7 @@ import (
 	"github.com/beatlabs/github-auth/key"
 	"github.com/cloudquery/plugin-sdk/v4/schema"
 	"github.com/gofri/go-github-ratelimit/github_ratelimit"
-	"github.com/google/go-github/v49/github"
+	"github.com/google/go-github/v59/github"
 	"github.com/rs/zerolog"
 	"golang.org/x/oauth2"
 	"golang.org/x/sync/errgroup"

--- a/plugins/source/github/client/client.go
+++ b/plugins/source/github/client/client.go
@@ -233,7 +233,7 @@ func githubClientForHTTPClient(httpClient *http.Client, logger zerolog.Logger, e
 	}
 
 	if enterpriseSettings != nil {
-		return github.NewEnterpriseClient(enterpriseSettings.BaseURL, enterpriseSettings.UploadURL, rateLimiter)
+		return github.NewClient(rateLimiter).WithEnterpriseURLs(enterpriseSettings.BaseURL, enterpriseSettings.UploadURL)
 	}
 
 	return github.NewClient(rateLimiter), nil

--- a/plugins/source/github/client/mocks/mock_actions.go
+++ b/plugins/source/github/client/mocks/mock_actions.go
@@ -9,7 +9,7 @@ import (
 	reflect "reflect"
 
 	gomock "github.com/golang/mock/gomock"
-	github "github.com/google/go-github/v49/github"
+	github "github.com/google/go-github/v59/github"
 )
 
 // MockActionsService is a mock of ActionsService interface.

--- a/plugins/source/github/client/mocks/mock_billing.go
+++ b/plugins/source/github/client/mocks/mock_billing.go
@@ -9,7 +9,7 @@ import (
 	reflect "reflect"
 
 	gomock "github.com/golang/mock/gomock"
-	github "github.com/google/go-github/v49/github"
+	github "github.com/google/go-github/v59/github"
 )
 
 // MockBillingService is a mock of BillingService interface.

--- a/plugins/source/github/client/mocks/mock_dependabot.go
+++ b/plugins/source/github/client/mocks/mock_dependabot.go
@@ -9,7 +9,7 @@ import (
 	reflect "reflect"
 
 	gomock "github.com/golang/mock/gomock"
-	github "github.com/google/go-github/v49/github"
+	github "github.com/google/go-github/v59/github"
 )
 
 // MockDependabotService is a mock of DependabotService interface.

--- a/plugins/source/github/client/mocks/mock_issues.go
+++ b/plugins/source/github/client/mocks/mock_issues.go
@@ -9,7 +9,7 @@ import (
 	reflect "reflect"
 
 	gomock "github.com/golang/mock/gomock"
-	github "github.com/google/go-github/v49/github"
+	github "github.com/google/go-github/v59/github"
 )
 
 // MockIssuesService is a mock of IssuesService interface.

--- a/plugins/source/github/client/mocks/mock_orgs.go
+++ b/plugins/source/github/client/mocks/mock_orgs.go
@@ -9,7 +9,7 @@ import (
 	reflect "reflect"
 
 	gomock "github.com/golang/mock/gomock"
-	github "github.com/google/go-github/v49/github"
+	github "github.com/google/go-github/v59/github"
 )
 
 // MockOrganizationsService is a mock of OrganizationsService interface.

--- a/plugins/source/github/client/mocks/mock_repositories.go
+++ b/plugins/source/github/client/mocks/mock_repositories.go
@@ -9,7 +9,7 @@ import (
 	reflect "reflect"
 
 	gomock "github.com/golang/mock/gomock"
-	github "github.com/google/go-github/v49/github"
+	github "github.com/google/go-github/v59/github"
 )
 
 // MockRepositoriesService is a mock of RepositoriesService interface.

--- a/plugins/source/github/client/mocks/mock_teams.go
+++ b/plugins/source/github/client/mocks/mock_teams.go
@@ -9,7 +9,7 @@ import (
 	reflect "reflect"
 
 	gomock "github.com/golang/mock/gomock"
-	github "github.com/google/go-github/v49/github"
+	github "github.com/google/go-github/v59/github"
 )
 
 // MockTeamsService is a mock of TeamsService interface.

--- a/plugins/source/github/client/services.go
+++ b/plugins/source/github/client/services.go
@@ -3,7 +3,7 @@ package client
 import (
 	"context"
 
-	"github.com/google/go-github/v49/github"
+	"github.com/google/go-github/v59/github"
 )
 
 type GithubServices struct {

--- a/plugins/source/github/client/testing.go
+++ b/plugins/source/github/client/testing.go
@@ -12,7 +12,7 @@ import (
 	"github.com/cloudquery/plugin-sdk/v4/schema"
 	"github.com/cloudquery/plugin-sdk/v4/transformers"
 	"github.com/golang/mock/gomock"
-	"github.com/google/go-github/v49/github"
+	"github.com/google/go-github/v59/github"
 	"github.com/rs/zerolog"
 )
 

--- a/plugins/source/github/client/transformers.go
+++ b/plugins/source/github/client/transformers.go
@@ -6,7 +6,7 @@ import (
 	"github.com/apache/arrow/go/v15/arrow"
 	"github.com/cloudquery/plugin-sdk/v4/schema"
 	"github.com/cloudquery/plugin-sdk/v4/transformers"
-	"github.com/google/go-github/v49/github"
+	"github.com/google/go-github/v59/github"
 )
 
 var options = []transformers.StructTransformerOption{

--- a/plugins/source/github/docs/tables/github_billing_action.md
+++ b/plugins/source/github/docs/tables/github_billing_action.md
@@ -11,7 +11,7 @@ The primary key for this table is **org**.
 |_cq_id|`uuid`|
 |_cq_parent_id|`uuid`|
 |org (PK)|`utf8`|
-|total_minutes_used|`int64`|
+|total_minutes_used|`float64`|
 |total_paid_minutes_used|`float64`|
-|included_minutes|`int64`|
+|included_minutes|`float64`|
 |minutes_used_breakdown|`json`|

--- a/plugins/source/github/docs/tables/github_billing_package.md
+++ b/plugins/source/github/docs/tables/github_billing_package.md
@@ -13,4 +13,4 @@ The primary key for this table is **org**.
 |org (PK)|`utf8`|
 |total_gigabytes_bandwidth_used|`int64`|
 |total_paid_gigabytes_bandwidth_used|`int64`|
-|included_gigabytes_bandwidth|`int64`|
+|included_gigabytes_bandwidth|`float64`|

--- a/plugins/source/github/docs/tables/github_billing_storage.md
+++ b/plugins/source/github/docs/tables/github_billing_storage.md
@@ -13,4 +13,4 @@ The primary key for this table is **org**.
 |org (PK)|`utf8`|
 |days_left_in_billing_cycle|`int64`|
 |estimated_paid_storage_for_month|`float64`|
-|estimated_storage_for_month|`int64`|
+|estimated_storage_for_month|`float64`|

--- a/plugins/source/github/docs/tables/github_issues.md
+++ b/plugins/source/github/docs/tables/github_issues.md
@@ -40,5 +40,6 @@ The composite primary key for this table is (**org**, **repository_id**, **id**)
 |reactions|`json`|
 |assignees|`json`|
 |node_id|`utf8`|
+|draft|`bool`|
 |text_matches|`json`|
 |active_lock_reason|`utf8`|

--- a/plugins/source/github/docs/tables/github_organization_dependabot_alerts.md
+++ b/plugins/source/github/docs/tables/github_organization_dependabot_alerts.md
@@ -29,3 +29,5 @@ This table depends on [github_organizations](github_organizations.md).
 |dismissed_reason|`utf8`|
 |dismissed_comment|`utf8`|
 |fixed_at|`timestamp[us, tz=UTC]`|
+|auto_dismissed_at|`timestamp[us, tz=UTC]`|
+|repository|`json`|

--- a/plugins/source/github/docs/tables/github_organizations.md
+++ b/plugins/source/github/docs/tables/github_organizations.md
@@ -66,6 +66,7 @@ The following tables depend on github_organizations:
 |dependency_graph_enabled_for_new_repositories|`bool`|
 |secret_scanning_enabled_for_new_repositories|`bool`|
 |secret_scanning_push_protection_enabled_for_new_repositories|`bool`|
+|secret_scanning_validity_checks_enabled|`bool`|
 |url|`utf8`|
 |events_url|`utf8`|
 |hooks_url|`utf8`|

--- a/plugins/source/github/docs/tables/github_repositories.md
+++ b/plugins/source/github/docs/tables/github_repositories.md
@@ -62,6 +62,7 @@ The following tables depend on github_repositories:
 |allow_merge_commit|`bool`|
 |allow_auto_merge|`bool`|
 |allow_forking|`bool`|
+|web_commit_signoff_required|`bool`|
 |delete_branch_on_merge|`bool`|
 |use_squash_pr_title_as_default|`bool`|
 |squash_merge_commit_title|`utf8`|
@@ -69,6 +70,7 @@ The following tables depend on github_repositories:
 |merge_commit_title|`utf8`|
 |merge_commit_message|`utf8`|
 |topics|`list<item: utf8, nullable>`|
+|custom_properties|`json`|
 |archived|`bool`|
 |disabled|`bool`|
 |license|`json`|

--- a/plugins/source/github/docs/tables/github_repository_dependabot_alerts.md
+++ b/plugins/source/github/docs/tables/github_repository_dependabot_alerts.md
@@ -30,3 +30,5 @@ This table depends on [github_repositories](github_repositories.md).
 |dismissed_reason|`utf8`|
 |dismissed_comment|`utf8`|
 |fixed_at|`timestamp[us, tz=UTC]`|
+|auto_dismissed_at|`timestamp[us, tz=UTC]`|
+|repository|`json`|

--- a/plugins/source/github/docs/tables/github_repository_keys.md
+++ b/plugins/source/github/docs/tables/github_repository_keys.md
@@ -23,3 +23,5 @@ This table depends on [github_repositories](github_repositories.md).
 |read_only|`bool`|
 |verified|`bool`|
 |created_at|`timestamp[us, tz=UTC]`|
+|added_by|`utf8`|
+|last_used|`timestamp[us, tz=UTC]`|

--- a/plugins/source/github/docs/tables/github_team_repositories.md
+++ b/plugins/source/github/docs/tables/github_team_repositories.md
@@ -58,6 +58,7 @@ This table depends on [github_teams](github_teams.md).
 |allow_merge_commit|`bool`|
 |allow_auto_merge|`bool`|
 |allow_forking|`bool`|
+|web_commit_signoff_required|`bool`|
 |delete_branch_on_merge|`bool`|
 |use_squash_pr_title_as_default|`bool`|
 |squash_merge_commit_title|`utf8`|
@@ -65,6 +66,7 @@ This table depends on [github_teams](github_teams.md).
 |merge_commit_title|`utf8`|
 |merge_commit_message|`utf8`|
 |topics|`list<item: utf8, nullable>`|
+|custom_properties|`json`|
 |archived|`bool`|
 |disabled|`bool`|
 |license|`json`|

--- a/plugins/source/github/docs/tables/github_workflow_jobs.md
+++ b/plugins/source/github/docs/tables/github_workflow_jobs.md
@@ -20,11 +20,13 @@ This table depends on [github_workflow_runs](github_workflow_runs.md).
 |id (PK)|`int64`|
 |run_url|`utf8`|
 |node_id|`utf8`|
+|head_branch|`utf8`|
 |head_sha|`utf8`|
 |url|`utf8`|
 |html_url|`utf8`|
 |status|`utf8`|
 |conclusion|`utf8`|
+|created_at|`timestamp[us, tz=UTC]`|
 |started_at|`timestamp[us, tz=UTC]`|
 |completed_at|`timestamp[us, tz=UTC]`|
 |name|`utf8`|
@@ -36,3 +38,4 @@ This table depends on [github_workflow_runs](github_workflow_runs.md).
 |runner_group_id|`int64`|
 |runner_group_name|`utf8`|
 |run_attempt|`int64`|
+|workflow_name|`utf8`|

--- a/plugins/source/github/docs/tables/github_workflow_runs.md
+++ b/plugins/source/github/docs/tables/github_workflow_runs.md
@@ -26,6 +26,7 @@ The following tables depend on github_workflow_runs:
 |run_number|`int64`|
 |run_attempt|`int64`|
 |event|`utf8`|
+|display_title|`utf8`|
 |status|`utf8`|
 |conclusion|`utf8`|
 |workflow_id|`int64`|
@@ -49,3 +50,5 @@ The following tables depend on github_workflow_runs:
 |repository|`json`|
 |head_repository|`json`|
 |actor|`json`|
+|triggering_actor|`json`|
+|referenced_workflows|`json`|

--- a/plugins/source/github/go.mod
+++ b/plugins/source/github/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/cloudquery/plugin-sdk/v4 v4.30.0
 	github.com/gofri/go-github-ratelimit v1.0.3
 	github.com/golang/mock v1.6.0
-	github.com/google/go-github/v49 v49.0.0
+	github.com/google/go-github/v59 v59.0.0
 	github.com/invopop/jsonschema v0.12.0
 	github.com/rs/zerolog v1.31.0
 	golang.org/x/oauth2 v0.16.0

--- a/plugins/source/github/go.sum
+++ b/plugins/source/github/go.sum
@@ -122,8 +122,8 @@ github.com/google/go-cmp v0.5.2/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/
 github.com/google/go-cmp v0.5.5/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.6.0 h1:ofyhxvXcZhMsU5ulbFiLKl/XBFqE1GSq7atu8tAmTRI=
 github.com/google/go-cmp v0.6.0/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
-github.com/google/go-github/v49 v49.0.0 h1:vSz1fnOeGztFxDe48q0RCOrd8Cg4o8INcZBPVpGPNaY=
-github.com/google/go-github/v49 v49.0.0/go.mod h1:MUUzHPrhGniB6vUKa27y37likpipzG+BXXJbG04J334=
+github.com/google/go-github/v59 v59.0.0 h1:7h6bgpF5as0YQLLkEiVqpgtJqjimMYhBkD4jT5aN3VA=
+github.com/google/go-github/v59 v59.0.0/go.mod h1:rJU4R0rQHFVFDOkqGWxfLNo6vEk4dv40oDjhV/gH6wM=
 github.com/google/go-querystring v1.1.0 h1:AnCroh3fv4ZBgVIf1Iwtovgjaw/GiKJo8M8yD/fhyJ8=
 github.com/google/go-querystring v1.1.0/go.mod h1:Kcdr2DB4koayq7X8pmAG4sNG59So17icRSOU623lUBU=
 github.com/google/gofuzz v1.0.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=

--- a/plugins/source/github/resources/services/actions/workflow_jobs.go
+++ b/plugins/source/github/resources/services/actions/workflow_jobs.go
@@ -7,7 +7,7 @@ import (
 	"github.com/cloudquery/cloudquery/plugins/source/github/client"
 	"github.com/cloudquery/plugin-sdk/v4/schema"
 	"github.com/cloudquery/plugin-sdk/v4/transformers"
-	"github.com/google/go-github/v49/github"
+	"github.com/google/go-github/v59/github"
 )
 
 func workflowJobs() *schema.Table {

--- a/plugins/source/github/resources/services/actions/workflow_run_usage.go
+++ b/plugins/source/github/resources/services/actions/workflow_run_usage.go
@@ -6,7 +6,7 @@ import (
 	"github.com/apache/arrow/go/v15/arrow"
 	"github.com/cloudquery/cloudquery/plugins/source/github/client"
 	"github.com/cloudquery/plugin-sdk/v4/schema"
-	"github.com/google/go-github/v49/github"
+	"github.com/google/go-github/v59/github"
 )
 
 func workflowRunUsage() *schema.Table {

--- a/plugins/source/github/resources/services/actions/workflow_runs.go
+++ b/plugins/source/github/resources/services/actions/workflow_runs.go
@@ -6,7 +6,7 @@ import (
 	"github.com/cloudquery/cloudquery/plugins/source/github/client"
 	"github.com/cloudquery/plugin-sdk/v4/schema"
 	"github.com/cloudquery/plugin-sdk/v4/transformers"
-	"github.com/google/go-github/v49/github"
+	"github.com/google/go-github/v59/github"
 )
 
 func WorkflowRuns() *schema.Table {

--- a/plugins/source/github/resources/services/actions/workflow_runs_test.go
+++ b/plugins/source/github/resources/services/actions/workflow_runs_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/cloudquery/cloudquery/plugins/source/github/client/mocks"
 	"github.com/cloudquery/plugin-sdk/v4/faker"
 	"github.com/golang/mock/gomock"
-	"github.com/google/go-github/v49/github"
+	"github.com/google/go-github/v59/github"
 )
 
 func buildWorkflowRuns(t *testing.T, ctrl *gomock.Controller) client.GithubServices {

--- a/plugins/source/github/resources/services/actions/workflows.go
+++ b/plugins/source/github/resources/services/actions/workflows.go
@@ -9,7 +9,7 @@ import (
 	"github.com/cloudquery/cloudquery/plugins/source/github/client"
 	"github.com/cloudquery/plugin-sdk/v4/schema"
 	"github.com/cloudquery/plugin-sdk/v4/transformers"
-	"github.com/google/go-github/v49/github"
+	"github.com/google/go-github/v59/github"
 )
 
 func Workflows() *schema.Table {

--- a/plugins/source/github/resources/services/actions/workflows_test.go
+++ b/plugins/source/github/resources/services/actions/workflows_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/cloudquery/cloudquery/plugins/source/github/client/mocks"
 	"github.com/cloudquery/plugin-sdk/v4/faker"
 	"github.com/golang/mock/gomock"
-	"github.com/google/go-github/v49/github"
+	"github.com/google/go-github/v59/github"
 )
 
 func buildWorkflows(t *testing.T, ctrl *gomock.Controller) client.GithubServices {

--- a/plugins/source/github/resources/services/billing/action.go
+++ b/plugins/source/github/resources/services/billing/action.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/cloudquery/cloudquery/plugins/source/github/client"
 	"github.com/cloudquery/plugin-sdk/v4/schema"
-	"github.com/google/go-github/v49/github"
+	"github.com/google/go-github/v59/github"
 )
 
 func Action() *schema.Table {

--- a/plugins/source/github/resources/services/billing/action_test.go
+++ b/plugins/source/github/resources/services/billing/action_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/cloudquery/cloudquery/plugins/source/github/client/mocks"
 	"github.com/cloudquery/plugin-sdk/v4/faker"
 	"github.com/golang/mock/gomock"
-	"github.com/google/go-github/v49/github"
+	"github.com/google/go-github/v59/github"
 )
 
 func buildAction(t *testing.T, ctrl *gomock.Controller) client.GithubServices {

--- a/plugins/source/github/resources/services/billing/package.go
+++ b/plugins/source/github/resources/services/billing/package.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/cloudquery/cloudquery/plugins/source/github/client"
 	"github.com/cloudquery/plugin-sdk/v4/schema"
-	"github.com/google/go-github/v49/github"
+	"github.com/google/go-github/v59/github"
 )
 
 func Package() *schema.Table {

--- a/plugins/source/github/resources/services/billing/packing_test.go
+++ b/plugins/source/github/resources/services/billing/packing_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/cloudquery/cloudquery/plugins/source/github/client/mocks"
 	"github.com/cloudquery/plugin-sdk/v4/faker"
 	"github.com/golang/mock/gomock"
-	"github.com/google/go-github/v49/github"
+	"github.com/google/go-github/v59/github"
 )
 
 func buildPackage(t *testing.T, ctrl *gomock.Controller) client.GithubServices {

--- a/plugins/source/github/resources/services/billing/storage.go
+++ b/plugins/source/github/resources/services/billing/storage.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/cloudquery/cloudquery/plugins/source/github/client"
 	"github.com/cloudquery/plugin-sdk/v4/schema"
-	"github.com/google/go-github/v49/github"
+	"github.com/google/go-github/v59/github"
 )
 
 func Storage() *schema.Table {

--- a/plugins/source/github/resources/services/billing/storage_test.go
+++ b/plugins/source/github/resources/services/billing/storage_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/cloudquery/cloudquery/plugins/source/github/client/mocks"
 	"github.com/cloudquery/plugin-sdk/v4/faker"
 	"github.com/golang/mock/gomock"
-	"github.com/google/go-github/v49/github"
+	"github.com/google/go-github/v59/github"
 )
 
 func buildStorage(t *testing.T, ctrl *gomock.Controller) client.GithubServices {

--- a/plugins/source/github/resources/services/external/groups.go
+++ b/plugins/source/github/resources/services/external/groups.go
@@ -6,7 +6,7 @@ import (
 	"github.com/cloudquery/cloudquery/plugins/source/github/client"
 	"github.com/cloudquery/plugin-sdk/v4/schema"
 	"github.com/cloudquery/plugin-sdk/v4/transformers"
-	"github.com/google/go-github/v49/github"
+	"github.com/google/go-github/v59/github"
 )
 
 func Groups() *schema.Table {

--- a/plugins/source/github/resources/services/external/groups_test.go
+++ b/plugins/source/github/resources/services/external/groups_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/cloudquery/cloudquery/plugins/source/github/client/mocks"
 	"github.com/cloudquery/plugin-sdk/v4/faker"
 	"github.com/golang/mock/gomock"
-	"github.com/google/go-github/v49/github"
+	"github.com/google/go-github/v59/github"
 )
 
 func buildExternalGroups(t *testing.T, ctrl *gomock.Controller) client.GithubServices {

--- a/plugins/source/github/resources/services/hooks/deliveries.go
+++ b/plugins/source/github/resources/services/hooks/deliveries.go
@@ -7,7 +7,7 @@ import (
 	"github.com/cloudquery/cloudquery/plugins/source/github/client"
 	"github.com/cloudquery/plugin-sdk/v4/schema"
 	"github.com/cloudquery/plugin-sdk/v4/transformers"
-	"github.com/google/go-github/v49/github"
+	"github.com/google/go-github/v59/github"
 )
 
 func deliveries() *schema.Table {

--- a/plugins/source/github/resources/services/hooks/hooks.go
+++ b/plugins/source/github/resources/services/hooks/hooks.go
@@ -6,7 +6,7 @@ import (
 	"github.com/cloudquery/cloudquery/plugins/source/github/client"
 	"github.com/cloudquery/plugin-sdk/v4/schema"
 	"github.com/cloudquery/plugin-sdk/v4/transformers"
-	"github.com/google/go-github/v49/github"
+	"github.com/google/go-github/v59/github"
 )
 
 func Hooks() *schema.Table {

--- a/plugins/source/github/resources/services/hooks/hooks_test.go
+++ b/plugins/source/github/resources/services/hooks/hooks_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/cloudquery/cloudquery/plugins/source/github/client/mocks"
 	"github.com/cloudquery/plugin-sdk/v4/faker"
 	"github.com/golang/mock/gomock"
-	"github.com/google/go-github/v49/github"
+	"github.com/google/go-github/v59/github"
 )
 
 func buildHooks(t *testing.T, ctrl *gomock.Controller) client.GithubServices {

--- a/plugins/source/github/resources/services/installations/installations.go
+++ b/plugins/source/github/resources/services/installations/installations.go
@@ -6,7 +6,7 @@ import (
 	"github.com/cloudquery/cloudquery/plugins/source/github/client"
 	"github.com/cloudquery/plugin-sdk/v4/schema"
 	"github.com/cloudquery/plugin-sdk/v4/transformers"
-	"github.com/google/go-github/v49/github"
+	"github.com/google/go-github/v59/github"
 )
 
 func Installations() *schema.Table {

--- a/plugins/source/github/resources/services/installations/installations_test.go
+++ b/plugins/source/github/resources/services/installations/installations_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/cloudquery/cloudquery/plugins/source/github/client/mocks"
 	"github.com/cloudquery/plugin-sdk/v4/faker"
 	"github.com/golang/mock/gomock"
-	"github.com/google/go-github/v49/github"
+	"github.com/google/go-github/v59/github"
 )
 
 func buildInstallations(t *testing.T, ctrl *gomock.Controller) client.GithubServices {

--- a/plugins/source/github/resources/services/issues/issues.go
+++ b/plugins/source/github/resources/services/issues/issues.go
@@ -6,7 +6,7 @@ import (
 	"github.com/cloudquery/cloudquery/plugins/source/github/client"
 	"github.com/cloudquery/plugin-sdk/v4/schema"
 	"github.com/cloudquery/plugin-sdk/v4/transformers"
-	"github.com/google/go-github/v49/github"
+	"github.com/google/go-github/v59/github"
 )
 
 func Issues() *schema.Table {

--- a/plugins/source/github/resources/services/issues/issues_test.go
+++ b/plugins/source/github/resources/services/issues/issues_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/cloudquery/cloudquery/plugins/source/github/client/mocks"
 	"github.com/cloudquery/plugin-sdk/v4/faker"
 	"github.com/golang/mock/gomock"
-	"github.com/google/go-github/v49/github"
+	"github.com/google/go-github/v59/github"
 )
 
 func buildIssues(t *testing.T, ctrl *gomock.Controller) client.GithubServices {

--- a/plugins/source/github/resources/services/organizations/alerts.go
+++ b/plugins/source/github/resources/services/organizations/alerts.go
@@ -6,7 +6,7 @@ import (
 	"github.com/cloudquery/cloudquery/plugins/source/github/client"
 	"github.com/cloudquery/plugin-sdk/v4/schema"
 	"github.com/cloudquery/plugin-sdk/v4/transformers"
-	"github.com/google/go-github/v49/github"
+	"github.com/google/go-github/v59/github"
 )
 
 func alerts() *schema.Table {

--- a/plugins/source/github/resources/services/organizations/dependabot_mock_test.go
+++ b/plugins/source/github/resources/services/organizations/dependabot_mock_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/cloudquery/cloudquery/plugins/source/github/client/mocks"
 	"github.com/cloudquery/plugin-sdk/v4/faker"
 	"github.com/golang/mock/gomock"
-	"github.com/google/go-github/v49/github"
+	"github.com/google/go-github/v59/github"
 )
 
 func buildDependabot(t *testing.T, ctrl *gomock.Controller) client.DependabotService {

--- a/plugins/source/github/resources/services/organizations/members.go
+++ b/plugins/source/github/resources/services/organizations/members.go
@@ -7,7 +7,7 @@ import (
 	"github.com/cloudquery/plugin-sdk/v4/schema"
 	"github.com/cloudquery/plugin-sdk/v4/transformers"
 	"github.com/cloudquery/plugin-sdk/v4/types"
-	"github.com/google/go-github/v49/github"
+	"github.com/google/go-github/v59/github"
 )
 
 func members() *schema.Table {

--- a/plugins/source/github/resources/services/organizations/organizations.go
+++ b/plugins/source/github/resources/services/organizations/organizations.go
@@ -6,7 +6,7 @@ import (
 	"github.com/cloudquery/cloudquery/plugins/source/github/client"
 	"github.com/cloudquery/plugin-sdk/v4/schema"
 	"github.com/cloudquery/plugin-sdk/v4/transformers"
-	"github.com/google/go-github/v49/github"
+	"github.com/google/go-github/v59/github"
 )
 
 func Organizations() *schema.Table {

--- a/plugins/source/github/resources/services/organizations/organizations_test.go
+++ b/plugins/source/github/resources/services/organizations/organizations_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/cloudquery/cloudquery/plugins/source/github/client/mocks"
 	"github.com/cloudquery/plugin-sdk/v4/faker"
 	"github.com/golang/mock/gomock"
-	"github.com/google/go-github/v49/github"
+	"github.com/google/go-github/v59/github"
 )
 
 func buildOrganizations(t *testing.T, ctrl *gomock.Controller) client.GithubServices {

--- a/plugins/source/github/resources/services/organizations/secrets.go
+++ b/plugins/source/github/resources/services/organizations/secrets.go
@@ -6,7 +6,7 @@ import (
 	"github.com/cloudquery/cloudquery/plugins/source/github/client"
 	"github.com/cloudquery/plugin-sdk/v4/schema"
 	"github.com/cloudquery/plugin-sdk/v4/transformers"
-	"github.com/google/go-github/v49/github"
+	"github.com/google/go-github/v59/github"
 )
 
 func secrets() *schema.Table {

--- a/plugins/source/github/resources/services/repositories/alerts.go
+++ b/plugins/source/github/resources/services/repositories/alerts.go
@@ -6,7 +6,7 @@ import (
 	"github.com/cloudquery/cloudquery/plugins/source/github/client"
 	"github.com/cloudquery/plugin-sdk/v4/schema"
 	"github.com/cloudquery/plugin-sdk/v4/transformers"
-	"github.com/google/go-github/v49/github"
+	"github.com/google/go-github/v59/github"
 )
 
 func alerts() *schema.Table {

--- a/plugins/source/github/resources/services/repositories/assets.go
+++ b/plugins/source/github/resources/services/repositories/assets.go
@@ -6,7 +6,7 @@ import (
 	"github.com/cloudquery/cloudquery/plugins/source/github/client"
 	"github.com/cloudquery/plugin-sdk/v4/schema"
 	"github.com/cloudquery/plugin-sdk/v4/transformers"
-	"github.com/google/go-github/v49/github"
+	"github.com/google/go-github/v59/github"
 )
 
 func assets() *schema.Table {

--- a/plugins/source/github/resources/services/repositories/branches.go
+++ b/plugins/source/github/resources/services/repositories/branches.go
@@ -7,7 +7,7 @@ import (
 	"github.com/cloudquery/plugin-sdk/v4/schema"
 	"github.com/cloudquery/plugin-sdk/v4/transformers"
 	"github.com/cloudquery/plugin-sdk/v4/types"
-	"github.com/google/go-github/v49/github"
+	"github.com/google/go-github/v59/github"
 )
 
 func branches() *schema.Table {

--- a/plugins/source/github/resources/services/repositories/dependabot_mock_test.go
+++ b/plugins/source/github/resources/services/repositories/dependabot_mock_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/cloudquery/cloudquery/plugins/source/github/client/mocks"
 	"github.com/cloudquery/plugin-sdk/v4/faker"
 	"github.com/golang/mock/gomock"
-	"github.com/google/go-github/v49/github"
+	"github.com/google/go-github/v59/github"
 )
 
 func buildDependabot(t *testing.T, ctrl *gomock.Controller) client.DependabotService {

--- a/plugins/source/github/resources/services/repositories/keys.go
+++ b/plugins/source/github/resources/services/repositories/keys.go
@@ -6,7 +6,7 @@ import (
 	"github.com/cloudquery/cloudquery/plugins/source/github/client"
 	"github.com/cloudquery/plugin-sdk/v4/schema"
 	"github.com/cloudquery/plugin-sdk/v4/transformers"
-	"github.com/google/go-github/v49/github"
+	"github.com/google/go-github/v59/github"
 )
 
 func keys() *schema.Table {

--- a/plugins/source/github/resources/services/repositories/releases.go
+++ b/plugins/source/github/resources/services/repositories/releases.go
@@ -6,7 +6,7 @@ import (
 	"github.com/cloudquery/cloudquery/plugins/source/github/client"
 	"github.com/cloudquery/plugin-sdk/v4/schema"
 	"github.com/cloudquery/plugin-sdk/v4/transformers"
-	"github.com/google/go-github/v49/github"
+	"github.com/google/go-github/v59/github"
 )
 
 func releases() *schema.Table {

--- a/plugins/source/github/resources/services/repositories/repositories.go
+++ b/plugins/source/github/resources/services/repositories/repositories.go
@@ -6,7 +6,7 @@ import (
 	"github.com/cloudquery/cloudquery/plugins/source/github/client"
 	"github.com/cloudquery/plugin-sdk/v4/schema"
 	"github.com/cloudquery/plugin-sdk/v4/transformers"
-	"github.com/google/go-github/v49/github"
+	"github.com/google/go-github/v59/github"
 )
 
 func Repositories() *schema.Table {

--- a/plugins/source/github/resources/services/repositories/repositories_test.go
+++ b/plugins/source/github/resources/services/repositories/repositories_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/cloudquery/cloudquery/plugins/source/github/client/mocks"
 	"github.com/cloudquery/plugin-sdk/v4/faker"
 	"github.com/golang/mock/gomock"
-	"github.com/google/go-github/v49/github"
+	"github.com/google/go-github/v59/github"
 )
 
 func buildRepositories(t *testing.T, ctrl *gomock.Controller) client.GithubServices {

--- a/plugins/source/github/resources/services/repositories/secrets.go
+++ b/plugins/source/github/resources/services/repositories/secrets.go
@@ -6,7 +6,7 @@ import (
 	"github.com/cloudquery/cloudquery/plugins/source/github/client"
 	"github.com/cloudquery/plugin-sdk/v4/schema"
 	"github.com/cloudquery/plugin-sdk/v4/transformers"
-	"github.com/google/go-github/v49/github"
+	"github.com/google/go-github/v59/github"
 )
 
 func secrets() *schema.Table {

--- a/plugins/source/github/resources/services/teams/members.go
+++ b/plugins/source/github/resources/services/teams/members.go
@@ -9,7 +9,7 @@ import (
 	"github.com/cloudquery/plugin-sdk/v4/schema"
 	"github.com/cloudquery/plugin-sdk/v4/transformers"
 	"github.com/cloudquery/plugin-sdk/v4/types"
-	"github.com/google/go-github/v49/github"
+	"github.com/google/go-github/v59/github"
 )
 
 func members() *schema.Table {

--- a/plugins/source/github/resources/services/teams/repositories.go
+++ b/plugins/source/github/resources/services/teams/repositories.go
@@ -8,7 +8,7 @@ import (
 	"github.com/cloudquery/cloudquery/plugins/source/github/client"
 	"github.com/cloudquery/plugin-sdk/v4/schema"
 	"github.com/cloudquery/plugin-sdk/v4/transformers"
-	"github.com/google/go-github/v49/github"
+	"github.com/google/go-github/v59/github"
 )
 
 func repositories() *schema.Table {

--- a/plugins/source/github/resources/services/teams/teams.go
+++ b/plugins/source/github/resources/services/teams/teams.go
@@ -7,7 +7,7 @@ import (
 	"github.com/cloudquery/cloudquery/plugins/source/github/client"
 	"github.com/cloudquery/plugin-sdk/v4/schema"
 	"github.com/cloudquery/plugin-sdk/v4/transformers"
-	"github.com/google/go-github/v49/github"
+	"github.com/google/go-github/v59/github"
 )
 
 func Teams() *schema.Table {

--- a/plugins/source/github/resources/services/teams/teams_test.go
+++ b/plugins/source/github/resources/services/teams/teams_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/cloudquery/cloudquery/plugins/source/github/client/mocks"
 	"github.com/cloudquery/plugin-sdk/v4/faker"
 	"github.com/golang/mock/gomock"
-	"github.com/google/go-github/v49/github"
+	"github.com/google/go-github/v59/github"
 )
 
 func buildTeams(t *testing.T, ctrl *gomock.Controller) client.GithubServices {

--- a/plugins/source/github/resources/services/traffic/clones.go
+++ b/plugins/source/github/resources/services/traffic/clones.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/cloudquery/cloudquery/plugins/source/github/client"
 	"github.com/cloudquery/plugin-sdk/v4/schema"
-	"github.com/google/go-github/v49/github"
+	"github.com/google/go-github/v59/github"
 )
 
 func Clones() *schema.Table {

--- a/plugins/source/github/resources/services/traffic/clones_test.go
+++ b/plugins/source/github/resources/services/traffic/clones_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/cloudquery/cloudquery/plugins/source/github/client/mocks"
 	"github.com/cloudquery/plugin-sdk/v4/faker"
 	"github.com/golang/mock/gomock"
-	"github.com/google/go-github/v49/github"
+	"github.com/google/go-github/v59/github"
 )
 
 func buildClones(t *testing.T, ctrl *gomock.Controller) client.GithubServices {

--- a/plugins/source/github/resources/services/traffic/paths.go
+++ b/plugins/source/github/resources/services/traffic/paths.go
@@ -6,7 +6,7 @@ import (
 	"github.com/cloudquery/cloudquery/plugins/source/github/client"
 	"github.com/cloudquery/plugin-sdk/v4/schema"
 	"github.com/cloudquery/plugin-sdk/v4/transformers"
-	"github.com/google/go-github/v49/github"
+	"github.com/google/go-github/v59/github"
 )
 
 func Paths() *schema.Table {

--- a/plugins/source/github/resources/services/traffic/paths_test.go
+++ b/plugins/source/github/resources/services/traffic/paths_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/cloudquery/cloudquery/plugins/source/github/client/mocks"
 	"github.com/cloudquery/plugin-sdk/v4/faker"
 	"github.com/golang/mock/gomock"
-	"github.com/google/go-github/v49/github"
+	"github.com/google/go-github/v59/github"
 )
 
 func buildPaths(t *testing.T, ctrl *gomock.Controller) client.GithubServices {

--- a/plugins/source/github/resources/services/traffic/referrers.go
+++ b/plugins/source/github/resources/services/traffic/referrers.go
@@ -6,7 +6,7 @@ import (
 	"github.com/cloudquery/cloudquery/plugins/source/github/client"
 	"github.com/cloudquery/plugin-sdk/v4/schema"
 	"github.com/cloudquery/plugin-sdk/v4/transformers"
-	"github.com/google/go-github/v49/github"
+	"github.com/google/go-github/v59/github"
 )
 
 func Referrers() *schema.Table {

--- a/plugins/source/github/resources/services/traffic/referrers_test.go
+++ b/plugins/source/github/resources/services/traffic/referrers_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/cloudquery/cloudquery/plugins/source/github/client/mocks"
 	"github.com/cloudquery/plugin-sdk/v4/faker"
 	"github.com/golang/mock/gomock"
-	"github.com/google/go-github/v49/github"
+	"github.com/google/go-github/v59/github"
 )
 
 func buildReferrers(t *testing.T, ctrl *gomock.Controller) client.GithubServices {

--- a/plugins/source/github/resources/services/traffic/views.go
+++ b/plugins/source/github/resources/services/traffic/views.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/cloudquery/cloudquery/plugins/source/github/client"
 	"github.com/cloudquery/plugin-sdk/v4/schema"
-	"github.com/google/go-github/v49/github"
+	"github.com/google/go-github/v59/github"
 )
 
 func Views() *schema.Table {

--- a/plugins/source/github/resources/services/traffic/views_test.go
+++ b/plugins/source/github/resources/services/traffic/views_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/cloudquery/cloudquery/plugins/source/github/client/mocks"
 	"github.com/cloudquery/plugin-sdk/v4/faker"
 	"github.com/golang/mock/gomock"
-	"github.com/google/go-github/v49/github"
+	"github.com/google/go-github/v59/github"
 )
 
 func buildViews(t *testing.T, ctrl *gomock.Controller) client.GithubServices {


### PR DESCRIPTION
<!-- 🎉 Thank you for making CloudQuery awesome by submitting a PR 🎉 -->

#### Summary

Bump `go-github` to v59 in the Github source plugin.

This allows Cloudquery to take advantage of some of the new Github APIs, specifically the [SBOM API](https://docs.github.com/en/rest/dependency-graph/sboms?apiVersion=2022-11-28) in https://github.com/cloudquery/cloudquery/pull/16796

I've tested this PR in our Cloudquery environment and did not notice any issues arising from this bump, although to be fair we don't collect every table due to resource and time constraints.

Looking at the [Release notes](https://github.com/google/go-github/releases) for go-github I don't see any breaking changes particularly concerning apart from a change of timestamp types in [v50](https://github.com/google/go-github/releases/tag/v50.0.0)

<!--
Use the following steps to ensure your PR is ready to be reviewed

- [x] Read the [contribution guidelines](https://github.com/cloudquery/cloudquery/blob/main/CONTRIBUTING.md) 🧑‍🎓
- [x] Run `make lint` to ensure the proposed changes follow the coding style 🚨 (install golangci-lint [here](https://golangci-lint.run/usage/install/#local-installation))
- [x] Run `make test` to ensure the proposed changes pass the tests 🧪
- [x] If changing a source plugin run `make gen` to ensure docs are up to date 📝
- [ ] Ensure the status checks below are successful ✅
--->
