### PR TITLE
fix: Remove outdated login hint message

### DIFF
--- a/cli/internal/auth/token.go
+++ b/cli/internal/auth/token.go
@@ -40,6 +40,11 @@ func GetAuthTokenIfNeeded(logger zerolog.Logger, sources []*specs.Source, destin
 	tc := cqapiauth.NewTokenClient()
 	token, err := tc.GetToken()
 	if err != nil {
+		hasLoginHint := strings.Contains(err.Error(), "Hint:")
+		if hasLoginHint {
+			return cqapiauth.UndefinedToken, nil
+		}
+
 		return cqapiauth.UndefinedToken, err
 	}
 

--- a/cli/internal/auth/token.go
+++ b/cli/internal/auth/token.go
@@ -40,12 +40,6 @@ func GetAuthTokenIfNeeded(logger zerolog.Logger, sources []*specs.Source, destin
 	tc := cqapiauth.NewTokenClient()
 	token, err := tc.GetToken()
 	if err != nil {
-		recommendLogin := strings.Contains(err.Error(), "Hint:")
-		if recommendLogin {
-			logger.Warn().Msg("when using the CloudQuery registry, it's recommended to log in via `cloudquery login`. Logging in allows for better rate limits and downloading of premium plugins")
-			return cqapiauth.UndefinedToken, nil
-		}
-
 		return cqapiauth.UndefinedToken, err
 	}
 


### PR DESCRIPTION
<!-- 🎉 Thank you for making CloudQuery awesome by submitting a PR 🎉 -->

#### Summary

This message is outdated and doesn't work well when someone has the plugins pre-downloaded already (e.g. using an offline license).

<!--
Use the following steps to ensure your PR is ready to be reviewed

- [ ] Read the [contribution guidelines](https://github.com/cloudquery/cloudquery/blob/main/CONTRIBUTING.md) 🧑‍🎓
- [ ] Run `make lint` to ensure the proposed changes follow the coding style 🚨 (install golangci-lint [here](https://golangci-lint.run/usage/install/#local-installation))
- [ ] Run `make test` to ensure the proposed changes pass the tests 🧪
- [ ] If changing a source plugin run `make gen` to ensure docs are up to date 📝
- [ ] Ensure the status checks below are successful ✅
--->
