### PR TITLE
feat!: Add path variable support to GCS destination plugin. 

### DIFF
--- a/plugins/destination/gcs/client/client.go
+++ b/plugins/destination/gcs/client/client.go
@@ -22,6 +22,7 @@ type Client struct {
 	streamingbatchwriter.UnimplementedDeleteStale
 	streamingbatchwriter.UnimplementedDeleteRecords
 
+	syncID string
 	logger zerolog.Logger
 	spec   *spec.Spec
 
@@ -32,9 +33,10 @@ type Client struct {
 	writer *streamingbatchwriter.StreamingBatchWriter
 }
 
-func New(ctx context.Context, logger zerolog.Logger, s []byte, _ plugin.NewClientOptions) (plugin.Client, error) {
+func New(ctx context.Context, logger zerolog.Logger, s []byte, newClientOpts plugin.NewClientOptions) (plugin.Client, error) {
 	c := &Client{
 		logger: logger.With().Str("module", "gcs").Logger(),
+		syncID: newClientOpts.InvocationID,
 	}
 
 	if err := json.Unmarshal(s, &c.spec); err != nil {

--- a/plugins/destination/gcs/client/client_test.go
+++ b/plugins/destination/gcs/client/client_test.go
@@ -40,7 +40,7 @@ func TestPlugin(t *testing.T) {
 		})
 
 		t.Run("write/"+string(ft), func(t *testing.T) {
-			testPluginCustom(t, &s, false, "")
+			testPluginCustom(t, &s, "")
 		})
 	}
 	t.Run("should give an error while reading when no_rotate is false", func(t *testing.T) {
@@ -50,7 +50,7 @@ func TestPlugin(t *testing.T) {
 			NoRotate: false,
 			FileSpec: filetypes.FileSpec{Format: filetypes.FormatTypeCSV},
 		}
-		testPluginCustom(t, &s, true, "reading is not supported when `no_rotate` is false")
+		testPluginCustom(t, &s, "reading is not supported when `no_rotate` is false")
 	})
 
 	t.Run("should give an error while reading when {{UUID}} path variable is present", func(t *testing.T) {
@@ -60,7 +60,7 @@ func TestPlugin(t *testing.T) {
 			NoRotate: true,
 			FileSpec: filetypes.FileSpec{Format: filetypes.FormatTypeCSV},
 		}
-		testPluginCustom(t, &s, true, "reading is not supported when path contains uuid variable")
+		testPluginCustom(t, &s, "reading is not supported when path contains uuid variable")
 	})
 }
 
@@ -86,7 +86,7 @@ func testPlugin(t *testing.T, s *spec.Spec) {
 	)
 }
 
