### PR TITLE
chore: Exclude `egghead.io` from broken links checks

### DIFF
--- a/.github/workflows/broken_links_scheduled.yml
+++ b/.github/workflows/broken_links_scheduled.yml
@@ -60,6 +60,7 @@ jobs:
             --exclude hub.cloudquery.io \
             --exclude www.g2.com \
             --exclude cql.ink \
+            --exclude egghead.io \
             ${{ steps.vercel.outputs.url }}/docs \
             | grep -v '───OK───' | grep -v '──SKIP──' | grep -v '0 broken'
       - name: Slack Notify


### PR DESCRIPTION
<!-- 🎉 Thank you for making CloudQuery awesome by submitting a PR 🎉 -->

#### Summary

Looks like they added some bot detection https://github.com/cloudquery/cloudquery/actions/runs/8938683008/job/24553300918#step:4:170

<!--
Use the following steps to ensure your PR is ready to be reviewed

- [ ] Read the [contribution guidelines](https://github.com/cloudquery/cloudquery/blob/main/CONTRIBUTING.md) 🧑‍🎓
- [ ] Run `make lint` to ensure the proposed changes follow the coding style 🚨 (install golangci-lint [here](https://golangci-lint.run/usage/install/#local-installation))
- [ ] Run `make test` to ensure the proposed changes pass the tests 🧪
- [ ] If changing a source plugin run `make gen` to ensure docs are up to date 📝
- [ ] Ensure the status checks below are successful ✅
--->
