### PR TITLE
chore: Update CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -3,6 +3,7 @@
 .github/workflows/dest_* @cloudquery/cloudquery-plugins
 .github/workflows/transf_* @cloudquery/cloudquery-plugins
 plugins/** @cloudquery/cloudquery-plugins
+plugins/transformer/** @cloudquery/cloudquery-framework
 
 **/go.mod
 **/go.sum


### PR DESCRIPTION
<!-- 🎉 Thank you for making CloudQuery awesome by submitting a PR 🎉 -->

#### Summary

Transformer plugins are currently owned by data framework. This should unblock my review to https://github.com/cloudquery/cloudquery/pull/19686

<!--
Use the following steps to ensure your PR is ready to be reviewed

- [ ] Read the [contribution guidelines](https://github.com/cloudquery/cloudquery/blob/main/CONTRIBUTING.md) 🧑‍🎓
- [ ] Run `make lint` to ensure the proposed changes follow the coding style 🚨 (install golangci-lint [here](https://golangci-lint.run/usage/install/#local-installation))
- [ ] Run `make test` to ensure the proposed changes pass the tests 🧪
- [ ] If changing a source plugin run `make gen` to ensure docs are up to date 📝
- [ ] Ensure the status checks below are successful ✅
--->
