### PR TITLE
chore: Re-enable no-migrate option for DuckDB

### DIFF
--- a/plugins/destination/duckdb/client/migrate.go
+++ b/plugins/destination/duckdb/client/migrate.go
@@ -110,6 +110,7 @@ func (c *Client) MigrateTables(ctx context.Context, msgs message.WriteMigrateTab
 		}
 		if t != nil {
 			duckdbTables = append(duckdbTables, t)
+			c.setTableInfoCache(t)
 		}
 	}
 
@@ -297,6 +298,12 @@ func (c *Client) getTableInfo(ctx context.Context, tableName string) (*schema.Ta
 func (c *Client) removeTableInfoCache(tableName string) {
 	c.dbTablesMu.Lock()
 	delete(c.dbTables, tableName)
+	c.dbTablesMu.Unlock()
+}
+
+func (c *Client) setTableInfoCache(table *schema.Table) {
+	c.dbTablesMu.Lock()
+	c.dbTables[table.Name] = table
 	c.dbTablesMu.Unlock()
 }
 

--- a/plugins/destination/duckdb/client/migrate.go
+++ b/plugins/destination/duckdb/client/migrate.go
@@ -135,10 +135,6 @@ func (c *Client) MigrateTables(ctx context.Context, msgs message.WriteMigrateTab
 	if err != nil {
 		return err
 	}
-	c.dbTables = duckdbTables
-	defer func() {
-		c.dbTables = c.dbTables.FlattenTables()
-	}()
 
 	normalizedTables := c.normalizeColumns(tables)
 	normalizedTablesSafeMode := make(schema.Tables, 0, len(normalizedTables))
@@ -169,14 +165,10 @@ func (c *Client) MigrateTables(ctx context.Context, msgs message.WriteMigrateTab
 			if err := c.createTableIfNotExist(ctx, table.Name, table); err != nil {
 				return err
 			}
-			c.dbTables = nil // force refresh
 			continue
 		}
 
 		changes := table.GetChanges(duckdb)
-		if len(changes) > 0 {
-			c.dbTables = nil // force refresh
-		}
 		if c.canAutoMigrate(changes) {
 			c.logger.Info().Str("table", table.Name).Msg("Table exists, auto-migrating")
 			if err := c.autoMigrateTable(ctx, table, changes); err != nil {
@@ -187,13 +179,6 @@ func (c *Client) MigrateTables(ctx context.Context, msgs message.WriteMigrateTab
 			if err := c.recreateTable(ctx, table); err != nil {
 				return err
 			}
-		}
-	}
-
-	if c.dbTables == nil {
-		c.dbTables, err = c.duckDBTables(ctx, tables)
-		if err != nil {
-			return fmt.Errorf("failed to get duckdb tables after migrations: %w", err)
 		}
 	}
 


### PR DESCRIPTION
This was broken in https://github.com/cloudquery/cloudquery/pull/16668

Chore, because it wasn't released.