### PR TITLE
Fix AWS_SHARED_CREDENTIALS configurations

### DIFF
--- a/plugins/source/aws/client/account.go
+++ b/plugins/source/aws/client/account.go
@@ -71,7 +71,6 @@ func (c *Client) setupAWSAccount(ctx context.Context, logger zerolog.Logger, aws
 		logger.Warn().Str("account", account.AccountName).Msg("No enabled regions provided in config for account")
 		return nil, nil
 	}
-	awsCfg.Region = getRegion(account.Regions)
 	output, err := getAccountId(ctx, awsCfg)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
For some reason setting the region here breaks configurations which use AWS_SHARED_CREDENTIALS with a session credentials for MFA or assumed role workflow.

<!-- 🎉 Thank you for making CloudQuery awesome by submitting a PR 🎉 -->

#### Summary

⚠️ **If you're contributing to a plugin please read this section of the [contribution guidelines](https://github.com/cloudquery/cloudquery/blob/main/CONTRIBUTING.md#open-core-vs-open-source) 🧑‍🎓 before submitting this PR** ⚠️

<!--
Explain what problem this PR addresses
-->

<!--
Use the following steps to ensure your PR is ready to be reviewed

- [ ] Read the [contribution guidelines](https://github.com/cloudquery/cloudquery/blob/main/CONTRIBUTING.md) 🧑‍🎓
- [ ] Run `make lint` to ensure the proposed changes follow the coding style 🚨 (install golangci-lint [here](https://golangci-lint.run/usage/install/#local-installation))
- [ ] Run `make test` to ensure the proposed changes pass the tests 🧪
- [ ] If changing a source plugin run `make gen` to ensure docs are up to date 📝
- [ ] Ensure the status checks below are successful ✅
--->
