### PR TITLE
chore: Exclude `app.datadoghq.com` from broken links check

### DIFF
--- a/.github/workflows/broken_links_scheduled.yml
+++ b/.github/workflows/broken_links_scheduled.yml
@@ -61,6 +61,7 @@ jobs:
             --exclude www.g2.com \
             --exclude cql.ink \
             --exclude egghead.io \
+            --exclude app.datadoghq.com \
             ${{ steps.vercel.outputs.url }}/docs \
             | grep -v '───OK───' | grep -v '──SKIP──' | grep -v '0 broken'
       - name: Slack Notify


### PR DESCRIPTION
<!-- 🎉 Thank you for making CloudQuery awesome by submitting a PR 🎉 -->

#### Summary

The links added in https://github.com/cloudquery/cloudquery/pull/18867 requires authentication so our broken links checker fails on them https://github.com/cloudquery/cloudquery/actions/runs/10283984123/job/28459044421#step:4:114

<!--
Use the following steps to ensure your PR is ready to be reviewed

- [ ] Read the [contribution guidelines](https://github.com/cloudquery/cloudquery/blob/main/CONTRIBUTING.md) 🧑‍🎓
- [ ] Run `make lint` to ensure the proposed changes follow the coding style 🚨 (install golangci-lint [here](https://golangci-lint.run/usage/install/#local-installation))
- [ ] Run `make test` to ensure the proposed changes pass the tests 🧪
- [ ] If changing a source plugin run `make gen` to ensure docs are up to date 📝
- [ ] Ensure the status checks below are successful ✅
--->
