### PR TITLE
chore: Revert "chore(main): Release plugins-source-airtable v2.1.1"

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -101,7 +101,7 @@
   "plugins/source/jira+FILLER": "0.0.0",
   "plugins/source/vault": "1.0.8",
   "plugins/source/vault+FILLER": "0.0.0",
-  "plugins/source/airtable": "2.1.1",
+  "plugins/source/airtable": "2.1.0",
   "plugins/source/airtable+FILLER": "0.0.0",
   "plugins/source/bitbucket": "1.1.0",
   "plugins/source/bitbucket+FILLER": "0.0.0",

--- a/plugins/source/airtable/CHANGELOG.md
+++ b/plugins/source/airtable/CHANGELOG.md
@@ -1,13 +1,5 @@
 # Changelog
 
-## [2.1.1](https://github.com/cloudquery/cloudquery/compare/plugins-source-airtable-v2.1.0...plugins-source-airtable-v2.1.1) (2024-03-05)
-
-
-### Bug Fixes
-
-* **deps:** Update dependency @cloudquery/plugin-sdk-javascript to v0.1.7 ([#16990](https://github.com/cloudquery/cloudquery/issues/16990)) ([73fdf0b](https://github.com/cloudquery/cloudquery/commit/73fdf0be450689917e86f2fbb1b4b2f7fe02279f))
-* **deps:** Update dependency @types/uuid to v9.0.8 ([#16983](https://github.com/cloudquery/cloudquery/issues/16983)) ([cb0c9b2](https://github.com/cloudquery/cloudquery/commit/cb0c9b213936b662b385f81400fe43edd8e93fea))
-
 ## [2.1.0](https://github.com/cloudquery/cloudquery/compare/plugins-source-airtable-v2.0.2...plugins-source-airtable-v2.1.0) (2024-02-13)
 
 

--- a/plugins/source/airtable/package-lock.json
+++ b/plugins/source/airtable/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@cloudquery/cq-source-airtable",
-  "version": "2.1.1",
+  "version": "2.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@cloudquery/cq-source-airtable",
-      "version": "2.1.1",
+      "version": "2.1.0",
       "license": "MPL-2.0",
       "dependencies": {
         "@cloudquery/plugin-sdk-javascript": "^0.1.6",

--- a/plugins/source/airtable/package.json
+++ b/plugins/source/airtable/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cloudquery/cq-source-airtable",
-  "version": "2.1.1",
+  "version": "2.1.0",
   "description": "A CloudQuery source plugin to sync data from Airtable",
   "keywords": [
     "nodejs",


### PR DESCRIPTION
Reverts cloudquery/cloudquery#16984

We need to re-do this release since it failed https://github.com/cloudquery/cloudquery/actions/runs/8155813989/job/22292120213#step:12:12

[New CLI](https://github.com/cloudquery/cloudquery/pull/17019) has [this fix](https://github.com/cloudquery/plugin-pb-go/pull/272) for it