### PR TITLE
fix: Remove Primary Key Validation

### DIFF
--- a/plugins/destination/bigquery/client/migrate.go
+++ b/plugins/destination/bigquery/client/migrate.go
@@ -21,12 +21,6 @@ func (c *Client) MigrateTables(ctx context.Context, msgs message.WriteMigrateTab
 	eg, gctx := errgroup.WithContext(ctx)
 	eg.SetLimit(concurrentMigrations)
 	for _, msg := range msgs {
-		if len(msg.Table.PrimaryKeys()) > 0 {
-			return fmt.Errorf("primary keys are not supported by the BigQuery plugin. Hint: try setting `write_mode: append` in the destination spec")
-		}
-	}
-
-	for _, msg := range msgs {
 		table := msg.Table
 		eg.Go(func() error {
 			c.logger.Debug().Str("table", table.Name).Msg("Migrating table")


### PR DESCRIPTION
<!-- 🎉 Thank you for making CloudQuery awesome by submitting a PR 🎉 -->

#### Summary

Prior to this version BQ would fail if any table has a primary key. Now if a PK is defined it will just ignore it.

All PKs should be removed by the CLI. In the case of state tables, when versioning is enabled, the SDK will handle duplicates by choosing the latest version