### PR TITLE
chore: Use redirect target instead of `https://cloudquery.io/`

### DIFF
--- a/website/components/mdx/_configure.mdx
+++ b/website/components/mdx/_configure.mdx
@@ -107,4 +107,4 @@ Now that you have successfully synced data from the [XKCD source](https://hub.cl
 
 - [Explore Source Plugins](https://hub.cloudquery.io/plugins/source)
 - [Explore Destination Plugins](https://hub.cloudquery.io/plugins/destination)
-- [Visit our Website for more information](https://cloudquery.io)
+- [Visit our Website for more information](https://www.cloudquery.io/)


### PR DESCRIPTION
<!-- 🎉 Thank you for making CloudQuery awesome by submitting a PR 🎉 -->

#### Summary

https://cloudquery.io/ redirects to https://www.cloudquery.io/ so better to use the latter.
Fixes https://github.com/cloudquery/cloudquery/actions/runs/10792110017/job/29931051568

<!--
Explain what problem this PR addresses
-->

<!--
Use the following steps to ensure your PR is ready to be reviewed

- [ ] Read the [contribution guidelines](https://github.com/cloudquery/cloudquery/blob/main/CONTRIBUTING.md) 🧑‍🎓
- [ ] Run `make lint` to ensure the proposed changes follow the coding style 🚨 (install golangci-lint [here](https://golangci-lint.run/usage/install/#local-installation))
- [ ] Run `make test` to ensure the proposed changes pass the tests 🧪
- [ ] If changing a source plugin run `make gen` to ensure docs are up to date 📝
- [ ] Ensure the status checks below are successful ✅
--->
