### PR TITLE
fix: Set parents for child tables

### DIFF
--- a/plugins/source/bitbucket/app/src/main/java/bitbucket/BitbucketPlugin.java
+++ b/plugins/source/bitbucket/app/src/main/java/bitbucket/BitbucketPlugin.java
@@ -95,6 +95,8 @@ public class BitbucketPlugin extends Plugin {
   public void close() {}
 
   private static List<Table> getTables() {
-    return List.of(Workspaces.getTable());
+    List<Table> tables = List.of(Workspaces.getTable());
+    Tables.setParents(tables, null);
+    return tables;
   }
 }


### PR DESCRIPTION
<!-- 🎉 Thank you for making CloudQuery awesome by submitting a PR 🎉 -->

#### Summary

Same as https://github.com/cloudquery/plugin-sdk-java/pull/217
This should fix the broken tables page for the Bitbucket plugin here https://hub.cloudquery.io/plugins/source/cloudquery/bitbucket/latest/tables

<!--
Use the following steps to ensure your PR is ready to be reviewed

- [ ] Read the [contribution guidelines](https://github.com/cloudquery/cloudquery/blob/main/CONTRIBUTING.md) 🧑‍🎓
- [ ] Run `make lint` to ensure the proposed changes follow the coding style 🚨 (install golangci-lint [here](https://golangci-lint.run/usage/install/#local-installation))
- [ ] Run `make test` to ensure the proposed changes pass the tests 🧪
- [ ] If changing a source plugin run `make gen` to ensure docs are up to date 📝
- [ ] Ensure the status checks below are successful ✅
--->
