### PR TITLE
chore: Publish ubuntu-based CLI image

### DIFF
--- a/cli/.goreleaser.yaml
+++ b/cli/.goreleaser.yaml
@@ -37,6 +37,32 @@ dockers:
       - "--pull"
       - "--platform=linux/arm64"
       - "--label=org.opencontainers.image.source=https://github.com/cloudquery/cloudquery"
+  -
+    goos: linux
+    goarch: amd64
+    dockerfile: Dockerfile.ubuntu.goreleaser
+    image_templates:
+      - "ghcr.io/cloudquery/cloudquery:latest-ubuntu-amd64"
+      - "ghcr.io/cloudquery/cloudquery:{{.Version}}-ubuntu-amd64"
+      - "ghcr.io/cloudquery/cloudquery:{{ .Major }}.{{ .Minor }}-ubuntu-amd64"
+    use: buildx
+    build_flag_templates:
+      - "--pull"
+      - "--platform=linux/amd64"
+      - "--label=org.opencontainers.image.source=https://github.com/cloudquery/cloudquery"
+  -
+    goos: linux
+    goarch: arm64
+    dockerfile: Dockerfile.ubuntu.goreleaser
+    image_templates:
+      - "ghcr.io/cloudquery/cloudquery:latest-ubuntu-arm64"
+      - "ghcr.io/cloudquery/cloudquery:{{.Version}}-ubuntu-arm64"
+      - "ghcr.io/cloudquery/cloudquery:{{ .Major }}.{{ .Minor }}-ubuntu-arm64"
+    use: buildx
+    build_flag_templates:
+      - "--pull"
+      - "--platform=linux/arm64"
+      - "--label=org.opencontainers.image.source=https://github.com/cloudquery/cloudquery"
 
 docker_manifests:
 - name_template: "ghcr.io/cloudquery/cloudquery:{{.Version}}"
@@ -53,6 +79,7 @@ docker_manifests:
   image_templates:
   - "ghcr.io/cloudquery/cloudquery:{{ .Major }}.{{ .Minor }}-linux-amd64"
   - "ghcr.io/cloudquery/cloudquery:{{ .Major }}.{{ .Minor }}-linux-arm64"
+
 
 brews:
   -

--- a/cli/Dockerfile.ubuntu.goreleaser
+++ b/cli/Dockerfile.ubuntu.goreleaser
@@ -1,0 +1,7 @@
+FROM ubuntu:22.04
+RUN apt-get update
+RUN apt-get install ca-certificates -y
+RUN update-ca-certificates
+ENTRYPOINT ["/app/cloudquery"]
+WORKDIR /app
+COPY cloudquery ./cloudquery


### PR DESCRIPTION
The Ubuntu-based image can be used to run plugins that require glibc, such as the DuckDB destination plugin.