### PR TITLE
fix: Don't include /api/v3/ in base URL

### DIFF
--- a/plugins/source/github/client/client.go
+++ b/plugins/source/github/client/client.go
@@ -102,7 +102,8 @@ func New(ctx context.Context, logger zerolog.Logger, spec Spec) (schema.ClientMe
 		if spec.EnterpriseSettings == nil {
 			i, err = inst.NewConfig(auth.AppID, auth.InstallationID, k)
 		} else {
-			i, err = inst.NewEnterpriseConfig(spec.EnterpriseSettings.BaseURL, auth.AppID, auth.InstallationID, k)
+			trimmedBaseURL := strings.TrimSuffix(spec.EnterpriseSettings.BaseURL, "/api/v3/")
+			i, err = inst.NewEnterpriseConfig(trimmedBaseURL, auth.AppID, auth.InstallationID, k)
 		}
 		if err != nil {
 			return nil, fmt.Errorf("failed to create app config: %w", err)


### PR DESCRIPTION
<!-- 🎉 Thank you for making CloudQuery awesome by submitting a PR 🎉 -->

#### Summary

Hopefully this works, the URL for generating tokens is `https://<host>/app/installations/<id>/access_tokens`.
See:
https://docs.github.com/en/rest/apps/installations?apiVersion=2022-11-28
https://github.com/beatlabs/github-auth/blob/98862c3ce8f9e05391aa0d762e59c8159226a7f9/endpoint/endpoint.go#L9
https://github.com/beatlabs/github-auth/blob/98862c3ce8f9e05391aa0d762e59c8159226a7f9/endpoint/endpoint.go#L41
https://github.com/beatlabs/github-auth/blob/98862c3ce8f9e05391aa0d762e59c8159226a7f9/app/inst/config.go#L27


<!--
Explain what problem this PR addresses
-->

<!--
Use the following steps to ensure your PR is ready to be reviewed

- [ ] Read the [contribution guidelines](https://github.com/cloudquery/cloudquery/blob/main/CONTRIBUTING.md) 🧑‍🎓
- [ ] Run `make lint` to ensure the proposed changes follow the coding style 🚨 (install golangci-lint [here](https://golangci-lint.run/usage/install/#local-installation))
- [ ] Run `make test` to ensure the proposed changes pass the tests 🧪
- [ ] If changing a source plugin run `make gen` to ensure docs are up to date 📝
- [ ] Ensure the status checks below are successful ✅
--->
