### PR TITLE
fix: Handle concurrent map writes

### DIFF
--- a/plugins/destination/s3/client/client.go
+++ b/plugins/destination/s3/client/client.go
@@ -7,6 +7,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"sync"
 	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
@@ -34,7 +35,8 @@ type Client struct {
 
 	s3Client *s3.Client
 
-	initializedTables map[string]string
+	initializedTablesLock sync.Mutex
+	initializedTables     map[string]string
 }
 
 func New(ctx context.Context, logger zerolog.Logger, s []byte, opts plugin.NewClientOptions) (plugin.Client, error) {

--- a/plugins/destination/s3/client/write.go
+++ b/plugins/destination/s3/client/write.go
@@ -68,11 +68,12 @@ func (c *Client) WriteTable(ctx context.Context, msgs <-chan *message.WriteInser
 			table := msg.GetTable()
 			objKey := c.spec.ReplacePathVariables(table.Name, uuid.NewString(), time.Now().UTC(), c.syncID)
 			// if object was already initialized, use the same key
-			// We don't need any locking here because all messages for the same table are processed sequentially
+			c.initializedTablesLock.Lock()
 			if val, ok := c.initializedTables[table.Name]; ok {
 				objKey = val
 				delete(c.initializedTables, table.Name)
 			}
+			c.initializedTablesLock.Unlock()
 
 			var err error
 			s, err = c.createObject(ctx, table, objKey)


### PR DESCRIPTION
<!-- 🎉 Thank you for making CloudQuery awesome by submitting a PR 🎉 -->

#### Summary

Fixes https://github.com/cloudquery/cloudquery-issues/issues/1999 (hopefully).
While the comment in the code is correct and all messages for the same table are processed sequentially, I don't think there's a guarantee that `WriteTable` is not called from multiple concurrent Go routines


<!--
Use the following steps to ensure your PR is ready to be reviewed

- [ ] Read the [contribution guidelines](https://github.com/cloudquery/cloudquery/blob/main/CONTRIBUTING.md) 🧑‍🎓
- [ ] Run `make lint` to ensure the proposed changes follow the coding style 🚨 (install golangci-lint [here](https://golangci-lint.run/usage/install/#local-installation))
- [ ] Run `make test` to ensure the proposed changes pass the tests 🧪
- [ ] If changing a source plugin run `make gen` to ensure docs are up to date 📝
- [ ] Ensure the status checks below are successful ✅
--->
