### PR TITLE
fix: Don't reuse memory pools between tables

### DIFF
--- a/plugins/destination/s3/client/client.go
+++ b/plugins/destination/s3/client/client.go
@@ -32,9 +32,7 @@ type Client struct {
 	*filetypes.Client
 	writer *streamingbatchwriter.StreamingBatchWriter
 
-	s3Client   *s3.Client
-	uploader   *manager.Uploader
-	downloader *manager.Downloader
+	s3Client *s3.Client
 
 	initializedTables map[string]string
 }
@@ -87,8 +85,6 @@ func New(ctx context.Context, logger zerolog.Logger, s []byte, opts plugin.NewCl
 		}
 		o.UsePathStyle = c.spec.UsePathStyle
 	})
-	c.uploader = manager.NewUploader(c.s3Client)
-	c.downloader = manager.NewDownloader(c.s3Client)
 
 	if *c.spec.TestWrite {
 		// we want to run this test because we want it to fail early if the bucket is not accessible
@@ -106,7 +102,7 @@ func New(ctx context.Context, logger zerolog.Logger, s []byte, opts plugin.NewCl
 			params.ServerSideEncryption = sseConfiguration.ServerSideEncryption
 		}
 
-		if _, err := c.uploader.Upload(ctx, params); err != nil {
+		if _, err := manager.NewUploader(c.s3Client).Upload(ctx, params); err != nil {
 			return nil, fmt.Errorf("failed to write test file to S3: %w", err)
 		}
 	}

--- a/plugins/destination/s3/client/read.go
+++ b/plugins/destination/s3/client/read.go
@@ -30,7 +30,7 @@ func (c *Client) Read(ctx context.Context, table *schema.Table, res chan<- arrow
 
 	name := c.spec.ReplacePathVariables(table.Name, uuid.NewString(), time.Time{}, c.syncID)
 	writerAtBuffer := manager.NewWriteAtBuffer(make([]byte, 0, maxFileSize))
-	_, err := c.downloader.Download(ctx,
+	_, err := manager.NewDownloader(c.s3Client).Download(ctx,
 		writerAtBuffer,
 		&s3.GetObjectInput{
 			Bucket: aws.String(c.spec.Bucket),

--- a/plugins/destination/s3/client/write.go
+++ b/plugins/destination/s3/client/write.go
@@ -11,6 +11,7 @@ import (
 	"github.com/apache/arrow/go/v16/arrow/array"
 	"github.com/apache/arrow/go/v16/arrow/memory"
 	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/feature/s3/manager"
 	"github.com/aws/aws-sdk-go-v2/service/s3"
 	awstypes "github.com/aws/aws-sdk-go-v2/service/s3/types"
 	"github.com/cloudquery/filetypes/v4"
@@ -41,7 +42,7 @@ func (c *Client) createObject(ctx context.Context, table *schema.Table, objKey s
 			params.ServerSideEncryption = sseConfiguration.ServerSideEncryption
 		}
 
-		_, err := c.uploader.Upload(ctx, params)
+		_, err := manager.NewUploader(c.s3Client).Upload(ctx, params)
 		return err
 	})
 	return s, err


### PR DESCRIPTION
Speedup memory GC
Testing on multi-row
Pre change:
![s3 mrow](https://github.com/cloudquery/cloudquery/assets/7649785/950512cf-7a5c-414d-ae86-0ccaf9843f37)

Post change
![s3-uploader mrow](https://github.com/cloudquery/cloudquery/assets/7649785/1e92fcb8-ce69-4aa9-afd1-db1f8c60869b)

