### PR TITLE
chore: Revert "chore(main): Release plugins-source-github v8.0.2"

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -11,7 +11,7 @@
   "plugins/source/digitalocean+FILLER": "0.0.0",
   "plugins/source/gcp": "10.0.0",
   "plugins/source/gcp+FILLER": "0.0.0",
-  "plugins/source/github": "8.0.2",
+  "plugins/source/github": "8.0.1",
   "plugins/source/github+FILLER": "0.0.0",
   "plugins/source/k8s": "6.0.4",
   "plugins/source/k8s+FILLER": "0.0.0",

--- a/plugins/source/github/CHANGELOG.md
+++ b/plugins/source/github/CHANGELOG.md
@@ -1,12 +1,5 @@
 # Changelog
 
-## [8.0.2](https://github.com/cloudquery/cloudquery/compare/plugins-source-github-v8.0.1...plugins-source-github-v8.0.2) (2024-02-23)
-
-
-### Bug Fixes
-
-* Don't include `/api/v3/` in base URL passed to `inst.NewEnterpriseConfig` ([#16834](https://github.com/cloudquery/cloudquery/issues/16834)) ([63f50cd](https://github.com/cloudquery/cloudquery/commit/63f50cdd6437df82ef75f674222679df25b9b85f))
-
 ## [8.0.1](https://github.com/cloudquery/cloudquery/compare/plugins-source-github-v8.0.0...plugins-source-github-v8.0.1) (2024-02-23)
 
 


### PR DESCRIPTION
Reverts cloudquery/cloudquery#16835

This fix didn't work so I'm reverting it