### PR TITLE
feat: Add custom JSON schema errors

### DIFF
--- a/plugins/destination/file/client/spec/schema.go
+++ b/plugins/destination/file/client/spec/schema.go
@@ -25,6 +25,22 @@ func (s Spec) JSONSchemaExtend(sc *jsonschema.Schema) {
 			return properties
 		}(),
 	}
+
+	pathNotWithUUID := &jsonschema.Schema{
+		Title: "Disallow {{UUID}} in path",
+		Properties: func() *orderedmap.OrderedMap[string, *jsonschema.Schema] {
+			// we make the non-zero requirement, so we want to allow only null here
+			properties := orderedmap.New[string, *jsonschema.Schema]()
+			properties.Set("path", &jsonschema.Schema{
+				Type: "string",
+				Not: &jsonschema.Schema{
+					Pattern: `^.*\{\{UUID\}\}.*$`,
+				},
+			})
+			return properties
+		}(),
+	}
+
 	// no_rotate:true -> no {{UUID}} should be present in path
 	noRotateNoUUID := &jsonschema.Schema{
 		Title: "Disallow {{UUID}} in path when using no_rotate",
@@ -40,10 +56,16 @@ func (s Spec) JSONSchemaExtend(sc *jsonschema.Schema) {
 			}(),
 			Required: []string{"no_rotate"},
 		},
-		Then: &jsonschema.Schema{
-			Not: pathWithUUID,
+		Then: pathNotWithUUID,
+		Extras: map[string]interface{}{
+			"errorMessage": map[string]interface{}{
+				"properties": map[string]interface{}{
+					"path": "the {{UUID}} placeholder must not be present in the path when no_rotate is enabled",
+				},
+			},
 		},
 	}
+
 	// no_rotate:true -> only nulls for batch options
 	noRotateNoBatch := &jsonschema.Schema{
 		Title: "Disallow batching when using no_rotate",
@@ -70,6 +92,16 @@ func (s Spec) JSONSchemaExtend(sc *jsonschema.Schema) {
 				return properties
 			}(),
 		},
+		Extras: map[string]interface{}{
+			"errorMessage": map[string]interface{}{
+				"properties": map[string]interface{}{
+					"no_rotate":        "batching options must not be present when no_rotate is enabled",
+					"batch_size":       "batching options must not be present when no_rotate is enabled",
+					"batch_size_bytes": "batching options must not be present when no_rotate is enabled",
+					"batch_timeout":    "batching options must not be present when no_rotate is enabled",
+				},
+			},
+		},
 	}
 
 	// batching enabled -> require {{UUID}} in path
@@ -90,6 +122,13 @@ func (s Spec) JSONSchemaExtend(sc *jsonschema.Schema) {
 			}(),
 		},
 		Then: pathWithUUID,
+		Extras: map[string]interface{}{
+			"errorMessage": map[string]interface{}{
+				"properties": map[string]interface{}{
+					"path": "the {{UUID}} placeholder must be present in the path",
+				},
+			},
+		},
 	}
 
 	sc.AllOf = append(sc.AllOf, noRotateNoUUID, noRotateNoBatch, uuidWhenBatching)

--- a/plugins/destination/file/client/spec/schema.json
+++ b/plugins/destination/file/client/spec/schema.json
@@ -51,17 +51,22 @@
             ]
           },
           "then": {
-            "not": {
-              "properties": {
-                "path": {
-                  "type": "string",
+            "properties": {
+              "path": {
+                "not": {
                   "pattern": "^.*\\{\\{UUID\\}\\}.*$"
-                }
-              },
-              "title": "Require {{UUID}} to be present in path"
-            }
+                },
+                "type": "string"
+              }
+            },
+            "title": "Disallow {{UUID}} in path"
           },
-          "title": "Disallow {{UUID}} in path when using no_rotate"
+          "title": "Disallow {{UUID}} in path when using no_rotate",
+          "errorMessage": {
+            "properties": {
+              "path": "the {{UUID}} placeholder must not be present in the path when no_rotate is enabled"
+            }
+          }
         },
         {
           "if": {
@@ -88,7 +93,15 @@
               }
             }
           },
-          "title": "Disallow batching when using no_rotate"
+          "title": "Disallow batching when using no_rotate",
+          "errorMessage": {
+            "properties": {
+              "batch_size": "batching options must not be present when no_rotate is enabled",
+              "batch_size_bytes": "batching options must not be present when no_rotate is enabled",
+              "batch_timeout": "batching options must not be present when no_rotate is enabled",
+              "no_rotate": "batching options must not be present when no_rotate is enabled"
+            }
+          }
         },
         {
           "if": {
@@ -109,7 +122,12 @@
             },
             "title": "Require {{UUID}} to be present in path"
           },
