### PR TITLE
feat: Check token validity on init

### DIFF
--- a/plugins/source/gitlab/client/client.go
+++ b/plugins/source/gitlab/client/client.go
@@ -45,6 +45,13 @@ func Configure(ctx context.Context, logger zerolog.Logger, s Spec) (schema.Clien
 	if err != nil {
 		return nil, err
 	}
+	// GET /personal_access_tokens/self
+	// More in https://docs.gitlab.com/ee/api/personal_access_tokens.html#get-single-personal-access-token
+	self, _, err := c.PersonalAccessTokens.GetSinglePersonalAccessToken()
+	if err != nil {
+		return nil, err
+	}
+	logger.Info().Str("token_name", self.Name).Msg("authenticated to GitLab")
 
 	return &Client{
 		logger:         logger,


### PR DESCRIPTION
<!-- 🎉 Thank you for making CloudQuery awesome by submitting a PR 🎉 -->

#### Summary

The GitLab source plugin doesn't support `cloudquery test-connection` since it doesn't validate the token on `init`.
This PR fixes that

<!--
Use the following steps to ensure your PR is ready to be reviewed

- [ ] Read the [contribution guidelines](https://github.com/cloudquery/cloudquery/blob/main/CONTRIBUTING.md) 🧑‍🎓
- [ ] Run `make lint` to ensure the proposed changes follow the coding style 🚨 (install golangci-lint [here](https://golangci-lint.run/usage/install/#local-installation))
- [ ] Run `make test` to ensure the proposed changes pass the tests 🧪
- [ ] If changing a source plugin run `make gen` to ensure docs are up to date 📝
- [ ] Ensure the status checks below are successful ✅
--->
