### PR TITLE
chore: Push CLI tag as latest repo tag, add root `go.mod`

### DIFF
--- a/.github/workflows/release_cli.yml
+++ b/.github/workflows/release_cli.yml
@@ -101,3 +101,6 @@ jobs:
           body: Updates the CLI latest version to ${{steps.split.outputs.version}}
           labels: automerge
           author: cq-bot <cq-bot@users.noreply.github.com>
+      - name: Push Tag Without `cli-` component
+        if: steps.semver_parser.outputs.prerelease == ''
+        run: git tag ${{ steps.split.outputs.version }} && git push origin ${{ steps.split.outputs.version }}

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module github.com/cloudquery/cloudquery
+
+go 1.22.7


### PR DESCRIPTION
<!-- 🎉 Thank you for making CloudQuery awesome by submitting a PR 🎉 -->

#### Summary

This PR tries to make so our latest CLI version shows up in https://pkg.go.dev/github.com/cloudquery/cloudquery

<!--
Use the following steps to ensure your PR is ready to be reviewed

- [ ] Read the [contribution guidelines](https://github.com/cloudquery/cloudquery/blob/main/CONTRIBUTING.md) 🧑‍🎓
- [ ] Run `make lint` to ensure the proposed changes follow the coding style 🚨 (install golangci-lint [here](https://golangci-lint.run/usage/install/#local-installation))
- [ ] Run `make test` to ensure the proposed changes pass the tests 🧪
- [ ] If changing a source plugin run `make gen` to ensure docs are up to date 📝
- [ ] Ensure the status checks below are successful ✅
--->
