### PR TITLE
feat: Support for partitioning by _cq_sync_group_id.

### DIFF
--- a/plugins/destination/clickhouse/client/spec/schema.json
+++ b/plugins/destination/clickhouse/client/spec/schema.json
@@ -92,7 +92,7 @@
         },
         "partition_by_sync_group_id": {
           "type": "boolean",
-          "description": "If true, the plugin will partition the data by the _cq_sync_group_id column."
+          "description": "If true, the plugin will partition the data by the _cq_sync_group_id column,\nexcept for incremental tables as the logical content of these spans all historical syncs."
         }
       },
       "additionalProperties": false,

--- a/plugins/destination/clickhouse/client/spec/schema.json
+++ b/plugins/destination/clickhouse/client/spec/schema.json
@@ -89,6 +89,10 @@
               "type": "null"
             }
           ]
+        },
+        "partition_by_sync_group_id": {
+          "type": "boolean",
+          "description": "If true, the plugin will partition the data by the _cq_sync_group_id column."
         }
       },
       "additionalProperties": false,

--- a/plugins/destination/clickhouse/client/spec/spec.go
+++ b/plugins/destination/clickhouse/client/spec/spec.go
@@ -44,6 +44,9 @@ type Spec struct {
 
 	// Maximum interval between batch writes.
 	BatchTimeout *configtype.Duration `json:"batch_timeout,omitempty"`
+
+	// If true, the plugin will partition the data by the _cq_sync_group_id column.
+	PartitionBySyncGroupID bool `json:"partition_by_sync_group_id,omitempty"`
 }
 
 func (s *Spec) Options() (*clickhouse.Options, error) {

--- a/plugins/destination/clickhouse/client/spec/spec.go
+++ b/plugins/destination/clickhouse/client/spec/spec.go
@@ -45,7 +45,8 @@ type Spec struct {
 	// Maximum interval between batch writes.
 	BatchTimeout *configtype.Duration `json:"batch_timeout,omitempty"`
 
-	// If true, the plugin will partition the data by the _cq_sync_group_id column.
+	// If true, the plugin will partition the data by the _cq_sync_group_id column,
+	// except for incremental tables as the logical content of these spans all historical syncs.
 	PartitionBySyncGroupID bool `json:"partition_by_sync_group_id,omitempty"`
 }
 

--- a/plugins/destination/clickhouse/queries/tables.go
+++ b/plugins/destination/clickhouse/queries/tables.go
@@ -47,7 +47,7 @@ func CreateTable(table *schema.Table, cluster string, engine *spec.Engine, parti
 	}
 	builder.WriteString("\n) ENGINE = ")
 	builder.WriteString(engine.String())
-	if partitionBySyncGroupID && hasColumn(table, cqSyncGroupID) {
+	if partitionBySyncGroupID && hasColumn(table, cqSyncGroupID) && !table.IsIncremental {
 		builder.WriteString(" PARTITION BY ")
 		builder.WriteString(cqSyncGroupID)
 	}

--- a/plugins/destination/clickhouse/queries/tables_test.go
+++ b/plugins/destination/clickhouse/queries/tables_test.go
@@ -27,9 +27,37 @@ func TestCreateTable(t *testing.T) {
 			schema.Column{Name: "extra_inet_col", Type: types.NewInetType()},
 			schema.Column{Name: "extra_inet_arr_col", Type: arrow.ListOf(types.NewInetType())},
 		},
-	}, "", spec.DefaultEngine())
+	}, "", spec.DefaultEngine(), false)
 	require.NoError(t, err)
 	ensureContents(t, query, "create_table.sql")