-func testPluginCustom(t *testing.T, s *spec.Spec, expectErrorWhenReading bool, readErrorString string) {
+func testPluginCustom(t *testing.T, s *spec.Spec, readErrorString string) {
 	ctx := context.Background()
 
 	var client plugin.Client
@@ -139,7 +139,7 @@ func testPluginCustom(t *testing.T, s *spec.Spec, expectErrorWhenReading bool, r
 	}
 
 	readRecords, err := readAll(ctx, client, table)
-	if expectErrorWhenReading {
+	if readErrorString != "" {
 		require.ErrorContains(t, err, readErrorString)
 		return
 	}

--- a/plugins/destination/gcs/client/client_test.go
+++ b/plugins/destination/gcs/client/client_test.go
@@ -141,7 +141,6 @@ func testPluginCustom(t *testing.T, s *spec.Spec, expectErrorWhenReading bool, r
 	readRecords, err := readAll(ctx, client, table)
 	if expectErrorWhenReading {
 		require.ErrorContains(t, err, readErrorString)
-		return
 	} else {
 		require.NoError(t, err)
 	}

--- a/plugins/destination/gcs/client/client_test.go
+++ b/plugins/destination/gcs/client/client_test.go
@@ -141,9 +141,10 @@ func testPluginCustom(t *testing.T, s *spec.Spec, expectErrorWhenReading bool, r
 	readRecords, err := readAll(ctx, client, table)
 	if expectErrorWhenReading {
 		require.ErrorContains(t, err, readErrorString)
-	} else {
-		require.NoError(t, err)
+		return
 	}
+
+	require.NoError(t, err)
 	totalItems := plugin.TotalRows(readRecords)
 	assert.Equalf(t, int64(2), totalItems, "expected 2 items, got %d", totalItems)
 }

--- a/plugins/destination/gcs/client/read.go
+++ b/plugins/destination/gcs/client/read.go
@@ -5,16 +5,23 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"time"
 
 	"github.com/apache/arrow/go/v15/arrow"
 	"github.com/cloudquery/plugin-sdk/v4/schema"
+	"github.com/google/uuid"
 )
 
 func (c *Client) Read(ctx context.Context, table *schema.Table, res chan<- arrow.Record) error {
 	if !c.spec.NoRotate {
 		return fmt.Errorf("reading is not supported when `no_rotate` is false. Table: %q", table.Name)
 	}
-	name := fmt.Sprintf("%s/%s.%s%s", c.spec.Path, table.Name, c.spec.Format, c.spec.FileSpec.Compression.Extension())
+	if c.spec.PathContainsUUID() {
+		return fmt.Errorf("reading is not supported when path contains uuid variable. Table: %q", table.Name)
+	}
+
+	name := c.spec.ReplacePathVariables(table.Name, uuid.NewString(), time.Time{}, c.syncID)
+
 	r, err := c.bucket.Object(name).NewReader(ctx)
 	if err != nil {
 		return err

--- a/plugins/destination/gcs/client/spec/schema.go
+++ b/plugins/destination/gcs/client/spec/schema.go
@@ -41,7 +41,39 @@ func (s Spec) JSONSchemaExtend(sc *jsonschema.Schema) {
 		},
 	}
 
-	sc.AllOf = append(sc.AllOf, noRotateNoBatch)
+	// path patterns: should be a clean path
+	cleanPath := &jsonschema.Schema{
+		Title: "`path` is a clean path value",
+		Not: &jsonschema.Schema{
+			Title: "`path` is not a clean path value",
+			AnyOf: []*jsonschema.Schema{
+				{
+					Title: "`path` contains `./`",
+					Properties: func() *orderedmap.OrderedMap[string, *jsonschema.Schema] {
+						properties := orderedmap.New[string, *jsonschema.Schema]()
+						properties.Set("path", &jsonschema.Schema{
+							Type:    "string",
+							Pattern: `^.*\./.*$`,
+						})
+						return properties
+					}(),
+				},
+				{
+					Title: "`path` contains `//`",
+					Properties: func() *orderedmap.OrderedMap[string, *jsonschema.Schema] {
+						properties := orderedmap.New[string, *jsonschema.Schema]()
+						properties.Set("path", &jsonschema.Schema{
+							Type:    "string",
+							Pattern: `^.*//.*$`,
+						})
+						return properties
+					}(),
+				},
+			},
+		},
+	}
+
+	sc.AllOf = append(sc.AllOf, noRotateNoBatch, cleanPath)
 }
 
 //go:embed schema.json

--- a/plugins/destination/gcs/client/spec/schema.json
+++ b/plugins/destination/gcs/client/spec/schema.json
@@ -39,6 +39,32 @@
     "Spec": {
       "allOf": [
         {
+          "not": {
+            "anyOf": [
+              {
+                "properties": {
+                  "path": {
+                    "type": "string",
+                    "pattern": "^.*\\./.*$"
+                  }
+                },
+                "title": "`path` contains `./`"
+              },
+              {
+                "properties": {
+                  "path": {
+                    "type": "string",
+                    "pattern": "^.*//.*$"
+                  }
+                },
+                "title": "`path` contains `//`"
+              }
+            ],
+            "title": "`path` is not a clean path value"
+          },
+          "title": "`path` is a clean path value"
+        },
+        {
           "if": {
             "properties": {
               "no_rotate": {

--- a/plugins/destination/gcs/client/spec/schema.json
+++ b/plugins/destination/gcs/client/spec/schema.json
@@ -77,6 +77,31 @@
             ]
           },
           "then": {
+            "not": {
+              "properties": {
+                "path": {
+                  "type": "string",
+                  "pattern": "^.*\\{\\{UUID\\}\\}.*$"
+                }
+              },
+              "title": "Require {{UUID}} to be present in path"
+            }
+          },
+          "title": "Disallow {{UUID}} in path when using no_rotate"
+        },
+        {
+          "if": {
+            "properties": {
+              "no_rotate": {
+                "type": "boolean",
+                "const": true
+              }
+            },
+            "required": [
+              "no_rotate"
+            ]
+          },
+          "then": {
             "properties": {
               "batch_size": {
                 "type": "null"

--- a/plugins/destination/gcs/client/spec/schema.json
+++ b/plugins/destination/gcs/client/spec/schema.json
@@ -115,6 +115,37 @@
             }
           },
           "title": "Disallow batching when using no_rotate"
+        },
+        {
+          "if": {
+            "properties": {
+              "no_rotate": {
+                "type": "boolean",
+                "const": false
+              }
+            },
+            "title": "Disallow setting no_rotate to true"
+          },
+          "then": {
+            "properties": {
+              "path": {
+                "anyOf": [
+                  {
+                    "type": "string",
+                    "pattern": "^.*\\{\\{UUID\\}\\}.*$"
+                  },
+                  {
+                    "not": {
+                      "type": "string",
+                      "pattern": "^.*{{.*}}.*$"
+                    }
+                  }
+                ]
+              }
+            },
+            "title": "Require {{UUID}} to be present in path"
+          },
+          "title": "Require {{UUID}} in path when batching"
         }
       ],
       "oneOf": [

--- a/plugins/destination/gcs/client/spec/schema.json
+++ b/plugins/destination/gcs/client/spec/schema.json
@@ -39,6 +39,33 @@
     "Spec": {
       "allOf": [
         {
+          "if": {
+            "properties": {
+              "no_rotate": {
+                "type": "boolean",
+                "const": true
+              }
+            },
+            "required": [
+              "no_rotate"
+            ]
+          },
+          "then": {
+            "properties": {
+              "batch_size": {
+                "type": "null"
+              },
+              "batch_size_bytes": {
+                "type": "null"
+              },
+              "batch_timeout": {
+                "type": "null"
+              }
+            }
+          },
+          "title": "Disallow batching when using no_rotate"
+        },
+        {
           "not": {
             "anyOf": [
               {
@@ -94,56 +121,34 @@
             "properties": {
               "no_rotate": {
                 "type": "boolean",
-                "const": true
-              }
-            },
-            "required": [
-              "no_rotate"
-            ]
-          },
-          "then": {
-            "properties": {
-              "batch_size": {
-                "type": "null"
-              },
-              "batch_size_bytes": {
-                "type": "null"
-              },
-              "batch_timeout": {
-                "type": "null"
-              }
-            }
-          },
-          "title": "Disallow batching when using no_rotate"
-        },
-        {
-          "if": {
-            "properties": {
-              "no_rotate": {
-                "type": "boolean",
                 "const": false
               }
             },
             "title": "Disallow setting no_rotate to true"
           },
           "then": {
-            "properties": {
-              "path": {
-                "anyOf": [
-                  {
+            "anyOf": [
+              {
+                "properties": {
+                  "path": {
                     "type": "string",
                     "pattern": "^.*\\{\\{UUID\\}\\}.*$"
-                  },
-                  {
+                  }
+                },
+                "title": "Require {{UUID}} to be present in path"
+              },
+              {
+                "properties": {
+                  "path": {
                     "not": {
                       "type": "string",
                       "pattern": "^.*{{.*}}.*$"
                     }
                   }
-                ]
+                },
+                "title": "`path` does not contain path variables"
               }
-            },
-            "title": "Require {{UUID}} to be present in path"
+            ]
           },
           "title": "Require {{UUID}} in path when batching"
         }

--- a/plugins/destination/gcs/client/spec/schema_test.go
+++ b/plugins/destination/gcs/client/spec/schema_test.go
@@ -161,16 +161,31 @@ func TestSpecJSONSchema(t *testing.T) {
 			Name: "null batch_timeout",
 			Spec: `{"format": "csv", "path": "abc", "bucket": "abc", "batch_timeout":null}`,
 		},
+
 		// no_rotate + path({{UUID}})
+		{
+			Name: "no_rotate:false & path:{{UUID}}",
+			Spec: `{"format": "csv", "path": "{{UUID}}", "bucket": "b", "no_rotate":false}`,
+		},
 		{
 			Name: "no_rotate:true & path:{{UUID}}",
 			Spec: `{"format": "csv", "path": "{{UUID}}", "bucket": "b", "no_rotate":true}`,
 			Err:  true,
 		},
 		{
+			Name: "no_rotate:false & path:abc",
+			Spec: `{"format": "csv", "path": "abc", "bucket": "b", "no_rotate":false}`,
+		},
+		{
 			Name: "no_rotate:true & path:abc",
 			Spec: `{"format": "csv", "path": "abc", "bucket": "b", "no_rotate":true}`,
 		},
+		{
+			Name: "no_rotate:false & path:{{TABLE}}",
+			Spec: `{"format": "csv", "path": "{{TABLE}}", "bucket": "b", "no_rotate":false}`,
+			Err:  true,
+		},
+
 		// no_rotate + batching
 		{
 			Name: "no_rotate:false & batch_size:100",

--- a/plugins/destination/gcs/client/spec/schema_test.go
+++ b/plugins/destination/gcs/client/spec/schema_test.go
@@ -71,7 +71,26 @@ func TestSpecJSONSchema(t *testing.T) {
 			Spec: `{"format": "csv", "path": "abc", "bucket": 123}`,
 			Err:  true,
 		},
-
+		{
+			Name: "path starts with /",
+			Spec: `{"format": "csv", "path": "/{{UUID}}", "bucket": "b", "region": "r"}`,
+			Err:  true,
+		},
+		{
+			Name: "path contains //",
+			Spec: `{"format": "csv", "path": "{{UUID}}//", "bucket": "b", "region": "r"}`,
+			Err:  true,
+		},
+		{
+			Name: "path contains ./",
+			Spec: `{"format": "csv", "path": "{{UUID}}/./", "bucket": "b", "region": "r"}`,
+			Err:  true,
+		},
+		{
+			Name: "path contains ../",
+			Spec: `{"format": "csv", "path": "{{UUID}}/../", "bucket": "b", "region": "r"}`,
+			Err:  true,
+		},
 		{
 			Name: "null no_rotate",
 			Spec: `{"format": "csv", "path": "abc", "bucket": "abc", "no_rotate": null}`,

--- a/plugins/destination/gcs/client/spec/schema_test.go
+++ b/plugins/destination/gcs/client/spec/schema_test.go
@@ -161,7 +161,16 @@ func TestSpecJSONSchema(t *testing.T) {
 			Name: "null batch_timeout",
 			Spec: `{"format": "csv", "path": "abc", "bucket": "abc", "batch_timeout":null}`,
 		},
-
+		// no_rotate + path({{UUID}})
+		{
+			Name: "no_rotate:true & path:{{UUID}}",
+			Spec: `{"format": "csv", "path": "{{UUID}}", "bucket": "b", "no_rotate":true}`,
+			Err:  true,
+		},
+		{
+			Name: "no_rotate:true & path:abc",
+			Spec: `{"format": "csv", "path": "abc", "bucket": "b", "no_rotate":true}`,
+		},
 		// no_rotate + batching
 		{
 			Name: "no_rotate:false & batch_size:100",

--- a/plugins/destination/gcs/client/spec/spec.go
+++ b/plugins/destination/gcs/client/spec/spec.go
@@ -111,6 +111,10 @@ func (s *Spec) Validate() error {
 	return s.FileSpec.Validate()
 }
 
+func (s *Spec) PathContainsUUID() bool {
+	return strings.Contains(s.Path, varUUID)
+}
+
 func isValidJson(content string) error {
 	var v map[string]any
 	err := json.Unmarshal([]byte(content), &v)

--- a/plugins/destination/gcs/client/spec/spec_test.go
+++ b/plugins/destination/gcs/client/spec/spec_test.go
@@ -1,0 +1,65 @@
+package spec
+
+import (
+	"testing"
+	"time"
+
+	"github.com/cloudquery/filetypes/v4"
+	"github.com/google/go-cmp/cmp"
+)
+
+func TestReplacePathVariables(t *testing.T) {
+	cases := []struct {
+		inputPath    string
+		uuid         string
+		tableName    string
+		expectedPath string
+	}{
+		{
+			inputPath:    "test/test/{{TABLE}}/{{UUID}}",
+			uuid:         "",
+			tableName:    "",
+			expectedPath: "test/test",
+		},
+		{
+			inputPath:    "test/test/{{TABLE}}/{{UUID}}.json",
+			tableName:    "test-table",
+			uuid:         "",
+			expectedPath: "test/test/test-table/.json",
+		},
+		{
+			inputPath:    "test/test/{{TABLE}}/{{UUID}}.json",
+			tableName:    "test-table",
+			uuid:         "FAKE-UUID",
+			expectedPath: "test/test/test-table/FAKE-UUID.json",
+		},
+		{
+			inputPath:    "test/test/{{TABLE}}/{{UUID}}.json",
+			tableName:    "",
+			uuid:         "FAKE-UUID",
+			expectedPath: "test/test/FAKE-UUID.json",
+		},
+		{
+			inputPath:    "test/test/{{TABLE}}/{{UUID}}.{{FORMAT}}",
+			tableName:    "",
+			uuid:         "FAKE-UUID",
+			expectedPath: "test/test/FAKE-UUID.json",
+		},
+		{
+			inputPath:    "test/test/{{TABLE}}/year={{YEAR}}/month={{MONTH}}/day={{DAY}}/hour={{HOUR}}/minute={{MINUTE}}/{{UUID}}.json",
+			tableName:    "test-table",
+			uuid:         "FAKE-UUID",
+			expectedPath: "test/test/test-table/year=2021/month=03/day=05/hour=04/minute=01/FAKE-UUID.json",
+		},
+	}
+	tm := time.Date(2021, 3, 5, 4, 1, 2, 3, time.UTC)
+	for _, tc := range cases {
+		s := &Spec{
+			Path:     tc.inputPath,
+			FileSpec: filetypes.FileSpec{Format: filetypes.FormatTypeJSON},
+		}
+		if diff := cmp.Diff(tc.expectedPath, s.ReplacePathVariables(tc.tableName, tc.uuid, tm, "")); diff != "" {
+			t.Errorf("unexpected Path Substitution (-want +got):\n%s", diff)
+		}
+	}
+}

--- a/plugins/destination/gcs/client/write.go
+++ b/plugins/destination/gcs/client/write.go
@@ -2,7 +2,7 @@ package client
 
 import (
 	"context"
-	"fmt"
+	"time"
 
 	"cloud.google.com/go/storage"
 	"github.com/apache/arrow/go/v15/arrow"
@@ -20,11 +20,7 @@ func (c *Client) WriteTable(ctx context.Context, msgs <-chan *message.WriteInser
 	for msg := range msgs {
 		if w == nil {
 			table := msg.GetTable()
-
-			name := fmt.Sprintf("%s/%s.%s%s.%s", c.spec.Path, table.Name, c.spec.Format, c.spec.FileSpec.Compression.Extension(), uuid.NewString())
-			if c.spec.NoRotate {
-				name = fmt.Sprintf("%s/%s.%s%s", c.spec.Path, table.Name, c.spec.Format, c.spec.FileSpec.Compression.Extension())
-			}
+			name := c.spec.ReplacePathVariables(table.Name, uuid.NewString(), time.Now().UTC(), c.syncID)
 
 			w = c.gcsClient.Bucket(c.spec.Bucket).Object(name).NewWriter(ctx)
 

--- a/plugins/destination/gcs/docs/overview.md
+++ b/plugins/destination/gcs/docs/overview.md
@@ -28,7 +28,17 @@ This is the (nested) spec used by the CSV destination Plugin.
 
 - `path` (`string`) (required)
 
-  Path to where the files will be uploaded in the above bucket.
+  Path to where the files will be uploaded in the above bucket. If no path variables are present, the path will be appended with TABLE, FORMAT and Compression extension by default. The path supports the following placeholder variables:
+
+  - `{{TABLE}}` will be replaced with the table name
+  - `{{SYNC_ID}}` will be replaced with the unique identifier of the sync. This value is a UUID and is randomly generated for each sync.
+  - `{{FORMAT}}` will be replaced with the file format, such as `csv`, `json` or `parquet`. If compression is enabled, the format will be `csv.gz`, `json.gz` etc.
+  - `{{UUID}}` will be replaced with a random UUID to uniquely identify each file
+  - `{{YEAR}}` will be replaced with the current year in `YYYY` format
+  - `{{MONTH}}` will be replaced with the current month in `MM` format
+  - `{{DAY}}` will be replaced with the current day in `DD` format
+  - `{{HOUR}}` will be replaced with the current hour in `HH` format
+  - `{{MINUTE}}` will be replaced with the current minute in `mm` format
 
 - `format` (`string`) (required)
 

--- a/plugins/destination/gcs/go.mod
+++ b/plugins/destination/gcs/go.mod
@@ -10,6 +10,7 @@ require (
 	github.com/cloudquery/codegen v0.3.13
 	github.com/cloudquery/filetypes/v4 v4.2.16
 	github.com/cloudquery/plugin-sdk/v4 v4.38.0
+	github.com/google/go-cmp v0.6.0
 	github.com/google/uuid v1.6.0
 	github.com/invopop/jsonschema v0.12.0
 	github.com/rs/zerolog v1.32.0


### PR DESCRIPTION
Fixes #15097 . Since the PR is fairly large, please review it commit by commit along with a read of the commit message descriptions to get a better sense of the changes. 

#### Summary

Add path variable support to GCS destination plugin. **This is a breaking change**. We check if the path string has any of the template variables like {{FORMAT}}, {{TABLE}} and so on. If they do, we follow the behaviour of S3 plugin wherein we replace the template variables and that's it. If there are no such variables, we revert back to the current behaviour in the code block shown above.

Please read the issue comments to check on how the decisions for this PR were made. 

This PR follows similar approach to the S3 plugin. I've added some extra tests for client.read() errors which we should probably copy back to S3 and File plugins in a follow up issue. 

Note: I have not made additions to CHANGELOG.md, I'm assuming the maintainer will do it just before merge, in order to make sure of the right tag at the time of merge. Please lmk if I need to make that change

<details> 
<summary> GCS screenshot for path `new/{{TABLE}}/{{UUID}}.{{FORMAT}}` </summary>

![Screenshot 2024-04-12 at 1 46 50 AM](https://github.com/cloudquery/cloudquery/assets/13910561/6b17748b-6686-4c42-8e9d-4d40a2c270b3)


</details>

- [x] Read the [contribution guidelines](https://github.com/cloudquery/cloudquery/blob/main/CONTRIBUTING.md) 🧑‍🎓
- [x] Run `make lint` to ensure the proposed changes follow the coding style 🚨 (install golangci-lint [here](https://golangci-lint.run/usage/install/#local-installation))
- [x] Run `make test` to ensure the proposed changes pass the tests 🧪
- [x] If changing a source plugin run `make gen` to ensure docs are up to date 📝
- [x] Ensure the status checks below are successful ✅
