### PR TITLE
fix: Use plain email string for user email

### DIFF
--- a/cli/internal/analytics/client.go
+++ b/cli/internal/analytics/client.go
@@ -167,7 +167,7 @@ func getSyncCommonProps(invocationUUID uuid.UUID, event SyncStartedEvent, detail
 		Set("source_path", event.Source.Path).
 		Set("destination_paths", destinationPaths).
 		Set("user_id", details.user.ID).
-		Set("user_email", details.user.Email)
+		Set("user_email", string(details.user.Email))
 
 	return props
 }


### PR DESCRIPTION
Otherwise MarshalJSON gets called on it, which leads to an error for an empty email address:

```
2024/06/11 14:42:52 ERROR: json: error calling MarshalJSON for type types.Email: email: failed to pass regex validation - {track 441f7b51-559a-4f0f-86c9-249528aa85c8 7c7b9a79-2e47-48a1-963d-9be3fd79a5f1 00000000-0000-0000-0000-000000000000 sync_run_started 2024-06-11 14:42:52.280882 +0300 EEST m=+4.534407834 2024-06-11 14:42:52.280882 +0300 EEST m=+4.534407834 0x140008dadc0 map[destination_paths:[cloudquery/postgresql] environment:cli invocation_uuid:58de237a-ceb0-472b-821e-288ea6555062 source_path:cloudquery/aws sync_name:aws sync_run_id:58de237a-ceb0-472b-821e-288ea6555062 team:cloudquery user_email: user_id:00000000-0000-0000-0000-000000000000] map[] server}
```