### PR TITLE
fix: Remove okta domain validation

### DIFF
--- a/plugins/source/okta/client/schema.json
+++ b/plugins/source/okta/client/schema.json
@@ -34,7 +34,6 @@
         },
         "domain": {
           "type": "string",
-          "pattern": "^https?://[^\n\u003c\u003e]+\\.okta\\.com$",
           "description": "Specify the Okta domain you are fetching from.\n[Visit this link](https://developer.okta.com/docs/guides/find-your-domain/findorg/) to find your Okta domain."
         },
         "rate_limit": {

--- a/plugins/source/okta/client/spec.go
+++ b/plugins/source/okta/client/spec.go
@@ -17,7 +17,7 @@ type (
 
 		// Specify the Okta domain you are fetching from.
 		// [Visit this link](https://developer.okta.com/docs/guides/find-your-domain/findorg/) to find your Okta domain.
-		Domain    string     `json:"domain" jsonschema:"required,pattern=^https?://[^\n<>]+\\.okta\\.com$"`
+		Domain    string     `json:"domain" jsonschema:"required"`
 		RateLimit *RateLimit `json:"rate_limit"`
 
 		// Enables debug logs within the Okta SDK.

--- a/plugins/source/okta/client/spec_test.go
+++ b/plugins/source/okta/client/spec_test.go
@@ -29,9 +29,24 @@ func TestJSONSchema(t *testing.T) {
 			Spec: `{"token": "tok", "domain": "https://domain.okta.com"}`,
 		},
 		{
-			Name: "spec with token and invalid domain",
+			Name: "spec with token and default domain",
+			Spec: `{"token": "tok", "domain": "https://domain.okta.com/"}`,
+		},
+		{
+			Name: "spec with token and preview domain",
+			Spec: `{"token": "tok", "domain": "https://domain.oktapreview.com"}`,
+		},
+		{
+			Name: "spec with token and emea domain",
+			Spec: `{"token": "tok", "domain": "https://domain.okta-emea.com"}`,
+		},
+		{
+			Name: "spec with token and env domain",
+			Spec: `{"token": "tok", "domain": "https://${OKTA_DOMAIN}.okta.com"}`,
+		},
+		{
+			Name: "spec with token and example domain",
 			Spec: `{"token": "tok", "domain": "https://<CHANGE_THIS_TO_YOUR_OKTA_DOMAIN>.okta.com"}`,
-			Err:  true,
 		},
 		{
 			Name: "spec with token and domain and empty rate limit",

--- a/plugins/source/okta/docs/_configuration.md
+++ b/plugins/source/okta/docs/_configuration.md
@@ -9,8 +9,8 @@ spec:
   tables: ["*"]
   destinations: ["DESTINATION_NAME"]
   spec:
-    # Okta domain name
-    domain: "https://<YOUR_OKTA_DOMAIN>.okta.com/"
+    # Okta domain name, for example: https://example.okta.com, https://example.okta-emea.com,  https://example.oktapreview.com
+    domain: "${OKTA_DOMAIN}"
     # Okta Token to access API
     token: "${OKTA_ACCESS_TOKEN}"
 
@@ -18,5 +18,4 @@ spec:
     # rate_limit:
     #   max_backoff: 5s
     #   max_retries: 3
-
 ```


### PR DESCRIPTION
<!-- 🎉 Thank you for making CloudQuery awesome by submitting a PR 🎉 -->

#### Summary

Looks like the domain validation is too strict as it doesn't allow for the following valid values (or trailing slashed in the URL):
![image](https://github.com/cloudquery/cloudquery/assets/26760571/57c47485-0f17-4aba-8791-f6e2e6e22e25)

I removed it altogether as I think we can let the Go library fail incase the domain is invalid

<!--
Use the following steps to ensure your PR is ready to be reviewed

- [ ] Read the [contribution guidelines](https://github.com/cloudquery/cloudquery/blob/main/CONTRIBUTING.md) 🧑‍🎓
- [ ] Run `make lint` to ensure the proposed changes follow the coding style 🚨 (install golangci-lint [here](https://golangci-lint.run/usage/install/#local-installation))
- [ ] Run `make test` to ensure the proposed changes pass the tests 🧪
- [ ] If changing a source plugin run `make gen` to ensure docs are up to date 📝
- [ ] Ensure the status checks below are successful ✅
--->
