### PR TITLE
feat: Add display name support to Hacker News Source UI

### DIFF
--- a/plugins/source/hackernews/cloud-config-ui/src/form/index.tsx
+++ b/plugins/source/hackernews/cloud-config-ui/src/form/index.tsx
@@ -88,7 +88,7 @@ export function Form({ initialValues }: Props) {
                   <Stack spacing={2}>
                     <Controller
                       control={control}
-                      name="name"
+                      name="displayName"
                       render={({ field, fieldState }) => (
                         <TextField
                           error={!!fieldState.error}

--- a/plugins/source/hackernews/cloud-config-ui/src/form/index.tsx
+++ b/plugins/source/hackernews/cloud-config-ui/src/form/index.tsx
@@ -98,7 +98,6 @@ export function Form({ initialValues }: Props) {
                             'Unique destination name that helps identify the destination within your workspace.',
                           )}
                           label="Source name"
-                          disabled={!!initialValues}
                           autoComplete="off"
                           {...field}
                         />

--- a/plugins/source/hackernews/cloud-config-ui/src/utils/formSchema.ts
+++ b/plugins/source/hackernews/cloud-config-ui/src/utils/formSchema.ts
@@ -1,6 +1,6 @@
 import { resetYupDefaultErrorMessages } from '@cloudquery/cloud-ui';
 import { FormMessagePayload } from '@cloudquery/plugin-config-ui-connector';
-import { generateName } from '@cloudquery/plugin-config-ui-lib';
+import { generateDisplayName, generateName } from '@cloudquery/plugin-config-ui-lib';
 
 import * as yup from 'yup';
 
@@ -20,13 +20,14 @@ export function getFormValidationSchema(
   initialValues?: FormMessagePayload['init']['initialValues'],
 ) {
   return yup.object({
+    displayName: yup
+      .string()
+      .default(initialValues?.displayName || generateDisplayName('Hacker News'))
+      .max(255)
+      .required(),
     name: yup
       .string()
-      .default(initialValues?.name || generateName('hackernews'))
-      .matches(
-        /^[a-z](-?[\da-z]+)+$/,
-        'Name must consist of a lower case letter, followed by alphanumeric segments separated by single dashes',
-      )
+      .default(initialValues?.name || '')
       .max(255)
       .required(),
     envs: yup

--- a/plugins/source/hackernews/cloud-config-ui/src/utils/prepareSubmitValues.ts
+++ b/plugins/source/hackernews/cloud-config-ui/src/utils/prepareSubmitValues.ts
@@ -1,4 +1,5 @@
 import { PluginUiMessagePayload } from '@cloudquery/plugin-config-ui-connector';
+import { convertStringToSlug } from '@cloudquery/plugin-config-ui-lib';
 
 import { FormValues } from './formSchema';
 
@@ -13,7 +14,8 @@ export function prepareSubmitValues(
   };
 
   return {
-    name: values.name,
+    displayName: values.displayName,
+    name: values.name || convertStringToSlug(values.displayName),
     envs,
     tables: Object.keys(values.tables).filter(
       (key) => values.tables[key as keyof typeof values.tables],


### PR DESCRIPTION
<!-- 🎉 Thank you for making CloudQuery awesome by submitting a PR 🎉 -->

#### Summary

This allows configuration of the display name in the Hacker News source plugin ui