### PR TITLE
fix: Clean up sign-in section of quick start guide

### DIFF
--- a/website/components/mdx/_cloudquery-sign-in.mdx
+++ b/website/components/mdx/_cloudquery-sign-in.mdx
@@ -21,12 +21,6 @@ export const SignIn = ({ os }) => {
 {/* <!-- vale on --> */}
 ## Sign in with CloudQuery
 
-We recommend that you authenticate using the CloudQuery CLI. Once signed in, you can use CloudQuery with premium plugins up to a free quota and premium plugins in preview without limitations.
-
-Authenticated users also have higher rate limits on plugin downloads than anonymous users.
-
-You will be able to create a new account when you sign in with the CLI for the first time. Alternatively, head to [CloudQuery Cloud](https://cloud.cloudquery.io) to create a new account.
-
 To sign in from the CLI, run the following command:
 
 <SignIn os={props.os} />

--- a/website/components/mdx/_cloudquery-sign-in.mdx
+++ b/website/components/mdx/_cloudquery-sign-in.mdx
@@ -26,6 +26,7 @@ To sign in from the CLI, run the following command:
 <SignIn os={props.os} />
 
 A new browser window will open where you will complete the sign-in process.
+
 You will be able to create a new account when you sign in with the CLI for the first time. Alternatively, head to [CloudQuery Cloud](https://cloud.cloudquery.io) to create a new account.
 
 :::callout{type="info"}

--- a/website/components/mdx/_cloudquery-sign-in.mdx
+++ b/website/components/mdx/_cloudquery-sign-in.mdx
@@ -26,6 +26,7 @@ To sign in from the CLI, run the following command:
 <SignIn os={props.os} />
 
 A new browser window will open where you will complete the sign-in process.
+You will be able to create a new account when you sign in with the CLI for the first time. Alternatively, head to [CloudQuery Cloud](https://cloud.cloudquery.io) to create a new account.
 
 :::callout{type="info"}
 For a non-interactive sign-in process and sync, you can [generate an API key](/docs/deployment/generate-api-key). This is useful for production deployments.


### PR DESCRIPTION
<!-- 🎉 Thank you for making CloudQuery awesome by submitting a PR 🎉 -->

#### Summary

I think this paragraph is a bit outdated. Aligned it with https://www.cloudquery.io/download.
`cloudquery login` also handles creating an account (via the browser Window) so we don't need that part either.

Feedback welcomed

<!--
Use the following steps to ensure your PR is ready to be reviewed

- [ ] Read the [contribution guidelines](https://github.com/cloudquery/cloudquery/blob/main/CONTRIBUTING.md) 🧑‍🎓
- [ ] Run `make lint` to ensure the proposed changes follow the coding style 🚨 (install golangci-lint [here](https://golangci-lint.run/usage/install/#local-installation))
- [ ] Run `make test` to ensure the proposed changes pass the tests 🧪
- [ ] If changing a source plugin run `make gen` to ensure docs are up to date 📝
- [ ] Ensure the status checks below are successful ✅
--->
