### PR TITLE
feat: Implement custom ORDER BY clause support.

### DIFF
--- a/plugins/destination/clickhouse/client/spec/schema.json
+++ b/plugins/destination/clickhouse/client/spec/schema.json
@@ -40,6 +40,54 @@
       "type": "object",
       "description": "Engine allows to specify a custom table engine to be used."
     },
+    "OrderByStrategy": {
+      "properties": {
+        "tables": {
+          "oneOf": [
+            {
+              "items": {
+                "type": "string"
+              },
+              "type": "array",
+              "description": "Table glob patterns that apply for this ORDER BY clause.\n\nIf unset, the ORDER BY clause will apply to all tables.\n\nIf a table matches both a pattern in `tables` and `skip_tables`, the table will be skipped.\n\nOrder by strategy table patterns should be disjointed sets: if a table matches two order by strategies,\nan error will be raised at runtime."
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "skip_tables": {
+          "oneOf": [
+            {
+              "items": {
+                "type": "string"
+              },
+              "type": "array",
+              "description": "Table glob patterns that should be skipped for this ORDER BY clause.\n\nIf unset, no tables will be skipped.\n\nIf a table matches both a pattern in `tables` and `skip_tables`, the table will be skipped.\n\nOrder by strategy table patterns should be disjointed sets: if a table matches two order by strategies,\nan error will be raised at runtime."
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "order_by": {
+          "oneOf": [
+            {
+              "items": {
+                "type": "string"
+              },
+              "type": "array",
+              "description": "ORDER BY list of expressions to use, e.g. `_cq_sync_group_id, toYYYYMM(_cq_sync_time), _cq_id`,\nthe strings are passed as is after \"ORDER BY\" clause, separated by commas, with no validation or quoting.\n\nAn unset order_by is not valid."
+            },
+            {
+              "type": "null"
+            }
+          ]
+        }
+      },
+      "additionalProperties": false,
+      "type": "object"
+    },
     "PartitionStrategy": {
       "properties": {
         "tables": {
@@ -136,6 +184,20 @@
               },
               "type": "array",
               "description": "Enables partitioning of tables via the `PARTITION BY` clause."
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "order": {
+          "oneOf": [
+            {
+              "items": {
+                "$ref": "#/$defs/OrderByStrategy"
+              },
+              "type": "array",
+              "description": "Enables setting table sort keys via the `ORDER BY` clause."
             },
             {
               "type": "null"

--- a/plugins/destination/clickhouse/client/spec/spec_test.go
+++ b/plugins/destination/clickhouse/client/spec/spec_test.go
@@ -150,3 +150,19 @@ func TestSpec_ValidateEmptyTables(t *testing.T) {
 	require.NoError(t, spec.Validate())
 	require.Equal(t, []string{"*"}, spec.Partition[0].Tables)
 }
+
+func TestSpec_ValidateEmptyOrderBy(t *testing.T) {
+	spec := Spec{OrderBy: []OrderByStrategy{{}}}
+	spec.SetDefaults()
+	err := spec.Validate()
+	require.Error(t, err)
+	require.ErrorContains(t, err, "order_by is required")
+}
+
+func TestSpec_ValidateEmptyOrderByTables(t *testing.T) {
+	spec := Spec{OrderBy: []OrderByStrategy{{OrderBy: []string{"test_field"}}}}
+	spec.SetDefaults()
+	err := spec.Validate()
+	require.NoError(t, err)
+	require.Equal(t, []string{"*"}, spec.OrderBy[0].Tables)
+}

--- a/plugins/destination/clickhouse/docs/overview.md
+++ b/plugins/destination/clickhouse/docs/overview.md
@@ -72,6 +72,10 @@ This is the (nested) spec used by the ClickHouse destination plugin.
 
   Partitioning strategy to be used for tables (i.e. `PARTITION BY` clause in `CREATE TABLE` statements).
 
+- `order` (optional, [ordering](#ordering)) (default: use existing primary key)
+
+  Ordering strategy to be used for tables (i.e. `ORDER BY` clause in `CREATE TABLE` statements).
+
 #### ClickHouse table engine
 
 This option allows to specify a custom table engine to be used.
@@ -141,6 +145,44 @@ partition:
   partition_by: "toYYYYMM(_cq_sync_time)"
 - tables: ["special_partition_table"]
   partition_by: "toYYYYMMDD(_cq_sync_time)"
+```
+
+#### Ordering
+
+This option allows to specify custom `ORDER BY` clauses for tables or groups of tables. It is an array of objects.
+
+Each object has the following fields:
+
+- `tables` (array of strings) (optional) (default: `["*"]`)
+
+  List of glob patterns to match table names against. Follows the same rules as the top-level spec `tables` option.
+
+  If a table matches both a pattern in `tables` and `skip_tables`, the table will be skipped.
+
+  Ordering strategy table patterns should be disjointed sets: if a table matches two ordering strategies, an error will be raised at runtime.
+
+- `skip_tables` (array of strings) (optional) (default: empty)
+
+  List of glob patterns to skip matching table names against. Follows the same rules as the top-level spec `skip_tables` option.
+
+  If a table matches both a pattern in `tables` and `skip_tables`, the table will be skipped.
+
+  Ordering strategy table patterns should be disjointed sets: if a table matches two ordering strategies, an error will be raised at runtime.
+
+- `order_by` (array of strings) (required)
+
+  Sort key to use, the strings are passed as is after "ORDER BY" clause with no validation or quoting.
+
+Example:
+
+```yaml copy
+order:
+- tables: ["aws_ec2_instances"]
+  order_by:
+  - "`account_id`"
+  - "`region`"
+  - "toYYYYMM(`_cq_sync_time`) DESC"
+  - "`_cq_id`"
 ```
 
 ### Connecting to ClickHouse Cloud

--- a/plugins/destination/clickhouse/queries/testdata/create_table_order_by.sql
+++ b/plugins/destination/clickhouse/queries/testdata/create_table_order_by.sql
@@ -1,0 +1,9 @@
+CREATE TABLE `table_name` (
+  `_cq_id` UUID,
+  `_cq_parent_id` Nullable(UUID),
+  `_cq_source_name` Nullable(String),
+  `_cq_sync_time` Nullable(DateTime64(6)),
+  `extra_col` Float64,
+  `extra_inet_col` Nullable(String),
+  `extra_inet_arr_col` Array(Nullable(String))
+) ENGINE = MergeTree() ORDER BY (`_cq_sync_time`, `_cq_id`) SETTINGS allow_nullable_key=1


### PR DESCRIPTION
This PR implements support for setting custom ORDER BY clauses on any table or group of tables in the ClickHouse destination.

Because tables are defined on the source side and every destination can have different optimal indexing/sorting circumstances, it is not practical to define destination-specific sorting strategies at the source. Therefore, this enables setting it at the destination.

<img width="532" alt="Screenshot 2024-11-19 at 16 08 06" src="https://github.com/user-attachments/assets/4f447521-504d-42ff-a51e-5957d11da9ea">
<img width="445" alt="Screenshot 2024-11-19 at 16 08 32" src="https://github.com/user-attachments/assets/1b24c17c-427e-4915-9b3f-1d10c51512fa">
