### PR TITLE
fix: Don't close metrics file before last print

### DIFF
--- a/cli/internal/otel/receiver.go
+++ b/cli/internal/otel/receiver.go
@@ -131,10 +131,7 @@ func newDefaultMetricConsumer(metricsFile *os.File, quit chan any) ConsumeMetric
 			case <-quit:
 				renderTable()
 				ticker.Stop()
-				err := metricsFile.Close()
-				if err != nil {
-					fmt.Println("Error closing file:", err)
-				}
+				_ = metricsFile.Close()
 				return
 			}
 		}


### PR DESCRIPTION
<!-- 🎉 Thank you for making CloudQuery awesome by submitting a PR 🎉 -->

#### Summary

We were closing the metrics file before the last print was done, so the last values where not printed.
This fixes it. Follow up to https://github.com/cloudquery/cloudquery/pull/18498

<!--
Use the following steps to ensure your PR is ready to be reviewed

- [ ] Read the [contribution guidelines](https://github.com/cloudquery/cloudquery/blob/main/CONTRIBUTING.md) 🧑‍🎓
- [ ] Run `make lint` to ensure the proposed changes follow the coding style 🚨 (install golangci-lint [here](https://golangci-lint.run/usage/install/#local-installation))
- [ ] Run `make test` to ensure the proposed changes pass the tests 🧪
- [ ] If changing a source plugin run `make gen` to ensure docs are up to date 📝
- [ ] Ensure the status checks below are successful ✅
--->
