### PR TITLE
chore: Update the `skip_dependent_tables` part in our docs

### DIFF
--- a/website/pages/docs/advanced-topics/performance-tuning.md
+++ b/website/pages/docs/advanced-topics/performance-tuning.md
@@ -181,7 +181,7 @@ The `shuffle` scheduler is the **default** for the AWS source plugin.
 
 Starting with version [v6.0.0](https://github.com/cloudquery/cloudquery/releases/tag/cli-v6.0.0) of the CloudQuery CLI `skip_dependent_tables` is set to `true` by default, to avoid new tables implicitly being synced when added to plugins. This can be overridden by setting `skip_dependent_tables: false` in the source config.
 
-When setting `skip_dependent_tables: false`, all tables that depend on other tables will be synced by default
+When setting `skip_dependent_tables: false`, all tables that depend on other tables will be synced by default.
 When syncing dependent tables multiple API calls need to be made for every row in the parent table. This can lead to thousands of API calls, increasing the time it takes to sync.
 
 Let's say we have three tables: `A`, `B` and `C`. `A` is the top-level table. `B` depends on it, and `C` depends on `B`:


### PR DESCRIPTION
<!-- 🎉 Thank you for making CloudQuery awesome by submitting a PR 🎉 -->

#### Summary

I noticed the `Improve Performance by Skipping Relations` part of https://docs.cloudquery.io/docs/advanced-topics/performance-tuning is out of date since now the default is to skip by default.

This PR
1. Updates the section with relevant information
2. Moves it to the bottom of the doc as it shouldn't be the first action users do to optimize syncs
3. Renames the file from `mdx` to `md`. Only reason we had `mdx` is the `import { Callout } from 'nextra-theme-docs'` but we support it in `md` files via `:::callout`

<!--
Use the following steps to ensure your PR is ready to be reviewed

- [ ] Read the [contribution guidelines](https://github.com/cloudquery/cloudquery/blob/main/CONTRIBUTING.md) 🧑‍🎓
- [ ] Run `make lint` to ensure the proposed changes follow the coding style 🚨 (install golangci-lint [here](https://golangci-lint.run/usage/install/#local-installation))
- [ ] Run `make test` to ensure the proposed changes pass the tests 🧪
- [ ] If changing a source plugin run `make gen` to ensure docs are up to date 📝
- [ ] Ensure the status checks below are successful ✅
--->
