### PR TITLE
fix: Adding firehose stream environment variable

### DIFF
--- a/plugins/destination/firehose/client/spec/spec.go
+++ b/plugins/destination/firehose/client/spec/spec.go
@@ -27,7 +27,7 @@ type Spec struct {
 }
 
 func (s *Spec) SetDefaults() {
-	if s.MaxRetries < 0 {
+	if s.MaxRetries < 1 {
 		s.MaxRetries = 5
 	}
 	if s.MaxRecordSizeBytes < 1 {

--- a/plugins/destination/firehose/docs/_configuration.md
+++ b/plugins/destination/firehose/docs/_configuration.md
@@ -7,7 +7,8 @@ spec:
   version: "VERSION_DESTINATION_FIREHOSE"
   write_mode: "append" # this plugin only supports 'append' mode
   spec:
-    stream_arn: "arn:aws:firehose:us-east-1:111122223333:deliverystream/TestRedshiftStream"
+    # Required parameters e.g. arn:aws:firehose:us-east-1:111122223333:deliverystream/TestRedshiftStream
+    stream_arn: "${FIREHOSE_STREAM_ARN}"
     # Optional parameters
     # max_retries: 5
     # max_record_size_bytes: 1024000 # optional


### PR DESCRIPTION
* Set environment variables in configuration
* Fix default `max_retries` - preventing the default from being `0`