### PR TITLE
chore: Update update-plugins-using-renovate.mdx

### DIFF
--- a/website/pages/how-to-guides/update-plugins-using-renovate.mdx
+++ b/website/pages/how-to-guides/update-plugins-using-renovate.mdx
@@ -42,7 +42,6 @@ kind: source
 spec:
   name: gcp
   path: cloudquery/gcp
-  registry: cloudquery
   version: "VERSION_SOURCE_GCP"
   tables: ["*"]
   destinations: ["postgresql"]
@@ -51,7 +50,6 @@ kind: source
 spec:
   name: aws
   path: cloudquery/aws
-  registry: cloudquery
   version: "VERSION_SOURCE_AWS"
   destinations: ["postgresql"]
   tables: ["*"]
@@ -60,7 +58,6 @@ kind: destination
 spec:
   name: postgresql
   path: cloudquery/postgresql
-  registry: cloudquery
   version: "VERSION_DESTINATION_POSTGRESQL"
   write_mode: overwrite-delete-stale
 ``` 


### PR DESCRIPTION
<!-- 🎉 Thank you for making CloudQuery awesome by submitting a PR 🎉 -->

#### Summary

The registry config breaks the regex used to update plugins (see a bit below in the guide `kind:\s(?<kind>.*)\nspec:\n\s{2}name:.*?\w\n\s{2}path:\scloudquery\/(?<plugin>.*)\n\s{2}version:\s\"?v(?<currentValue>.*\d)\"?\n`)

<!--
Explain what problem this PR addresses
-->

<!--
Use the following steps to ensure your PR is ready to be reviewed

- [ ] Read the [contribution guidelines](https://github.com/cloudquery/cloudquery/blob/main/CONTRIBUTING.md) 🧑‍🎓
- [ ] Run `make lint` to ensure the proposed changes follow the coding style 🚨 (install golangci-lint [here](https://golangci-lint.run/usage/install/#local-installation))
- [ ] Run `make test` to ensure the proposed changes pass the tests 🧪
- [ ] If changing a source plugin run `make gen` to ensure docs are up to date 📝
- [ ] Ensure the status checks below are successful ✅
--->
