### PR TITLE
fix: Fix user id format in example configuration comment

### DIFF
--- a/plugins/destination/mssql/docs/_configuration.md
+++ b/plugins/destination/mssql/docs/_configuration.md
@@ -6,7 +6,7 @@ spec:
   registry: "cloudquery"
   version: "VERSION_DESTINATION_MSSQL"
   spec:
-    # Connection string in the format `server=localhost;user_id=SA;password=yourStrongP@ssword;port=1433;database=cloudquery;`
+    # Connection string in the format `server=localhost;user id=SA;password=yourStrongP@ssword;port=1433;database=cloudquery;`
     connection_string: "${MSSQL_CONNECTION_STRING}"
     # Optional parameters:
     # auth_mode: ms


### PR DESCRIPTION
<!-- 🎉 Thank you for making CloudQuery awesome by submitting a PR 🎉 -->

#### Summary

The current format doesn't work. This PR fixes it, you can see the correct format in https://hub.cloudquery.io/plugins/destination/cloudquery/mssql/latest/docs#example-configure-microsoft-sql-server-destination-plugin

<!--
Use the following steps to ensure your PR is ready to be reviewed

- [ ] Read the [contribution guidelines](https://github.com/cloudquery/cloudquery/blob/main/CONTRIBUTING.md) 🧑‍🎓
- [ ] Run `make lint` to ensure the proposed changes follow the coding style 🚨 (install golangci-lint [here](https://golangci-lint.run/usage/install/#local-installation))
- [ ] Run `make test` to ensure the proposed changes pass the tests 🧪
- [ ] If changing a source plugin run `make gen` to ensure docs are up to date 📝
- [ ] Ensure the status checks below are successful ✅
--->