-          "title": "Require {{UUID}} in path when batching"
+          "title": "Require {{UUID}} in path when batching",
+          "errorMessage": {
+            "properties": {
+              "path": "the {{UUID}} placeholder must be present in the path"
+            }
+          }
         }
       ],
       "oneOf": [
@@ -209,7 +227,11 @@
         "path": {
           "type": "string",
           "minLength": 1,
-          "description": "Path template string that determines where files will be written.\n\nThe path supports the following placeholder variables:\n- `{{TABLE}}` will be replaced with the table name\n- `{{FORMAT}}` will be replaced with the file format, such as `csv`, `json` or `parquet`. If compression is enabled, the format will be `csv.gz`, `json.gz` etc.\n- `{{UUID}}` will be replaced with a random UUID to uniquely identify each file\n- `{{YEAR}}` will be replaced with the current year in `YYYY` format\n- `{{MONTH}}` will be replaced with the current month in `MM` format\n- `{{DAY}}` will be replaced with the current day in `DD` format\n- `{{HOUR}}` will be replaced with the current hour in `HH` format\n- `{{MINUTE}}` will be replaced with the current minute in `mm` format\n\n **Note** that timestamps are in `UTC` and will be the current time at the time the file is written, not when the sync started."
+          "description": "Path template string that determines where files will be written, for example `path/to/files/{{TABLE}}/{{UUID}}.parquet`.\n\nThe path supports the following placeholder variables:\n- `{{TABLE}}` will be replaced with the table name\n- `{{FORMAT}}` will be replaced with the file format, such as `csv`, `json` or `parquet`. If compression is enabled, the format will be `csv.gz`, `json.gz` etc.\n- `{{UUID}}` will be replaced with a random UUID to uniquely identify each file\n- `{{YEAR}}` will be replaced with the current year in `YYYY` format\n- `{{MONTH}}` will be replaced with the current month in `MM` format\n- `{{DAY}}` will be replaced with the current day in `DD` format\n- `{{HOUR}}` will be replaced with the current hour in `HH` format\n- `{{MINUTE}}` will be replaced with the current minute in `mm` format\n\n **Note** that timestamps are in `UTC` and will be the current time at the time the file is written, not when the sync started.",
+          "examples": [
+            "path/to/files/{{TABLE}}/{{UUID}}.parquet"
+          ],
+          "errorMessage": "value should not start with /"
         },
         "no_rotate": {
           "type": "boolean",

--- a/plugins/destination/file/client/spec/spec.go
+++ b/plugins/destination/file/client/spec/spec.go
@@ -25,7 +25,7 @@ const (
 type Spec struct {
 	filetypes.FileSpec
 
-	// Path template string that determines where files will be written.
+	// Path template string that determines where files will be written, for example `path/to/files/{{TABLE}}/{{UUID}}.parquet`.
 	//
 	// The path supports the following placeholder variables:
 	// - `{{TABLE}}` will be replaced with the table name
@@ -38,7 +38,7 @@ type Spec struct {
 	// - `{{MINUTE}}` will be replaced with the current minute in `mm` format
 	//
 	//  **Note** that timestamps are in `UTC` and will be the current time at the time the file is written, not when the sync started.
-	Path string `json:"path,omitempty" jsonschema:"required,minLength=1"`
+	Path string `json:"path,omitempty" jsonschema:"required,minLength=1,example=path/to/files/{{TABLE}}/{{UUID}}.parquet" jsonschema_extras:"errorMessage=value should not start with /"`
 
 	// If set to `true`, the plugin will write to one file per table.
 	// Otherwise, for every batch a new file will be created with a different `.<UUID>` suffix.

--- a/plugins/destination/file/docs/_configuration.md
+++ b/plugins/destination/file/docs/_configuration.md
@@ -10,7 +10,7 @@ spec:
   write_mode: "append"
   spec:
     path: "path/to/files/{{TABLE}}/{{UUID}}.{{FORMAT}}"
-    format: "csv" # options: parquet, json, csv
+    format: "parquet" # options: parquet, json, csv
     # Optional parameters
     # format_spec:
       # CSV-specific parameters:

--- a/plugins/destination/file/docs/overview.md
+++ b/plugins/destination/file/docs/overview.md
@@ -22,7 +22,9 @@ This is the (nested) spec used by the file destination Plugin.
 
 - `path` (`string`) (**required**)
 
-  Path template string that determines where files will be written. The path supports the following placeholder variables:
+  Path template string that determines where files will be written, for example `path/to/files/{{TABLE}}/{{UUID}}.parquet`.
+
+  The path supports the following placeholder variables:
 
   - `{{TABLE}}` will be replaced with the table name
   - `{{FORMAT}}` will be replaced with the file format, such as `csv`, `json` or `parquet`. If compression is enabled, the format will be `csv.gz`, `json.gz` etc.

--- a/plugins/destination/gcs/client/spec/schema.go
+++ b/plugins/destination/gcs/client/spec/schema.go
@@ -39,38 +39,46 @@ func (s Spec) JSONSchemaExtend(sc *jsonschema.Schema) {
 				return properties
 			}(),
 		},
+		Extras: map[string]interface{}{
+			"errorMessage": map[string]interface{}{
+				"properties": map[string]interface{}{
+					"no_rotate":        "batching options must not be present when no_rotate is enabled",
+					"batch_size":       "batching options must not be present when no_rotate is enabled",
+					"batch_size_bytes": "batching options must not be present when no_rotate is enabled",
+					"batch_timeout":    "batching options must not be present when no_rotate is enabled",
+				},
+			},
+		},
 	}
 
 	// path patterns: should be a clean path
 	cleanPath := &jsonschema.Schema{
 		Title: "`path` is a clean path value",
-		Not: &jsonschema.Schema{
-			Title: "`path` is not a clean path value",
-			AnyOf: []*jsonschema.Schema{
-				{
-					Title: "`path` contains `./`",
-					Properties: func() *orderedmap.OrderedMap[string, *jsonschema.Schema] {
-						properties := orderedmap.New[string, *jsonschema.Schema]()
-						properties.Set("path", &jsonschema.Schema{
-							Type:    "string",
-							Pattern: `^.*\./.*$`,
-						})
-						return properties
-					}(),
-				},
-				{
-					Title: "`path` contains `//`",
-					Properties: func() *orderedmap.OrderedMap[string, *jsonschema.Schema] {
-						properties := orderedmap.New[string, *jsonschema.Schema]()
-						properties.Set("path", &jsonschema.Schema{
-							Type:    "string",
-							Pattern: `^.*//.*$`,
-						})
-						return properties
-					}(),
+		Extras: map[string]interface{}{
+			"errorMessage": map[string]interface{}{
+				"properties": map[string]interface{}{
+					"path": "value must not contain ./ or //",
 				},
 			},
 		},
+		Properties: func() *orderedmap.OrderedMap[string, *jsonschema.Schema] {
+			// we make the non-zero requirement, so we want to allow only null here
+			properties := orderedmap.New[string, *jsonschema.Schema]()
+			properties.Set("path", &jsonschema.Schema{
+				Type: "string",
+				Not: &jsonschema.Schema{
+					AnyOf: []*jsonschema.Schema{
+						{
+							Pattern: `^.*\./.*$`,
+						},
+						{
+							Pattern: `^.*//.*$`,
+						},
+					},
+				},
+			})
+			return properties
+		}(),
 	}
 
 	pathWithUUID := &jsonschema.Schema{
@@ -85,6 +93,22 @@ func (s Spec) JSONSchemaExtend(sc *jsonschema.Schema) {
 			return properties
 		}(),
 	}
+
+	pathNotWithUUID := &jsonschema.Schema{
+		Title: "Disallow {{UUID}} in path",
+		Properties: func() *orderedmap.OrderedMap[string, *jsonschema.Schema] {
+			// we make the non-zero requirement, so we want to allow only null here
+			properties := orderedmap.New[string, *jsonschema.Schema]()
+			properties.Set("path", &jsonschema.Schema{
+				Type: "string",
+				Not: &jsonschema.Schema{
+					Pattern: `^.*\{\{UUID\}\}.*$`,
+				},
+			})
+			return properties
+		}(),
+	}
+
 	// no_rotate:true -> no {{UUID}} should be present in path
 	noRotateNoUUID := &jsonschema.Schema{
 		Title: "Disallow {{UUID}} in path when using no_rotate",
@@ -100,13 +124,18 @@ func (s Spec) JSONSchemaExtend(sc *jsonschema.Schema) {
 			}(),
 			Required: []string{"no_rotate"},
 		},
-		Then: &jsonschema.Schema{
-			Not: pathWithUUID,
+		Then: pathNotWithUUID,
+		Extras: map[string]interface{}{
+			"errorMessage": map[string]interface{}{
+				"properties": map[string]interface{}{
+					"path": "the {{UUID}} placeholder must not be present in the path when no_rotate is enabled",
+				},
+			},
 		},
 	}
 
-	/* batching enabled -> require {{UUID}} in path or require no path variables in path,
-	since we will use UUID by default if batch */
+	// batching enabled -> require {{UUID}} in path or require no path variables in path,
+	// since we will use UUID by default if batch
 	uuidWhenBatching := &jsonschema.Schema{
 		Title: "Require {{UUID}} in path when batching",
 		If: &jsonschema.Schema{
@@ -133,11 +162,18 @@ func (s Spec) JSONSchemaExtend(sc *jsonschema.Schema) {
 						properties.Set("path", &jsonschema.Schema{
 							Not: &jsonschema.Schema{
 								Type:    "string",
-								Pattern: `^.*{{.*}}.*$`,
+								Pattern: `^.*\{\{.*\}\}.*$`,
 							},
 						})
 						return properties
 					}(),
+				},
+			},
+		},
+		Extras: map[string]interface{}{
+			"errorMessage": map[string]interface{}{
+				"properties": map[string]interface{}{
+					"path": "value must contain the {{UUID}} placeholder or no path variables at all",
 				},
 			},
 		},

--- a/plugins/destination/gcs/client/spec/schema.json
+++ b/plugins/destination/gcs/client/spec/schema.json
@@ -63,33 +63,38 @@
               }
             }
           },
-          "title": "Disallow batching when using no_rotate"
+          "title": "Disallow batching when using no_rotate",
+          "errorMessage": {
+            "properties": {
+              "batch_size": "batching options must not be present when no_rotate is enabled",
+              "batch_size_bytes": "batching options must not be present when no_rotate is enabled",
+              "batch_timeout": "batching options must not be present when no_rotate is enabled",
+              "no_rotate": "batching options must not be present when no_rotate is enabled"
+            }
+          }
         },
         {
-          "not": {
-            "anyOf": [
-              {
-                "properties": {
-                  "path": {
-                    "type": "string",
+          "properties": {
+            "path": {
+              "not": {
+                "anyOf": [
+                  {
                     "pattern": "^.*\\./.*$"
-                  }
-                },
-                "title": "`path` contains `./`"
-              },
-              {
-                "properties": {
-                  "path": {
-                    "type": "string",
+                  },
+                  {
                     "pattern": "^.*//.*$"
                   }
-                },
-                "title": "`path` contains `//`"
-              }
-            ],
-            "title": "`path` is not a clean path value"
+                ]
+              },
+              "type": "string"
+            }
           },
-          "title": "`path` is a clean path value"
+          "title": "`path` is a clean path value",
+          "errorMessage": {
+            "properties": {
+              "path": "value must not contain ./ or //"
+            }
+          }
         },
         {
           "if": {
@@ -104,17 +109,22 @@
             ]
           },
           "then": {
-            "not": {
-              "properties": {
-                "path": {
-                  "type": "string",
+            "properties": {
+              "path": {
+                "not": {
                   "pattern": "^.*\\{\\{UUID\\}\\}.*$"
-                }
-              },
-              "title": "Require {{UUID}} to be present in path"
-            }
+                },
+                "type": "string"
+              }
+            },
+            "title": "Disallow {{UUID}} in path"
           },
-          "title": "Disallow {{UUID}} in path when using no_rotate"
+          "title": "Disallow {{UUID}} in path when using no_rotate",
+          "errorMessage": {
+            "properties": {
+              "path": "the {{UUID}} placeholder must not be present in the path when no_rotate is enabled"
+            }
+          }
         },
         {
           "if": {
@@ -142,7 +152,7 @@
                   "path": {
                     "not": {
                       "type": "string",
-                      "pattern": "^.*{{.*}}.*$"
+                      "pattern": "^.*\\{\\{.*\\}\\}.*$"
                     }
                   }
                 },
@@ -150,7 +160,12 @@
               }
             ]
           },
