### PR TITLE
feat: Support `private_key` env variable

### DIFF
--- a/plugins/source/oracle/client/configProvider.go
+++ b/plugins/source/oracle/client/configProvider.go
@@ -20,7 +20,7 @@ type rawPrivateKeyConfigProvider struct {
 }
 
 func (rawPrivateKeyConfigProvider) PrivateRSAKey() (*rsa.PrivateKey, error) {
-	const(
+	const (
 		tfVarEnvironmentVariable = tfVarEnvironmentVariable + "private_key"
 		ocCLIEnvironmentVariable = ocCLIEnvironmentVariable + "private_key"
 	)

--- a/plugins/source/oracle/client/configProvider.go
+++ b/plugins/source/oracle/client/configProvider.go
@@ -1,0 +1,82 @@
+package client
+
+import (
+	"crypto/rsa"
+	"errors"
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/oracle/oci-go-sdk/v65/common"
+)
+
+const (
+	tfVarEnvironmentVariable = "TF_VAR"
+	ocCLIEnvironmentVariable = "OCI_CLI"
+)
+
+type rawPrivateKeyConfigProvider struct {
+	provider common.ConfigurationProvider
+}
+
+func (r rawPrivateKeyConfigProvider) AuthType() (common.AuthConfig, error) {
+	return r.provider.AuthType()
+}
+
+func (r rawPrivateKeyConfigProvider) KeyFingerprint() (string, error) {
+	return r.provider.KeyFingerprint()
+}
+
+func (r rawPrivateKeyConfigProvider) KeyID() (string, error) {
+	return r.provider.KeyID()
+}
+
+func (r rawPrivateKeyConfigProvider) PrivateRSAKey() (*rsa.PrivateKey, error) {
+	tfVarEnvironmentVariable := fmt.Sprintf("%s_%s", tfVarEnvironmentVariable, "private_key")
+	ocCLIEnvironmentVariable := fmt.Sprintf("%s_%s", ocCLIEnvironmentVariable, "private_key")
+	var envName string
+	var ok bool
+	var value string
+	var err error
+	envsToTry := []string{tfVarEnvironmentVariable, ocCLIEnvironmentVariable}
+	for _, env := range envsToTry {
+		if value, ok = os.LookupEnv(env); ok {
+			envName = env
+			break
+		}
+	}
+	if !ok {
+		err = errors.Join(err, fmt.Errorf("can not read PrivateKey from env variable: %s", tfVarEnvironmentVariable))
+		err = errors.Join(err, fmt.Errorf("can not read PrivateKey from env variable: %s", ocCLIEnvironmentVariable))
+		return nil, err
+	}
+	withLineBreaksNormalized := strings.ReplaceAll(value, "\\n", "\n")
+	privateKey, err := common.PrivateKeyFromBytesWithPassword([]byte(withLineBreaksNormalized), nil)
+	if err != nil {
+		return nil, fmt.Errorf("can not parse PrivateKey from env variable: %s", envName)
+	}
+
+	return privateKey, nil
+}
+
+func (r rawPrivateKeyConfigProvider) Region() (string, error) {
+	return r.provider.Region()
+}
+
+func (r rawPrivateKeyConfigProvider) TenancyOCID() (string, error) {
+	return r.provider.TenancyOCID()
+}
+
+func (r rawPrivateKeyConfigProvider) UserOCID() (string, error) {
+	return r.provider.UserOCID()
+}
+
+func newRawPrivateKeyConfigProvider() rawPrivateKeyConfigProvider {
+	tfVarEnvProvider := common.ConfigurationProviderEnvironmentVariables(tfVarEnvironmentVariable, "")
+	ociCLIEnvProvider := common.ConfigurationProviderEnvironmentVariables(ocCLIEnvironmentVariable, "")
+	// ComposingConfigurationProvider fails on empty provider list or nil provider so we can safely ignore the error
+	provider, _ := common.ComposingConfigurationProvider([]common.ConfigurationProvider{tfVarEnvProvider, ociCLIEnvProvider})
+	return rawPrivateKeyConfigProvider{
+		provider: provider,
+	}
+}

--- a/plugins/source/oracle/client/configProvider.go
+++ b/plugins/source/oracle/client/configProvider.go
@@ -16,19 +16,7 @@ const (
 )
 
 type rawPrivateKeyConfigProvider struct {
-	provider common.ConfigurationProvider
-}
-
-func (r rawPrivateKeyConfigProvider) AuthType() (common.AuthConfig, error) {
-	return r.provider.AuthType()
-}
-
-func (r rawPrivateKeyConfigProvider) KeyFingerprint() (string, error) {
-	return r.provider.KeyFingerprint()
-}
-
-func (r rawPrivateKeyConfigProvider) KeyID() (string, error) {
-	return r.provider.KeyID()
+	common.ConfigurationProvider
 }
 
 func (rawPrivateKeyConfigProvider) PrivateRSAKey() (*rsa.PrivateKey, error) {
@@ -59,24 +47,12 @@ func (rawPrivateKeyConfigProvider) PrivateRSAKey() (*rsa.PrivateKey, error) {
 	return privateKey, nil
 }
 
-func (r rawPrivateKeyConfigProvider) Region() (string, error) {
-	return r.provider.Region()
-}
-
-func (r rawPrivateKeyConfigProvider) TenancyOCID() (string, error) {
-	return r.provider.TenancyOCID()
-}
-
-func (r rawPrivateKeyConfigProvider) UserOCID() (string, error) {
-	return r.provider.UserOCID()
-}
-
 func newRawPrivateKeyConfigProvider() rawPrivateKeyConfigProvider {
 	tfVarEnvProvider := common.ConfigurationProviderEnvironmentVariables(tfVarEnvironmentVariable, "")
 	ociCLIEnvProvider := common.ConfigurationProviderEnvironmentVariables(ocCLIEnvironmentVariable, "")
 	// ComposingConfigurationProvider fails on empty provider list or nil provider so we can safely ignore the error
 	provider, _ := common.ComposingConfigurationProvider([]common.ConfigurationProvider{tfVarEnvProvider, ociCLIEnvProvider})
 	return rawPrivateKeyConfigProvider{
-		provider: provider,
+		ConfigurationProvider: provider,
 	}
 }

--- a/plugins/source/oracle/client/configProvider.go
+++ b/plugins/source/oracle/client/configProvider.go
@@ -20,8 +20,10 @@ type rawPrivateKeyConfigProvider struct {
 }
 
 func (rawPrivateKeyConfigProvider) PrivateRSAKey() (*rsa.PrivateKey, error) {
-	tfVarEnvironmentVariable := fmt.Sprintf("%s_%s", tfVarEnvironmentVariable, "private_key")
-	ocCLIEnvironmentVariable := fmt.Sprintf("%s_%s", ocCLIEnvironmentVariable, "private_key")
+	const(
+		tfVarEnvironmentVariable = tfVarEnvironmentVariable + "private_key"
+		ocCLIEnvironmentVariable = ocCLIEnvironmentVariable + "private_key"
+	)
 	var envName string
 	var ok bool
 	var value string

--- a/plugins/source/oracle/client/configProvider.go
+++ b/plugins/source/oracle/client/configProvider.go
@@ -31,7 +31,7 @@ func (r rawPrivateKeyConfigProvider) KeyID() (string, error) {
 	return r.provider.KeyID()
 }
 
-func (r rawPrivateKeyConfigProvider) PrivateRSAKey() (*rsa.PrivateKey, error) {
+func (rawPrivateKeyConfigProvider) PrivateRSAKey() (*rsa.PrivateKey, error) {
 	tfVarEnvironmentVariable := fmt.Sprintf("%s_%s", tfVarEnvironmentVariable, "private_key")
 	ocCLIEnvironmentVariable := fmt.Sprintf("%s_%s", ocCLIEnvironmentVariable, "private_key")
 	var envName string

--- a/plugins/source/oracle/client/oracle_clients.go
+++ b/plugins/source/oracle/client/oracle_clients.go
@@ -1573,7 +1573,8 @@ func getConfigProvider() (common.ConfigurationProvider, error) {
 	return common.ComposingConfigurationProvider(
 		[]common.ConfigurationProvider{
 			common.DefaultConfigProvider(), // has to be the first as the auth is checked only for the 1st in chain
-			common.ConfigurationProviderEnvironmentVariables("OCI_CLI", ""),
+			common.ConfigurationProviderEnvironmentVariables(ocCLIEnvironmentVariable, ""),
+			newRawPrivateKeyConfigProvider(),
 		},
 	)
 }

--- a/plugins/source/oracle/docs/_authentication.md
+++ b/plugins/source/oracle/docs/_authentication.md
@@ -33,4 +33,6 @@ export OCI_CLI_tenancy_ocid="ocid1.tenancy.oc1..<unique_ID>"
 export OCI_CLI_user_ocid="ocid1.user.oc1..<unique_ID>"
 export OCI_CLI_region="us-ashburn-1"
 export OCI_CLI_private_key_path="~/.oci/oci_api_key.pem"
+# Can be used instead of `OCI_CLI_private_key_path`, starting from version v4.3.0 of the Oracle source plugin
+export OCI_CLI_private_key="<raw-content-of-private-key-with-line-breaks-replaced-with-\n>" # e.g. -----BEGIN PRIVATE KEY-----\n<private-key-content>\n-----END PRIVATE
 ```


### PR DESCRIPTION
<!-- 🎉 Thank you for making CloudQuery awesome by submitting a PR 🎉 -->

#### Summary

Allows referencing the private key content directly instead of a path to the key.
Part of https://github.com/cloudquery/cloudquery-issues/issues/1361 (internal issue).

This should allow running the Oracle source plugin in environments when one can't populate the file system with the private key

<!--
Use the following steps to ensure your PR is ready to be reviewed

- [ ] Read the [contribution guidelines](https://github.com/cloudquery/cloudquery/blob/main/CONTRIBUTING.md) 🧑‍🎓
- [ ] Run `make lint` to ensure the proposed changes follow the coding style 🚨 (install golangci-lint [here](https://golangci-lint.run/usage/install/#local-installation))
- [ ] Run `make test` to ensure the proposed changes pass the tests 🧪
- [ ] If changing a source plugin run `make gen` to ensure docs are up to date 📝
- [ ] Ensure the status checks below are successful ✅
--->
