### PR TITLE
fix!: Properly replace JSON values when using `athena: true`

### DIFF
--- a/plugins/destination/s3/client/write_test.go
+++ b/plugins/destination/s3/client/write_test.go
@@ -44,17 +44,17 @@ func TestSanitizeJSONKeys(t *testing.T) {
 		},
 		"foo:bar":     "baz",
 		"foo-bar-baz": []any{"baz", map[string]any{"foo:bar": "baz"}},
-		"string": map[string]string{
+		"string": map[string]any{
 			"foo-bar": "baz",
 		},
-		"int": map[string]int{
+		"int": map[string]any{
 			"foo-bar": 123,
 		},
-		"pointer": map[string]*string{
-			"foo-bar": &[]string{"baz"}[0],
+		"pointer": map[string]any{
+			"foo-bar": "baz",
 		},
 	}
-	sanitizeJSONKeysForObject(m)
+	sanitized := sanitizeJSONKeysForObject(m)
 	want := map[string]any{
 		"foo": "bar",
 		"bar": map[string]any{
@@ -62,17 +62,17 @@ func TestSanitizeJSONKeys(t *testing.T) {
 		},
 		"foo_bar":     "baz",
 		"foo_bar_baz": []any{"baz", map[string]any{"foo_bar": "baz"}},
-		"string": map[string]string{
+		"string": map[string]any{
 			"foo_bar": "baz",
 		},
-		"int": map[string]int{
+		"int": map[string]any{
 			"foo_bar": 123,
 		},
-		"pointer": map[string]*string{
-			"foo_bar": &[]string{"baz"}[0],
+		"pointer": map[string]any{
+			"foo_bar": "baz",
 		},
 	}
-	if diff := cmp.Diff(want, m); diff != "" {
+	if diff := cmp.Diff(want, sanitized); diff != "" {
 		t.Errorf("sanitizeJSONKeys() mismatch (-want +got):\n%s", diff)
 	}
 }

--- a/plugins/destination/s3/client/write_test.go
+++ b/plugins/destination/s3/client/write_test.go
@@ -10,28 +10,28 @@ import (
 	"github.com/google/go-cmp/cmp"
 )
 
-func TestSanitizeRawJsonMessage(t *testing.T) {
+func TestSanitizeJSONRawMessage(t *testing.T) {
 	testTable := []struct {
 		initialArray []byte
-		expected     []uint8
+		expected     any
 	}{
 		{
 			initialArray: []byte(`{"target": "localhost"}`),
-			expected:     []uint8(`{"target":"localhost"}`),
+			expected:     map[string]any{"target": "localhost"},
 		},
 		{
 			initialArray: []byte(`{"ta.rget*": "localhost**"}`),
-			expected:     []uint8(`{"ta_rget_":"localhost**"}`),
+			expected:     map[string]any{"ta_rget_": "localhost**"},
 		},
 	}
 	for _, test := range testTable {
 		data := (json.RawMessage)(test.initialArray)
-		bArray, err := sanitizeRawJsonMessage(data)
+		bArray, err := sanitizeJSONRawMessage(data)
 		if err != nil {
 			t.Errorf("unexpected error: %s", err)
 		}
 		if diff := cmp.Diff(bArray, test.expected); diff != "" {
-			t.Errorf("sanitizeRawJsonMessage() mismatch (-want +got):\n%s", diff)
+			t.Errorf("sanitizeJSONRawMessage() mismatch (-want +got):\n%s", diff)
 		}
 	}
 }


### PR DESCRIPTION
Instead of marshaling the `[]byte` array which obviously results in base64 encoding, pass objects to the `Append` directly.

BEGIN_COMMIT_OVERRIDE
fix: Properly replace JSON values when using `athena: true` (https://github.com/cloudquery/cloudquery/pull/16942)
BREAKING-CHANGE: Properly replace JSON values when using `athena: true` (https://github.com/cloudquery/cloudquery/pull/16942). Previously, `json` columns would have been sanitized & then marshaled twice, resulting in `base64` encoded bytes value. Now, the `json` columns have a proper object value.
END_COMMIT_OVERRIDE