### PR TITLE
doc: Simplify headers in plugin docs

### DIFF
--- a/plugins/source/bitbucket/docs/overview.md
+++ b/plugins/source/bitbucket/docs/overview.md
@@ -1,14 +1,3 @@
----
-name: Bitbucket
-stage: Preview
-title: Bitbucket Source Plugin
-description: CloudQuery Bitbucket source plugin documentation
----
-
-# Bitbucket Source Plugin
-
-:badge
-
 The CloudQuery Bitbucket plugin pulls data from [Bitbucket](https://bitbucket.org/) and loads it into any supported CloudQuery destination (e.g. PostgreSQL, BigQuery, Snowflake, and [more](https://hub.cloudquery.io/plugins/destination)).
 
 The plugin discover all workspaces and repositories in your account and syncs them to the destination.

--- a/plugins/source/hackernews/docs/overview.md
+++ b/plugins/source/hackernews/docs/overview.md
@@ -1,13 +1,3 @@
----
-name: Hacker News
-stage: GA
-title: Hacker News Source Plugin
-description: CloudQuery Hacker News source plugin documentation
----
-# Hacker News Source Plugin
-
-:badge
-
 The Hacker News Source plugin for CloudQuery extracts configuration from the [Hacker News API](https://github.com/HackerNews/API) and loads it into any supported CloudQuery destination (e.g. PostgreSQL, BigQuery, Snowflake, and [more](/docs/plugins/destinations/overview)).
 
 It can be used for real applications, but is mainly intended to serve as an example of CloudQuery Source plugin with an incremental table.

--- a/plugins/source/k8s/docs/overview.md
+++ b/plugins/source/k8s/docs/overview.md
@@ -1,13 +1,3 @@
----
-name: Kubernetes
-stage: GA
-title: Kubernetes Source Plugin
-description: CloudQuery Kubernetes source plugin documentation
----
-# Kubernetes Source Plugin
-
-:badge
-
 The K8s Source plugin for CloudQuery extracts configuration from a variety of K8s APIs.
 
 ## Libraries in Use

--- a/plugins/source/xkcd/docs/overview.md
+++ b/plugins/source/xkcd/docs/overview.md
@@ -1,7 +1,3 @@
-# CloudQuery XKCD Source Plugin
-
-:badge
-
 This CloudQuery source plugin fetches data from the [XKCD API](https://xkcd.com/json.html), allowing you to load the XKCD comic data into any CloudQuery-supported destination (e.g. PostgreSQL, Elasticsearch, Snowflake, etc.). See [CloudQuery destinations](https://www.cloudquery.io/docs/plugins/destinations/overview) for a complete list of supported destinations.
 
 It was originally developed as part of a live-coding tutorial on how to write your own CloudQuery source plugin. It only took 30 minutes! You can watch the video here: https://www.youtube.com/watch?v=3Ka_Ob8E6P8


### PR DESCRIPTION
Removes some redundant headers in a few plugins' docs.