### PR TITLE
fix: Renames tables before writing summary.

### DIFF
--- a/cli/cmd/sync_v3.go
+++ b/cli/cmd/sync_v3.go
@@ -613,7 +613,7 @@ func syncConnectionV3(ctx context.Context, syncOptions syncV3Options) (syncErr e
 			SourceName:          sourceSpec.Name,
 			SourceVersion:       sourceSpec.Version,
 			SourcePath:          sourceSpec.Path,
-			SourceTables:        sourceTables.TableNames(),
+			SourceTables:        tableNameChanger.UpdateTableNamesSlice(destinationSpecs[i].Name, sourceTables.TableNames()),
 			CLIVersion:          Version,
 			DestinationErrors:   m.Errors,
 			DestinationWarnings: m.Warnings,

--- a/cli/internal/tablenamechanger/table_name_changer.go
+++ b/cli/internal/tablenamechanger/table_name_changer.go
@@ -35,6 +35,14 @@ func (c TableNameChanger) UpdateTableNames(destinationName string, tables map[st
 	return newTables
 }
 
+func (c TableNameChanger) UpdateTableNamesSlice(destinationName string, tables []string) []string {
+	newTables := make([]string, len(tables))
+	for i, oldTableName := range tables {
+		newTables[i] = c.UpdateTableName(destinationName, oldTableName)
+	}
+	return newTables
+}
+
 func (c TableNameChanger) UpdateTableName(destinationName string, oldTableName string) string {
 	if newTableName, ok := c.tableNameChanges[destinationName][oldTableName]; ok {
 		return newTableName


### PR DESCRIPTION
The Basic Transformer introduced the concept of renaming tables.

This works well, but an unfortunate side-effect of it is that sync_v3 had to be aware of the renames, because it does post-processing things to the tables, like delete-stale.

Because of this, a `tableNameChanger` was implemented back then, which is used for all that happens after the sync.

At the time this was implemented, we didn't use to write table names to the sync summary.

When we added this feature, we forgot to replace table names. This PR does just that.

Here's a before/after sync summary row:
<img width="513" alt="Screenshot 2024-11-14 at 16 33 31" src="https://github.com/user-attachments/assets/f3158cbb-c851-423b-a699-69b646ba2f6d">
