### PR TITLE
fix: Add missing docs

### DIFF
--- a/plugins/source/bitbucket/docs/_authentication.md
+++ b/plugins/source/bitbucket/docs/_authentication.md
@@ -1,0 +1,1 @@
+In order to fetch information from Bitbucket Cloud, `cloudquery` needs to authenticate using an [app password](https://support.atlassian.com/bitbucket-cloud/docs/app-passwords/). Follow the instructions on the Bitbucket website and create a read-only token with `account:read`, `projects:read` and `repositories:read` permissions.

--- a/plugins/source/bitbucket/docs/_configuration.md
+++ b/plugins/source/bitbucket/docs/_configuration.md
@@ -1,0 +1,18 @@
+```yaml copy
+kind: source
+# Common source-plugin configuration
+spec:
+  name: bitbucket
+  registry: docker
+  path: ghcr.io/cloudquery/cq-source-bitbucket:VERSION_SOURCE_BITBUCKET
+  tables: ["*"]
+  destinations: ["DESTINATION_NAME"]
+  # bitbucket-specific configuration
+  spec:
+    username: "${BITBUCKET_USERNAME}" # required
+    password: "${BITBUCKET_PASSWORD}" # required
+```
+
+:::callout{type="info"}
+This example uses environment variable expansion to read the `username` and `password` options from `BITBUCKET_USERNAME` and `BITBUCKET_PASSWORD` environment variables respectively. You can also hardcode the value in the configuration file, but this is not advised for production settings.
+:::

--- a/plugins/source/bitbucket/docs/overview.md
+++ b/plugins/source/bitbucket/docs/overview.md
@@ -1,0 +1,53 @@
+---
+name: Bitucket
+stage: Preview
+title: Bitbucket Source Plugin
+description: CloudQuery Bitbucket source plugin documentation
+---
+
+# Bitbucket Source Plugin
+
+:badge
+
+The CloudQuery Bitbucket plugin pulls data from [Bitbucket](https://bitbucket.org/) and loads it into any supported CloudQuery destination (e.g. PostgreSQL, BigQuery, Snowflake, and [more](https://hub.cloudquery.io/plugins/destination)).
+
+The plugin discover all workspaces and repositories in your account and syncs them to the destination.
+
+## Example Configuration
+
+This example syncs from Bitbucket to a Postgres destination. The (top level) source spec section is described in the [Source Spec Reference](/docs/reference/source-spec).
+
+:configuration
+
+## Authentication
+
+:authentication
+
+## Example
+
+```yaml
+kind: source
+spec:
+  name: bitbucket
+  registry: docker
+  path: ghcr.io/cloudquery/cq-source-bitbucket:VERSION_SOURCE_BITBUCKET
+  tables: ["*"]
+  destinations: ["DESTINATION_NAME"]
+  # bitbucket-specific configuration
+  spec:
+    username: "${BITBUCKET_USERNAME}" # required
+    password: "${BITBUCKET_PASSWORD}" # required
+  ...
+```
+
+## Configuration Reference
+
+This is the (nested) spec used by the Bitbucket source plugin:
+
+- `username` (`string`) (required):
+
+  The Bitbucket username associated with the [app password](https://support.atlassian.com/bitbucket-cloud/docs/app-passwords/).
+
+- `password` (`string`) (required):
+
+  The Bitbucket password associated with the [app password](https://support.atlassian.com/bitbucket-cloud/docs/app-passwords/).

--- a/website/vercel.json
+++ b/website/vercel.json
@@ -427,6 +427,10 @@
       "destination": "https://hub.cloudquery.io/plugins/source/cloudquery/azuredevops/tables/:path*"
     },
     {
+      "source": "/docs/plugins/sources/bitbucket/tables/:path*",
+      "destination": "https://hub.cloudquery.io/plugins/source/cloudquery/bitbucket/tables/:path*"
+    },
+    {
       "source": "/docs/plugins/sources/cloudflare/tables/:path*",
       "destination": "https://hub.cloudquery.io/plugins/source/cloudquery/cloudflare/tables/:path*"
     },
@@ -617,6 +621,10 @@
     {
       "source": "/docs/plugins/sources/azuredevops/:path*",
       "destination": "https://hub.cloudquery.io/plugins/source/cloudquery/azuredevops"
+    },
+    {
+      "source": "/docs/plugins/sources/bitbucket/:path*",
+      "destination": "https://hub.cloudquery.io/plugins/source/cloudquery/bitbucket"
     },
     {
       "source": "/docs/plugins/sources/cloudflare/:path*",


### PR DESCRIPTION
<!-- 🎉 Thank you for making CloudQuery awesome by submitting a PR 🎉 -->

#### Summary

Adds the missing docs for the Bitbucket plugin (see https://hub.cloudquery.io/plugins/source/cloudquery/bitbucket/latest/docs).

Also redirects from the old Website to the Hub

<!--
Use the following steps to ensure your PR is ready to be reviewed

- [ ] Read the [contribution guidelines](https://github.com/cloudquery/cloudquery/blob/main/CONTRIBUTING.md) 🧑‍🎓
- [ ] Run `make lint` to ensure the proposed changes follow the coding style 🚨 (install golangci-lint [here](https://golangci-lint.run/usage/install/#local-installation))
- [ ] Run `make test` to ensure the proposed changes pass the tests 🧪
- [ ] If changing a source plugin run `make gen` to ensure docs are up to date 📝
- [ ] Ensure the status checks below are successful ✅
--->
