### PR TITLE
fix: Allow `plugin install` command to be run with a single-plugin spec

### DIFF
--- a/cli/cmd/install.go
+++ b/cli/cmd/install.go
@@ -45,7 +45,7 @@ func installPlugin(cmd *cobra.Command, args []string) error {
 	ctx := cmd.Context()
 	log.Info().Strs("args", args).Msg("Loading spec(s)")
 	fmt.Printf("Loading spec(s) from %s\n", strings.Join(args, ", "))
-	specReader, err := specs.NewSpecReader(args)
+	specReader, err := specs.NewRelaxedSpecReader(args)
 	if err != nil {
 		return fmt.Errorf("failed to load spec(s) from %s. Error: %w", strings.Join(args, ", "), err)
 	}


### PR DESCRIPTION
<!-- 🎉 Thank you for making CloudQuery awesome by submitting a PR 🎉 -->

#### Summary

Similar to https://github.com/cloudquery/cloudquery/pull/18542, so you can install a single plugin without linking it to a destination/source

<!--
Use the following steps to ensure your PR is ready to be reviewed

- [ ] Read the [contribution guidelines](https://github.com/cloudquery/cloudquery/blob/main/CONTRIBUTING.md) 🧑‍🎓
- [ ] Run `make lint` to ensure the proposed changes follow the coding style 🚨 (install golangci-lint [here](https://golangci-lint.run/usage/install/#local-installation))
- [ ] Run `make test` to ensure the proposed changes pass the tests 🧪
- [ ] If changing a source plugin run `make gen` to ensure docs are up to date 📝
- [ ] Ensure the status checks below are successful ✅
--->
