### PR TITLE
chore: Upgrade test source plugin version on tests.

### DIFF
--- a/cli/cmd/testdata/destination-errors.yml
+++ b/cli/cmd/testdata/destination-errors.yml
@@ -3,7 +3,7 @@ spec:
   name: "test"
   registry: "cloudquery"
   path: "cloudquery/test"
-  version: "v4.7.0" # latest version of source test plugin
+  version: "v4.7.1" # latest version of source test plugin
   destinations: [test]
   tables: ["test_some_table"]
   spec:

--- a/cli/cmd/testdata/destination-exits.yml
+++ b/cli/cmd/testdata/destination-exits.yml
@@ -3,7 +3,7 @@ spec:
   name: "test"
   registry: "cloudquery"
   path: "cloudquery/test"
-  version: "v4.7.0" # latest version of source test plugin
+  version: "v4.7.1" # latest version of source test plugin
   destinations: [test]
   tables: ["test_some_table"]
   spec:

--- a/cli/cmd/testdata/source-errors.yml
+++ b/cli/cmd/testdata/source-errors.yml
@@ -3,7 +3,7 @@ spec:
   name: "test"
   registry: "cloudquery"
   path: "cloudquery/test"
-  version: "v4.7.0" # latest version of source test plugin
+  version: "v4.7.1" # latest version of source test plugin
   destinations: [test]
   tables: ["test_some_table"]
   spec:

--- a/cli/cmd/testdata/source-exits.yml
+++ b/cli/cmd/testdata/source-exits.yml
@@ -3,7 +3,7 @@ spec:
   name: "test"
   registry: "cloudquery"
   path: "cloudquery/test"
-  version: "v4.7.0" # latest version of source test plugin
+  version: "v4.7.1" # latest version of source test plugin
   destinations: [test]
   tables: ["test_some_table"]
   spec:

--- a/cli/cmd/testdata/transformer-errors.yml
+++ b/cli/cmd/testdata/transformer-errors.yml
@@ -3,7 +3,7 @@ spec:
   name: "test"
   registry: "cloudquery"
   path: "cloudquery/test"
-  version: "v4.7.0" # latest version of source test plugin
+  version: "v4.7.1" # latest version of source test plugin
   destinations: [test]
   tables: ["test_some_table"]
   spec:

--- a/cli/cmd/testdata/transformer-exits.yml
+++ b/cli/cmd/testdata/transformer-exits.yml
@@ -3,7 +3,7 @@ spec:
   name: "test"
   registry: "cloudquery"
   path: "cloudquery/test"
-  version: "v4.7.0" # latest version of source test plugin
+  version: "v4.7.1" # latest version of source test plugin
   destinations: [test]
   tables: ["test_some_table"]
   spec:

--- a/cli/cmd/testdata/transformer-succeeds.yml
+++ b/cli/cmd/testdata/transformer-succeeds.yml
@@ -3,7 +3,7 @@ spec:
   name: "test"
   registry: "cloudquery"
   path: "cloudquery/test"
-  version: "v4.7.0" # latest version of source test plugin
+  version: "v4.7.1" # latest version of source test plugin
   destinations: [test]
   tables: ["test_some_table"]
   spec:


### PR DESCRIPTION
Not to be merged. This is just to test that CI E2E tests pass with the newer version of the SDK.