### PR TITLE
fix: Emit event groups in a format that posthog accepts

### DIFF
--- a/cli/internal/analytics/client.go
+++ b/cli/internal/analytics/client.go
@@ -123,6 +123,8 @@ func getSyncCommonProps(invocationUUID uuid.UUID, event SyncStartedEvent, detail
 		Set("invocation_uuid", invocationUUID).
 		Set("sync_run_id", invocationUUID).
 		Set("team", details.currentTeam).
+		Set("$groups", rudderstack.NewProperties().
+			Set("team", details.currentTeam)).
 		Set("environment", details.environment).
 		Set("sync_name", event.Source.Name).
 		Set("source_path", event.Source.Path).

--- a/cli/internal/analytics/client.go
+++ b/cli/internal/analytics/client.go
@@ -101,6 +101,9 @@ func TrackLoginSuccess(ctx context.Context, invocationUUID uuid.UUID) {
 			"invocation_uuid": invocationUUID,
 			"team":            details.currentTeam,
 			"environment":     details.environment,
+			"$groups": rudderstack.Properties{
+				"team": details.currentTeam,
+			},
 		},
 	})
 }


### PR DESCRIPTION
<!-- 🎉 Thank you for making CloudQuery awesome by submitting a PR 🎉 -->

#### Summary

This adds a property `"$groups": {"team": "<team-name>"}` to emitted events so that they are associated with teams properly in posthog