### PR TITLE
feat: Add log message at end of sync with stats

### DIFF
--- a/cli/cmd/sync_v3.go
+++ b/cli/cmd/sync_v3.go
@@ -404,6 +404,13 @@ func syncConnectionV3(ctx context.Context, source v3source, destinations []v3des
 		msg = "Sync completed with errors, see logs for details"
 	}
 	fmt.Printf("%s. Resources: %d, Errors: %d, Warnings: %d, Time: %s\n", msg, totalResources, totals.Errors, totals.Warnings, syncTimeTook.Truncate(time.Second).String())
+	log.Info().
+		Int64("resources", totalResources).
+		Uint64("errors", totals.Errors).
+		Uint64("warnings", totals.Warnings).
+		Str("duration", syncTimeTook.Truncate(time.Second).String()).
+		Str("result", msg).
+		Msg("Sync summary")
 
 	if remoteProgressReporter != nil {
 		remoteProgressReporter.SendSignal()


### PR DESCRIPTION
This adds a log line at the end of a sync to summarize the number of rows, errors and warnings, mirroring what would normally be displayed by the CLI if `--log-console` is not used.

Example:

```
{
  "level": "info",
  "module": "cli",
  "invocation-id": "5b90c610-ff42-4f85-a018-02d472c049f3",
  "resources": 227,
  "errors": 0,
  "warnings": 0,
  "duration": "1s",
  "result": "Sync completed successfully",
  "time": "2024-04-30T11:27:42Z",
  "message": "Sync summary"
}
```