### PR TITLE
feat: Flush batch on Primary Key collision

### DIFF
--- a/plugins/destination/postgresql/client/insert.go
+++ b/plugins/destination/postgresql/client/insert.go
@@ -56,6 +56,7 @@ func getPKValues(r arrow.Record, pkIndex []int) []string {
 	for ri := range results {
 		for _, i := range pkIndex {
 			col := r.Column(i)
+			results[ri] += fmt.Sprintf("%d", i)
 			results[ri] += col.String()
 		}
 	}

--- a/plugins/destination/postgresql/client/insert.go
+++ b/plugins/destination/postgresql/client/insert.go
@@ -100,6 +100,7 @@ func (c *Client) InsertBatch(ctx context.Context, messages message.WriteInserts)
 			detail = tableDetail{
 				indexes: table.PrimaryKeysIndexes(),
 				sql:     sql,
+				values:  make(map[string]bool),
 			}
 			details[tableName] = detail
 		}


### PR DESCRIPTION
<!-- 🎉 Thank you for making CloudQuery awesome by submitting a PR 🎉 -->

#### Summary

Prior to this PR if a batch had rows (for the same table) with duplicate PK values we would just error out and stop the sync. With this change on a PK collision we flush the batch prior to adding the new value. This means all data will hit the DB (so users can still use Triggers)
