### PR TITLE
fix: Truncate table description if over the limit

### DIFF
--- a/plugins/destination/bigquery/client/migrate.go
+++ b/plugins/destination/bigquery/client/migrate.go
@@ -15,7 +15,15 @@ const (
 	concurrentMigrations = 10
 	checkTableFrequency  = 6 * time.Second
 	maxTableChecks       = 20
+	maxDescriptionLength = 16384
 )
+
+func trimDescription(description string) string {
+	if len(description) > maxDescriptionLength {
+		return description[:maxDescriptionLength]
+	}
+	return description
+}
 
 func (c *Client) MigrateTables(ctx context.Context, msgs message.WriteMigrateTables) error {
 	eg, gctx := errgroup.WithContext(ctx)
@@ -130,7 +138,7 @@ func (c *Client) autoMigrateTable(ctx context.Context, client *bigquery.Client, 
 	}
 	tm := bigquery.TableMetadataToUpdate{
 		Name:        table.Name,
-		Description: table.Description,
+		Description: trimDescription(table.Description),
 		Schema:      wantSchema,
 	}
 	_, err = bqTable.Update(ctx, tm, "")
@@ -196,7 +204,7 @@ func (c *Client) createTable(ctx context.Context, client *bigquery.Client, table
 	tm := bigquery.TableMetadata{
 		Name:             table.Name,
 		Location:         "",
-		Description:      table.Description,
+		Description:      trimDescription(table.Description),
 		Schema:           bqSchema,
 		TimePartitioning: c.timePartitioning(),
 	}


### PR DESCRIPTION
<!-- 🎉 Thank you for making CloudQuery awesome by submitting a PR 🎉 -->

#### Summary

Moving AWS table options docs to the table description caused some descriptions to trigger the limit on BigQuery,
see internal failure https://github.com/cloudquery/policies/actions/runs/10939828521/job/30370943857#step:10:485:

```
Descriptions can be at most 16384 characters long., invalid
```

<!--
Use the following steps to ensure your PR is ready to be reviewed

- [ ] Read the [contribution guidelines](https://github.com/cloudquery/cloudquery/blob/main/CONTRIBUTING.md) 🧑‍🎓
- [ ] Run `make lint` to ensure the proposed changes follow the coding style 🚨 (install golangci-lint [here](https://golangci-lint.run/usage/install/#local-installation))
- [ ] Run `make test` to ensure the proposed changes pass the tests 🧪
- [ ] If changing a source plugin run `make gen` to ensure docs are up to date 📝
- [ ] Ensure the status checks below are successful ✅
--->
