### PR TITLE
fix: Use error string for  analytics events

### DIFF
--- a/cli/internal/analytics/client.go
+++ b/cli/internal/analytics/client.go
@@ -242,8 +242,11 @@ func getInitCommonProps(invocationUUID uuid.UUID, event InitEvent, details *even
 		Set("source", event.Source).
 		Set("destination", event.Destination).
 		Set("accept_defaults", event.AcceptDefaults).
-		Set("spec_path", event.SpecPath).
-		Set("error", event.Error)
+		Set("spec_path", event.SpecPath)
+
+	if event.Error != nil {
+		props.Set("error", event.Error.Error())
+	}
 
 	if details != nil {
 		userID, userEmail := getUserIDEmail(details.user, details.currentTeam)


### PR DESCRIPTION
<!-- 🎉 Thank you for making CloudQuery awesome by submitting a PR 🎉 -->

#### Summary

Passing the error instance doesn't seem to get serialized correctly in our analytics stack, so this PR changes the code to use the error string

<!--
Use the following steps to ensure your PR is ready to be reviewed

- [ ] Read the [contribution guidelines](https://github.com/cloudquery/cloudquery/blob/main/CONTRIBUTING.md) 🧑‍🎓
- [ ] Run `make lint` to ensure the proposed changes follow the coding style 🚨 (install golangci-lint [here](https://golangci-lint.run/usage/install/#local-installation))
- [ ] Run `make test` to ensure the proposed changes pass the tests 🧪
- [ ] If changing a source plugin run `make gen` to ensure docs are up to date 📝
- [ ] Ensure the status checks below are successful ✅
--->
