### PR TITLE
refactor: Don't use request URL path to build zip path in addons download

### DIFF
--- a/cli/cmd/addon_download.go
+++ b/cli/cmd/addon_download.go
@@ -6,6 +6,8 @@ import (
 	"net/http"
 	"os"
 	"os/signal"
+	"path"
+	"path/filepath"
 	"strings"
 	"syscall"
 
@@ -110,5 +112,10 @@ func runAddonDownload(ctx context.Context, cmd *cobra.Command, args []string) er
 		return fmt.Errorf("addon download failed: %d %s", res.StatusCode, location)
 	}
 
-	return publish.DownloadAddonFromResponse(res, checksum, targetDir)
+	zipPath := "-"
+	if targetDir != "-" {
+		zipPath = filepath.Join(targetDir, path.Base(location))
+	}
+
+	return publish.DownloadAddonFromResponse(res, checksum, zipPath)
 }

--- a/cli/cmd/addon_download.go
+++ b/cli/cmd/addon_download.go
@@ -6,7 +6,6 @@ import (
 	"net/http"
 	"os"
 	"os/signal"
-	"path"
 	"path/filepath"
 	"strings"
 	"syscall"
@@ -93,7 +92,11 @@ func runAddonDownload(ctx context.Context, cmd *cobra.Command, args []string) er
 		return err
 	}
 
-	location, checksum, err := publish.GetAddonMetadata(ctx, c, currentTeam, addonParts[0], addonParts[1], addonVer[0], addonVer[1])
+	addonTeam := addonParts[0]
+	addonType := addonParts[1]
+	addonName := addonVer[0]
+	addonVersion := addonVer[1]
+	location, checksum, err := publish.GetAddonMetadata(ctx, c, currentTeam, addonTeam, addonType, addonName, addonVersion)
 	if err != nil {
 		return err
 	}
@@ -114,7 +117,7 @@ func runAddonDownload(ctx context.Context, cmd *cobra.Command, args []string) er
 
 	zipPath := "-"
 	if targetDir != "-" {
-		zipPath = filepath.Join(targetDir, path.Base(location))
+		zipPath = filepath.Join(targetDir, fmt.Sprintf("%s_%s_%s_%s.zip", addonTeam, addonType, addonName, addonVersion))
 	}
 
 	return publish.DownloadAddonFromResponse(res, checksum, zipPath)

--- a/cli/internal/publish/addons.go
+++ b/cli/internal/publish/addons.go
@@ -10,7 +10,6 @@ import (
 	"io"
 	"net/http"
 	"os"
-	"path"
 	"path/filepath"
 	"strings"
 
@@ -155,18 +154,17 @@ func GetAddonMetadata(ctx context.Context, c *cloudquery_api.ClientWithResponses
 	return resp.JSON200.Location, resp.JSON200.Checksum, nil
 }
 
-func DownloadAddonFromResponse(res *http.Response, expectedChecksum, targetDir string) (retErr error) {
+func DownloadAddonFromResponse(res *http.Response, expectedChecksum, zipPath string) (retErr error) {
 	var (
 		fileWriter io.WriteCloser
 		size       int64
 		err        error
 	)
 
-	switch targetDir {
+	switch zipPath {
 	case "-":
 		fileWriter = os.Stdout
 	default:
-		zipPath := filepath.Join(targetDir, path.Base(res.Request.URL.Path))
 		if st, err := os.Stat(zipPath); err == nil {
 			if st.IsDir() {
 				return fmt.Errorf("file %s already exists: is a directory", zipPath)


### PR DESCRIPTION
<!-- 🎉 Thank you for making CloudQuery awesome by submitting a PR 🎉 -->

#### Summary

Fixes https://github.com/cloudquery/cloudquery/security/code-scanning/4
Fixes https://github.com/cloudquery/cloudquery/security/code-scanning/3
Fixes https://github.com/cloudquery/cloudquery/security/code-scanning/2

Technically those are all false positives since:
1. The request path is derived from the location [here](https://github.com/cloudquery/cloudquery/blob/83cab0b4b34bfbe33a89b444659087dfa5b4ef7b/cli/cmd/addon_download.go#L94), which is built from the addon parts which are validated [here](https://github.com/cloudquery/cloudquery/blob/83cab0b4b34bfbe33a89b444659087dfa5b4ef7b/cli/cmd/addon_download.go#L67) (though not validated for `..` in the argument)
2. If `/` or `..` are part of the addon name the request to get it will fail so we won't reach the code that downloads it.

Regardless I think we can refactor the code to make it more clear where that value is coming from


<!--
Use the following steps to ensure your PR is ready to be reviewed

- [ ] Read the [contribution guidelines](https://github.com/cloudquery/cloudquery/blob/main/CONTRIBUTING.md) 🧑‍🎓
- [ ] Run `make lint` to ensure the proposed changes follow the coding style 🚨 (install golangci-lint [here](https://golangci-lint.run/usage/install/#local-installation))
- [ ] Run `make test` to ensure the proposed changes pass the tests 🧪
- [ ] If changing a source plugin run `make gen` to ensure docs are up to date 📝
- [ ] Ensure the status checks below are successful ✅
--->
