### PR TITLE
fix: Pipeline context overlap

### DIFF
--- a/cli/cmd/sync_v3.go
+++ b/cli/cmd/sync_v3.go
@@ -352,11 +352,7 @@ func syncConnectionV3(ctx context.Context, source v3source, destinations []v3des
 		destinationName := destinationSpecs[i].Name
 
 		// Start a pipeline of transformers that will receive & transform the source records
-		var (
-			pipeline *transformerpipeline.TransformerPipeline
-			err      error
-		)
-		pipeline, gctx, err = transformerpipeline.New(gctx, transformClientsByDestination[destinationName])
+		pipeline, _, err := transformerpipeline.New(gctx, transformClientsByDestination[destinationName])
 		if err != nil {
 			return fmt.Errorf("failed to create transformer pipeline: %w", err)
 		}


### PR DESCRIPTION
There’s an issue here where we overwrite each `gctx` with a new one, as we create pipelines. The earlies pipelines getting cancelled (due to error) would affect the later ones but not vice versa.

I haven't tested this yet, but it reads better for me.