### PR TITLE
fix: Allow empty auth mode

### DIFF
--- a/plugins/destination/gremlin/client/spec.go
+++ b/plugins/destination/gremlin/client/spec.go
@@ -4,6 +4,7 @@ import (
 	_ "embed"
 	"fmt"
 	"runtime"
+	"slices"
 	"strings"
 
 	"github.com/invopop/jsonschema"
@@ -100,7 +101,8 @@ func (s *Spec) Validate() error {
 	if s.Endpoint == "" {
 		return fmt.Errorf("endpoint is required")
 	}
-	if s.AuthMode != authModeNone && s.AuthMode != authModeBasic && s.AuthMode != authModeAWS {
+	allowedAuthModes := []authMode{"", authModeNone, authModeBasic, authModeAWS}
+	if !slices.Contains(allowedAuthModes, s.AuthMode) {
 		return fmt.Errorf("invalid auth_mode, valid values are %q, %q and %q", authModeNone, authModeBasic, authModeAWS)
 	}
 	if s.AuthMode == authModeAWS && s.AWSRegion == "" {


### PR DESCRIPTION
<!-- 🎉 Thank you for making CloudQuery awesome by submitting a PR 🎉 -->

#### Summary

Gremlin should allow not setting `auth_mode` and it will default to `none`, however it doesn't work at the moment.
This PR fixes it

<!--
Use the following steps to ensure your PR is ready to be reviewed

- [ ] Read the [contribution guidelines](https://github.com/cloudquery/cloudquery/blob/main/CONTRIBUTING.md) 🧑‍🎓
- [ ] Run `make lint` to ensure the proposed changes follow the coding style 🚨 (install golangci-lint [here](https://golangci-lint.run/usage/install/#local-installation))
- [ ] Run `make test` to ensure the proposed changes pass the tests 🧪
- [ ] If changing a source plugin run `make gen` to ensure docs are up to date 📝
- [ ] Ensure the status checks below are successful ✅
--->
