### PR TITLE
chore: Add GITHUB_TOKEN and GITHUB_ACTOR envs to Java package command

### DIFF
--- a/.github/workflows/publish_plugin_to_hub.yml
+++ b/.github/workflows/publish_plugin_to_hub.yml
@@ -147,6 +147,9 @@ jobs:
 
       - name: Run package command
         working-directory: ${{ needs.prepare.outputs.plugin_dir }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_ACTOR: ${{ github.actor }}
         run: |
           rm -rf docs/tables.md
           java -jar app/build/libs/app.jar package -m ${{ steps.release-notes.outputs.result }} ${{ needs.prepare.outputs.plugin_version }} .


### PR DESCRIPTION
<!-- 🎉 Thank you for making CloudQuery awesome by submitting a PR 🎉 -->

#### Summary

These are needed for download the Java SDK from GitHub packages

<!--
Use the following steps to ensure your PR is ready to be reviewed

- [ ] Read the [contribution guidelines](https://github.com/cloudquery/cloudquery/blob/main/CONTRIBUTING.md) 🧑‍🎓
- [ ] Run `make lint` to ensure the proposed changes follow the coding style 🚨 (install golangci-lint [here](https://golangci-lint.run/usage/install/#local-installation))
- [ ] Run `make test` to ensure the proposed changes pass the tests 🧪
- [ ] If changing a source plugin run `make gen` to ensure docs are up to date 📝
- [ ] Ensure the status checks below are successful ✅
--->
