### PR TITLE
chore: Override nth-check in config UI

### DIFF
--- a/plugins/source/hackernews/cloud-config-ui/package-lock.json
+++ b/plugins/source/hackernews/cloud-config-ui/package-lock.json
@@ -19520,15 +19520,6 @@
         "js-yaml": "bin/js-yaml.js"
       }
     },
-    "node_modules/svgo/node_modules/nth-check": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/nth-check/-/nth-check-1.0.2.tgz",
-      "integrity": "sha512-WeBOdju8SnzPN5vTUJYxYUxLeXpCaVP5i5e0LF8fg7WORF2Wd7wFX/pk0tYZk7s8T+J7VLy0Da6J1+wCT0AtHg==",
-      "license": "BSD-2-Clause",
-      "dependencies": {
-        "boolbase": "~1.0.0"
-      }
-    },
     "node_modules/symbol-tree": {
       "version": "3.2.4",
       "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",

--- a/plugins/source/hackernews/cloud-config-ui/package.json
+++ b/plugins/source/hackernews/cloud-config-ui/package.json
@@ -64,7 +64,9 @@
   "overrides": {
     "react-scripts": {
       "typescript": "^5",
-      "postcss": "^8",
+      "postcss": "^8"
+    },
+    "css-select": {
       "nth-check": "^2"
     }
   }

--- a/plugins/source/xkcd/cloud-config-ui/package-lock.json
+++ b/plugins/source/xkcd/cloud-config-ui/package-lock.json
@@ -17892,14 +17892,6 @@
         "js-yaml": "bin/js-yaml.js"
       }
     },
-    "node_modules/svgo/node_modules/nth-check": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/nth-check/-/nth-check-1.0.2.tgz",
-      "integrity": "sha512-WeBOdju8SnzPN5vTUJYxYUxLeXpCaVP5i5e0LF8fg7WORF2Wd7wFX/pk0tYZk7s8T+J7VLy0Da6J1+wCT0AtHg==",
-      "dependencies": {
-        "boolbase": "~1.0.0"
-      }
-    },
     "node_modules/symbol-tree": {
       "version": "3.2.4",
       "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",

--- a/plugins/source/xkcd/cloud-config-ui/package.json
+++ b/plugins/source/xkcd/cloud-config-ui/package.json
@@ -63,7 +63,9 @@
   "overrides": {
     "react-scripts": {
       "typescript": "^5",
-      "postcss": "^8",
+      "postcss": "^8"
+    },
+    "css-select": {
       "nth-check": "^2"
     }
   }


### PR DESCRIPTION
<!-- 🎉 Thank you for making CloudQuery awesome by submitting a PR 🎉 -->

#### Summary

Follow up to https://github.com/cloudquery/cloudquery/pull/19868.
We need to override `css-select` for this to work, not `react-scripts`

Fixes https://github.com/cloudquery/cloudquery/security/dependabot/340
Fixes https://github.com/cloudquery/cloudquery/security/dependabot/338

<!--
Use the following steps to ensure your PR is ready to be reviewed

- [ ] Read the [contribution guidelines](https://github.com/cloudquery/cloudquery/blob/main/CONTRIBUTING.md) 🧑‍🎓
- [ ] Run `make lint` to ensure the proposed changes follow the coding style 🚨 (install golangci-lint [here](https://golangci-lint.run/usage/install/#local-installation))
- [ ] Run `make test` to ensure the proposed changes pass the tests 🧪
- [ ] If changing a source plugin run `make gen` to ensure docs are up to date 📝
- [ ] Ensure the status checks below are successful ✅
--->
