### PR TITLE
fix: Allow `tables` command to be run with a single spec

### DIFF
--- a/cli/cmd/tables.go
+++ b/cli/cmd/tables.go
@@ -61,7 +61,7 @@ func tables(cmd *cobra.Command, args []string) error {
 	ctx := cmd.Context()
 	log.Info().Strs("args", args).Msg("Loading spec(s)")
 	fmt.Printf("Loading spec(s) from %s\n", strings.Join(args, ", "))
-	specReader, err := specs.NewSpecReader(args)
+	specReader, err := specs.NewRelaxedSpecReader(args)
 	if err != nil {
 		return fmt.Errorf("failed to load spec(s) from %s. Error: %w", strings.Join(args, ", "), err)
 	}

--- a/cli/cmd/test_connection.go
+++ b/cli/cmd/test_connection.go
@@ -118,7 +118,7 @@ func testConnection(cmd *cobra.Command, args []string) error {
 
 	log.Info().Strs("args", args).Msg("Loading spec(s)")
 	fmt.Printf("Loading spec(s) from %s\n", strings.Join(args, ", "))
-	specReader, err := specs.NewTestConnectionSpecReader(args)
+	specReader, err := specs.NewRelaxedSpecReader(args)
 	if err != nil {
 		return fmt.Errorf("failed to load spec(s) from %s. Error: %w", strings.Join(args, ", "), err)
 	}

--- a/cli/internal/specs/v0/spec_reader.go
+++ b/cli/internal/specs/v0/spec_reader.go
@@ -189,7 +189,7 @@ func (r *SpecReader) validate() error {
 	return err
 }
 
-func (r *SpecReader) validateTestConnection() error {
+func (r *SpecReader) relaxedValidate() error {
 	if len(r.Sources) == 0 && len(r.Destinations) == 0 {
 		return errors.New("expecting at least one source or destination")
 	}
@@ -244,13 +244,13 @@ func NewSpecReader(paths []string) (*SpecReader, error) {
 	return reader, nil
 }
 
-func NewTestConnectionSpecReader(paths []string) (*SpecReader, error) {
+func NewRelaxedSpecReader(paths []string) (*SpecReader, error) {
 	reader, err := newSpecReader(paths)
 	if err != nil {
 		return nil, err
 	}
 
-	if err := reader.validateTestConnection(); err != nil {
+	if err := reader.relaxedValidate(); err != nil {
 		return nil, err
 	}
 


### PR DESCRIPTION
`tables` command unnecessarily requires a full spec, but we have a relaxed spec reader now, implemented for the `test-connection` command some time ago.