### PR TITLE
fix: Prevent reaching Okta rate limits

### DIFF
--- a/plugins/source/okta/go.mod
+++ b/plugins/source/okta/go.mod
@@ -136,4 +136,4 @@ require (
 // github.com/cloudquery/jsonschema @ cqmain
 replace github.com/invopop/jsonschema => github.com/cloudquery/jsonschema v0.0.0-20240220124159-92878faa2a66
 
-replace github.com/okta/okta-sdk-golang/v4 => github.com/cloudquery/okta-sdk-golang/v4 v4.0.1-0.20240405141335-5497c68a9a1e
+replace github.com/okta/okta-sdk-golang/v4 => github.com/cloudquery/okta-sdk-golang/v4 v4.0.1-0.20240418181414-42a320cff787

--- a/plugins/source/okta/go.sum
+++ b/plugins/source/okta/go.sum
@@ -51,8 +51,8 @@ github.com/cloudquery/codegen v0.3.15 h1:gAwSQC1DfQune+rOgAjukxp1wvbEIaDDhIz+rsi
 github.com/cloudquery/codegen v0.3.15/go.mod h1:3MkDEDYuia3xjPBtpVWK6cf0D7E/7JGWurREzoZ3mMo=
 github.com/cloudquery/jsonschema v0.0.0-20240220124159-92878faa2a66 h1:OZLPSIBYEfvkAUeOeM8CwTgVQy5zhayI99ishCrsFV0=
 github.com/cloudquery/jsonschema v0.0.0-20240220124159-92878faa2a66/go.mod h1:0SoZ/U7yJlNOR+fWsBSeTvTbGXB6DK01tzJ7m2Xfg34=
-github.com/cloudquery/okta-sdk-golang/v4 v4.0.1-0.20240405141335-5497c68a9a1e h1:0vx91JlME5We01H2YJqZInrMMpoWvwgVhcYd1MiSsjA=
-github.com/cloudquery/okta-sdk-golang/v4 v4.0.1-0.20240405141335-5497c68a9a1e/go.mod h1:IIYXqbNgAg3IOuSidey7NJkkg8Ozb1x5QHQTKMZfeHo=
+github.com/cloudquery/okta-sdk-golang/v4 v4.0.1-0.20240418181414-42a320cff787 h1:t9OQ29Br5es8FzKfjp0g/G6FYMHrzyju4qYfu9nz9wU=
+github.com/cloudquery/okta-sdk-golang/v4 v4.0.1-0.20240418181414-42a320cff787/go.mod h1:IIYXqbNgAg3IOuSidey7NJkkg8Ozb1x5QHQTKMZfeHo=
 github.com/cloudquery/plugin-pb-go v1.19.9 h1:1FVrXO8b5wUtrmfWe5YCXQZWk3VZQM5mnj4skwpdYFA=
 github.com/cloudquery/plugin-pb-go v1.19.9/go.mod h1:heowdB8Wsp9jMGYin+tElLteHpbnn8Sh3ym7aUOil+M=
 github.com/cloudquery/plugin-sdk/v2 v2.7.0 h1:hRXsdEiaOxJtsn/wZMFQC9/jPfU1MeMK3KF+gPGqm7U=

--- a/plugins/source/okta/resources/plugin/client.go
+++ b/plugins/source/okta/resources/plugin/client.go
@@ -83,6 +83,7 @@ func Configure(_ context.Context, logger zerolog.Logger, specBytes []byte, opts 
 		okta.WithCache(true),
 		okta.WithRateLimitMaxBackOff(int64(config.RateLimit.MaxBackoff.Duration()/time.Second)), // this param takes int64 of seconds
 		okta.WithRateLimitMaxRetries(config.RateLimit.MaxRetries),
+		okta.WithRateLimitPrevent(true),
 	)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create okta configuration: %w", err)


### PR DESCRIPTION
<!-- 🎉 Thank you for making CloudQuery awesome by submitting a PR 🎉 -->

#### Summary

This uses our forked version with the PR from https://github.com/okta/okta-sdk-golang/pull/450 (until approved) to prevent hitting Okta rate limits and blocking until the limit has reset (or context was cancelled).
This follows Okta's best practices https://developer.okta.com/docs/reference/rl-best-practices/#check-your-rate-limits-with-okta-s-rate-limit-headers

<!--
Use the following steps to ensure your PR is ready to be reviewed

- [ ] Read the [contribution guidelines](https://github.com/cloudquery/cloudquery/blob/main/CONTRIBUTING.md) 🧑‍🎓
- [ ] Run `make lint` to ensure the proposed changes follow the coding style 🚨 (install golangci-lint [here](https://golangci-lint.run/usage/install/#local-installation))
- [ ] Run `make test` to ensure the proposed changes pass the tests 🧪
- [ ] If changing a source plugin run `make gen` to ensure docs are up to date 📝
- [ ] Ensure the status checks below are successful ✅
--->
