### PR TITLE
fix: Update the helper text

### DIFF
--- a/plugins/destination/postgresql/cloud-config-ui/src/hooks/useConfig.tsx
+++ b/plugins/destination/postgresql/cloud-config-ui/src/hooks/useConfig.tsx
@@ -61,7 +61,7 @@ export const useConfig = ({ initialValues }: Props): DestinationConfig => {
                   component: 'control-secret-field',
                   name: 'connection_string',
                   helperText:
-                    'Connection string to connect to the database. E.g. postgres://jack:secret@localhost:5432/mydb?sslmode=prefer',
+                    'Connection string to connect to the database. E.g. postgres://user:pass@localhost:5432/mydb?sslmode=prefer',
                   label: 'Connection string',
                   shouldRender: (values: any) => values._connectionType === 'string',
                   schema: yup


### PR DESCRIPTION
Small correction to the helper text for the connection string, we should use `user:pass` instead of `jack:secret`.