### PR TITLE
feat: Add `exit_immediately` spec option to all test plugins.

### DIFF
--- a/plugins/destination/test/client/schema.json
+++ b/plugins/destination/test/client/schema.json
@@ -25,6 +25,21 @@
           "description": "If true, will return an error on insert record messages rather than consume from the channel",
           "default": false
         },
+        "exit_on_write": {
+          "type": "boolean",
+          "description": "If true, will call os.Exit(1) on any write message rather than consume from the channel",
+          "default": false
+        },
+        "exit_on_migrate": {
+          "type": "boolean",
+          "description": "If true, will call os.Exit(1) on migrate table messages rather than consume from the channel",
+          "default": false
+        },
+        "exit_on_insert": {
+          "type": "boolean",
+          "description": "If true, will call os.Exit(1) on insert record messages rather than consume from the channel",
+          "default": false
+        },
         "batch_writer": {
           "type": "boolean",
           "description": "Whether to use a BatchWriter or not.",

--- a/plugins/destination/test/client/spec.go
+++ b/plugins/destination/test/client/spec.go
@@ -17,6 +17,15 @@ type Spec struct {
 	// If true, will return an error on insert record messages rather than consume from the channel
 	ErrorOnInsert bool `json:"error_on_insert,omitempty" jsonschema:"default=false"`
 
+	// If true, will call os.Exit(1) on any write message rather than consume from the channel
+	ExitOnWrite bool `json:"exit_on_write,omitempty" jsonschema:"default=false"`
+
+	// If true, will call os.Exit(1) on migrate table messages rather than consume from the channel
+	ExitOnMigrate bool `json:"exit_on_migrate,omitempty" jsonschema:"default=false"`
+
+	// If true, will call os.Exit(1) on insert record messages rather than consume from the channel
+	ExitOnInsert bool `json:"exit_on_insert,omitempty" jsonschema:"default=false"`
+
 	// Whether to use a BatchWriter or not.
 	BatchWriter bool `json:"batch_writer" jsonschema:"default=false"`
 

--- a/plugins/source/test/client/schema.json
+++ b/plugins/source/test/client/schema.json
@@ -69,6 +69,11 @@
           "type": "boolean",
           "description": "If true, the plugin will fail immediately at the table resolver level, before any resources are synced",
           "default": false
+        },
+        "exit_immediately": {
+          "type": "boolean",
+          "description": "If true, the plugin will os.Exit(1) immediately at the table resolver level, before any resources are synced",
+          "default": false
         }
       },
       "additionalProperties": false,

--- a/plugins/source/test/client/spec.go
+++ b/plugins/source/test/client/spec.go
@@ -26,6 +26,9 @@ type Spec struct {
 
 	// If true, the plugin will fail immediately at the table resolver level, before any resources are synced
 	FailImmediately bool `json:"fail_immediately" jsonschema:"default=false"`
+
+	// If true, the plugin will os.Exit(1) immediately at the table resolver level, before any resources are synced
+	ExitImmediately bool `json:"exit_immediately" jsonschema:"default=false"`
 }
 
 //go:embed schema.json

--- a/plugins/source/test/resources/services/paid_table.go
+++ b/plugins/source/test/resources/services/paid_table.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"os"
 
 	"github.com/apache/arrow/go/v17/arrow"
 	"github.com/cloudquery/cloudquery/plugins/source/test/v4/client"
