### PR TITLE
fix: Fix incorrect location of metrics calculation.

### DIFF
--- a/cli/cmd/sync_v3.go
+++ b/cli/cmd/sync_v3.go
@@ -550,6 +550,7 @@ func syncConnectionV3(ctx context.Context, source v3source, destinations []v3des
 	if err != nil {
 		return err
 	}
+	totals = sourceClient.Metrics()
 	sourceWarnings := totals.Warnings
 	sourceErrors := totals.Errors
 	var metadataDataErrors error


### PR DESCRIPTION
I accidentally elided certain CLI metrics reporting while fixing Rudderstack event tracking. This PR fixes that issue.