### PR TITLE
fix: Remove constraints from internal fields if needed

### DIFF
--- a/cli/internal/transformer/transformer.go
+++ b/cli/internal/transformer/transformer.go
@@ -98,9 +98,11 @@ func (t *RecordTransformer) TransformSchema(sc *arrow.Schema) *arrow.Schema {
 				[]string{schema.MetadataTrue},
 			)})
 	}
-	for _, field := range sc.Fields() {
-		mdMap := field.Metadata.ToMap()
+	fields = append(fields, sc.Fields()...)
 
+	transformedFields := make([]arrow.Field, 0, len(fields))
+	for _, field := range fields {
+		mdMap := field.Metadata.ToMap()
 		if _, ok := mdMap[schema.MetadataUnique]; ok && t.removeUniqueConstraints {
 			delete(mdMap, schema.MetadataUnique)
 		}
@@ -112,17 +114,15 @@ func (t *RecordTransformer) TransformSchema(sc *arrow.Schema) *arrow.Schema {
 			mdMap[schema.MetadataPrimaryKey] = schema.MetadataTrue
 		}
 
-		newMd := arrow.MetadataFrom(mdMap)
-
-		fields = append(fields, arrow.Field{
+		transformedFields = append(transformedFields, arrow.Field{
 			Name:     field.Name,
 			Type:     field.Type,
 			Nullable: field.Nullable,
-			Metadata: newMd,
+			Metadata: arrow.MetadataFrom(mdMap),
 		})
 	}
 	scMd := sc.Metadata()
-	return arrow.NewSchema(fields, &scMd)
+	return arrow.NewSchema(transformedFields, &scMd)
 }
 
 func (t *RecordTransformer) Transform(record arrow.Record) arrow.Record {

--- a/cli/internal/transformer/transformer.go
+++ b/cli/internal/transformer/transformer.go
@@ -100,8 +100,8 @@ func (t *RecordTransformer) TransformSchema(sc *arrow.Schema) *arrow.Schema {
 	}
 	fields = append(fields, sc.Fields()...)
 
-	transformedFields := make([]arrow.Field, 0, len(fields))
-	for _, field := range fields {
+	transformedFields := make([]arrow.Field, len(fields))
+	for i, field := range fields {
 		mdMap := field.Metadata.ToMap()
 		if _, ok := mdMap[schema.MetadataUnique]; ok && t.removeUniqueConstraints {
 			delete(mdMap, schema.MetadataUnique)
@@ -114,12 +114,12 @@ func (t *RecordTransformer) TransformSchema(sc *arrow.Schema) *arrow.Schema {
 			mdMap[schema.MetadataPrimaryKey] = schema.MetadataTrue
 		}
 
-		transformedFields = append(transformedFields, arrow.Field{
+		transformedFields[i] = arrow.Field{
 			Name:     field.Name,
 			Type:     field.Type,
 			Nullable: field.Nullable,
 			Metadata: arrow.MetadataFrom(mdMap),
-		})
+		}
 	}
 	scMd := sc.Metadata()
 	return arrow.NewSchema(transformedFields, &scMd)


### PR DESCRIPTION
<!-- 🎉 Thank you for making CloudQuery awesome by submitting a PR 🎉 -->

#### Summary

This PR fixes an issue with `sync_group_id` in append mode where the PK constraint for it was't removed

<!--
Use the following steps to ensure your PR is ready to be reviewed

- [ ] Read the [contribution guidelines](https://github.com/cloudquery/cloudquery/blob/main/CONTRIBUTING.md) 🧑‍🎓
- [ ] Run `make lint` to ensure the proposed changes follow the coding style 🚨 (install golangci-lint [here](https://golangci-lint.run/usage/install/#local-installation))
- [ ] Run `make test` to ensure the proposed changes pass the tests 🧪
- [ ] If changing a source plugin run `make gen` to ensure docs are up to date 📝
- [ ] Ensure the status checks below are successful ✅
--->
