### PR TITLE
feat: Add s3 destination connection test

### DIFF
--- a/plugins/destination/s3/client/test_connection.go
+++ b/plugins/destination/s3/client/test_connection.go
@@ -1,0 +1,31 @@
+package client
+
+import (
+	"context"
+	"errors"
+
+	"github.com/cloudquery/plugin-sdk/v4/plugin"
+	"github.com/rs/zerolog"
+)
+
+type NewClientFn func(context.Context, zerolog.Logger, []byte, plugin.NewClientOptions) (plugin.Client, error)
+
+const (
+	codeInvalidSpec  string = "INVALID_SPEC"
+	codeUnauthorized string = "UNAUTHORIZED"
+)
+
+func NewConnectionTester(createClientFn NewClientFn) plugin.ConnectionTester {
+	return func(ctx context.Context, logger zerolog.Logger, specBytes []byte) error {
+		_, err := createClientFn(ctx, logger, specBytes, plugin.NewClientOptions{})
+		if err == nil {
+			return nil
+		}
+
+		if errors.Is(err, errTestWriteFailed) {
+			return plugin.NewTestConnError(codeUnauthorized, err)
+		}
+
+		return plugin.NewTestConnError(codeInvalidSpec, err)
+	}
+}

--- a/plugins/destination/s3/client/test_connection_test.go
+++ b/plugins/destination/s3/client/test_connection_test.go
@@ -1,0 +1,75 @@
+package client
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/cloudquery/cloudquery/plugins/destination/s3/client/spec"
+	"github.com/cloudquery/plugin-sdk/v4/plugin"
+	"github.com/rs/zerolog"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestConnectionTester(t *testing.T) {
+	cases := []struct {
+		name          string
+		spec          []byte
+		err           *plugin.TestConnError
+		clientBuilder func() (plugin.Client, error)
+	}{
+		{
+			name: "ok",
+			spec: []byte(`{"bucket": "test", "region": "test", "path": "test", "format": "csv"}`),
+			clientBuilder: func() (plugin.Client, error) {
+				return &Client{}, nil
+			},
+		},
+		{
+			name: "error/unauthorized",
+			spec: []byte(`{"bucket": "test", "region": "test", "path": "test", "format": "csv"}`),
+			err:  plugin.NewTestConnError(codeUnauthorized, assert.AnError),
+			clientBuilder: func() (plugin.Client, error) {
+				return nil, errTestWriteFailed
+			},
+		},
+		{
+			name: "error/spec",
+			spec: []byte(`{null}`),
+			err:  plugin.NewTestConnError(codeInvalidSpec, assert.AnError),
+			clientBuilder: func() (plugin.Client, error) {
+				return &Client{}, nil
+			},
+		},
+	}
+
+	for idx := range cases {
+		tc := cases[idx]
+
+		t.Run(tc.name, func(t *testing.T) {
+			tester := NewConnectionTester(func(_ context.Context, _ zerolog.Logger, specBytes []byte, _ plugin.NewClientOptions) (plugin.Client, error) {
+				spec := &spec.Spec{}
+				if err := json.Unmarshal(specBytes, spec); err != nil {
+					return nil, err
+				}
+				spec.SetDefaults()
+				if err := spec.Validate(); err != nil {
+					return nil, err
+				}
+
+				return tc.clientBuilder()
+			})
+
+			err := tester(context.Background(), zerolog.Nop(), tc.spec)
+			if tc.err == nil {
+				require.NoError(t, err)
+				return
+			}
+
+			var e *plugin.TestConnError
+			require.ErrorAs(t, err, &e)
+			require.Equal(t, tc.err.Code, err.(*plugin.TestConnError).Code)
+		})
+	}
+}

--- a/plugins/destination/s3/main.go
+++ b/plugins/destination/s3/main.go
@@ -16,6 +16,7 @@ func main() {
 		plugin.WithKind(internalPlugin.Kind),
 		plugin.WithTeam(internalPlugin.Team),
 		plugin.WithJSONSchema(spec.JSONSchema),
+		plugin.WithConnectionTester(client.NewConnectionTester(client.New)),
 	)
 
 	if err := serve.Plugin(p, serve.WithDestinationV0V1Server()).Serve(context.Background()); err != nil {


### PR DESCRIPTION
#### Summary

This PR implements the ConnectionTester interface for the S3 destination, enabling the `test-connection` command.

<img width="1263" alt="Screenshot 2024-07-11 at 11 35 56" src="https://github.com/cloudquery/cloudquery/assets/40720931/a69b59a4-21e8-42c9-b0d4-6caa1c190f1c">
