### PR TITLE
chore: Use `cloudquery plugin` instead of `cloudquery integration` in docs

### DIFF
--- a/website/pages/docs/deployment/docker-offline.mdx
+++ b/website/pages/docs/deployment/docker-offline.mdx
@@ -38,7 +38,7 @@ WORKDIR /app
 COPY ./build.spec.yaml /app/build.spec.yaml
 ARG CLOUDQUERY_API_KEY
 
-RUN /app/cloudquery integration install build.spec.yaml
+RUN /app/cloudquery plugin install build.spec.yaml
 
 FROM ghcr.io/cloudquery/cloudquery:latest
 


### PR DESCRIPTION
#### Summary

The command is `cloudquery plugin` not `cloudquery integration` at least until we decide to change it

<!--
Use the following steps to ensure your PR is ready to be reviewed

- [ ] Read the [contribution guidelines](https://github.com/cloudquery/cloudquery/blob/main/CONTRIBUTING.md) 🧑‍🎓
- [ ] Run `make lint` to ensure the proposed changes follow the coding style 🚨 (install golangci-lint [here](https://golangci-lint.run/usage/install/#local-installation))
- [ ] Run `make test` to ensure the proposed changes pass the tests 🧪
- [ ] If changing a source plugin run `make gen` to ensure docs are up to date 📝
- [ ] Ensure the status checks below are successful ✅
--->
