### PR TITLE
fix: Pass enterprise base URL to app auth if needed

### DIFF
--- a/plugins/source/github/client/client.go
+++ b/plugins/source/github/client/client.go
@@ -87,6 +87,7 @@ func New(ctx context.Context, logger zerolog.Logger, spec Spec) (schema.ClientMe
 	ghServices := map[string]GithubServices{}
 	for _, auth := range spec.AppAuth {
 		var (
+			i   *inst.Config
 			k   *rsa.PrivateKey
 			err error
 		)
@@ -98,7 +99,11 @@ func New(ctx context.Context, logger zerolog.Logger, spec Spec) (schema.ClientMe
 		if err != nil {
 			return nil, fmt.Errorf("failed to parse private key: %w", err)
 		}
-		i, err := inst.NewConfig(auth.AppID, auth.InstallationID, k)
+		if spec.EnterpriseSettings == nil {
+			i, err = inst.NewConfig(auth.AppID, auth.InstallationID, k)
+		} else {
+			i, err = inst.NewEnterpriseConfig(spec.EnterpriseSettings.BaseURL, auth.AppID, auth.InstallationID, k)
+		}
 		if err != nil {
 			return nil, fmt.Errorf("failed to create app config: %w", err)
 		}


### PR DESCRIPTION
<!-- 🎉 Thank you for making CloudQuery awesome by submitting a PR 🎉 -->

#### Summary

We should pass the enterprise base URL to the package that handles app installation authentication https://github.com/beatlabs/github-auth?tab=readme-ov-file#enterprise

We do `WithEnterpriseURLs` on the GitHub go client, but we use a different package to handle app installation authentication.

<!--
Explain what problem this PR addresses
-->

<!--
Use the following steps to ensure your PR is ready to be reviewed

- [ ] Read the [contribution guidelines](https://github.com/cloudquery/cloudquery/blob/main/CONTRIBUTING.md) 🧑‍🎓
- [ ] Run `make lint` to ensure the proposed changes follow the coding style 🚨 (install golangci-lint [here](https://golangci-lint.run/usage/install/#local-installation))
- [ ] Run `make test` to ensure the proposed changes pass the tests 🧪
- [ ] If changing a source plugin run `make gen` to ensure docs are up to date 📝
- [ ] Ensure the status checks below are successful ✅
--->
