### PR TITLE
chore: Updated Case Study redirect to the new landing page.

### DIFF
--- a/website/vercel.json
+++ b/website/vercel.json
@@ -988,7 +988,7 @@
     },
     {
       "source": "/case-studies",
-      "destination": "https://www.cloudquery.io/blog?tags=case%20studies"
+      "destination": "https://www.cloudquery.io/case-studies"
     },
     {
       "source": "/case-studies/how-hexagon-built-an-infrastructure-data-lake",


### PR DESCRIPTION
Redirect now goes to the Case Study landing page: https://www.cloudquery.io/case-studies

This solves: https://github.com/cloudquery/cloudquery-issues/issues/2702