### PR TITLE
fix: Clean env prefixes for cloud syncs

### DIFF
--- a/cli/cmd/sync.go
+++ b/cli/cmd/sync.go
@@ -302,7 +302,8 @@ func sync(cmd *cobra.Command, args []string) error {
 
 func filterPluginEnv(environ []string, pluginName, kind string) []string {
 	env := make([]string, 0)
-	prefix := "__" + kind + "_" + pluginName + "__"
+	cleanName := strings.ReplaceAll(pluginName, "-", "_")
+	prefix := strings.ToUpper("__" + kind + "_" + cleanName + "__")
 	for _, v := range environ {
 		if strings.HasPrefix(v, "CLOUDQUERY_API_KEY=") || strings.HasPrefix(v, "_CQ_TEAM_NAME=") {
 			env = append(env, v)

--- a/cli/cmd/sync_test.go
+++ b/cli/cmd/sync_test.go
@@ -148,7 +148,7 @@ func TestSync_IsolatedPluginEnvironmentsInCloud(t *testing.T) {
 	t.Setenv("_CQ_TEAM_NAME", "test_team")
 	t.Setenv("_CQ_SYNC_NAME", "test_sync")
 	t.Setenv("_CQ_SYNC_RUN_ID", uuid.Must(uuid.NewUUID()).String())
-	t.Setenv("__source_test__TEST_KEY", "test_value")
+	t.Setenv("__SOURCE_TEST__TEST_KEY", "test_value")
 	t.Setenv("NOT_TEST_ENV", "should_not_be_visible_to_plugin")
 
 	for _, tc := range configs {


### PR DESCRIPTION
This replaces dashes in plugin names with underscores, and makes the entire prefix upper case, in order to get valid, consistent environment variables.