### PR TITLE
fix: Retry on network errors

### DIFF
--- a/plugins/source/hackernews/client/errors.go
+++ b/plugins/source/hackernews/client/errors.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"math/rand"
+	"net"
 	"net/http"
 	"time"
 
@@ -36,5 +37,6 @@ func isRetryable(err error) bool {
 	if errors.As(err, &httpErr) {
 		return httpErr.Code >= http.StatusInternalServerError || httpErr.Code == http.StatusTooManyRequests
 	}
-	return false
+	var opErr *net.OpError
+	return errors.As(err, &opErr)
 }


### PR DESCRIPTION
Should help address this error:

```
[2024-03-04 15:05:55:000] | ERROR | {"module":"hackernews-src","client":"hackernews","error":"while getting item: Get \"https://hacker-news.firebaseio.com/v0/item/39551242.json\": dial tcp 35.201.97.85:443: i/o timeout","message":"table resolver finished with error","table":"hackernews_items"}
```