### PR TITLE
fix: Ensure login callback is only handled once

### DIFF
--- a/cli/cmd/login.go
+++ b/cli/cmd/login.go
@@ -11,7 +11,7 @@ import (
 	"os/signal"
 	"strconv"
 	"strings"
-	goSync "sync"
+	gosync "sync"
 	"syscall"
 	"time"
 
@@ -98,7 +98,7 @@ func runLogin(ctx context.Context, cmd *cobra.Command) (err error) {
 	mux := http.NewServeMux()
 	refreshToken := ""
 	gotToken := make(chan struct{})
-	var callbackLock goSync.Mutex
+	var callbackLock gosync.Mutex
 	callbackHandled := false
 	mux.HandleFunc("/callback", func(w http.ResponseWriter, r *http.Request) {
 		callbackLock.Lock()


### PR DESCRIPTION
<!-- 🎉 Thank you for making CloudQuery awesome by submitting a PR 🎉 -->

#### Summary

Fixes https://github.com/cloudquery/cloudquery-issues/issues/1454 (internal issue).
It seems that a recent change in Brave browser causes the login callback to be called multiple times, causing us to panic when we close an already closed channel

<!--
Use the following steps to ensure your PR is ready to be reviewed

- [ ] Read the [contribution guidelines](https://github.com/cloudquery/cloudquery/blob/main/CONTRIBUTING.md) 🧑‍🎓
- [ ] Run `make lint` to ensure the proposed changes follow the coding style 🚨 (install golangci-lint [here](https://golangci-lint.run/usage/install/#local-installation))
- [ ] Run `make test` to ensure the proposed changes pass the tests 🧪
- [ ] If changing a source plugin run `make gen` to ensure docs are up to date 📝
- [ ] Ensure the status checks below are successful ✅
--->
