### PR TITLE
feat: Add `install` support for Transformer plugins

### DIFF
--- a/cli/cmd/migrate.go
+++ b/cli/cmd/migrate.go
@@ -62,7 +62,7 @@ func migrate(cmd *cobra.Command, args []string) error {
 		transformerSpecsByName[transformer.Name] = *transformer
 	}
 
-	authToken, err := auth.GetAuthTokenIfNeeded(log.Logger, sources, destinations)
+	authToken, err := auth.GetAuthTokenIfNeeded(log.Logger, sources, destinations, transformers)
 	if err != nil {
 		return fmt.Errorf("failed to get auth token: %w", err)
 	}

--- a/cli/cmd/sync.go
+++ b/cli/cmd/sync.go
@@ -117,7 +117,7 @@ func sync(cmd *cobra.Command, args []string) error {
 			fmt.Println(err)
 		}
 	}()
-	authToken, err := auth.GetAuthTokenIfNeeded(log.Logger, sources, destinations)
+	authToken, err := auth.GetAuthTokenIfNeeded(log.Logger, sources, destinations, transformers)
 	if err != nil {
 		return fmt.Errorf("failed to get auth token: %w", err)
 	}

--- a/cli/cmd/tables.go
+++ b/cli/cmd/tables.go
@@ -66,7 +66,7 @@ func tables(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("failed to load spec(s) from %s. Error: %w", strings.Join(args, ", "), err)
 	}
 	sources := specReader.Sources
-	authToken, err := auth.GetAuthTokenIfNeeded(log.Logger, sources, nil)
+	authToken, err := auth.GetAuthTokenIfNeeded(log.Logger, sources, nil, nil)
 	if err != nil {
 		return fmt.Errorf("failed to get auth token: %w", err)
 	}

--- a/cli/cmd/test_connection.go
+++ b/cli/cmd/test_connection.go
@@ -148,7 +148,7 @@ func testConnection(cmd *cobra.Command, args []string) error {
 	sources := specReader.Sources
 	destinations := specReader.Destinations
 
-	authToken, err := auth.GetAuthTokenIfNeeded(log.Logger, sources, destinations)
+	authToken, err := auth.GetAuthTokenIfNeeded(log.Logger, sources, destinations, nil)
 	if err != nil {
 		return fmt.Errorf("failed to get auth token: %w", err)
 	}

--- a/cli/cmd/testdata/transformation.yml
+++ b/cli/cmd/testdata/transformation.yml
@@ -1,0 +1,29 @@
+kind: "source"
+spec:
+  name: "test"
+  path: "cloudquery/test"
+  registry: "github"
+  destinations: [test]
+  version: "v3.1.15" # latest version of source test plugin
+  tables: ["*"]
+---
+kind: "destination"
+spec:
+  name: "test"
+  path: "cloudquery/test"
+  registry: "github"
+  version: "v2.2.14" # latest version of destination test plugin
+  transformers:
+    - basic # we add the basic transformer here
+---
+kind: transformer
+spec:
+  name: "basic"
+  registry: cloudquery
+  path: "cloudquery/basic"
+  version: "v1.1.0"
+  spec:
+    transformations:
+      - kind: add_current_timestamp_column
+        tables: ["*"]
+        name: "_record_processed_at"

--- a/cli/cmd/validate_config.go
+++ b/cli/cmd/validate_config.go
@@ -54,7 +54,7 @@ func validateConfig(cmd *cobra.Command, args []string) error {
 	sources := specReader.Sources
 	destinations := specReader.Destinations
 
-	authToken, err := auth.GetAuthTokenIfNeeded(log.Logger, sources, destinations)
+	authToken, err := auth.GetAuthTokenIfNeeded(log.Logger, sources, destinations, nil)
 	if err != nil {
 		return fmt.Errorf("failed to get auth token: %w", err)
 	}

--- a/cli/internal/auth/token.go
+++ b/cli/internal/auth/token.go
@@ -12,9 +12,9 @@ func tokenNeeded(registry specs.Registry, path string) bool {
 	return registry == specs.RegistryCloudQuery || (registry == specs.RegistryDocker && strings.HasPrefix(path, "docker.cloudquery.io"))
 }
 
-func transformerNeedsToken(sources []*specs.Transformer) bool {
-	for _, source := range sources {
-		if tokenNeeded(source.Registry, source.Path) {
+func transformerNeedsToken(transformers []*specs.Transformer) bool {
+	for _, transformer := range transformers {
+		if tokenNeeded(transformer.Registry, transformer.Path) {
 			return true
 		}
 	}

--- a/cli/internal/auth/token.go
+++ b/cli/internal/auth/token.go
@@ -12,6 +12,15 @@ func tokenNeeded(registry specs.Registry, path string) bool {
 	return registry == specs.RegistryCloudQuery || (registry == specs.RegistryDocker && strings.HasPrefix(path, "docker.cloudquery.io"))
 }
 
+func transformerNeedsToken(sources []*specs.Transformer) bool {
+	for _, source := range sources {
+		if tokenNeeded(source.Registry, source.Path) {
+			return true
+		}
+	}
+	return false
+}
+
 func sourcesNeedToken(sources []*specs.Source) bool {
 	for _, source := range sources {
 		if tokenNeeded(source.Registry, source.Path) {
@@ -30,8 +39,8 @@ func destinationsNeedToken(destinations []*specs.Destination) bool {
 	return false
 }
 
-func GetAuthTokenIfNeeded(logger zerolog.Logger, sources []*specs.Source, destinations []*specs.Destination) (cqapiauth.Token, error) {
-	needsToken := sourcesNeedToken(sources) || destinationsNeedToken(destinations)
+func GetAuthTokenIfNeeded(logger zerolog.Logger, sources []*specs.Source, destinations []*specs.Destination, transformers []*specs.Transformer) (cqapiauth.Token, error) {
+	needsToken := sourcesNeedToken(sources) || destinationsNeedToken(destinations) || transformerNeedsToken(transformers)
 	if !needsToken {
 		logger.Debug().Msg("no need to get token since no source or destination uses the CloudQuery registry")
 		return cqapiauth.UndefinedToken, nil


### PR DESCRIPTION
<!-- 🎉 Thank you for making CloudQuery awesome by submitting a PR 🎉 -->

#### Summary


This PR allows for transformer plugins to be downloaded by the `cloudquery install` command