+}
+
+var CqSyncGroupIDColumn = schema.Column{
+	Name:        "_cq_sync_group_id",
+	Type:        arrow.BinaryTypes.String,
+	Description: "Internal CQ row of the sync group id (this will be the same for all rows in the same sync group)",
+}
+
+func TestCreateTableWithSyncGroupID(t *testing.T) {
+	query, err := CreateTable(&schema.Table{
+		Name: "table_name",
+		Columns: schema.ColumnList{
+			schema.CqIDColumn,
+			schema.CqParentIDColumn,
+			schema.CqSourceNameColumn,
+			schema.CqSyncTimeColumn,
+			CqSyncGroupIDColumn,
+			schema.Column{
+				Name:    "extra_col",
+				Type:    arrow.PrimitiveTypes.Float64,
+				NotNull: true,
+			},
+			schema.Column{Name: "extra_inet_col", Type: types.NewInetType()},
+			schema.Column{Name: "extra_inet_arr_col", Type: arrow.ListOf(types.NewInetType())},
+		},
+	}, "", spec.DefaultEngine(), false)
+	require.NoError(t, err)
+	ensureContents(t, query, "create_table_with_sync_group_id.sql")
 }
 
 func TestCreateTableNoOrderBy(t *testing.T) {
@@ -40,7 +68,7 @@ func TestCreateTableNoOrderBy(t *testing.T) {
 			schema.Column{Name: "extra_inet_col", Type: types.NewInetType()},
 			schema.Column{Name: "extra_inet_arr_col", Type: arrow.ListOf(types.NewInetType())},
 		},
-	}, "", spec.DefaultEngine())
+	}, "", spec.DefaultEngine(), false)
 	require.NoError(t, err)
 	ensureContents(t, query, "create_table_empty_order_by.sql")
 }
@@ -61,7 +89,7 @@ func TestCreateTableOnCluster(t *testing.T) {
 			schema.Column{Name: "extra_inet_col", Type: types.NewInetType()},
 			schema.Column{Name: "extra_inet_arr_col", Type: arrow.ListOf(types.NewInetType())},
 		},
-	}, "my_cluster", spec.DefaultEngine())
+	}, "my_cluster", spec.DefaultEngine(), false)
 	require.NoError(t, err)
 	ensureContents(t, query, "create_table_cluster.sql")
 }
@@ -85,7 +113,7 @@ func TestCreateTableWithEngine(t *testing.T) {
 	}, "", &spec.Engine{
 		Name:       "ReplicatedMergeTree",
 		Parameters: []any{"a", "b", 1, int32(2), int64(3), float32(1.2), float64(3.4), json.Number("327"), false, true},
-	})
+	}, false)
 	require.NoError(t, err)
 	ensureContents(t, query, "create_table_engine.sql")
 }

--- a/plugins/destination/clickhouse/queries/testdata/create_table_with_sync_group_id.sql
+++ b/plugins/destination/clickhouse/queries/testdata/create_table_with_sync_group_id.sql
@@ -1,0 +1,10 @@
+CREATE TABLE `table_name` (
+  `_cq_id` UUID,
+  `_cq_parent_id` Nullable(UUID),
+  `_cq_source_name` Nullable(String),
+  `_cq_sync_time` Nullable(DateTime64(6)),
+  `_cq_sync_group_id` Nullable(String),
+  `extra_col` Float64,
+  `extra_inet_col` Nullable(String),
+  `extra_inet_arr_col` Array(Nullable(String))
+) ENGINE = MergeTree() ORDER BY (`extra_col`, `_cq_id`) SETTINGS allow_nullable_key=1


### PR DESCRIPTION
This PR adds a `partition_by_sync_group_id` bool option to the spec that partitions tables by `_cq_sync_group_id` if the schema has the field.

<img width="1420" alt="Screenshot 2024-11-11 at 15 59 44" src="https://github.com/user-attachments/assets/5b624dd3-d8a4-4115-93bb-fe62c4682909">
<img width="756" alt="Screenshot 2024-11-11 at 16 05 59" src="https://github.com/user-attachments/assets/fc4f42dd-7f92-4daa-a16b-e6f9c26e5634">
