### PR TITLE
chore: Use `strip_html_comments: true` instead of hard coded strings

### DIFF
--- a/.github/.kodiak.toml
+++ b/.github/.kodiak.toml
@@ -6,7 +6,7 @@ auto_approve_usernames = ["cq-bot"]
 
 [merge.message]
 body = "pull_request_body"
-strip_html_comments: true
+strip_html_comments = true
 title = "pull_request_title"
 
 [merge.automerge_dependencies]

--- a/.github/.kodiak.toml
+++ b/.github/.kodiak.toml
@@ -6,9 +6,7 @@ auto_approve_usernames = ["cq-bot"]
 
 [merge.message]
 body = "pull_request_body"
-cut_body_after = "Use the following steps to ensure your PR is ready to be reviewed"
-cut_body_and_text = true
-cut_body_before = "<!-- 🎉 Thank you for making CloudQuery awesome by submitting a PR 🎉 -->"
+strip_html_comments: true
 title = "pull_request_title"
 
 [merge.automerge_dependencies]


### PR DESCRIPTION
<!-- 🎉 Thank you for making CloudQuery awesome by submitting a PR 🎉 -->

#### Summary

See https://kodiakhq.com/docs/config-reference#mergemessagestrip_html_comments.
This is a better way to clean up the PR body from any template comments

<!--
Explain what problem this PR addresses
-->

<!--
Use the following steps to ensure your PR is ready to be reviewed

- [ ] Read the [contribution guidelines](https://github.com/cloudquery/cloudquery/blob/main/CONTRIBUTING.md) 🧑‍🎓
- [ ] Run `make lint` to ensure the proposed changes follow the coding style 🚨 (install golangci-lint [here](https://golangci-lint.run/usage/install/#local-installation))
- [ ] Run `make test` to ensure the proposed changes pass the tests 🧪
- [ ] If changing a source plugin run `make gen` to ensure docs are up to date 📝
- [ ] Ensure the status checks below are successful ✅
--->
