### PR TITLE
fix: Do not combine source and destination warnings and errors

### DIFF
--- a/cli/cmd/sync_v3.go
+++ b/cli/cmd/sync_v3.go
@@ -365,6 +365,8 @@ func syncConnectionV3(ctx context.Context, source v3source, destinations []v3des
 		}
 	}
 
+	sourceWarnings := totals.Warnings
+	sourceErrors := totals.Errors
 	syncSummaries := make([]syncSummary, len(destinationsClients))
 	for i := range destinationsClients {
 		m := destinationsClients[i].Metrics()
@@ -372,8 +374,8 @@ func syncConnectionV3(ctx context.Context, source v3source, destinations []v3des
 		totals.Errors += m.Errors
 		syncSummaries[i] = syncSummary{
 			Resources:           uint64(totalResources),
-			SourceErrors:        totals.Errors,
-			SourceWarnings:      totals.Warnings,
+			SourceErrors:        sourceErrors,
+			SourceWarnings:      sourceWarnings,
 			SyncID:              uid,
 			SourceName:          sourceSpec.Name,
 			SourceVersion:       sourceSpec.Version,


### PR DESCRIPTION
<!-- 🎉 Thank you for making CloudQuery awesome by submitting a PR 🎉 -->

#### Summary

This fixes a bug where source errors and warnings were a summed with some of the destination errors and warning as well