### PR TITLE
fix: Remove identify, group events

### DIFF
--- a/cli/cmd/root.go
+++ b/cli/cmd/root.go
@@ -105,8 +105,6 @@ func NewCmdRoot() *cobra.Command {
 				disableSentry = true
 			}
 
-			analytics.Identify(cmd.Context(), invocationUUID)
-
 			return nil
 		},
 	}

--- a/cli/internal/analytics/client.go
+++ b/cli/internal/analytics/client.go
@@ -70,40 +70,6 @@ func getEventDetails(ctx context.Context) *eventDetails {
 	}
 }
 
-func Identify(ctx context.Context, invocationUUID uuid.UUID) {
-	if client == nil {
-		return
-	}
-
-	details := getEventDetails(ctx)
-	if details == nil {
-		_ = client.Enqueue(rudderstack.Identify{
-			AnonymousId: invocationUUID.String(),
-			Traits: rudderstack.Traits{
-				"environment": getEnvironment(),
-			},
-		})
-		return
-	}
-
-	err := client.Enqueue(rudderstack.Identify{
-		AnonymousId: invocationUUID.String(),
-		UserId:      details.user.ID.String(),
-	})
-	if err != nil {
-		return
-	}
-
-	_ = client.Enqueue(rudderstack.Group{
-		UserId:  details.user.ID.String(),
-		GroupId: details.currentTeam,
-		Traits: rudderstack.Traits{
-			"groupType": "team",
-			"name":      details.currentTeam,
-		},
-	})
-}
-
 func TrackLoginSuccess(ctx context.Context, invocationUUID uuid.UUID) {
 	if client == nil {
 		return
@@ -115,9 +81,8 @@ func TrackLoginSuccess(ctx context.Context, invocationUUID uuid.UUID) {
 	}
 
 	_ = client.Enqueue(rudderstack.Track{
-		AnonymousId: invocationUUID.String(),
-		UserId:      details.user.ID.String(),
-		Event:       "login_success",
+		UserId: details.user.ID.String(),
+		Event:  "login_success",
 		Properties: rudderstack.Properties{
 			"invocation_uuid": invocationUUID,
 			"team":            details.currentTeam,


### PR DESCRIPTION
<!-- 🎉 Thank you for making CloudQuery awesome by submitting a PR 🎉 -->

#### Summary

We're already doing identify and group in the backend so no need for the CLI to do them

<!--
Use the following steps to ensure your PR is ready to be reviewed

- [ ] Read the [contribution guidelines](https://github.com/cloudquery/cloudquery/blob/main/CONTRIBUTING.md) 🧑‍🎓
- [ ] Run `make lint` to ensure the proposed changes follow the coding style 🚨 (install golangci-lint [here](https://golangci-lint.run/usage/install/#local-installation))
- [ ] Run `make test` to ensure the proposed changes pass the tests 🧪
- [ ] If changing a source plugin run `make gen` to ensure docs are up to date 📝
- [ ] Ensure the status checks below are successful ✅
--->
