### PR TITLE
fix!: Support Apache Arrow types with non-default options

### DIFF
--- a/plugins/destination/bigquery/client/client.go
+++ b/plugins/destination/bigquery/client/client.go
@@ -4,14 +4,12 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"net/http"
 
 	"cloud.google.com/go/bigquery"
 	internalPlugin "github.com/cloudquery/cloudquery/plugins/destination/bigquery/resources/plugin"
 	"github.com/cloudquery/plugin-sdk/v4/plugin"
 	"github.com/cloudquery/plugin-sdk/v4/writers/batchwriter"
 	"github.com/rs/zerolog"
-	"google.golang.org/api/googleapi"
 	"google.golang.org/api/option"
 )
 
@@ -100,10 +98,8 @@ func validateCreds(ctx context.Context, c *bigquery.Client, datasetID string) er
 	datasetRef := c.Dataset(datasetID)
 	_, err := datasetRef.Metadata(ctx)
 	if err != nil {
-		if e, ok := err.(*googleapi.Error); ok {
-			if e.Code == http.StatusNotFound {
-				return fmt.Errorf("invalid dataset. dataset must be created before sync or migration: %w", err)
-			}
+		if isAPINotFoundError(err) {
+			return fmt.Errorf("invalid dataset. dataset must be created before sync or migration: %w", err)
 		}
 		return fmt.Errorf("failed to validate credentials: %w", err)
 	}

--- a/plugins/destination/bigquery/client/client_test.go
+++ b/plugins/destination/bigquery/client/client_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"os"
 	"testing"
+	"time"
 
 	"github.com/cloudquery/plugin-sdk/v4/plugin"
 	"github.com/cloudquery/plugin-sdk/v4/schema"
@@ -40,7 +41,8 @@ func TestPlugin(t *testing.T) {
 		plugin.WithTestDataOptions(schema.TestSourceOptions{
 			SkipMaps: true,
 			// https://github.com/cloudquery/cloudquery/issues/12022
-			SkipTimes: true,
+			SkipTimes:     true,
+			TimePrecision: time.Microsecond,
 		}),
 		plugin.WithTestIgnoreNullsInLists(),
 	)

--- a/plugins/destination/bigquery/client/errors.go
+++ b/plugins/destination/bigquery/client/errors.go
@@ -1,0 +1,16 @@
+package client
+
+import (
+	"errors"
+	"net/http"
+
+	"google.golang.org/api/googleapi"
+)
+
+func isAPINotFoundError(err error) bool {
+	var apiErr *googleapi.Error
+	if !errors.As(err, &apiErr) {
+		return false
+	}
+	return apiErr.Code == http.StatusNotFound
+}

--- a/plugins/destination/bigquery/client/migrate.go
+++ b/plugins/destination/bigquery/client/migrate.go
@@ -3,14 +3,12 @@ package client
 import (
 	"context"
 	"fmt"
-	"net/http"
 	"time"
 
 	"cloud.google.com/go/bigquery"
 	"github.com/cloudquery/plugin-sdk/v4/message"
 	"github.com/cloudquery/plugin-sdk/v4/schema"
 	"golang.org/x/sync/errgroup"
-	"google.golang.org/api/googleapi"
 )
 
 const (
@@ -66,10 +64,8 @@ func (c *Client) doesTableExist(ctx context.Context, client *bigquery.Client, ta
 	tableRef := client.Dataset(c.spec.DatasetID).Table(table)
 	md, err := tableRef.Metadata(ctx)
 	if err != nil {
-		if e, ok := err.(*googleapi.Error); ok {
-			if e.Code == http.StatusNotFound {
-				return false, nil
-			}
+		if isAPINotFoundError(err) {
+			return false, nil
 		}
 		c.logger.Error().Str("dataset", c.spec.DatasetID).Str("table", table).Err(err).Msg("Got unexpected error while checking table metadata")
 		return false, err

--- a/plugins/destination/bigquery/client/read.go
+++ b/plugins/destination/bigquery/client/read.go
@@ -137,28 +137,12 @@ func appendValue(builder array.Builder, value any) error {
 		bldr.Append(arrow.MonthInterval(t[0].(int64)))
 		return nil
 	case *array.TimestampBuilder:
-		unit := bldr.Type().(*arrow.TimestampType).Unit
-		switch unit {
-		case arrow.Nanosecond:
-			v := value.([]bigquery.Value)
-			t := v[0].(time.Time)
-			nano := v[1].(int64)
-			nanoTime := t.Add(time.Duration(nano) * time.Nanosecond)
-			ts, err := arrow.TimestampFromString(nanoTime.Format(time.RFC3339Nano), arrow.Nanosecond)
-			if err != nil {
-				return fmt.Errorf("failed to call arrow.TimestampFromString: %w", err)
-			}
-			bldr.Append(ts)
-			return nil
-		default:
-			t := value.(time.Time)
-			ts, err := arrow.TimestampFromString(t.Format(time.RFC3339Nano), unit)
-			if err != nil {
-				return fmt.Errorf("failed to call arrow.TimestampFromString: %w", err)
-			}
-			bldr.Append(ts)
-			return nil
+		ts, err := arrow.TimestampFromTime(value.(time.Time), bldr.Type().(*arrow.TimestampType).Unit)
+		if err != nil {
+			return fmt.Errorf("failed to call arrow.TimestampFromString: %w", err)
 		}
+		bldr.Append(ts)
+		return nil
 	case *array.Decimal128Builder:
 		r := value.(*big.Rat)
 		str, precision, scale := parseRat(r)

--- a/plugins/destination/bigquery/client/read.go
+++ b/plugins/destination/bigquery/client/read.go
@@ -137,11 +137,7 @@ func appendValue(builder array.Builder, value any) error {
 		bldr.Append(arrow.MonthInterval(t[0].(int64)))
 		return nil
 	case *array.TimestampBuilder:
-		ts, err := arrow.TimestampFromTime(value.(time.Time), bldr.Type().(*arrow.TimestampType).Unit)
-		if err != nil {
-			return fmt.Errorf("failed to call arrow.TimestampFromString: %w", err)
-		}
-		bldr.Append(ts)
+		bldr.AppendTime(value.(time.Time))
 		return nil
 	case *array.Decimal128Builder:
 		r := value.(*big.Rat)

--- a/plugins/destination/bigquery/client/types.go
+++ b/plugins/destination/bigquery/client/types.go
@@ -63,7 +63,7 @@ func (c *Client) DataTypeToBigQueryType(dt arrow.DataType) bigquery.FieldType {
 		return bigquery.IntegerFieldType
 	case *arrow.Uint64Type:
 		return bigquery.NumericFieldType
-	case *arrow.Float32Type, *arrow.Float64Type:
+	case *arrow.Float16Type, *arrow.Float32Type, *arrow.Float64Type:
 		return bigquery.FloatFieldType
 	case arrow.BinaryDataType:
 		if dt.IsUtf8() {

--- a/plugins/destination/bigquery/client/types.go
+++ b/plugins/destination/bigquery/client/types.go
@@ -73,10 +73,6 @@ func (c *Client) DataTypeToBigQueryType(dt arrow.DataType) bigquery.FieldType {
 	case *arrow.Date32Type, *arrow.Date64Type:
 		return bigquery.DateFieldType
 	case *arrow.TimestampType:
-		// TODO: remove
-		if dt.Unit == arrow.Nanosecond {
-			return bigquery.RecordFieldType
-		}
 		return bigquery.TimestampFieldType
 	case *arrow.Time32Type, *arrow.Time64Type:
 		return bigquery.TimeFieldType

--- a/plugins/destination/bigquery/client/types.go
+++ b/plugins/destination/bigquery/client/types.go
@@ -110,6 +110,8 @@ func (c *Client) DataTypeToBigQuerySchema(dt arrow.DataType) bigquery.Schema {
 			})
 		}
 		return fields
+	case *arrow.MapType:
+		return nil
 	case arrow.ListLikeType:
 		// TODO: handle maps
 		return c.DataTypeToBigQuerySchema(dt.Elem())

--- a/plugins/destination/bigquery/client/types.go
+++ b/plugins/destination/bigquery/client/types.go
@@ -144,20 +144,6 @@ func (c *Client) DataTypeToBigQuerySchema(dt arrow.DataType) bigquery.Schema {
 				Type: bigquery.IntegerFieldType,
 			},
 		}
-	case *arrow.TimestampType:
-		// TODO: remove this
-		if dt.Unit == arrow.Nanosecond {
-			return []*bigquery.FieldSchema{
-				{
-					Name: "timestamp",
-					Type: bigquery.TimestampFieldType,
-				},
-				{
-					Name: "nanoseconds",
-					Type: bigquery.IntegerFieldType,
-				},
-			}
-		}
 	}
 	return nil
 }

--- a/plugins/destination/bigquery/client/types.go
+++ b/plugins/destination/bigquery/client/types.go
@@ -34,137 +34,93 @@ func isListType(t arrow.DataType) bool {
 	return t.ID() == arrow.LIST || t.ID() == arrow.LARGE_LIST || t.ID() == arrow.FIXED_SIZE_LIST
 }
 
-func (c *Client) DataTypeToBigQueryType(dataType arrow.DataType) bigquery.FieldType {
-	switch {
+func (c *Client) DataTypeToBigQueryType(dt arrow.DataType) bigquery.FieldType {
+	switch dt := dt.(type) {
 	// handle known extensions that require special handling
-	case typeOneOf(dataType,
-		types.ExtensionTypes.JSON):
+	case *types.JSONType:
 		return bigquery.JSONFieldType
-	case typeOneOf(dataType,
-		types.ExtensionTypes.Inet,
-		types.ExtensionTypes.MAC,
-		types.ExtensionTypes.UUID):
+	case *types.InetType, *types.MACType, *types.UUIDType:
 		return bigquery.StringFieldType
 
 	// handle complex types
-	case dataType.ID() == arrow.MAP:
+	case *arrow.MapType:
 		return bigquery.JSONFieldType
-	case dataType.ID() == arrow.STRUCT:
+	case *arrow.StructType:
 		return bigquery.RecordFieldType
-	case isListType(dataType):
-		switch v := dataType.(type) {
-		case *arrow.ListType:
-			return c.DataTypeToBigQueryType(v.Elem())
-		case *arrow.LargeListType:
-			return c.DataTypeToBigQueryType(v.Elem())
-		case *arrow.FixedSizeListType:
-			return c.DataTypeToBigQueryType(v.Elem())
-		}
-		fallthrough
+	case arrow.ListLikeType:
+		return c.DataTypeToBigQueryType(dt.Elem())
 
 	// handle basic types
-	case typeOneOf(dataType,
-		arrow.FixedWidthTypes.Boolean):
+	case *arrow.BooleanType:
 		return bigquery.BooleanFieldType
-	case typeOneOf(dataType,
-		arrow.PrimitiveTypes.Int8,
-		arrow.PrimitiveTypes.Int16,
-		arrow.PrimitiveTypes.Int32,
-		arrow.PrimitiveTypes.Int64,
-		arrow.PrimitiveTypes.Uint8,
-		arrow.PrimitiveTypes.Uint16,
-		arrow.PrimitiveTypes.Uint32):
+	case *arrow.Int8Type,
+		*arrow.Int16Type,
+		*arrow.Int32Type,
+		*arrow.Int64Type,
+		*arrow.Uint8Type,
+		*arrow.Uint16Type,
+		*arrow.Uint32Type:
 		return bigquery.IntegerFieldType
-	case typeOneOf(dataType,
-		arrow.PrimitiveTypes.Uint64):
+	case *arrow.Uint64Type:
 		return bigquery.NumericFieldType
-	case typeOneOf(dataType,
-		arrow.PrimitiveTypes.Float32,
-		arrow.PrimitiveTypes.Float64):
+	case *arrow.Float32Type, *arrow.Float64Type:
 		return bigquery.FloatFieldType
-	case typeOneOf(dataType,
-		arrow.BinaryTypes.String,
-		arrow.BinaryTypes.LargeString):
-		return bigquery.StringFieldType
-	case typeOneOf(dataType,
-		arrow.BinaryTypes.Binary,
-		arrow.BinaryTypes.LargeBinary):
+	case arrow.BinaryDataType:
+		if dt.IsUtf8() {
+			return bigquery.StringFieldType
+		}
 		return bigquery.BytesFieldType
-	case typeOneOf(dataType,
-		arrow.FixedWidthTypes.Date32,
-		arrow.FixedWidthTypes.Date64):
+	case *arrow.Date32Type, *arrow.Date64Type:
 		return bigquery.DateFieldType
-	case typeOneOf(dataType,
-		arrow.FixedWidthTypes.Timestamp_s,
-		arrow.FixedWidthTypes.Timestamp_ms,
-		arrow.FixedWidthTypes.Timestamp_us):
+	case *arrow.TimestampType:
+		// TODO: remove
+		if dt.Unit == arrow.Nanosecond {
+			return bigquery.RecordFieldType
+		}
 		return bigquery.TimestampFieldType
-	case typeOneOf(dataType,
-		arrow.FixedWidthTypes.Timestamp_ns):
-		return bigquery.RecordFieldType
-	case typeOneOf(dataType,
-		arrow.FixedWidthTypes.Time32s,
-		arrow.FixedWidthTypes.Time32ms,
-		arrow.FixedWidthTypes.Time64us,
-		arrow.FixedWidthTypes.Time64ns):
+	case *arrow.Time32Type, *arrow.Time64Type:
 		return bigquery.TimeFieldType
-	case typeOneOf(dataType,
-		arrow.FixedWidthTypes.Duration_s,
-		arrow.FixedWidthTypes.Duration_ms,
-		arrow.FixedWidthTypes.Duration_us,
-		arrow.FixedWidthTypes.Duration_ns):
+	case *arrow.DurationType:
 		// BigQuery does not support intervals with precisions higher than seconds,
 		// and in the case of seconds the max value is not large enough to contain the
 		// max Arrow duration, so we store durations as plain integers. Users will need
 		// to cast or transform to interval, if necessary.
 		return bigquery.IntegerFieldType
-	case typeOneOf(dataType,
-		arrow.FixedWidthTypes.MonthInterval):
-		return bigquery.RecordFieldType
-	case typeOneOf(dataType,
-		arrow.FixedWidthTypes.DayTimeInterval):
-		return bigquery.RecordFieldType
-	case typeOneOf(dataType,
-		arrow.FixedWidthTypes.MonthDayNanoInterval):
+	case *arrow.MonthIntervalType,
+		*arrow.DayTimeIntervalType,
+		*arrow.MonthDayNanoIntervalType:
 		return bigquery.RecordFieldType
 		// We don't use `typeOneOf` as `arrow.TypeEqual` checks for equality of precision and scale.
-	case arrow.IsDecimal(dataType.ID()):
+	case arrow.DecimalType:
 		// BigQuery NumericFieldType has a scale limit of 9, so we use BigNumeric for both decimal128 and decimal256.
 		return bigquery.BigNumericFieldType
 	default:
-		panic("unsupported data type: " + dataType.String())
+		panic("unsupported data type: " + dt.String())
 	}
 }
 
-func (c *Client) DataTypeToBigQuerySchema(dataType arrow.DataType) bigquery.Schema {
-	switch {
-	case dataType.ID() == arrow.STRUCT:
-		v := dataType.(*arrow.StructType)
-		fields := make([]*bigquery.FieldSchema, len(v.Fields()))
-		for i, field := range v.Fields() {
+func (c *Client) DataTypeToBigQuerySchema(dt arrow.DataType) bigquery.Schema {
+	switch dt := dt.(type) {
+	case *arrow.StructType:
+		fields := make([]*bigquery.FieldSchema, len(dt.Fields()))
+		for i, field := range dt.Fields() {
 			fields[i] = c.ColumnToBigQuerySchema(schema.Column{
 				Name: field.Name,
 				Type: field.Type,
 			})
 		}
 		return fields
-	case arrow.IsListLike(dataType.ID()):
-		switch v := dataType.(type) {
-		case *arrow.ListType:
-			return c.DataTypeToBigQuerySchema(v.Elem())
-		case *arrow.LargeListType:
-			return c.DataTypeToBigQuerySchema(v.Elem())
-		default:
-			panic("unsupported list type: " + dataType.String())
-		}
-	case arrow.TypeEqual(dataType, arrow.FixedWidthTypes.MonthInterval):
+	case arrow.ListLikeType:
+		// TODO: handle maps
+		return c.DataTypeToBigQuerySchema(dt.Elem())
+	case *arrow.MonthIntervalType:
 		return []*bigquery.FieldSchema{
 			{
 				Name: "months",
 				Type: bigquery.IntegerFieldType,
 			},
 		}
-	case arrow.TypeEqual(dataType, arrow.FixedWidthTypes.DayTimeInterval):
+	case *arrow.DayTimeIntervalType:
 		return []*bigquery.FieldSchema{
 			{
 				Name: "days",
@@ -175,7 +131,7 @@ func (c *Client) DataTypeToBigQuerySchema(dataType arrow.DataType) bigquery.Sche
 				Type: bigquery.IntegerFieldType,
 			},
 		}
-	case arrow.TypeEqual(dataType, arrow.FixedWidthTypes.MonthDayNanoInterval):
+	case *arrow.MonthDayNanoIntervalType:
 		return []*bigquery.FieldSchema{
 			{
 				Name: "months",
@@ -190,26 +146,20 @@ func (c *Client) DataTypeToBigQuerySchema(dataType arrow.DataType) bigquery.Sche
 				Type: bigquery.IntegerFieldType,
 			},
 		}
-	case typeOneOf(dataType, arrow.FixedWidthTypes.Timestamp_ns):
-		return []*bigquery.FieldSchema{
-			{
-				Name: "timestamp",
-				Type: bigquery.TimestampFieldType,
-			},
-			{
-				Name: "nanoseconds",
-				Type: bigquery.IntegerFieldType,
-			},
+	case *arrow.TimestampType:
+		// TODO: remove this
+		if dt.Unit == arrow.Nanosecond {
+			return []*bigquery.FieldSchema{
+				{
+					Name: "timestamp",
+					Type: bigquery.TimestampFieldType,
+				},
+				{
+					Name: "nanoseconds",
+					Type: bigquery.IntegerFieldType,
+				},
+			}
 		}
 	}
 	return nil
-}
-
-func typeOneOf(left arrow.DataType, dt ...arrow.DataType) bool {
-	for _, t := range dt {
-		if arrow.TypeEqual(left, t) {
-			return true
-		}
-	}
-	return false
 }

--- a/plugins/destination/bigquery/client/types.go
+++ b/plugins/destination/bigquery/client/types.go
@@ -7,13 +7,6 @@ import (
 	"github.com/cloudquery/plugin-sdk/v4/types"
 )
 
-// TimestampNanoseconds is a struct to hold a timestamp with nanosecond precision,
-// because BigQuery does not support nanosecond precision timestamps.
-type TimestampNanoseconds struct {
-	Timestamp   string `json:"timestamp" bigquery:"timestamp"`
-	Nanoseconds int    `json:"nanoseconds" bigquery:"nanoseconds"`
-}
-
 func (c *Client) ColumnToBigQuerySchema(col schema.Column) *bigquery.FieldSchema {
 	sc := bigquery.FieldSchema{
 		Name:        col.Name,

--- a/plugins/destination/bigquery/client/types.go
+++ b/plugins/destination/bigquery/client/types.go
@@ -30,8 +30,15 @@ func (c *Client) ColumnToBigQuerySchema(col schema.Column) *bigquery.FieldSchema
 	return &sc
 }
 
-func isListType(t arrow.DataType) bool {
-	return t.ID() == arrow.LIST || t.ID() == arrow.LARGE_LIST || t.ID() == arrow.FIXED_SIZE_LIST
+func isListType(dt arrow.DataType) bool {
+	switch dt.(type) {
+	case *arrow.MapType:
+		return false
+	case arrow.ListLikeType:
+		return true
+	default:
+		return false
+	}
 }
 
 func (c *Client) DataTypeToBigQueryType(dt arrow.DataType) bigquery.FieldType {

--- a/plugins/destination/bigquery/client/write.go
+++ b/plugins/destination/bigquery/client/write.go
@@ -11,7 +11,6 @@ import (
 	"github.com/apache/arrow/go/v16/arrow/array"
 	"github.com/cloudquery/plugin-sdk/v4/message"
 	"github.com/cloudquery/plugin-sdk/v4/types"
-	"google.golang.org/api/googleapi"
 )
 
 const (
@@ -61,7 +60,7 @@ func (c *Client) WriteTableBatch(ctx context.Context, name string, msgs message.
 
 	for err := inserter.Put(timeoutCtx, batch); err != nil; err = inserter.Put(timeoutCtx, batch) {
 		// check if bigquery error is 404 (table does not exist yet), then wait a bit and retry until it does exist
-		if e, ok := err.(*googleapi.Error); ok && e.Code == 404 {
+		if isAPINotFoundError(err) {
 			// retry
 			c.logger.Info().Str("table", name).Msg("Table does not exist yet, waiting for it to be created before retrying write")
 			time.Sleep(1 * time.Second)

--- a/plugins/destination/bigquery/client/write.go
+++ b/plugins/destination/bigquery/client/write.go
@@ -112,7 +112,7 @@ func getValueForBigQuery(col arrow.Array, i int) any {
 	case *array.Duration:
 		return v.Value(i)
 	case *array.Timestamp:
-		return v.GetOneForMarshal(i)
+		return v.Value(i).ToTime(v.DataType().(*arrow.TimestampType).Unit)
 	case *types.JSONArray:
 		return v.ValueStr(i)
 	}

--- a/plugins/destination/bigquery/client/write.go
+++ b/plugins/destination/bigquery/client/write.go
@@ -112,7 +112,7 @@ func getValueForBigQuery(col arrow.Array, i int) any {
 	case *array.Duration:
 		return v.Value(i)
 	case *array.Timestamp:
-		return v.Value(i).ToTime(v.DataType().(*arrow.TimestampType).Unit)
+		return v.GetOneForMarshal(i)
 	case *types.JSONArray:
 		return v.ValueStr(i)
 	}

--- a/plugins/destination/bigquery/client/write.go
+++ b/plugins/destination/bigquery/client/write.go
@@ -93,9 +93,6 @@ func getValueForBigQuery(col arrow.Array, i int) any {
 		elems := make([]any, 0, slc.Len())
 		for j := 0; j < slc.Len(); j++ {
 			if slc.IsNull(j) {
-				continue
-			}
-			if slc.IsNull(j) {
 				// LIMITATION: BigQuery does not support null values in repeated columns.
 				// Therefore, these get stripped out here. In the future, perhaps we should support
 				// an option to use JSON instead of repeated columns for users who need to preserve

--- a/plugins/destination/bigquery/client/write.go
+++ b/plugins/destination/bigquery/client/write.go
@@ -112,18 +112,7 @@ func getValueForBigQuery(col arrow.Array, i int) any {
 	case *array.Duration:
 		return v.Value(i)
 	case *array.Timestamp:
-		unit := v.DataType().(*arrow.TimestampType).Unit
-		switch unit {
-		case arrow.Nanosecond:
-			t := v.Value(i).ToTime(arrow.Nanosecond)
-			format := "2006-01-02 15:04:05.999999"
-			return TimestampNanoseconds{
-				Timestamp:   t.Format(format),
-				Nanoseconds: t.Nanosecond() % 1000,
-			}
-		default:
-			return v.GetOneForMarshal(i)
-		}
+		return v.Value(i).ToTime(v.DataType().(*arrow.TimestampType).Unit)
 	case *types.JSONArray:
 		return v.ValueStr(i)
 	}

--- a/plugins/destination/bigquery/docs/types.md
+++ b/plugins/destination/bigquery/docs/types.md
@@ -1,52 +1,50 @@
 # BigQuery Types
 
-The BigQuery destination (`v3.0.0` and later) supports most [Apache Arrow](https://arrow.apache.org/docs/index.html) types. The following table shows the supported types and how they are mapped to [BigQuery data types](https://cloud.google.com/bigquery/docs/reference/standard-sql/data-types).
+The BigQuery destination (`v3.0.0` and later) supports most [Apache Arrow](https://arrow.apache.org/docs/index.html)
+types. The following table shows the supported types and how they are mapped
+to [BigQuery data types](https://cloud.google.com/bigquery/docs/reference/standard-sql/data-types).
 
-| Arrow Column Type      | Supported?    | BigQuery Type                                            |
-|------------------------|---------------|----------------------------------------------------------|
-| Binary                 | ✅ Yes        | `BYTES`                                                  |
-| Boolean                | ✅ Yes        | `BOOL`                                                   |
-| Date32                 | ✅ Yes        | `DATE`                                                   |
-| Date64                 | ✅ Yes        | `DATE`                                                   |
-| Decimal                | ✅ Yes        | `BIGNUMERIC`                                             |
-| Dense Union            | ❌ No         |                                                          |
-| Dictionary             | ❌ No         |                                                          |
-| Duration[ms]           | ✅ Yes        | `INT64`                                                  |
-| Duration[ns]           | ✅ Yes        | `INT64`                                                  |
-| Duration[s]            | ✅ Yes        | `INT64`                                                  |
-| Duration[us]           | ✅ Yes        | `INT64`                                                  |
-| Fixed Size List        | ❌ No         |                                                          |
-| Float16                | ❌ No         |                                                          |
-| Float32                | ✅ Yes        | `FLOAT64`                                                |
-| Float64                | ✅ Yes        | `FLOAT64`                                                |
-| Inet                   | ✅ Yes        | `STRING`                                                 |
-| Int8                   | ✅ Yes        | `INT64`                                                  |
-| Int16                  | ✅ Yes        | `INT64`                                                  |
-| Int32                  | ✅ Yes        | `INT64`                                                  |
-| Int64                  | ✅ Yes        | `INT64`                                                  |
-| Interval[DayTime]      | ✅ Yes        | `RECORD<days: INT64, milliseconds: INT64>`               |
-| Interval[MonthDayNano] | ✅ Yes        | `RECORD<months: INT64, days: int64, nanoseconds: int64>` |
-| Interval[Month]        | ✅ Yes        | `RECORD<months: INT64>`                                  |
-| JSON                   | ✅ Yes        | `JSON`                                                   |
-| Large Binary           | ✅ Yes        | `BYTES`                                                  |
-| Large List             | ❌ No         |                                                          |
-| Large String           | ✅ Yes        | `STRING`                                                 |
-| List                   | ✅ Yes        | (Repeated column) †                                      |
-| MAC                    | ✅ Yes        | `STRING`                                                 |
-| Map                    | ❌ No         |                                                          |
-| String                 | ✅ Yes        | `STRING`                                                 |
-| Struct                 | ✅ Yes        | `RECORD`                                                 |
-| Timestamp[ms]          | ✅ Yes        | `TIMESTAMP`                                              |
-| Timestamp[ns]          | ✅ Yes        | `RECORD<timestamp: TIMESTAMP, nanoseconds: INT64>`       |
-| Timestamp[s]           | ✅ Yes        | `TIMESTAMP`                                              |
-| Timestamp[us]          | ✅ Yes        | `TIMESTAMP`                                              |
-| UUID                   | ✅ Yes        | `STRING`                                                 |
-| Uint8                  | ✅ Yes        | `INT64`                                                  |
-| Uint16                 | ✅ Yes        | `INT64`                                                  |
-| Uint32                 | ✅ Yes        | `INT64`                                                  |
-| Uint64                 | ✅ Yes        | `NUMERIC`                                                |
-| Union                  | ❌ No         |                                                          |
+| Arrow Column Type      | Supported? | BigQuery Type                                            |
+|------------------------|------------|----------------------------------------------------------|
+| Binary                 | ✅ Yes      | `BYTES`                                                  |
+| Boolean                | ✅ Yes      | `BOOL`                                                   |
+| Date32                 | ✅ Yes      | `DATE`                                                   |
+| Date64                 | ✅ Yes      | `DATE`                                                   |
+| Decimal                | ✅ Yes      | `BIGNUMERIC`                                             |
+| Dense Union            | ❌ No       |                                                          |
+| Dictionary             | ❌ No       |                                                          |
+| Duration               | ✅ Yes      | `INT64`                                                  |
+| Fixed Size List        | ✅ Yes      | (Repeated column) †                                      |
+| Float16                | ✅ Yes      | `FLOAT64`                                                |
+| Float32                | ✅ Yes      | `FLOAT64`                                                |
+| Float64                | ✅ Yes      | `FLOAT64`                                                |
+| Inet                   | ✅ Yes      | `STRING`                                                 |
+| Int8                   | ✅ Yes      | `INT64`                                                  |
+| Int16                  | ✅ Yes      | `INT64`                                                  |
+| Int32                  | ✅ Yes      | `INT64`                                                  |
+| Int64                  | ✅ Yes      | `INT64`                                                  |
+| Interval[DayTime]      | ✅ Yes      | `RECORD<days: INT64, milliseconds: INT64>`               |
+| Interval[MonthDayNano] | ✅ Yes      | `RECORD<months: INT64, days: int64, nanoseconds: int64>` |
+| Interval[Month]        | ✅ Yes      | `RECORD<months: INT64>`                                  |
+| JSON                   | ✅ Yes      | `JSON`                                                   |
+| Large Binary           | ✅ Yes      | `BYTES`                                                  |
+| Large List             | ✅ Yes      | (Repeated column) †                                      |
+| Large String           | ✅ Yes      | `STRING`                                                 |
+| List                   | ✅ Yes      | (Repeated column) †                                      |
+| MAC                    | ✅ Yes      | `STRING`                                                 |
+| Map                    | ❌ No       |                                                          |
+| String                 | ✅ Yes      | `STRING`                                                 |
+| Struct                 | ✅ Yes      | `RECORD`                                                 |
+| Timestamp              | ✅ Yes      | `TIMESTAMP`                                              |
+| UUID                   | ✅ Yes      | `STRING`                                                 |
+| Uint8                  | ✅ Yes      | `INT64`                                                  |
+| Uint16                 | ✅ Yes      | `INT64`                                                  |
+| Uint32                 | ✅ Yes      | `INT64`                                                  |
+| Uint64                 | ✅ Yes      | `NUMERIC`                                                |
+| Union                  | ❌ No       |                                                          |
 
 ## Notes
 
-† Repeated columns in BigQuery do not support null values. Right now, if an array contains null values, these null values will be dropped when writing to BigQuery. Also, because we use `REPEATED` columns to represent lists, lists of lists are not supported right now.
+† Repeated columns in BigQuery do not support null values. Right now, if an array contains null values, these null
+values will be dropped when writing to BigQuery. Also, because we use `REPEATED` columns to represent lists, lists of
+lists are not supported right now.


### PR DESCRIPTION
BEGIN_COMMIT_OVERRIDE
fix: Support Apache Arrow types with non-default options (#18198). Previously some Apache Arrow types (namely, `timestamp` with non-default time zone) would result in plugin failure.
BREAKING-CHANGE: Apache Arrow `timestamp` now always maps to BigQuery `timestamp` type (#18198). Previously, `timestamp` with `nanoseconds` precision was mapped to a `record` type.

END_COMMIT_OVERRIDE

Instead of https://github.com/cloudquery/cloudquery/pull/18126
Fixes https://github.com/cloudquery/cloudquery-issues/issues/1786 (internal issue)