### PR TITLE
chore: If both CLI and Scaffold are updated, validate both

### DIFF
--- a/scripts/workflows/wait_for_required_workflows.js
+++ b/scripts/workflows/wait_for_required_workflows.js
@@ -33,13 +33,13 @@ module.exports = async ({github, context}) => {
         return
     }
 
-    // Validate Go Releaser only if we are testing the CLI or scaffold
-    if (actions.includes("cli") || actions.includes("scaffold")) {
+    if (actions.includes("scaffold")) {
         actions = [...actions, 'validate-release']
     }
 
     // We test the CLI on multiple OSes, so we need to wait for all of them
     if (actions.includes("cli")) {
+        actions = [...actions, 'validate-release']
         actions = actions.filter(action => action !== "cli")
         actions = ["cli (ubuntu-latest)", "cli (windows-latest)", "cli (macos-latest)", ...actions]
     }


### PR DESCRIPTION
<!-- 🎉 Thank you for making CloudQuery awesome by submitting a PR 🎉 -->

#### Summary

If both CLI and Scaffold were changed we should add `validate-release` for each one

<!--
Use the following steps to ensure your PR is ready to be reviewed

- [ ] Read the [contribution guidelines](https://github.com/cloudquery/cloudquery/blob/main/CONTRIBUTING.md) 🧑‍🎓
- [ ] Run `make lint` to ensure the proposed changes follow the coding style 🚨 (install golangci-lint [here](https://golangci-lint.run/usage/install/#local-installation))
- [ ] Run `make test` to ensure the proposed changes pass the tests 🧪
- [ ] If changing a source plugin run `make gen` to ensure docs are up to date 📝
- [ ] Ensure the status checks below are successful ✅
--->
