### PR TITLE
chore: Replacing deprecated run.skip-dirs for issues.exclude-dirs in golanci.yml

### DIFF
--- a/cli/.golangci.yml
+++ b/cli/.golangci.yml
@@ -1,10 +1,6 @@
 run:
   tests: true
   timeout: 5m
-  skip-dirs:
-    - bin
-    - docs
-    - internal/pb
 
 linters-settings:
   errcheck:
@@ -93,3 +89,8 @@ linters:
     - unparam
     - unused
 
+issues: 
+  exclude-dirs:
+    - bin
+    - docs
+    - internal/pb

--- a/plugins/.golangci.yml
+++ b/plugins/.golangci.yml
@@ -1,11 +1,5 @@
 run:
   tests: true
-  skip-dirs:
-    - bin
-    - docs
-    - client/mocks
-    - resources/forks
-    - codegen
   timeout: 15m
   build-tags:
     - all
@@ -119,3 +113,10 @@ issues:
     - path: services\.go
       linters:
         - dupl
+  exclude-dirs:
+    - bin
+    - docs
+    - client/mocks
+    - resources/forks
+    - codegen
+


### PR DESCRIPTION
#### Summary

This PR resolve the issue https://github.com/cloudquery/cloudquery/issues/17455  => it removes the deprecated run.skipdir from .golangci.yml 

I used the documentation for golangci-lint here : https://golangci-lint.run/usage/configuration/#issues-configuration

#### Changes

there was only 2 .golangci.yml that needed changes (out of 4) : 
- the one in the cli folder 
- the one in the plugins folder (destination + source)


I did not change theses 2 : 
- plugin-sdk did not have the run.skipdir directive.
- codegen did not have any .golangci.yml file.

#### Testing method 

I tested  with golangci-lint before and after my modification : 
**Before**:
![before](https://github.com/cloudquery/cloudquery/assets/16516886/9b710643-d812-4753-a363-f61bb4f549cd)
**After:**
![after](https://github.com/cloudquery/cloudquery/assets/16516886/aaa4e511-1129-44a2-a5a9-ea6d22ae33d8)


This is my first contribution, I hope I did everything well,
Have a good day


