### PR TITLE
fix: Remove stream_arn regex validation

### DIFF
--- a/plugins/destination/firehose/client/spec/schema.json
+++ b/plugins/destination/firehose/client/spec/schema.json
@@ -7,7 +7,7 @@
       "properties": {
         "stream_arn": {
           "type": "string",
-          "pattern": "^arn:[^:]+:firehose:[^:]+:[^:]+:deliverystream/[^:]+$",
+          "pattern": "^arn:[^:]+:firehose:[^:]+:[^:]+:deliverystream\\/[^:]+$",
           "description": "Kinesis Firehose delivery stream ARN where data will be sent to.\nFormat: `arn:${Partition}:firehose:${Region}:${Account}:deliverystream/${DeliveryStreamName}`."
         },
         "max_retries": {

--- a/plugins/destination/firehose/client/spec/schema.json
+++ b/plugins/destination/firehose/client/spec/schema.json
@@ -7,7 +7,7 @@
       "properties": {
         "stream_arn": {
           "type": "string",
-          "pattern": "^arn:[^:]+:firehose:[^:]+:[^:]+:deliverystream\\/[^:]+$",
+          "minLength": 1,
           "description": "Kinesis Firehose delivery stream ARN where data will be sent to.\nFormat: `arn:${Partition}:firehose:${Region}:${Account}:deliverystream/${DeliveryStreamName}`."
         },
         "max_retries": {

--- a/plugins/destination/firehose/client/spec/spec.go
+++ b/plugins/destination/firehose/client/spec/spec.go
@@ -11,7 +11,7 @@ import (
 type Spec struct {
 	// Kinesis Firehose delivery stream ARN where data will be sent to.
 	// Format: `arn:${Partition}:firehose:${Region}:${Account}:deliverystream/${DeliveryStreamName}`.
-	StreamARN string `json:"stream_arn" jsonschema:"required,pattern=^arn:[^:]+:firehose:[^:]+:[^:]+:deliverystream/[^:]+$"`
+	StreamARN string `json:"stream_arn" jsonschema:"required,pattern=^arn:[^:]+:firehose:[^:]+:[^:]+:deliverystream\\/[^:]+$"`
 
 	// Amount of retries to perform when writing a batch.
 	MaxRetries int `json:"max_retries,omitempty" jsonschema:"minimum=1,default=5"`

--- a/plugins/destination/firehose/client/spec/spec.go
+++ b/plugins/destination/firehose/client/spec/spec.go
@@ -11,7 +11,7 @@ import (
 type Spec struct {
 	// Kinesis Firehose delivery stream ARN where data will be sent to.
 	// Format: `arn:${Partition}:firehose:${Region}:${Account}:deliverystream/${DeliveryStreamName}`.
-	StreamARN string `json:"stream_arn" jsonschema:"required,pattern=^arn:[^:]+:firehose:[^:]+:[^:]+:deliverystream\\/[^:]+$"`
+	StreamARN string `json:"stream_arn" jsonschema:"required,minLength=1"`
 
 	// Amount of retries to perform when writing a batch.
 	MaxRetries int `json:"max_retries,omitempty" jsonschema:"minimum=1,default=5"`

--- a/plugins/destination/firehose/client/spec/spec_test.go
+++ b/plugins/destination/firehose/client/spec/spec_test.go
@@ -29,21 +29,6 @@ func TestSpec_JSONSchema(t *testing.T) {
 			Err:  true,
 		},
 		{
-			Name: "bad stream_arn",
-			Spec: `{"stream_arn": "abc"}`,
-			Err:  true,
-		},
-		{
-			Name: "bad stream_arn service",
-			Spec: `{"stream_arn": "arn:aws:kinesis:us-east-1:01234:stream/name"}`,
-			Err:  true,
-		},
-		{
-			Name: "missing stream name in stream_arn",
-			Spec: `{"stream_arn": "arn:aws:firehose:us-east-1:01234:deliverystream"}`,
-			Err:  true,
-		},
-		{
 			Name: "proper stream_arn",
 			Spec: `{"stream_arn": "arn:aws:firehose:us-east-1:01234:deliverystream/name"}`,
 		},


### PR DESCRIPTION
The frontend was showing the following validation error:

`jsonschema: '/stream_arn' does not validate with https://github.com/cloudquery/cloudquery/plugins/destination/firehose/client/spec/spec#/$ref/properties/stream_arn/pattern: does not match pattern '^arn:[^:]+:firehose:[^:]+:[^:]+:deliverystream/[^:]+$'`

Which I think is down to the `/` needing to be escaped. The `spec_test.go` tests still pass with this, so will give it a go.