### PR TITLE
chore: Fix broken link in Kestra guide

### DIFF
--- a/website/pages/docs/deployment/kestra.mdx
+++ b/website/pages/docs/deployment/kestra.mdx
@@ -113,4 +113,4 @@ With this in place, remember to click `Save` again. Your CloudQuery sync will no
 
 This tutorial was just a quick introduction to help you get started with a CloudQuery deployment on [Kestra](https://kestra.io/). You can now create additional Kestra tasks to perform transformations, send notifications and more. For more information, check out the [CloudQuery docs](/docs) and the [Kestra docs](https://kestra.io/docs/). 
 
-To productionize your Kestra deployment, you will likely need to deploy it to a cloud environment, such as Kubernetes. For more information, see the [Kestra Deployment with Kubernetes guide](https://kestra.io/docs/administrator-guide/deployment/kubernetes) and if you have any questions, you can reach the Kestra team [via Community Slack](https://kestra.io/slack).
+To productionize your Kestra deployment, you will likely need to deploy it to a cloud environment, such as Kubernetes. For more information, see the [Kestra Deployment with Kubernetes guide](https://kestra.io/docs/installation/kubernetes) and if you have any questions, you can reach the Kestra team [via Community Slack](https://kestra.io/slack).


### PR DESCRIPTION
<!-- 🎉 Thank you for making CloudQuery awesome by submitting a PR 🎉 -->

#### Summary

Current link is 404, this is the best replacement I found

<!--
Use the following steps to ensure your PR is ready to be reviewed

- [ ] Read the [contribution guidelines](https://github.com/cloudquery/cloudquery/blob/main/CONTRIBUTING.md) 🧑‍🎓
- [ ] Run `make lint` to ensure the proposed changes follow the coding style 🚨 (install golangci-lint [here](https://golangci-lint.run/usage/install/#local-installation))
- [ ] Run `make test` to ensure the proposed changes pass the tests 🧪
- [ ] If changing a source plugin run `make gen` to ensure docs are up to date 📝
- [ ] Ensure the status checks below are successful ✅
--->
