### PR TITLE
chore: Add working directory when running Java plugin build

### DIFF
--- a/.github/workflows/publish_plugin_to_hub.yml
+++ b/.github/workflows/publish_plugin_to_hub.yml
@@ -139,6 +139,7 @@ jobs:
         uses: docker/setup-buildx-action@v3
 
       - name: Build package
+        working-directory: ${{ needs.prepare.outputs.plugin_dir }}
         run: ./gradlew build
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
<!-- 🎉 Thank you for making CloudQuery awesome by submitting a PR 🎉 -->

#### Summary

Follow up to https://github.com/cloudquery/cloudquery/pull/17336

<!--
Use the following steps to ensure your PR is ready to be reviewed

- [ ] Read the [contribution guidelines](https://github.com/cloudquery/cloudquery/blob/main/CONTRIBUTING.md) 🧑‍🎓
- [ ] Run `make lint` to ensure the proposed changes follow the coding style 🚨 (install golangci-lint [here](https://golangci-lint.run/usage/install/#local-installation))
- [ ] Run `make test` to ensure the proposed changes pass the tests 🧪
- [ ] If changing a source plugin run `make gen` to ensure docs are up to date 📝
- [ ] Ensure the status checks below are successful ✅
--->
