### PR TITLE
fix: Update docs example to use env variable replacement

### DIFF
--- a/plugins/destination/mssql/client/schema.json
+++ b/plugins/destination/mssql/client/schema.json
@@ -13,7 +13,10 @@
         "connection_string": {
           "type": "string",
           "minLength": 1,
-          "description": "Connection string to connect to the database.\nSee [SDK documentation](https://github.com/microsoft/go-mssqldb#connection-parameters-and-dsn) for details."
+          "description": "Connection string to connect to the database.\nSee [SDK documentation](https://github.com/microsoft/go-mssqldb#connection-parameters-and-dsn) for details.",
+          "examples": [
+            "${MSSQL_CONNECTION_STRING}"
+          ]
         },
         "auth_mode": {
           "type": "string",

--- a/plugins/destination/mssql/client/spec.go
+++ b/plugins/destination/mssql/client/spec.go
@@ -22,7 +22,7 @@ const (
 type Spec struct {
 	// Connection string to connect to the database.
 	// See [SDK documentation](https://github.com/microsoft/go-mssqldb#connection-parameters-and-dsn) for details.
-	ConnectionString string `json:"connection_string" jsonschema:"required,minLength=1"`
+	ConnectionString string `json:"connection_string" jsonschema:"required,minLength=1,example=${MSSQL_CONNECTION_STRING}"`
 
 	//  If you need to authenticate via Azure Active Directory ensure you specify `azure` value.
 	//  See [SDK documentation](https://github.com/microsoft/go-mssqldb#azure-active-directory-authentication) for more information.

--- a/plugins/destination/mssql/docs/_configuration.md
+++ b/plugins/destination/mssql/docs/_configuration.md
@@ -6,7 +6,8 @@ spec:
   registry: "cloudquery"
   version: "VERSION_DESTINATION_MSSQL"
   spec:
-    connection_string: "server=localhost;user id=SA;password=yourStrongP@ssword;port=1433;database=cloudquery;"
+    # Connection string in the format `server=localhost;user id=SA;password=yourStrongP@ssword;port=1433;database=cloudquery;`
+    connection_string: "${MSSQL_CONNECTION_STRING}"
     # Optional parameters:
     # auth_mode: ms
     # schema: dbo

--- a/plugins/destination/mssql/docs/configuration.md
+++ b/plugins/destination/mssql/docs/configuration.md
@@ -66,5 +66,5 @@ spec:
   version:  "VERSION_DESTINATION_MSSQL"
 
   spec:
-    connection_string: "${MS_SQL_CONN_STRING};log=255"
+    connection_string: "${MSSQL_CONNECTION_STRING};log=255"
 ```


### PR DESCRIPTION
<!-- 🎉 Thank you for making CloudQuery awesome by submitting a PR 🎉 -->

#### Summary

Added an example to the JSON schema and the docs using env variables replacement so the managed syncs UI populates the secrets list:
![image](https://github.com/cloudquery/cloudquery/assets/26760571/d150fd05-11b3-401b-a9a1-93089c82cbec)


<!--
Use the following steps to ensure your PR is ready to be reviewed

- [ ] Read the [contribution guidelines](https://github.com/cloudquery/cloudquery/blob/main/CONTRIBUTING.md) 🧑‍🎓
- [ ] Run `make lint` to ensure the proposed changes follow the coding style 🚨 (install golangci-lint [here](https://golangci-lint.run/usage/install/#local-installation))
- [ ] Run `make test` to ensure the proposed changes pass the tests 🧪
- [ ] If changing a source plugin run `make gen` to ensure docs are up to date 📝
- [ ] Ensure the status checks below are successful ✅
--->
