### PR TITLE
fix: Add groupType to team Group event

### DIFF
--- a/cli/internal/analytics/client.go
+++ b/cli/internal/analytics/client.go
@@ -98,6 +98,9 @@ func Identify(ctx context.Context, invocationUUID uuid.UUID) {
 	_ = client.Enqueue(rudderstack.Group{
 		UserId:  details.user.ID.String(),
 		GroupId: details.currentTeam,
+		Traits: rudderstack.Traits{
+			"groupType": "team",
+		},
 	})
 }
 


### PR DESCRIPTION
This adds `groupType` to the team event, as documented [here](https://www.rudderstack.com/docs/destinations/streaming-destinations/posthog/posthog-device-mode/):

> It is mandatory to include groupId and groupType in your group calls to create or update the group details.

> RudderStack removes the groupType field from the traits and passes them to PostHog as the group properties.