### PR TITLE
fix: Better connection tester error codes

### DIFF
--- a/plugins/destination/postgresql/client/connection_tester.go
+++ b/plugins/destination/postgresql/client/connection_tester.go
@@ -17,17 +17,11 @@ import (
 func ConnectionTester(ctx context.Context, _ zerolog.Logger, specBytes []byte) error {
 	var s spec.Spec
 	if err := json.Unmarshal(specBytes, &s); err != nil {
-		return &plugin.TestConnError{
-			Code:    "INVALID_SPEC",
-			Message: fmt.Errorf("failed to unmarshal spec: %w", err),
-		}
+		return plugin.NewTestConnError("INVALID_SPEC", fmt.Errorf("failed to unmarshal spec: %w", err))
 	}
 	s.SetDefaults()
 	if err := s.Validate(); err != nil {
-		return &plugin.TestConnError{
-			Code:    "INVALID_SPEC",
-			Message: fmt.Errorf("failed to validate spec: %w", err),
-		}
+		return plugin.NewTestConnError("INVALID_SPEC", fmt.Errorf("failed to validate spec: %w", err))
 	}
 
 	pgxConfig, err := pgxpool.ParseConfig(s.ConnectionString)

--- a/plugins/destination/postgresql/client/connection_tester_test.go
+++ b/plugins/destination/postgresql/client/connection_tester_test.go
@@ -50,6 +50,7 @@ func TestConnectionTester(t *testing.T) {
 			name:      "should return an error for an invalid connection string",
 			specBytes: marshalSpec(t, &spec.Spec{ConnectionString: invalidConnectionString}),
 			wantErr: &wantErr{
+				Code:             "INVALID_CONFIG",
 				ErrorDescription: "cannot parse `invalid`: failed to parse as DSN (invalid dsn)",
 			},
 		},
@@ -57,6 +58,7 @@ func TestConnectionTester(t *testing.T) {
 			name:      "should return an error for an unknown host",
 			specBytes: marshalSpec(t, &spec.Spec{ConnectionString: unknownHostConnectionString}),
 			wantErr: &wantErr{
+				Code:             "DNS_FAILED",
 				ErrorDescription: "no such host \"unknownhost\"",
 			},
 		},
@@ -64,6 +66,7 @@ func TestConnectionTester(t *testing.T) {
 			name:      "should return an error for an unknown database",
 			specBytes: marshalSpec(t, &spec.Spec{ConnectionString: unknownDatabaseConnectionString}),
 			wantErr: &wantErr{
+				Code:             "UNKNOWN_DATABASE",
 				ErrorDescription: "database \"unknowndb\" does not exist",
 			},
 		},
@@ -71,6 +74,7 @@ func TestConnectionTester(t *testing.T) {
 			name:      "should return an error for an unknown user",
 			specBytes: marshalSpec(t, &spec.Spec{ConnectionString: unknownUserConnectionString}),
 			wantErr: &wantErr{
+				Code:             "AUTH_FAILED",
 				ErrorDescription: "password authentication failed for user \"unknownuser\"",
 			},
 		},
@@ -78,6 +82,7 @@ func TestConnectionTester(t *testing.T) {
 			name:      "should return an error for an unknown password",
 			specBytes: marshalSpec(t, &spec.Spec{ConnectionString: unknownPasswordConnectionString}),
 			wantErr: &wantErr{
+				Code:             "AUTH_FAILED",
 				ErrorDescription: "password authentication failed for user \"postgres\"",
 			},
 		},


### PR DESCRIPTION
Since we're relying on error codes more, we need to provide more than just `UNKNOWN` (which is the default if a non-`TestConnError` error is returned)

Should help with https://github.com/cloudquery/cloudquery-issues/issues/2129 (internal issue)