### PR TITLE
chore: Revert "chore: Update CLI version to v5.20.4"

### DIFF
--- a/website/versions/cli.json
+++ b/website/versions/cli.json
@@ -1,1 +1,1 @@
-{ "latest": "cli-v5.20.4" }
+{ "latest": "cli-v5.20.3" }


### PR DESCRIPTION
Reverts cloudquery/cloudquery#18122

We reverted this version to an regression in `--log-console`