### PR TITLE
chore: Add E2E testing to CLI.

### DIFF
--- a/cli/cmd/sync_test.go
+++ b/cli/cmd/sync_test.go
@@ -153,7 +153,7 @@ func TestSync(t *testing.T) {
 		{
 			name:   "transformer exits immediately",
 			config: "transformer-exits.yml",
-			err:    []string{"rpc error: code = Unavailable desc = error reading from server: EOF"}, // rpc disconnection
+			err:    []string{"rpc error: code = Unavailable desc = error reading from server"}, // rpc disconnection
 		},
 		{
 			name:   "transformer succeeds",
@@ -182,6 +182,7 @@ func TestSync(t *testing.T) {
 			// this is a mitigation for flakiness that we want to fix later, so that we can have
 			// E2E tests right away.
 			err: []string{
+				"failed to sync v3 source test: write client returned error (insert)",
 				"failed to sync v3 source test: failed to send insert: EOF",
 				"failed to sync v3 source test: EOF",
 			},

--- a/cli/cmd/sync_test.go
+++ b/cli/cmd/sync_test.go
@@ -143,7 +143,7 @@ func TestSync(t *testing.T) {
 		{
 			name:   "source exits immediately",
 			config: "source-exits.yml",
-			err:    []string{"rpc error: code = Unavailable desc = error reading from server: EOF"}, // rpc disconnection
+			err:    []string{"rpc error: code = Unavailable desc = error reading from server"}, // rpc disconnection
 		},
 		{
 			name:   "destination exits immediately",
@@ -153,7 +153,10 @@ func TestSync(t *testing.T) {
 		{
 			name:   "transformer exits immediately",
 			config: "transformer-exits.yml",
-			err:    []string{"rpc error: code = Unavailable desc = error reading from server"}, // rpc disconnection
+			err: []string{
+				"rpc error: code = Unavailable desc = error reading from server", // rpc disconnection
+				"failed to sync v3 source test: EOF",
+			},
 		},
 		{
 			name:   "transformer succeeds",

--- a/cli/cmd/sync_test.go
+++ b/cli/cmd/sync_test.go
@@ -139,6 +139,46 @@ func TestSync(t *testing.T) {
 			config: "sync-missing-path-error.yml",
 			err:    "Error: failed to validate destination test: path is required",
 		},
+		{
+			name:   "source exits immediately",
+			config: "source-exits.yml",
+			err:    "rpc error: code = Unavailable desc = error reading from server: EOF", // rpc disconnection
+		},
+		{
+			name:   "destination exits immediately",
+			config: "destination-exits.yml",
+			err:    "write client returned error",
+		},
+		{
+			name:   "transformer exits immediately",
+			config: "transformer-exits.yml",
+			err:    "rpc error: code = Unavailable desc = error reading from server: EOF", // rpc disconnection
+		},
+		{
+			name:   "transformer succeeds",
+			config: "transformer-succeeds.yml",
+		},
+		{
+			name:   "source errors immediately",
+			config: "source-errors.yml",
+			summary: []syncSummary{
+				{
+					CLIVersion:      "development",
+					Resources:       0,
+					SourceErrors:    1,
+					DestinationName: "test",
+					DestinationPath: "cloudquery/test",
+					SourceName:      "test",
+					SourcePath:      "cloudquery/test",
+					SourceTables:    []string{"test_some_table"},
+				},
+			},
+		},
+		{
+			name:   "destination errors immediately",
+			config: "destination-errors.yml",
+			err:    "failed to sync v3 source test: EOF",
+		},
 	}
 	_, filename, _, _ := runtime.Caller(0)
 	currentDir := path.Dir(filename)

--- a/cli/cmd/testdata/destination-errors.yml
+++ b/cli/cmd/testdata/destination-errors.yml
@@ -7,6 +7,7 @@ spec:
   destinations: [test]
   tables: ["test_some_table"]
   spec:
+    num_rows: 1000000
 ---
 kind: "destination"
 spec:

--- a/cli/cmd/testdata/destination-errors.yml
+++ b/cli/cmd/testdata/destination-errors.yml
@@ -1,0 +1,18 @@
+kind: "source"
+spec:
+  name: "test"
+  registry: "cloudquery"
+  path: "cloudquery/test"
+  version: "v4.7.0" # latest version of source test plugin
+  destinations: [test]
+  tables: ["test_some_table"]
+  spec:
+---
+kind: "destination"
+spec:
+  name: "test"
+  registry: "cloudquery"
+  path: "cloudquery/test"
+  version: "v2.7.0" # latest version of destination test plugin
+  spec:
+    error_on_write: true

--- a/cli/cmd/testdata/destination-exits.yml
+++ b/cli/cmd/testdata/destination-exits.yml
@@ -7,6 +7,7 @@ spec:
   destinations: [test]
   tables: ["test_some_table"]
   spec:
+    num_rows: 1000000
 ---
 kind: "destination"
 spec:

--- a/cli/cmd/testdata/destination-exits.yml
+++ b/cli/cmd/testdata/destination-exits.yml
@@ -1,0 +1,18 @@
+kind: "source"
+spec:
+  name: "test"
+  registry: "cloudquery"
+  path: "cloudquery/test"
+  version: "v4.7.0" # latest version of source test plugin
+  destinations: [test]
+  tables: ["test_some_table"]
+  spec:
+---
+kind: "destination"
+spec:
+  name: "test"
+  registry: "cloudquery"
+  path: "cloudquery/test"
+  version: "v2.7.0" # latest version of destination test plugin
+  spec:
+    exit_on_write: true

--- a/cli/cmd/testdata/source-errors.yml
+++ b/cli/cmd/testdata/source-errors.yml
@@ -7,6 +7,7 @@ spec:
   destinations: [test]
   tables: ["test_some_table"]
   spec:
+    num_rows: 1000000
     fail_immediately: true
 ---
 kind: "destination"

--- a/cli/cmd/testdata/source-errors.yml
+++ b/cli/cmd/testdata/source-errors.yml
@@ -1,0 +1,17 @@
+kind: "source"
+spec:
+  name: "test"
+  registry: "cloudquery"
+  path: "cloudquery/test"
+  version: "v4.7.0" # latest version of source test plugin
+  destinations: [test]
+  tables: ["test_some_table"]
+  spec:
+    fail_immediately: true
+---
+kind: "destination"
+spec:
+  name: "test"
+  registry: "cloudquery"
+  path: "cloudquery/test"
+  version: "v2.7.0" # latest version of destination test plugin

--- a/cli/cmd/testdata/source-exits.yml
+++ b/cli/cmd/testdata/source-exits.yml
@@ -7,6 +7,7 @@ spec:
   destinations: [test]
   tables: ["test_some_table"]
   spec:
+    num_rows: 1000000
     exit_immediately: true
 ---
 kind: "destination"

--- a/cli/cmd/testdata/source-exits.yml
+++ b/cli/cmd/testdata/source-exits.yml
@@ -1,0 +1,17 @@
+kind: "source"
+spec:
+  name: "test"
+  registry: "cloudquery"
+  path: "cloudquery/test"
+  version: "v4.7.0" # latest version of source test plugin
+  destinations: [test]
+  tables: ["test_some_table"]
+  spec:
+    exit_immediately: true
+---
+kind: "destination"
+spec:
+  name: "test"
+  registry: "cloudquery"
+  path: "cloudquery/test"
+  version: "v2.7.0" # latest version of destination test plugin

--- a/cli/cmd/testdata/transformer-errors.yml
+++ b/cli/cmd/testdata/transformer-errors.yml
@@ -1,0 +1,27 @@
+kind: "source"
+spec:
+  name: "test"
+  registry: "cloudquery"
+  path: "cloudquery/test"
+  version: "v4.7.0" # latest version of source test plugin
+  destinations: [test]
+  tables: ["test_some_table"]
+  spec:
+---
+kind: "destination"
+spec:
+  name: "test"
+  registry: "cloudquery"
+  path: "cloudquery/test"
+  version: "v2.7.0" # latest version of destination test plugin
+  transformers: [test-transformer]
+  spec:
+---
+kind: "transformer"
+spec:
+  name: "test-transformer"
+  registry: "cloudquery"
+  path: "cloudquery/test"
+  version: "v1.1.0" # latest version of transformer test plugin
+  spec:
+    fail_immediately: true

--- a/cli/cmd/testdata/transformer-errors.yml
+++ b/cli/cmd/testdata/transformer-errors.yml
@@ -16,6 +16,7 @@ spec:
   version: "v2.7.0" # latest version of destination test plugin
   transformers: [test-transformer]
   spec:
+    num_rows: 1000000
 ---
 kind: "transformer"
 spec:

--- a/cli/cmd/testdata/transformer-exits.yml
+++ b/cli/cmd/testdata/transformer-exits.yml
@@ -7,6 +7,7 @@ spec:
   destinations: [test]
   tables: ["test_some_table"]
   spec:
+    num_rows: 1000000
 ---
 kind: "destination"
 spec:

--- a/cli/cmd/testdata/transformer-exits.yml
+++ b/cli/cmd/testdata/transformer-exits.yml
@@ -1,0 +1,27 @@
+kind: "source"
+spec:
+  name: "test"
+  registry: "cloudquery"
+  path: "cloudquery/test"
+  version: "v4.7.0" # latest version of source test plugin
+  destinations: [test]
+  tables: ["test_some_table"]
+  spec:
+---
+kind: "destination"
+spec:
+  name: "test"
+  registry: "cloudquery"
+  path: "cloudquery/test"
+  version: "v2.7.0" # latest version of destination test plugin
+  transformers: [test-transformer]
+  spec:
+---
+kind: "transformer"
+spec:
+  name: "test-transformer"
+  registry: "cloudquery"
+  path: "cloudquery/test"
+  version: "v1.1.0" # latest version of transformer test plugin
+  spec:
+    exit_immediately: true

--- a/cli/cmd/testdata/transformer-succeeds.yml
+++ b/cli/cmd/testdata/transformer-succeeds.yml
@@ -1,0 +1,27 @@
+kind: "source"
+spec:
+  name: "test"
+  registry: "cloudquery"
+  path: "cloudquery/test"
+  version: "v4.7.0" # latest version of source test plugin
+  destinations: [test]
+  tables: ["test_some_table"]
+  spec:
+    num_rows: 100
+---
+kind: "destination"
+spec:
+  name: "test"
+  registry: "cloudquery"
+  path: "cloudquery/test"
+  version: "v2.7.0" # latest version of destination test plugin
+  transformers: [test-transformer]
+  spec:
+---
+kind: "transformer"
+spec:
+  name: "test-transformer"
+  registry: "cloudquery"
+  path: "cloudquery/test"
+  version: "v1.1.0" # latest version of transformer test plugin
+  spec:


### PR DESCRIPTION
Adds the following E2E tests to CLI:

- Source exits immediately
- Destination exits immediately
- Transformer exits immediately
- Source errors immediately
- Destination errors immediately

Missing: cannot add a test where transformer errors immediately, because there's a bug where this is not causing erroring resources. Will work on that separately.

This PR will allow us to merge an SDK performance improvement for the DFS strategy.