### PR TITLE
chore: Revert "fix: Don't include `/api/v3/` in base URL passed to `inst.NewEnterpriseConfig`"

### DIFF
--- a/plugins/source/github/client/client.go
+++ b/plugins/source/github/client/client.go
@@ -102,8 +102,7 @@ func New(ctx context.Context, logger zerolog.Logger, spec Spec) (schema.ClientMe
 		if spec.EnterpriseSettings == nil {
 			i, err = inst.NewConfig(auth.AppID, auth.InstallationID, k)
 		} else {
-			trimmedBaseURL := strings.TrimSuffix(spec.EnterpriseSettings.BaseURL, "/api/v3/")
-			i, err = inst.NewEnterpriseConfig(trimmedBaseURL, auth.AppID, auth.InstallationID, k)
+			i, err = inst.NewEnterpriseConfig(spec.EnterpriseSettings.BaseURL, auth.AppID, auth.InstallationID, k)
 		}
 		if err != nil {
 			return nil, fmt.Errorf("failed to create app config: %w", err)


### PR DESCRIPTION
Reverts cloudquery/cloudquery#16834

This fix didn't work. I retracted the published version