### PR TITLE
feat: Provide `aws_neptune_host` option for Neptune IAM authentication over proxy

### DIFF
--- a/plugins/destination/gremlin/client/client.go
+++ b/plugins/destination/gremlin/client/client.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"net/url"
 	"strings"
 	"sync"
 	"time"
@@ -95,9 +96,23 @@ func (c *Client) getAuthInfo(ctx context.Context, baseURL string) (gremlingo.Aut
 		// emptyStringSHA256 is a SHA256 of an empty string
 		const emptyStringSHA256 = `e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855`
 
-		req, err := http.NewRequest(http.MethodGet, baseURL, strings.NewReader(""))
+		urlToSign := baseURL
+		if c.spec.AWSNeptuneHost != "" {
+			u, err := url.Parse(baseURL)
+			if err != nil {
+				return nil, err
+			}
+			u.Host = c.spec.AWSNeptuneHost // signer.SignHTTP will use this as the Host header
+			urlToSign = u.String()
+		}
+
+		req, err := http.NewRequest(http.MethodGet, urlToSign, strings.NewReader(""))
 		if err != nil {
 			return nil, err
+		}
+
+		if c.spec.AWSNeptuneHost != "" {
+			req.Header.Set("Host", c.spec.AWSNeptuneHost)
 		}
 
 		cfg, err := config.LoadDefaultConfig(ctx)

--- a/plugins/destination/gremlin/client/schema.json
+++ b/plugins/destination/gremlin/client/schema.json
@@ -175,6 +175,11 @@
           "type": "string",
           "description": "AWS region to use for AWS IAM authentication. Required when `auth_mode` is `aws`."
         },
+        "aws_neptune_host": {
+          "type": "string",
+          "pattern": "^[\\w\\.-]+$",
+          "description": "AWS Neptune host header to use with AWS IAM authentication. Required when `auth_mode` is `aws`."
+        },
         "max_concurrent_connections": {
           "type": "integer",
           "minimum": 1,

--- a/plugins/destination/gremlin/client/spec.go
+++ b/plugins/destination/gremlin/client/spec.go
@@ -33,6 +33,9 @@ type Spec struct {
 	// AWS region to use for AWS IAM authentication. Required when `auth_mode` is `aws`.
 	AWSRegion string `json:"aws_region"`
 
+	// AWS Neptune host header to use with AWS IAM authentication. Required when `auth_mode` is `aws`.
+	AWSNeptuneHost string `json:"aws_neptune_host" jsonschema:"pattern=^[\\w\\.-]+$"`
+
 	// Maximum number of concurrent connections to the database. Defaults to the number of CPUs.
 	MaxConcurrentConnections int `json:"max_concurrent_connections" jsonschema:"minimum=1"`
 

--- a/plugins/destination/gremlin/client/spec_test.go
+++ b/plugins/destination/gremlin/client/spec_test.go
@@ -80,8 +80,12 @@ func TestJSONSchema(t *testing.T) {
 			Err:  true,
 		},
 		{
-			Name: "spec with endpoint, auth_mode aws, region",
-			Spec: `{"endpoint": "ws://localhost:8182", "auth_mode": "aws", "aws_region":"reg"}`,
+			Name: "spec with endpoint, auth_mode aws, region, without host",
+			Spec: `{"endpoint": "ws://localhost:8182", "auth_mode": "aws", "aws_region":"us-east-1"}`,
+		},
+		{
+			Name: "spec with endpoint, auth_mode aws, region, host",
+			Spec: `{"endpoint": "ws://localhost:8182", "auth_mode": "aws", "aws_region":"us-east-1", "aws_neptune_host":"my-neptune.cluster-testtesttest.us-east-1.neptune.amazonaws.com"}`,
 		},
 		{
 			Name: "spec with bool endpoint",

--- a/plugins/destination/gremlin/docs/_configuration.md
+++ b/plugins/destination/gremlin/docs/_configuration.md
@@ -14,6 +14,7 @@ spec:
     # username: ""
     # password: ""
     # aws_region: ""
+    # aws_neptune_host: ""
     # max_retries: 5
     # max_concurrent_connections: 5 # default: number of CPUs
     # batch_size: 200

--- a/plugins/destination/gremlin/docs/overview.md
+++ b/plugins/destination/gremlin/docs/overview.md
@@ -69,6 +69,10 @@ This is the (nested) spec used by the Gremlin destination Plugin.
 
   AWS region to use for AWS IAM authentication.
 
+- `aws_neptune_host` (`string`) (optional, used when `auth_mode` is `aws`)
+
+  AWS Neptune host header to use with AWS IAM authentication. Use if you're not accessing Neptune directly, when `auth_mode` is `aws`.
+
 - `max_retries` (`integer`) (optional) (default: `5`)
 
   Number of retries on `ConcurrentModificationException` before giving up for each batch.


### PR DESCRIPTION
Recently tested AWS Neptune IAM auth over HAProxy and it didn't work.