### PR TITLE
fix: Ignore utf8 keys.

### DIFF
--- a/plugins/transformer/jsonflattener/client/recordupdater/record_updater.go
+++ b/plugins/transformer/jsonflattener/client/recordupdater/record_updater.go
@@ -160,6 +160,12 @@ func (*RecordUpdater) preprocessRow(colName string, rowIndex int, rawRow any) (m
 func preprocessTypeSchema(unprocessedTypeSchema map[string]any) map[string]string {
 	typeSchema := make(map[string]string)
 	for key, typ := range unprocessedTypeSchema {
+		// Edge case: if the key is utf8, we don't process it, because utf8 is a special
+		// string that means that there can be many keys with any name.
+		if key == "utf8" {
+			continue
+		}
+
 		// If the type of a given key is not string, we consider it as a JSON type
 		// so that we don't flatten deeper than the first level.
 		if _, ok := typ.(string); !ok {


### PR DESCRIPTION
fixes https://github.com/cloudquery/cloudquery-issues/issues/2763
(internal issue)

Normally, the JSON Flattener will attempt to flatten JSON objects to the first level, e.g.:

```json
"type_schema": "[{\"availability_domain\":\"utf8\",\"display_name\":\"utf8\",\"volume_group_replica_id\":\"utf8\"}]"
```

But the TypeSchema notation had a special case that the JSON Flattener wasn't aware of:

```json
      {
        "name": "freeform_tags",
        "type": "json",
        "type_schema": "{\"utf8\":\"utf8\"}"
      },
```

In this case, the `utf8` key is not a literal string, but a special value that means "any string key". This should be ignored by the flattener, because it's meant to contain different keys on different rows, and table schemas are fixed.

The only way to implement this would be to do a linear pass over all rows and learn all possible keys, then do another pass and create nullable columns on all non-supplied columns for each row. We definitely don't want to support this.

Instead, this PR simply ignores keys with this special literal string.


The practice is common on the Oracle source plugin; here's a flattened Oracle table that was suffering from this issue, now fixed:

<img width="561" alt="Screenshot 2024-11-20 at 10 14 43" src="https://github.com/user-attachments/assets/33013665-eb4f-4191-8e50-53004471d43a">
