### PR TITLE
fix: Remove JSON schema validation warnings

### DIFF
--- a/cli/cmd/specs.go
+++ b/cli/cmd/specs.go
@@ -98,13 +98,6 @@ func CLIDestinationSpecToPbSpec(spec specs.Destination) pbSpecs.Destination {
 
 // initPlugin is a simple wrapper that will try to validate the spec before actually passing it to Init.
 func initPlugin(ctx context.Context, client plugin.PluginClient, spec map[string]any, noConnection bool, syncID string) error {
-	if !noConnection {
-		// perform spec validation
-		if err := validatePluginSpec(ctx, client, spec); err != nil {
-			log.Warn().Err(err).Msg("plugin spec validation failed, but continuing with Init")
-		}
-	}
-
 	var (
 		specBytes []byte
 		err       error


### PR DESCRIPTION
<!-- 🎉 Thank you for making CloudQuery awesome by submitting a PR 🎉 -->

#### Summary

Part of https://github.com/cloudquery/cloudquery-issues/issues/1676 (internal issue). We're moving JSON schema validation to only be in the Cloud and use the current validation login in the CLI.
We can't remove it fully at the moment as it's used by the `validate-config` command, so that would come later on

<!--
Use the following steps to ensure your PR is ready to be reviewed

- [ ] Read the [contribution guidelines](https://github.com/cloudquery/cloudquery/blob/main/CONTRIBUTING.md) 🧑‍🎓
- [ ] Run `make lint` to ensure the proposed changes follow the coding style 🚨 (install golangci-lint [here](https://golangci-lint.run/usage/install/#local-installation))
- [ ] Run `make test` to ensure the proposed changes pass the tests 🧪
- [ ] If changing a source plugin run `make gen` to ensure docs are up to date 📝
- [ ] Ensure the status checks below are successful ✅
--->
