### PR TITLE
fix: Redirect to Cloud signup

### DIFF
--- a/website/next.config.mjs
+++ b/website/next.config.mjs
@@ -218,6 +218,11 @@ export default withNextra({
         permanent: true,
         destination: "https://github.com/cloudquery/cloudquery/releases",
       },
+      {
+        source: "/register-for-cloud",
+        permanent: true,
+        destination: "https://cloud.cloudquery.io/auth/register",
+      }
     ];
   },
   webpack: (config) => {


### PR DESCRIPTION
Redirecting from cloud signup form to the actual signup url