### PR TITLE
chore: Push CLI tag with directory prefix

### DIFF
--- a/.github/workflows/release_cli.yml
+++ b/.github/workflows/release_cli.yml
@@ -84,9 +84,11 @@ jobs:
           # A custom token is required for publishing to Homebrew
           GITHUB_TOKEN: ${{ secrets.GH_CQ_BOT }}
 
-      - name: Push Tag Without `cli-` component
+      - name: Push Tag Without `cli-` component and tag prefixed with `cli/`
         if: steps.semver_parser.outputs.prerelease == ''
-        run: git tag ${{ steps.split.outputs.version }} && git push origin ${{ steps.split.outputs.version }}
+        run: |
+          git tag ${{ steps.split.outputs.version }} && git push origin ${{ steps.split.outputs.version }}
+          git tag cli/${{ steps.split.outputs.version }} && git push origin cli/${{ steps.split.outputs.version }}
 
       - name: Checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
<!-- 🎉 Thank you for making CloudQuery awesome by submitting a PR 🎉 -->

#### Summary

This should allow pkg.go.dev to index the CLI subdirectory as a module https://go.dev/ref/mod#glos-module-subdirectory

<!--
Use the following steps to ensure your PR is ready to be reviewed

- [ ] Read the [contribution guidelines](https://github.com/cloudquery/cloudquery/blob/main/CONTRIBUTING.md) 🧑‍🎓
- [ ] Run `make lint` to ensure the proposed changes follow the coding style 🚨 (install golangci-lint [here](https://golangci-lint.run/usage/install/#local-installation))
- [ ] Run `make test` to ensure the proposed changes pass the tests 🧪
- [ ] If changing a source plugin run `make gen` to ensure docs are up to date 📝
- [ ] Ensure the status checks below are successful ✅
--->
