### PR TITLE
fix: Set default `pgx_log_level` level

### DIFF
--- a/plugins/destination/postgresql/client/spec/spec.go
+++ b/plugins/destination/postgresql/client/spec/spec.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/cloudquery/plugin-sdk/v4/configtype"
 	"github.com/invopop/jsonschema"
+	"github.com/jackc/pgx/v5/tracelog"
 )
 
 const (
@@ -49,6 +50,9 @@ func (s *Spec) SetDefaults() {
 	}
 	if s.BatchTimeout.Duration() <= 0 {
 		s.BatchTimeout = configtype.NewDuration(defaultBatchTimeout)
+	}
+	if s.PgxLogLevel == 0 {
+		s.PgxLogLevel = LogLevel(tracelog.LogLevelError)
 	}
 }
 


### PR DESCRIPTION
<!-- 🎉 Thank you for making CloudQuery awesome by submitting a PR 🎉 -->

#### Summary

If you run a sync with Postgres and don't specify you get this log message:

```
INF Initializing postgresql destination invocation_id=fc72fdc1-96ba-46ea-bf84-cad2a5dd8540 module=pg-dest pgx_log_level="invalid level 0"
```

The log message also hides that we're not setting the log level properly.

This PR fixes that

<!--
Use the following steps to ensure your PR is ready to be reviewed

- [ ] Read the [contribution guidelines](https://github.com/cloudquery/cloudquery/blob/main/CONTRIBUTING.md) 🧑‍🎓
- [ ] Run `make lint` to ensure the proposed changes follow the coding style 🚨 (install golangci-lint [here](https://golangci-lint.run/usage/install/#local-installation))
- [ ] Run `make test` to ensure the proposed changes pass the tests 🧪
- [ ] If changing a source plugin run `make gen` to ensure docs are up to date 📝
- [ ] Ensure the status checks below are successful ✅
--->
