### PR TITLE
chore(main): Add Call-to-Action to Quickstart AWS Authentication Step

### DIFF
--- a/website/components/mdx/_configure.mdx
+++ b/website/components/mdx/_configure.mdx
@@ -75,6 +75,8 @@ The CloudQuery AWS integration requires read only permissions in order to sync i
 
 There are [several different methods for authenticating to your AWS cloud environment](https://hub.cloudquery.io/plugins/source/cloudquery/aws/latest/docs#authentication). Be sure you authenticate before you run your first sync.
 
+If you need help authenticating and syncing your AWS data with CloudQuery, the best place to get help is on the [CloudQuery Community forum](https://community.cloudquery.io/), or [you can setup a demo with our team](https://cloudquery.typeform.com/to/UrgOydHV?typeform-source=www.cloudquery.io/docs).
+
 ## Start Syncing
 
 Run the following command to start syncing:


### PR DESCRIPTION
This PR adds a **call-to-action** (CTA) to the "Authenticate to AWS" step in the Quickstart guide. The CTA encourages users to either **join our community** or **contact us for a demo** if they encounter issues.

<img width="1111" alt="image" src="https://github.com/user-attachments/assets/771a84ef-b94c-4c56-9853-6632e2d5b4ec">

#### Changes:
- Added a CTA to the "Authenticate to AWS" step with links to:
  - Join our community.
  - Contact us for a demo.
- Updated the step text to include guidance on seeking help if users get stuck.

#### Reasoning:
- We've observed significant user drop-off at this step due to failed attempts to sync using this plugin.
- Providing clear next steps for support will help reduce frustration and guide users toward resolving their issues.
- This CTA serves as an immediate solution until a video walkthrough of the demo can be added in the future.

#### Future Plans:
- A video walkthrough demo will be created and added to this step for further clarity and user assistance.

#### Testing:
- Verified that the CTA appears correctly in the Quickstart guide.
- Checked all links to ensure they navigate to the appropriate destinations.