### PR TITLE
fix: Add name property to team group

### DIFF
--- a/cli/internal/analytics/client.go
+++ b/cli/internal/analytics/client.go
@@ -100,6 +100,7 @@ func Identify(ctx context.Context, invocationUUID uuid.UUID) {
 		GroupId: details.currentTeam,
 		Traits: rudderstack.Traits{
 			"groupType": "team",
+			"name":      details.currentTeam,
 		},
 	})
 }


### PR DESCRIPTION
Adds `name` trait to Rudderstack team group 