### PR TITLE
feat: Include Object Paths in S3 sync summary

### DIFF
--- a/plugins/destination/s3/client/client.go
+++ b/plugins/destination/s3/client/client.go
@@ -37,12 +37,20 @@ type Client struct {
 	uploader            *manager.Uploader
 	downloader          *manager.Downloader
 	jsonFiletypesClient *filetypes.Client
-	objectKeys          map[string][]string
+	objectKeys          keyMap
 }
+
+type keyMap struct {
+	keys    map[string][]string
+	limit   int
+	current int
+}
+
+const MAX_KEYS = 10000
 
 func New(ctx context.Context, logger zerolog.Logger, s []byte, opts plugin.NewClientOptions) (plugin.Client, error) {
 	c := &Client{
-		logger: logger.With().Str("module", "s3").Logger(), objectKeys: map[string][]string{},
+		logger: logger.With().Str("module", "s3").Logger(), objectKeys: keyMap{map[string][]string{}, MAX_KEYS, 0},
 	}
 	if opts.NoConnection {
 		return c, nil

--- a/plugins/destination/s3/client/spec/spec.go
+++ b/plugins/destination/s3/client/spec/spec.go
@@ -181,10 +181,21 @@ func (s *Spec) Validate() error {
 
 func (s *Spec) ReplacePathVariables(table string, fileIdentifier string, t time.Time) string {
 	name := strings.ReplaceAll(s.Path, varTable, table)
+
+	if table == "cloudquery_sync_summary" {
+		name = strings.ReplaceAll(name, varFormat, "json")
+		fullSuffix := string(s.Format) + s.Compression.Extension()
+		if strings.HasSuffix(s.Path, fullSuffix) {
+			name = strings.TrimSuffix(name, fullSuffix)
+			name += "json"
+		}
+	}
+
 	if strings.Contains(name, varFormat) {
 		e := string(s.Format) + s.Compression.Extension()
 		name = strings.ReplaceAll(name, varFormat, e)
 	}
+
 	name = strings.ReplaceAll(name, varUUID, fileIdentifier)
 	name = strings.ReplaceAll(name, varYear, t.Format("2006"))
 	name = strings.ReplaceAll(name, varMonth, t.Format("01"))

--- a/plugins/destination/s3/client/summary.go
+++ b/plugins/destination/s3/client/summary.go
@@ -1,0 +1,47 @@
+package client
+
+import (
+	"github.com/apache/arrow/go/v15/arrow"
+	"github.com/apache/arrow/go/v15/arrow/array"
+	"github.com/apache/arrow/go/v15/arrow/memory"
+	"github.com/cloudquery/plugin-sdk/v4/types"
+)
+
+func (c *Client) addObjectsSyncedToSummary(record arrow.Record) arrow.Record {
+	sc := record.Schema()
+	newSchema := transformSchema(sc)
+	nRows := int(record.NumRows())
+
+	cols := make([]arrow.Array, 0, len(newSchema.Fields())+1)
+
+	objKeyBuilder := types.NewJSONBuilder(array.NewExtensionBuilder(memory.DefaultAllocator, types.NewJSONType()))
+	for i := 0; i < nRows; i++ {
+		objKeyBuilder.Append(c.objectKeys)
+	}
+	cols = append(cols, objKeyBuilder.NewArray())
+
+	for i := range sc.Fields() {
+		cols = append(cols, record.Column(i))
+	}
+
+	return array.NewRecord(newSchema, cols, int64(nRows))
+}
+
+func transformSchema(sc *arrow.Schema) *arrow.Schema {
+	fields := make([]arrow.Field, 0, len(sc.Fields())+1)
+	fields = append(fields, arrow.Field{Name: "objects_synced", Type: &types.JSONType{}, Nullable: true})
+	for _, field := range sc.Fields() {
+		mdMap := field.Metadata.ToMap()
+
+		newMd := arrow.MetadataFrom(mdMap)
+
+		fields = append(fields, arrow.Field{
+			Name:     field.Name,
+			Type:     field.Type,
+			Nullable: field.Nullable,
+			Metadata: newMd,
+		})
+	}
+	scMd := sc.Metadata()
+	return arrow.NewSchema(fields, &scMd)
+}

--- a/plugins/destination/s3/client/write.go
+++ b/plugins/destination/s3/client/write.go
@@ -39,7 +39,7 @@ func (c *Client) WriteTable(ctx context.Context, msgs <-chan *message.WriteInser
 				c.logger.Warn().Msgf("maximum key limit reached, no more keys will be added to the `cloudquery_sync_summary` file")
 			}
 
-			if table.Name == "cloudquery_sync_summary" {
+			if table.Name == "_cq_sync_summary" {
 				msg.Record = c.addObjectsSyncedToSummary(msg.Record)
 				table = msg.GetTable()
 				// The summary table is always represented as a JSON file


### PR DESCRIPTION
<!-- 🎉 Thank you for making CloudQuery awesome by submitting a PR 🎉 -->

This PR adds in a column that will include the full keys of all objects synced in the sync

`objects_synced` contains a `map[string][]string` where the map key is the table name and the array of strings are the object keys


```
{
  "_cq_source_name": "aws",
  "_cq_sync_time": "2024-03-11 17:11:16.369293",
  "cli_version": "development",
  "destination_name": "s3",
  "destination_path": "localhost:7778",
  "destination_version": null,
  "errors": 9,
  "objects_synced": {
    "aws_s3_buckets": [
      "aws_s3_buckets/8c862045-ed27-43f4-a70d-2b5f955e0748.parquet"
    ]
  },
  "resources": 29,
  "source_name": "aws",
  "source_path": "cloudquery/aws",
  "source_version": "v25.2.0",
  "sync_id": "a61ca899-1210-497b-ba1d-f442c26792a3",
  "warnings": 1
}
```

This is an extension of https://github.com/cloudquery/cloudquery/pull/17112