### PR TITLE
chore: Revert "chore(main): Release plugins-source-bitbucket v1.2.0 (#17360)"

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -103,7 +103,7 @@
   "plugins/source/vault+FILLER": "0.0.0",
   "plugins/source/airtable": "2.1.1",
   "plugins/source/airtable+FILLER": "0.0.0",
-  "plugins/source/bitbucket": "1.2.0",
+  "plugins/source/bitbucket": "1.1.0",
   "plugins/source/bitbucket+FILLER": "0.0.0",
   "plugins/source/notion": "1.1.5"
 }

--- a/plugins/source/bitbucket/CHANGELOG.md
+++ b/plugins/source/bitbucket/CHANGELOG.md
@@ -1,12 +1,5 @@
 # Changelog
 
-## [1.2.0](https://github.com/cloudquery/cloudquery/compare/plugins-source-bitbucket-v1.1.0...plugins-source-bitbucket-v1.2.0) (2024-03-27)
-
-
-### Features
-
-* Update SDK, support package command ([#17336](https://github.com/cloudquery/cloudquery/issues/17336)) ([dfb0c61](https://github.com/cloudquery/cloudquery/commit/dfb0c61a9cd75a5391c01a8b8abe2cb56c2b27b7))
-
 ## [1.1.0](https://github.com/cloudquery/cloudquery/compare/plugins-source-bitbucket-v1.0.5...plugins-source-bitbucket-v1.1.0) (2024-02-13)
 
 


### PR DESCRIPTION
This reverts commit 8041438555cbcec32abdb3301095bc0aa5de6bd4.

<!-- 🎉 Thank you for making CloudQuery awesome by submitting a PR 🎉 -->

Should have merged first https://github.com/cloudquery/cloudquery/pull/17359

<!--
Use the following steps to ensure your PR is ready to be reviewed

- [ ] Read the [contribution guidelines](https://github.com/cloudquery/cloudquery/blob/main/CONTRIBUTING.md) 🧑‍🎓
- [ ] Run `make lint` to ensure the proposed changes follow the coding style 🚨 (install golangci-lint [here](https://golangci-lint.run/usage/install/#local-installation))
- [ ] Run `make test` to ensure the proposed changes pass the tests 🧪
- [ ] If changing a source plugin run `make gen` to ensure docs are up to date 📝
- [ ] Ensure the status checks below are successful ✅
--->
