### PR TITLE
doc: Add a missing comma to json config

### DIFF
--- a/website/pages/docs/deployment/ecs.md
+++ b/website/pages/docs/deployment/ecs.md
@@ -220,7 +220,7 @@ Create a new file named `task-definition.json` with the following content:
       "secrets": [{
         "name": "CLOUDQUERY_API_KEY",
         "valueFrom": "<REPLACE_WITH_FULL_ARN_OF_SECRET>"
-      }]
+      }],
       "logConfiguration": {
         "logDriver": "awslogs",
         "options": {


### PR DESCRIPTION
Adding a missing comma to the json config for AWS ECS setup instructions.