### PR TITLE
chore: Fix replace versions logic to prioritize the Hub

### DIFF
--- a/website/next.config.mjs
+++ b/website/next.config.mjs
@@ -75,11 +75,11 @@ function getStaticVersions() {
 }
 
 async function getHubVersions() {
-  const response = await fetch("https://api.cloudquery.io/plugins");
+  const response = await fetch("https://api.cloudquery.io/plugins?per_page=1000");
   const { items: allPlugins } = await response.json();
-  const paidPlugins = allPlugins.filter((plugin) => plugin.tier === "paid" && plugin.team_name === "cloudquery" && plugin.latest_version);
-  const sources = paidPlugins.filter((plugin) => plugin.kind === "source");
-  const destinations = paidPlugins.filter((plugin) => plugin.kind === "destination");
+  const cloudqueryPlugins = allPlugins.filter((plugin) => plugin.team_name === "cloudquery" && plugin.latest_version);
+  const sources = cloudqueryPlugins.filter((plugin) => plugin.kind === "source");
+  const destinations = cloudqueryPlugins.filter((plugin) => plugin.kind === "destination");
 
   return {
     sources: Object.fromEntries(
@@ -99,12 +99,12 @@ async function getVersions() {
   return {
     ...staticVersions,
     sources: {
-      ...hubVersions.sources,
       ...staticVersions.sources,
+      ...hubVersions.sources,
     },
     destinations: {
-      ...hubVersions.destinations,
       ...staticVersions.destinations,
+      ...hubVersions.destinations,
     },
   };
 }


### PR DESCRIPTION
<!-- 🎉 Thank you for making CloudQuery awesome by submitting a PR 🎉 -->

#### Summary

Fixes https://github.com/cloudquery/cloudquery-issues/issues/1342

This should ensure Hub plugins version takes precedence over GitHub ones in our docs

<!--
Use the following steps to ensure your PR is ready to be reviewed

- [ ] Read the [contribution guidelines](https://github.com/cloudquery/cloudquery/blob/main/CONTRIBUTING.md) 🧑‍🎓
- [ ] Run `make lint` to ensure the proposed changes follow the coding style 🚨 (install golangci-lint [here](https://golangci-lint.run/usage/install/#local-installation))
- [ ] Run `make test` to ensure the proposed changes pass the tests 🧪
- [ ] If changing a source plugin run `make gen` to ensure docs are up to date 📝
- [ ] Ensure the status checks below are successful ✅
--->
