### PR TITLE
fix: Catch any unparseable strings

### DIFF
--- a/plugins/destination/postgresql/cloud-config-ui/src/utils/convertConnectionStringToFields.ts
+++ b/plugins/destination/postgresql/cloud-config-ui/src/utils/convertConnectionStringToFields.ts
@@ -1,18 +1,27 @@
 export const convertConnectionStringToFields = (connectionString?: string) => {
-  const connectionParams: Record<string, any> = {};
+  try {
+    const connectionParams: Record<string, any> = {};
 
-  if (!connectionString) {
+    if (!connectionString) {
+      return {
+        connectionParams,
+      };
+    }
+
+    if (
+      connectionString.startsWith('postgres://') ||
+      connectionString.startsWith('postgresql://')
+    ) {
+      return parseConnectionFieldsFromURI(connectionString);
+    }
+
+    // Return parsed components
+    return parseConnectionFieldsFromKeyValue(connectionString);
+  } catch {
     return {
-      connectionParams,
+      connectionParams: {},
     };
   }
-
-  if (connectionString.startsWith('postgres://') || connectionString.startsWith('postgresql://')) {
-    return parseConnectionFieldsFromURI(connectionString);
-  }
-
-  // Return parsed components
-  return parseConnectionFieldsFromKeyValue(connectionString);
 };
 
 /**

--- a/plugins/destination/postgresql/cloud-config-ui/src/utils/tests/convertConnectionStringToFields.test.ts
+++ b/plugins/destination/postgresql/cloud-config-ui/src/utils/tests/convertConnectionStringToFields.test.ts
@@ -9,6 +9,14 @@ describe('connectionStringToFields (URI)', () => {
     });
   });
 
+  test('bad connection string', () => {
+    const result = convertConnectionStringToFields('bad');
+
+    expect(result).toEqual({
+      connectionParams: {},
+    });
+  });
+
   test('basic empty connection string', () => {
     const result = convertConnectionStringToFields('postgres://');
 


### PR DESCRIPTION
Catch any strings that can't be parsed - preventing the UI from hanging.

With this approach, the test connection will ultimately report the error state.