### PR TITLE
chore: Enforce postgres UI config build in CI

### DIFF
--- a/.github/workflows/dest_postgresql.yml
+++ b/.github/workflows/dest_postgresql.yml
@@ -75,10 +75,9 @@ jobs:
           wait-for-it -h localhost -p 26257
       - name: Test CockroachDB
         run: CQ_DEST_PG_TEST_CONN="postgresql://root@localhost:26257/postgres?sslmode=disable" make test
-  plugins-destination-postgresql-config-ui:
+  validate-config-ui:
     timeout-minutes: 15
     if: github.event_name == 'pull_request'
-    name: "plugins/destination/postgresql/cloud-config-ui"
     permissions:
       id-token: write
       contents: read

--- a/scripts/workflows/wait_for_required_workflows.js
+++ b/scripts/workflows/wait_for_required_workflows.js
@@ -44,6 +44,11 @@ module.exports = async ({github, context}) => {
         actions = ["cli (ubuntu-latest)", "cli (windows-latest)", "cli (macos-latest)", ...actions]
     }
 
+    const pluginsWithConfigUI = ["plugins/destination/postgresql"]
+    if (actions.some(action => pluginsWithConfigUI.includes(action))) {
+        actions = [...actions, 'validate-config-ui']
+    }
+
     pendingActions = [...actions]
     console.log(`Waiting for ${pendingActions.join(", ")}`)
     while (now <= deadline) {


### PR DESCRIPTION
<!-- 🎉 Thank you for making CloudQuery awesome by submitting a PR 🎉 -->

#### Summary

This PR enforces the CI added in https://github.com/cloudquery/cloudquery/pull/18714 passes before merging a PR to the PostgreSQL destination plugin

<!--
Use the following steps to ensure your PR is ready to be reviewed

- [ ] Read the [contribution guidelines](https://github.com/cloudquery/cloudquery/blob/main/CONTRIBUTING.md) 🧑‍🎓
- [ ] Run `make lint` to ensure the proposed changes follow the coding style 🚨 (install golangci-lint [here](https://golangci-lint.run/usage/install/#local-installation))
- [ ] Run `make test` to ensure the proposed changes pass the tests 🧪
- [ ] If changing a source plugin run `make gen` to ensure docs are up to date 📝
- [ ] Ensure the status checks below are successful ✅
--->
