### PR TITLE
fix: Wait for last print of table metrics before exiting

### DIFF
--- a/cli/internal/otel/receiver.go
+++ b/cli/internal/otel/receiver.go
@@ -50,10 +50,8 @@ type Consumer struct {
 }
 
 func (c *Consumer) Shutdown(ctx context.Context) {
-	if c.quit != nil {
-		close(c.quit)
-		c.wg.Wait()
-	}
+	close(c.quit)
+	c.wg.Wait()
 }
 
 func newMetricConsumer(metricsFile *os.File, quit chan any, wg *sync.WaitGroup) func(context.Context, pluginMetric) {

--- a/cli/internal/otel/receiver.go
+++ b/cli/internal/otel/receiver.go
@@ -46,15 +46,17 @@ type Consumer struct {
 	metricsFilename string
 	metricsFile     *os.File
 	consumeMetric   func(context.Context, pluginMetric)
+	wg              *sync.WaitGroup
 }
 
 func (c *Consumer) Shutdown(ctx context.Context) {
 	if c.quit != nil {
 		close(c.quit)
+		c.wg.Wait()
 	}
 }
 
-func newMetricConsumer(metricsFile *os.File, quit chan any) func(context.Context, pluginMetric) {
+func newMetricConsumer(metricsFile *os.File, quit chan any, wg *sync.WaitGroup) func(context.Context, pluginMetric) {
 	tableLock := sync.Mutex{}
 	metricsMap := make(map[string]*tableMetric)
 	ticker := time.NewTicker(20 * time.Second)
@@ -113,7 +115,9 @@ func newMetricConsumer(metricsFile *os.File, quit chan any) func(context.Context
 		t.Render()
 	}
 
+	wg.Add(1)
 	go func() {
+		defer wg.Done()
 		for {
 			select {
 			case <-ticker.C:
@@ -231,7 +235,9 @@ func WithMetricsFilename(filename string) OtelReceiverOption {
 }
 
 func StartOtelReceiver(ctx context.Context, opts ...OtelReceiverOption) (*OtelReceiver, error) {
-	c := Consumer{}
+	c := Consumer{
+		wg: &sync.WaitGroup{},
+	}
 	for _, opt := range opts {
 		opt(&c)
 	}
@@ -241,7 +247,7 @@ func StartOtelReceiver(ctx context.Context, opts ...OtelReceiverOption) (*OtelRe
 		return nil, err
 	}
 	quit := make(chan any)
-	c.consumeMetric = newMetricConsumer(metricsFile, quit)
+	c.consumeMetric = newMetricConsumer(metricsFile, quit, c.wg)
 	c.metricsFile = metricsFile
 	c.quit = quit
 


### PR DESCRIPTION
<!-- 🎉 Thank you for making CloudQuery awesome by submitting a PR 🎉 -->

#### Summary

This PR fixes an issue with the table metrics flag where we would not print the last update of the metrics, since we didn't wait for the Go routine that does it to finish

<!--
Use the following steps to ensure your PR is ready to be reviewed

- [ ] Read the [contribution guidelines](https://github.com/cloudquery/cloudquery/blob/main/CONTRIBUTING.md) 🧑‍🎓
- [ ] Run `make lint` to ensure the proposed changes follow the coding style 🚨 (install golangci-lint [here](https://golangci-lint.run/usage/install/#local-installation))
- [ ] Run `make test` to ensure the proposed changes pass the tests 🧪
- [ ] If changing a source plugin run `make gen` to ensure docs are up to date 📝
- [ ] Ensure the status checks below are successful ✅
--->