-          "title": "Require {{UUID}} in path when batching"
+          "title": "Require {{UUID}} in path when batching",
+          "errorMessage": {
+            "properties": {
+              "path": "value must contain the {{UUID}} placeholder or no path variables at all"
+            }
+          }
         }
       ],
       "oneOf": [
@@ -255,7 +270,11 @@
         "path": {
           "type": "string",
           "minLength": 1,
-          "description": "Path to where the files will be uploaded in the above bucket."
+          "description": "Path to where the files will be uploaded in the above bucket, for example `path/to/files/{{TABLE}}/{{UUID}}.parquet`\n\nThe path supports the following placeholder variables:\n- `{{TABLE}}` will be replaced with the table name\n- `{{FORMAT}}` will be replaced with the file format, such as `csv`, `json` or `parquet`. If compression is enabled, the format will be `csv.gz`, `json.gz` etc.\n- `{{UUID}}` will be replaced with a random UUID to uniquely identify each file\n- `{{YEAR}}` will be replaced with the current year in `YYYY` format\n- `{{MONTH}}` will be replaced with the current month in `MM` format\n- `{{DAY}}` will be replaced with the current day in `DD` format\n- `{{HOUR}}` will be replaced with the current hour in `HH` format\n- `{{MINUTE}}` will be replaced with the current minute in `mm` format\n\n **Note** that timestamps are in `UTC` and will be the current time at the time the file is written, not when the sync started.",
+          "examples": [
+            "path/to/files/{{TABLE}}/{{UUID}}.parquet"
+          ],
+          "errorMessage": "value should not start with /"
         },
         "no_rotate": {
           "type": "boolean",

--- a/plugins/destination/gcs/client/spec/spec.go
+++ b/plugins/destination/gcs/client/spec/spec.go
@@ -29,8 +29,20 @@ type Spec struct {
 	// Bucket where to sync the files.
 	Bucket string `json:"bucket,omitempty" jsonschema:"required,minLength=1"`
 
-	// Path to where the files will be uploaded in the above bucket.
-	Path string `json:"path,omitempty" jsonschema:"required,minLength=1"`
+	// Path to where the files will be uploaded in the above bucket, for example `path/to/files/{{TABLE}}/{{UUID}}.parquet`
+	//
+	// The path supports the following placeholder variables:
+	// - `{{TABLE}}` will be replaced with the table name
+	// - `{{FORMAT}}` will be replaced with the file format, such as `csv`, `json` or `parquet`. If compression is enabled, the format will be `csv.gz`, `json.gz` etc.
+	// - `{{UUID}}` will be replaced with a random UUID to uniquely identify each file
+	// - `{{YEAR}}` will be replaced with the current year in `YYYY` format
+	// - `{{MONTH}}` will be replaced with the current month in `MM` format
+	// - `{{DAY}}` will be replaced with the current day in `DD` format
+	// - `{{HOUR}}` will be replaced with the current hour in `HH` format
+	// - `{{MINUTE}}` will be replaced with the current minute in `mm` format
+	//
+	//  **Note** that timestamps are in `UTC` and will be the current time at the time the file is written, not when the sync started.
+	Path string `json:"path,omitempty" jsonschema:"required,minLength=1,example=path/to/files/{{TABLE}}/{{UUID}}.parquet" jsonschema_extras:"errorMessage=value should not start with /"`
 
 	// If set to `true`, the plugin will write to one file per table.
 	// Otherwise, for every batch a new file will be created with a different `.<UUID>` suffix.

--- a/plugins/destination/gcs/docs/_configuration.md
+++ b/plugins/destination/gcs/docs/_configuration.md
@@ -10,8 +10,8 @@ spec:
   write_mode: "append"
   spec:
     bucket: "bucket_name"
-    path: "path/to/files"
-    format: "csv" # options: parquet, json, csv
+    path: "path/to/files/{{TABLE}}/{{UUID}}.{{FORMAT}}"
+    format: "parquet" # options: parquet, json, csv
     format_spec:
       # CSV-specific parameters:
       # delimiter: ","

--- a/plugins/destination/gcs/docs/overview.md
+++ b/plugins/destination/gcs/docs/overview.md
@@ -28,7 +28,11 @@ This is the (nested) spec used by the CSV destination Plugin.
 
 - `path` (`string`) (required)
 
-  Path to where the files will be uploaded in the above bucket. If no path variables are present, the path will be appended with TABLE, FORMAT and Compression extension by default. The path supports the following placeholder variables:
+  Path to where the files will be uploaded in the above bucket, for example `path/to/files/{{TABLE}}/{{UUID}}.parquet`.
+
+  If no path variables are present, the path will be appended with TABLE, FORMAT and Compression extension by default.
+
+  The path supports the following placeholder variables:
 
   - `{{TABLE}}` will be replaced with the table name
   - `{{SYNC_ID}}` will be replaced with the unique identifier of the sync. This value is a UUID and is randomly generated for each sync.

--- a/plugins/destination/s3/client/spec/schema.go
+++ b/plugins/destination/s3/client/spec/schema.go
@@ -16,33 +16,31 @@ func (s Spec) JSONSchemaExtend(sc *jsonschema.Schema) {
 	// path patterns: should be a clean path
 	cleanPath := &jsonschema.Schema{
 		Title: "`path` is a clean path value",
-		Not: &jsonschema.Schema{
-			Title: "`path` is not a clean path value",
-			AnyOf: []*jsonschema.Schema{
-				{
-					Title: "`path` contains `./`",
-					Properties: func() *orderedmap.OrderedMap[string, *jsonschema.Schema] {
-						properties := orderedmap.New[string, *jsonschema.Schema]()
-						properties.Set("path", &jsonschema.Schema{
-							Type:    "string",
-							Pattern: `^.*\./.*$`,
-						})
-						return properties
-					}(),
-				},
-				{
-					Title: "`path` contains `//`",
-					Properties: func() *orderedmap.OrderedMap[string, *jsonschema.Schema] {
-						properties := orderedmap.New[string, *jsonschema.Schema]()
-						properties.Set("path", &jsonschema.Schema{
-							Type:    "string",
-							Pattern: `^.*//.*$`,
-						})
-						return properties
-					}(),
+		Extras: map[string]interface{}{
+			"errorMessage": map[string]interface{}{
+				"properties": map[string]interface{}{
+					"path": "value must not contain ./ or //",
 				},
 			},
 		},
+		Properties: func() *orderedmap.OrderedMap[string, *jsonschema.Schema] {
+			// we make the non-zero requirement, so we want to allow only null here
+			properties := orderedmap.New[string, *jsonschema.Schema]()
+			properties.Set("path", &jsonschema.Schema{
+				Type: "string",
+				Not: &jsonschema.Schema{
+					AnyOf: []*jsonschema.Schema{
+						{
+							Pattern: `^.*\./.*$`,
+						},
+						{
+							Pattern: `^.*//.*$`,
+						},
+					},
+				},
+			})
+			return properties
+		}(),
 	}
 
 	pathWithUUID := &jsonschema.Schema{
@@ -57,6 +55,22 @@ func (s Spec) JSONSchemaExtend(sc *jsonschema.Schema) {
 			return properties
 		}(),
 	}
+
+	pathNotWithUUID := &jsonschema.Schema{
+		Title: "Disallow {{UUID}} in path",
+		Properties: func() *orderedmap.OrderedMap[string, *jsonschema.Schema] {
+			// we make the non-zero requirement, so we want to allow only null here
+			properties := orderedmap.New[string, *jsonschema.Schema]()
+			properties.Set("path", &jsonschema.Schema{
+				Type: "string",
+				Not: &jsonschema.Schema{
+					Pattern: `^.*\{\{UUID\}\}.*$`,
+				},
+			})
+			return properties
+		}(),
+	}
+
 	// no_rotate:true -> no {{UUID}} should be present in path
 	noRotateNoUUID := &jsonschema.Schema{
 		Title: "Disallow {{UUID}} in path when using no_rotate",
@@ -72,10 +86,16 @@ func (s Spec) JSONSchemaExtend(sc *jsonschema.Schema) {
 			}(),
 			Required: []string{"no_rotate"},
 		},
-		Then: &jsonschema.Schema{
-			Not: pathWithUUID,
+		Then: pathNotWithUUID,
+		Extras: map[string]interface{}{
+			"errorMessage": map[string]interface{}{
+				"properties": map[string]interface{}{
+					"path": "the {{UUID}} placeholder must not be present in the path when no_rotate is enabled",
+				},
+			},
 		},
 	}
+
 	// no_rotate:true -> only nulls for batch options
 	noRotateNoBatch := &jsonschema.Schema{
 		Title: "Disallow batching when using no_rotate",
@@ -102,6 +122,16 @@ func (s Spec) JSONSchemaExtend(sc *jsonschema.Schema) {
 				return properties
 			}(),
 		},
+		Extras: map[string]interface{}{
+			"errorMessage": map[string]interface{}{
+				"properties": map[string]interface{}{
+					"no_rotate":        "batching options must not be present when no_rotate is enabled",
+					"batch_size":       "batching options must not be present when no_rotate is enabled",
+					"batch_size_bytes": "batching options must not be present when no_rotate is enabled",
+					"batch_timeout":    "batching options must not be present when no_rotate is enabled",
+				},
+			},
+		},
 	}
 
 	// batching enabled -> require {{UUID}} in path
@@ -122,6 +152,13 @@ func (s Spec) JSONSchemaExtend(sc *jsonschema.Schema) {
 			}(),
 		},
 		Then: pathWithUUID,
+		Extras: map[string]interface{}{
+			"errorMessage": map[string]interface{}{
+				"properties": map[string]interface{}{
+					"path": "the {{UUID}} placeholder must be present in the path",
+				},
+			},
+		},
 	}
 
 	sc.AllOf = append(sc.AllOf, cleanPath, noRotateNoUUID, noRotateNoBatch, uuidWhenBatching)

--- a/plugins/destination/s3/client/spec/schema.json
+++ b/plugins/destination/s3/client/spec/schema.json
@@ -62,30 +62,27 @@
     "Spec": {
       "allOf": [
         {
-          "not": {
-            "anyOf": [
-              {
-                "properties": {
-                  "path": {
-                    "type": "string",
+          "properties": {
+            "path": {
+              "not": {
+                "anyOf": [
+                  {
                     "pattern": "^.*\\./.*$"
-                  }
-                },
-                "title": "`path` contains `./`"
-              },
-              {
-                "properties": {
-                  "path": {
-                    "type": "string",
+                  },
+                  {
                     "pattern": "^.*//.*$"
                   }
-                },
-                "title": "`path` contains `//`"
-              }
-            ],
-            "title": "`path` is not a clean path value"
+                ]
+              },
+              "type": "string"
+            }
           },
-          "title": "`path` is a clean path value"
+          "title": "`path` is a clean path value",
+          "errorMessage": {
+            "properties": {
+              "path": "value must not contain ./ or //"
+            }
+          }
         },
         {
           "if": {
@@ -100,17 +97,22 @@
             ]
           },
           "then": {
-            "not": {
-              "properties": {
-                "path": {
-                  "type": "string",
+            "properties": {
+              "path": {
+                "not": {
                   "pattern": "^.*\\{\\{UUID\\}\\}.*$"
-                }
-              },
-              "title": "Require {{UUID}} to be present in path"
-            }
+                },
+                "type": "string"
+              }
+            },
+            "title": "Disallow {{UUID}} in path"
           },
-          "title": "Disallow {{UUID}} in path when using no_rotate"
+          "title": "Disallow {{UUID}} in path when using no_rotate",
+          "errorMessage": {
+            "properties": {
+              "path": "the {{UUID}} placeholder must not be present in the path when no_rotate is enabled"
+            }
+          }
         },
         {
           "if": {
@@ -137,7 +139,15 @@
               }
             }
           },
-          "title": "Disallow batching when using no_rotate"
+          "title": "Disallow batching when using no_rotate",
+          "errorMessage": {
+            "properties": {
+              "batch_size": "batching options must not be present when no_rotate is enabled",
+              "batch_size_bytes": "batching options must not be present when no_rotate is enabled",
+              "batch_timeout": "batching options must not be present when no_rotate is enabled",
+              "no_rotate": "batching options must not be present when no_rotate is enabled"
+            }
+          }
         },
         {
           "if": {
@@ -158,7 +168,12 @@
             },
             "title": "Require {{UUID}} to be present in path"
           },
-          "title": "Require {{UUID}} in path when batching"
+          "title": "Require {{UUID}} in path when batching",
+          "errorMessage": {
+            "properties": {
+              "path": "the {{UUID}} placeholder must be present in the path"
+            }
+          }
         }
       ],
       "oneOf": [
@@ -268,7 +283,11 @@
         "path": {
           "type": "string",
           "pattern": "^[^/].*$",
-          "description": "Path to where the files will be uploaded in the above bucket. The path supports the following placeholder variables:\n\n- `{{TABLE}}` will be replaced with the table name\n- `{{FORMAT}}` will be replaced with the file format, such as `csv`, `json` or `parquet`. If compression is enabled, the format will be `csv.gz`, `json.gz` etc.\n- `{{UUID}}` will be replaced with a random UUID to uniquely identify each file\n- `{{YEAR}}` will be replaced with the current year in `YYYY` format\n- `{{MONTH}}` will be replaced with the current month in `MM` format\n- `{{DAY}}` will be replaced with the current day in `DD` format\n- `{{HOUR}}` will be replaced with the current hour in `HH` format\n- `{{MINUTE}}` will be replaced with the current minute in `mm` format\n\n**Note** that timestamps are in `UTC` and will be the current time at the time the file is written, not when the sync started."
+          "description": "Path to where the files will be uploaded in the above bucket, for example `path/to/files/{{TABLE}}/{{UUID}}.parquet`.\n   The path supports the following placeholder variables:\n\n- `{{TABLE}}` will be replaced with the table name\n- `{{FORMAT}}` will be replaced with the file format, such as `csv`, `json` or `parquet`. If compression is enabled, the format will be `csv.gz`, `json.gz` etc.\n- `{{UUID}}` will be replaced with a random UUID to uniquely identify each file\n- `{{YEAR}}` will be replaced with the current year in `YYYY` format\n- `{{MONTH}}` will be replaced with the current month in `MM` format\n- `{{DAY}}` will be replaced with the current day in `DD` format\n- `{{HOUR}}` will be replaced with the current hour in `HH` format\n- `{{MINUTE}}` will be replaced with the current minute in `mm` format\n\n**Note** that timestamps are in `UTC` and will be the current time at the time the file is written, not when the sync started.",
+          "examples": [
+            "path/to/files/{{TABLE}}/{{UUID}}.parquet"
+          ],
+          "errorMessage": "value should not start with /"
         },
         "no_rotate": {
           "type": "boolean",

--- a/plugins/destination/s3/client/spec/spec.go
+++ b/plugins/destination/s3/client/spec/spec.go
@@ -34,7 +34,8 @@ type Spec struct {
 	// Region where bucket is located.
 	Region string `json:"region,omitempty" jsonschema:"required,minLength=1"`
 
-	//  Path to where the files will be uploaded in the above bucket. The path supports the following placeholder variables:
+	//    Path to where the files will be uploaded in the above bucket, for example `path/to/files/{{TABLE}}/{{UUID}}.parquet`.
+	//    The path supports the following placeholder variables:
 	//
 	// - `{{TABLE}}` will be replaced with the table name
 	// - `{{FORMAT}}` will be replaced with the file format, such as `csv`, `json` or `parquet`. If compression is enabled, the format will be `csv.gz`, `json.gz` etc.
@@ -46,7 +47,7 @@ type Spec struct {
 	// - `{{MINUTE}}` will be replaced with the current minute in `mm` format
 	//
 	// **Note** that timestamps are in `UTC` and will be the current time at the time the file is written, not when the sync started.
-	Path string `json:"path,omitempty" jsonschema:"required,pattern=^[^/].*$"` // other cases (//, ./, ../) are covered in extended part
+	Path string `json:"path,omitempty" jsonschema:"required,pattern=^[^/].*$,example=path/to/files/{{TABLE}}/{{UUID}}.parquet" jsonschema_extras:"errorMessage=value should not start with /"` // other cases (//, ./, ../) are covered in extended part
 
 	// If set to `true`, the plugin will write to one file per table.
 	// Otherwise, for every batch a new file will be created with a different `.<UUID>` suffix.

--- a/plugins/destination/s3/docs/_configuration.md
+++ b/plugins/destination/s3/docs/_configuration.md
@@ -13,7 +13,7 @@ spec:
   spec:
     bucket: "bucket_name"
     region: "region-name" # Example: us-east-1
-    path: "path/to/files/{{TABLE}}/{{UUID}}.parquet"
+    path: "path/to/files/{{TABLE}}/{{UUID}}.{{FORMAT}}"
     format: "parquet" # options: parquet, json, csv
     format_spec:
       # CSV-specific parameters:

--- a/plugins/destination/s3/docs/overview.md
+++ b/plugins/destination/s3/docs/overview.md
@@ -32,7 +32,9 @@ This is the (nested) spec used by the CSV destination Plugin.
 
 - `path` (`string`) (required)
 
-  Path to where the files will be uploaded in the above bucket. The path supports the following placeholder variables:
+  Path to where the files will be uploaded in the above bucket, for example `path/to/files/{{TABLE}}/{{UUID}}.parquet`.
+
+  The path supports the following placeholder variables:
 
   - `{{TABLE}}` will be replaced with the table name
   - `{{SYNC_ID}}` will be replaced with the unique identifier of the sync. This value is a UUID and is randomly generated for each sync.


### PR DESCRIPTION
<!-- 🎉 Thank you for making CloudQuery awesome by submitting a PR 🎉 -->

#### Summary

Fixes https://github.com/cloudquery/cloudquery-issues/issues/1526 (internal issue).
This PR uses the custom errors syntax from https://ajv.js.org/packages/ajv-errors.html#messages-for-properties-and-items to improve the errors we provide for the S3 destination plugin (and aligns file and GCS plugin with it).
While this won't help with the Go validation until https://github.com/santhosh-tekuri/jsonschema/issues/44 is implemented it does help with our Cloud Syncs, examples below.

Before:
![image](https://github.com/cloudquery/cloudquery/assets/26760571/e5d252a1-5ca5-4650-bde8-ce1b79960eb0)

After:
![image](https://github.com/cloudquery/cloudquery/assets/26760571/3de97312-eaf3-4230-bb3b-cf20aebed0c2)

Before:
![image](https://github.com/cloudquery/cloudquery/assets/26760571/10a0da89-8f1c-4620-adfd-532832915b99)

After:
![image](https://github.com/cloudquery/cloudquery/assets/26760571/2945a600-1fc0-4e08-9ee2-b139c0d90a5d)

(The latter still need some frontend work not to show the top level error)


<!--
Use the following steps to ensure your PR is ready to be reviewed

- [ ] Read the [contribution guidelines](https://github.com/cloudquery/cloudquery/blob/main/CONTRIBUTING.md) 🧑‍🎓
- [ ] Run `make lint` to ensure the proposed changes follow the coding style 🚨 (install golangci-lint [here](https://golangci-lint.run/usage/install/#local-installation))
- [ ] Run `make test` to ensure the proposed changes pass the tests 🧪
- [ ] If changing a source plugin run `make gen` to ensure docs are up to date 📝
- [ ] Ensure the status checks below are successful ✅
--->
