### PR TITLE
feat: Add progress log message every minute after 15 minutes.

### DIFF
--- a/cli/cmd/sync_v3.go
+++ b/cli/cmd/sync_v3.go
@@ -439,6 +439,7 @@ func syncConnectionV3(ctx context.Context, syncOptions syncV3Options) (syncErr e
 	t := time.NewTicker(100 * time.Millisecond)
 	newResources := int64(0)
 	go func() {
+		ticks := 0
 		for {
 			select {
 			case <-gctx.Done():
@@ -452,6 +453,11 @@ func syncConnectionV3(ctx context.Context, syncOptions syncV3Options) (syncErr e
 			case <-t.C:
 				change := atomic.SwapInt64(&newResources, 0)
 				_ = bar.Add(int(change))
+				// Log a positive feedback message every minute, after the 15 minute mark
+				ticks++
+				if time.Since(syncTime) > 15*60*time.Second && ticks%(10*60) == 0 {
+					log.Info().Msg("Still syncing...")
+				}
 			}
 		}
 	}()


### PR DESCRIPTION
This PR is meant as an option for letting the user know that tables are still syncing.

After the 15 minute mark, it will output an INFO log every minute saying `Still syncing...`, with no other information.

From the CLI, it's not easy to tell whether a particular table has finished syncing; this info exists in the sdk's scheduler, but not all source plugins use the scheduler anyway. This solution works for Go/Python, scheduler or not (i.e. works for every single case).

I'd argue that, for the purposes of knowing whether a sync is stalled, it is not useful to know which tables are syncing, but instead it's useful to know that the CloudQuery CLI process is still running. If you want to know which tables are long-running, I'd use our monitoring/observation solutions instead 🤷 