### PR TITLE
fix: Handle multiple changes to a single table

### DIFF
--- a/plugins/destination/postgresql/client/migrate.go
+++ b/plugins/destination/postgresql/client/migrate.go
@@ -107,11 +107,19 @@ func (c *Client) autoMigrateTable(ctx context.Context, table *schema.Table, chan
 	for _, change := range changes {
 		switch change.Type {
 		case schema.TableColumnChangeTypeAdd:
-			return c.addColumn(ctx, tableName, change.Current)
+			err := c.addColumn(ctx, tableName, change.Current)
+			if err != nil {
+				return err
+			}
+			continue
 		case schema.TableColumnChangeTypeRemove:
 			continue
 		case schema.TableColumnChangeTypeMoveToCQOnly:
-			return c.migrateToCQID(ctx, table, change.Current)
+			err := c.migrateToCQID(ctx, table, change.Current)
+			if err != nil {
+				return err
+			}
+			continue
 		default:
 			return fmt.Errorf("unsupported column change type: %s for column: %v from %v", change.Type.String(), change.Current, change.Previous)
 		}


### PR DESCRIPTION
<!-- 🎉 Thank you for making CloudQuery awesome by submitting a PR 🎉 -->

#### Summary

Prior to this change if multiple automigratable changes happened to a single table only the first one would be executed. This change makes it so all changes will be migrated