### PR TITLE
chore: Don't validate PR title on bot PRs

### DIFF
--- a/.github/workflows/validate_pr_title.yml
+++ b/.github/workflows/validate_pr_title.yml
@@ -12,6 +12,7 @@ jobs:
     timeout-minutes: 5
     name: validate-pr-title
     runs-on: ubuntu-latest
+    if: github.event.pull_request.user.login != 'cq-bot'
     steps:
       # Please look up the latest version from
       # https://github.com/amannn/action-semantic-pull-request/releases


### PR DESCRIPTION
<!-- 🎉 Thank you for making CloudQuery awesome by submitting a PR 🎉 -->

#### Summary

We've been hitting GitHub rate limits quite a lot during releases recently. This is an optimization to skip the PR title validator when the PR is generated from our bot, as the title for such PRs is always valid

<!--
Use the following steps to ensure your PR is ready to be reviewed

- [ ] Read the [contribution guidelines](https://github.com/cloudquery/cloudquery/blob/main/CONTRIBUTING.md) 🧑‍🎓
- [ ] Run `make lint` to ensure the proposed changes follow the coding style 🚨 (install golangci-lint [here](https://golangci-lint.run/usage/install/#local-installation))
- [ ] Run `make test` to ensure the proposed changes pass the tests 🧪
- [ ] If changing a source plugin run `make gen` to ensure docs are up to date 📝
- [ ] Ensure the status checks below are successful ✅
--->
