### PR TITLE
doc: Link to hub from example specs

### DIFF
--- a/plugins/destination/bigquery/docs/_configuration.md
+++ b/plugins/destination/bigquery/docs/_configuration.md
@@ -6,6 +6,7 @@ spec:
   registry: cloudquery
   version: "VERSION_DESTINATION_BIGQUERY"
   write_mode: "append"
+  # Learn more about the configuration options at https://cql.ink/bigquery_destination
   spec:
     project_id: ${PROJECT_ID}
     dataset_id: ${DATASET_ID}

--- a/plugins/destination/clickhouse/docs/_configuration.md
+++ b/plugins/destination/clickhouse/docs/_configuration.md
@@ -6,6 +6,7 @@ spec:
   registry: "cloudquery"
   version: "VERSION_DESTINATION_CLICKHOUSE"
   write_mode: "append"
+  # Learn more about the configuration options at https://cql.ink/clickhouse_destination
   spec:
     connection_string: "clickhouse://${CH_USER}:${CH_PASSWORD}@localhost:9000/${CH_DATABASE}"
     # Optional parameters

--- a/plugins/destination/duckdb/docs/_configuration.md
+++ b/plugins/destination/duckdb/docs/_configuration.md
@@ -8,6 +8,7 @@ spec:
   registry: cloudquery
   version: "VERSION_DESTINATION_DUCKDB"
   write_mode: "overwrite-delete-stale"
+  # Learn more about the configuration options at https://cql.ink/duckdb_destination
   spec:
     connection_string: /path/to/example.db
     # Optional parameters

--- a/plugins/destination/file/docs/_configuration.md
+++ b/plugins/destination/file/docs/_configuration.md
@@ -8,6 +8,7 @@ spec:
   registry: "cloudquery"
   version: "VERSION_DESTINATION_FILE"
   write_mode: "append"
+  # Learn more about the configuration options at https://cql.ink/file_destination
   spec:
     path: "path/to/files/{{TABLE}}/{{UUID}}.{{FORMAT}}"
     format: "parquet" # options: parquet, json, csv

--- a/plugins/destination/meilisearch/docs/_configuration.md
+++ b/plugins/destination/meilisearch/docs/_configuration.md
@@ -8,6 +8,7 @@ spec:
   registry: cloudquery
   version: "VERSION_DESTINATION_MEILISEARCH"
   write_mode: "overwrite"
+  # Learn more about the configuration options at https://cql.ink/meilisearch_destination
   spec:
     # meilisearch plugin spec
     host: "${MEILISEARCH_HOST}"

--- a/plugins/destination/mysql/docs/_configuration.md
+++ b/plugins/destination/mysql/docs/_configuration.md
@@ -5,6 +5,7 @@ spec:
   path: "cloudquery/mysql"
   registry: "cloudquery"
   version: "VERSION_DESTINATION_MYSQL"
+  # Learn more about the configuration options at https://cql.ink/mysql_destination
   spec:
     connection_string: "user:password@/dbname"
     # Optional parameters:

--- a/plugins/destination/neo4j/docs/_configuration.md
+++ b/plugins/destination/neo4j/docs/_configuration.md
@@ -7,6 +7,7 @@ spec:
   path: "cloudquery/neo4j"
   registry: "cloudquery"
   version: "VERSION_DESTINATION_NEO4J"
+  # Learn more about the configuration options at https://cql.ink/neo4j_destination
   spec:
     connection_string: "${NEO4J_CONNECTION_STRING}"
     username: "${NEO4J_USERNAME}"

--- a/plugins/destination/postgresql/docs/_configuration.md
+++ b/plugins/destination/postgresql/docs/_configuration.md
@@ -7,7 +7,7 @@ spec:
   path: "cloudquery/postgresql"
   registry: "cloudquery"
   version: "VERSION_DESTINATION_POSTGRESQL"
-
+  # Learn more about the configuration options at https://cql.ink/postgresql_destination
   spec:
     connection_string: "${POSTGRESQL_CONNECTION_STRING}" # set the environment variable in a format like postgres://postgres:pass@localhost:5432/postgres?sslmode=disable
     # you can also specify it in DSN format, which can hold special characters in the password field:

--- a/plugins/destination/s3/docs/_configuration.md
+++ b/plugins/destination/s3/docs/_configuration.md
@@ -10,6 +10,7 @@ spec:
   registry: "cloudquery"
   version: "VERSION_DESTINATION_S3"
   write_mode: "append"
+  # Learn more about the configuration options at https://cql.ink/s3_destination
   spec:
     bucket: "bucket_name"
     region: "region-name" # Example: us-east-1

--- a/plugins/destination/snowflake/docs/_configuration.md
+++ b/plugins/destination/snowflake/docs/_configuration.md
@@ -8,6 +8,7 @@ spec:
   registry: cloudquery
   version: "VERSION_DESTINATION_SNOWFLAKE"
   write_mode: "append"
+  # Learn more about the configuration options at https://cql.ink/snowflake_destination
   spec:
     connection_string: "${SNOWFLAKE_CONNECTION_STRING}"
     # Optional parameters

--- a/plugins/destination/sqlite/docs/_configuration.md
+++ b/plugins/destination/sqlite/docs/_configuration.md
@@ -7,6 +7,7 @@ spec:
   path: cloudquery/sqlite
   registry: cloudquery
   version: "VERSION_DESTINATION_SQLITE"
+  # Learn more about the configuration options at https://cql.ink/sqlite_destination
   spec:
     connection_string: ./db.sql
 ```

--- a/plugins/source/hackernews/docs/_configuration.md
+++ b/plugins/source/hackernews/docs/_configuration.md
@@ -11,6 +11,7 @@ spec:
     connection: "@@plugins.DESTINATION_NAME.connection"
   destinations:
     - "DESTINATION_NAME"
+  # Learn more about the configuration options at https://cql.ink/hackernews_source
   spec:
     item_concurrency: 100
 ```

--- a/plugins/source/k8s/docs/_configuration.md
+++ b/plugins/source/k8s/docs/_configuration.md
@@ -8,7 +8,7 @@ spec:
   version: "VERSION_SOURCE_K8S"
   tables: ["*"]
   destinations: ["DESTINATION_NAME"]
-
+  # Learn more about the configuration options at https://cql.ink/k8s_source
   spec:
     contexts: ["context"]
 ```


### PR DESCRIPTION
Some customers appear to be using our SEO (export) pages as a walkthrough and they miss the fact that there's detailed documentation somewhere else. This is adding a link directly in the example spec to help users getting back to the detailed documentation directly from the code. I am using bitly links on purpose to be able to measure whether this actually had any effect. That is why this change is affecting only a selected subset of plugins.