### PR TITLE
fix: Add missing OTEL logs component

### DIFF
--- a/cli/internal/otel/receiver.go
+++ b/cli/internal/otel/receiver.go
@@ -172,7 +172,7 @@ func (Consumer) ConsumeTraces(ctx context.Context, td ptrace.Traces) error {
 }
 
 // ConsumeLogs implements consumer.Logs.
-func (c Consumer) ConsumeLogs(ctx context.Context, ld plog.Logs) error {
+func (Consumer) ConsumeLogs(ctx context.Context, ld plog.Logs) error {
 	// Do nothing, the CLI only needs metrics to print the table metrics file
 	return nil
 }

--- a/cli/internal/otel/receiver.go
+++ b/cli/internal/otel/receiver.go
@@ -12,6 +12,7 @@ import (
 	"github.com/jedib0t/go-pretty/v6/table"
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/consumer"
+	"go.opentelemetry.io/collector/pdata/plog"
 	"go.opentelemetry.io/collector/pdata/pmetric"
 	"go.opentelemetry.io/collector/pdata/ptrace"
 	"go.opentelemetry.io/collector/receiver"
@@ -170,6 +171,12 @@ func (Consumer) ConsumeTraces(ctx context.Context, td ptrace.Traces) error {
 	return nil
 }
 
+// ConsumeLogs implements consumer.Logs.
+func (c Consumer) ConsumeLogs(ctx context.Context, ld plog.Logs) error {
+	// Do nothing, the CLI only needs metrics to print the table metrics file
+	return nil
+}
+
 // ConsumeMetrics implements consumer.Metrics.
 func (c Consumer) ConsumeMetrics(ctx context.Context, md pmetric.Metrics) error {
 	resourceMetrics := md.ResourceMetrics()
@@ -268,6 +275,12 @@ func StartOtelReceiver(ctx context.Context, opts ...OtelReceiverOption) (*OtelRe
 		return nil, err
 	}
 	components = append(components, metrics)
+
+	logs, err := factory.CreateLogsReceiver(ctx, settings, config, c)
+	if err != nil {
+		return nil, err
+	}
+	components = append(components, logs)
 
 	for _, c := range components {
 		if err := c.Start(ctx, nil); err != nil {


### PR DESCRIPTION
<!-- 🎉 Thank you for making CloudQuery awesome by submitting a PR 🎉 -->

#### Summary

This fixes an issue with the `--tables-metrics-location` flag, that when you pass it you'd see the following log warnings:

```
2024-09-20T13:28:20Z WRN otel error error="failed to send logs to http://localhost:51875/v1/logs: 404 Not Found" invocation_id=95b765f7-2472-4c7a-b062-c0c799743bf7 module=cli
```

The reason is that now plugins send OTEL logs data as well, but the CLI is not set up to receive them. This was an oversight on my end when adding logs support to plugins.

The PR also cleans up some unused options

<!--
Use the following steps to ensure your PR is ready to be reviewed

- [ ] Read the [contribution guidelines](https://github.com/cloudquery/cloudquery/blob/main/CONTRIBUTING.md) 🧑‍🎓
- [ ] Run `make lint` to ensure the proposed changes follow the coding style 🚨 (install golangci-lint [here](https://golangci-lint.run/usage/install/#local-installation))
- [ ] Run `make test` to ensure the proposed changes pass the tests 🧪
- [ ] If changing a source plugin run `make gen` to ensure docs are up to date 📝
- [ ] Ensure the status checks below are successful ✅
--->
