### PR TITLE
fix: Ensure not adding duplicate CQ columns

### DIFF
--- a/cli/internal/transformer/transformer.go
+++ b/cli/internal/transformer/transformer.go
@@ -72,10 +72,10 @@ func NewRecordTransformer(opts ...RecordTransformerOption) *RecordTransformer {
 
 func (t *RecordTransformer) TransformSchema(sc *arrow.Schema) *arrow.Schema {
 	fields := make([]arrow.Field, 0, len(sc.Fields())+t.internalColumns)
-	if t.withSyncTime {
+	if t.withSyncTime && !fieldExists(cqSyncTime, sc) {
 		fields = append(fields, arrow.Field{Name: cqSyncTime, Type: arrow.FixedWidthTypes.Timestamp_us, Nullable: true})
 	}
-	if t.withSourceName {
+	if t.withSourceName && !fieldExists(cqSourceName, sc) {
 		fields = append(fields, arrow.Field{Name: cqSourceName, Type: arrow.BinaryTypes.String, Nullable: true})
 	}
 	for _, field := range sc.Fields() {
@@ -105,19 +105,29 @@ func (t *RecordTransformer) TransformSchema(sc *arrow.Schema) *arrow.Schema {
 	return arrow.NewSchema(fields, &scMd)
 }
 
+func fieldExists(name string, sc *arrow.Schema) bool {
+	for _, field := range sc.Fields() {
+		if field.Name == name {
+			return true
+		}
+	}
+	return false
+}
+
 func (t *RecordTransformer) Transform(record arrow.Record) arrow.Record {
 	sc := record.Schema()
 	newSchema := t.TransformSchema(sc)
 	nRows := int(record.NumRows())
+
 	cols := make([]arrow.Array, 0, len(sc.Fields())+t.internalColumns)
-	if t.withSyncTime {
+	if t.withSyncTime && !fieldExists(cqSyncTime, sc) {
 		syncTimeBldr := array.NewTimestampBuilder(memory.DefaultAllocator, &arrow.TimestampType{Unit: arrow.Microsecond, TimeZone: "UTC"})
 		for i := 0; i < nRows; i++ {
 			syncTimeBldr.AppendTime(t.syncTime)
 		}
 		cols = append(cols, syncTimeBldr.NewArray())
 	}
-	if t.withSourceName {
+	if t.withSourceName && !fieldExists(cqSourceName, sc) {
 		sourceBldr := array.NewStringBuilder(memory.DefaultAllocator)
 		for i := 0; i < nRows; i++ {
 			sourceBldr.Append(t.sourceName)


### PR DESCRIPTION
<!-- 🎉 Thank you for making CloudQuery awesome by submitting a PR 🎉 -->

#### Summary

If user syncs CQ data from a data source, the sync will fail because the CLI always adds `cqsynctime` and `cqsource`. This pr only adds the columns if they are not present