@@ -48,6 +49,9 @@ func fetchPaidTableData(ctx context.Context, meta schema.ClientMeta, parent *sch
 	cl := meta.(*client.Client)
 	if cl.Spec.FailImmediately {
 		return ErrFailImmediately
+	}
+	if cl.Spec.ExitImmediately {
+		os.Exit(1)
 	}
 	for i := 0; i < *cl.Spec.NumRows; i++ {
 		res <- map[string]any{

--- a/plugins/source/test/resources/services/test_some_table.go
+++ b/plugins/source/test/resources/services/test_some_table.go
@@ -3,6 +3,7 @@ package services
 import (
 	"context"
 	"fmt"
+	"os"
 
 	"github.com/apache/arrow/go/v17/arrow"
 	"github.com/cloudquery/cloudquery/plugins/source/test/v4/client"
@@ -47,6 +48,9 @@ func fetchSomeTableData(ctx context.Context, meta schema.ClientMeta, parent *sch
 	cl := meta.(*client.Client)
 	if cl.Spec.FailImmediately {
 		return ErrFailImmediately
+	}
+	if cl.Spec.ExitImmediately {
+		os.Exit(1)
 	}
 	for i := 0; i < *cl.Spec.NumRows; i++ {
 		res <- map[string]any{

--- a/plugins/source/test/resources/services/test_sub_table.go
+++ b/plugins/source/test/resources/services/test_sub_table.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"math/rand"
+	"os"
 	"strconv"
 
 	"github.com/apache/arrow/go/v17/arrow"
@@ -56,7 +57,9 @@ func fetchSubTableData(ctx context.Context, meta schema.ClientMeta, parent *sche
 	if cl.Spec.FailImmediately {
 		return ErrFailImmediately
 	}
-
+	if cl.Spec.ExitImmediately {
+		os.Exit(1)
+	}
 	colMap := make(map[string]any, *cl.Spec.NumSubCols)
 	for i := 0; i < *cl.Spec.NumSubCols; i++ {
 		colMap["extra_column_"+strconv.FormatInt(int64(i), 10)] = rand.Int63()

--- a/plugins/transformer/test/client/client.go
+++ b/plugins/transformer/test/client/client.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"os"
 
 	"github.com/apache/arrow/go/v17/arrow"
 	"github.com/cloudquery/cloudquery/plugins/transformer/test/client/spec"
@@ -50,6 +51,9 @@ func (c *Client) Transform(ctx context.Context, recvRecords <-chan arrow.Record,
 			sourceRecords++
 			if c.spec.FailImmediately || (c.spec.FailAfterNSourceRecords > 0 && sourceRecords > c.spec.FailAfterNSourceRecords) {
 				return fmt.Errorf("failing at the transformer stage according to spec requirements")
+			}
+			if c.spec.ExitImmediately {
+				os.Exit(1)
 			}
 
 			sendRecords <- record

--- a/plugins/transformer/test/client/spec/spec.go
+++ b/plugins/transformer/test/client/spec/spec.go
@@ -3,6 +3,7 @@ package spec
 type Spec struct {
 	FailImmediately         bool `json:"fail_immediately"`
 	FailAfterNSourceRecords int  `json:"fail_after_n_source_records"`
+	ExitImmediately         bool `json:"exit_immediately"`
 }
 
 func (*Spec) SetDefaults() {


### PR DESCRIPTION
This PR adds spec options on all test plugins to cause an `os.Exit(1)` upon syncing, to enable e2e testing in the `cli`.

The spec option is a boolean called `exit_immediately`, except in the destination test plugin which has granular options for erroring already (write, insert, migrate), so in this case I added analogous `exit` versions.

I tested the options by running syncs which each component exiting (source, destination, transformer):

### Source exits on sync immediately

```bash
$ cli sync testdata
Loading spec(s) from testdata
Starting sync for: test (local@./test) -> [test-destination (grpc@localhost:7778)]
source plugin process failed with exit status 1
Error: failed to sync v3 source test: unexpected error from sync client receive: rpc error: code = Unavailable desc = error reading from server: EOF
```

### Destination exits on insert

```bash
$ cli sync testdata
Loading spec(s) from testdata
Starting sync for: test (local@./test) -> [test-destination (grpc@localhost:7778)]
Error: failed to sync v3 source test: write client returned error (migrate): error reading from server: EOF
```

### Transformer exits on transform

```bash
$ cli sync testdata
Loading spec(s) from testdata
Starting sync for: test (local@./test) -> [test-destination (grpc@localhost:7778)]
Error: failed to sync v3 source test: rpc error: code = Unavailable desc = error reading from server: EOF
```