### PR TITLE
fix: Return correct error from transformers pipeline

### DIFF
--- a/cli/internal/transformerpipeline/pipeline.go
+++ b/cli/internal/transformerpipeline/pipeline.go
@@ -11,6 +11,10 @@ import (
 	"golang.org/x/sync/errgroup"
 )
 
+var (
+	ErrPipelineClosed = errors.New("pipeline is closed")
+)
+
 // TransformerPipeline runs a pipeline of transform clients.
 //
 // Ideally we'd just call the result of each transform to the next one, but transformations are not synchronous calls,
@@ -72,7 +76,7 @@ func (lp *TransformerPipeline) Send(data []byte) error {
 	}
 
 	if lp.clientWrappers[0].isClosed.Load() {
-		return errors.New("pipeline is closed")
+		return ErrPipelineClosed
 	}
 
 	sendCh := make(chan error)
@@ -90,7 +94,7 @@ func (lp *TransformerPipeline) Send(data []byte) error {
 			return err
 		case <-time.After(1 * time.Second): // Check if pipeline is closed every second
 			if lp.clientWrappers[0].isClosed.Load() {
-				return errors.New("pipeline is closed")
+				return ErrPipelineClosed
 			}
 		}
 	}


### PR DESCRIPTION
<!-- 🎉 Thank you for making CloudQuery awesome by submitting a PR 🎉 -->

#### Summary

Fixes https://github.com/cloudquery/cloudquery-issues/issues/2591 (internal issue)

We have 2 Go routines in play in `sync_v3`, one for the transformer pipeline and one for handling sync messages on the gRPC channel.
Any of those Go routines can return an error, and the error group will report the first one which is not consistent in case the pipelined was closed due to a destination error where `OnOutput` returns the error and closes the pipeline.
In the latter case we should signal the sync Go routine to exit early but not with an error that will get reported from the pipeline Go routine.

<!--
Use the following steps to ensure your PR is ready to be reviewed

- [ ] Read the [contribution guidelines](https://github.com/cloudquery/cloudquery/blob/main/CONTRIBUTING.md) 🧑‍🎓
- [ ] Run `make lint` to ensure the proposed changes follow the coding style 🚨 (install golangci-lint [here](https://golangci-lint.run/usage/install/#local-installation))
- [ ] Run `make test` to ensure the proposed changes pass the tests 🧪
- [ ] If changing a source plugin run `make gen` to ensure docs are up to date 📝
- [ ] Ensure the status checks below are successful ✅
--->
