### PR TITLE
feat: Separate CLI tokens

### DIFF
--- a/cli/cmd/sync_v3.go
+++ b/cli/cmd/sync_v3.go
@@ -84,16 +84,7 @@ type shard struct {
 }
 
 func getProgressAPIClient() (*cloudquery_api.ClientWithResponses, error) {
-	authClient := auth.NewTokenClient()
-	if authClient.GetTokenType() != auth.SyncRunAPIKey {
-		return nil, nil
-	}
-
-	token, err := authClient.GetToken()
-	if err != nil {
-		return nil, err
-	}
-	return api.NewClient(token.Value)
+	return api.NewLocalClient(auth.SyncRunAPIKey)
 }
 
 type syncV3Options struct {

--- a/cli/cmd/test_connection.go
+++ b/cli/cmd/test_connection.go
@@ -33,16 +33,7 @@ cloudquery test-connection ./directory ./aws.yml ./pg.yml
 )
 
 func getSyncTestConnectionAPIClient() (*cloudquery_api.ClientWithResponses, error) {
-	authClient := apiAuth.NewTokenClient()
-	if authClient.GetTokenType() != apiAuth.SyncTestConnectionAPIKey {
-		return nil, nil
-	}
-
-	token, err := authClient.GetToken()
-	if err != nil {
-		return nil, err
-	}
-	return api.NewClient(token.Value)
+	return api.NewLocalClient(apiAuth.SyncTestConnectionAPIKey)
 }
 
 func updateSyncTestConnectionStatus(ctx context.Context, logger zerolog.Logger, status cloudquery_api.SyncTestConnectionStatus, tcrs ...testConnectionResult) {

--- a/cli/internal/api/client.go
+++ b/cli/internal/api/client.go
@@ -18,7 +18,7 @@ const (
 	defaultAPIURL = "https://api.cloudquery.io"
 	envAPIURL     = "CLOUDQUERY_API_URL"
 	envCLIAPIURL  = "CLOUDQUERY_CLI_API_URL"
-	envCLIToken   = "CLOUDQUERY_CLI_TOKEN"
+	envCLIKey     = "CLOUDQUERY_CLI_KEY"
 )
 
 // NewClient creates a new client with the given token.
@@ -46,7 +46,7 @@ func NewLocalClient(acceptableKeyTypes ...auth.TokenType) (*cloudquery_api.Clien
 		}
 		tokenValue, tokenType = token.Value, token.Type
 	} else {
-		tokenValue = env.GetEnvOrDefault(envCLIToken, "")
+		tokenValue = env.GetEnvOrDefault(envCLIKey, "")
 		tokenType = tokenTypeFromValue(tokenValue)
 	}
 

--- a/cli/internal/api/client.go
+++ b/cli/internal/api/client.go
@@ -28,9 +28,9 @@ func NewAnonymousClient() (*cloudquery_api.ClientWithResponses, error) {
 	return NewClient("")
 }
 
-// NewLocalClient creates a client that connects to the local API if possible.
-func NewLocalClient() (*cloudquery_api.ClientWithResponses, error) {
-	return newClient("", true)
+// NewLocalClient creates a client that connects to the local API if possible. If not, it falls back to the regular API using `nonLocalToken`.
+func NewLocalClient(nonLocalToken string) (*cloudquery_api.ClientWithResponses, error) {
+	return newClient(nonLocalToken, true)
 }
 
 func ListAllPlugins(cl *cloudquery_api.ClientWithResponses) ([]cloudquery_api.ListPlugin, error) {

--- a/cli/internal/api/client.go
+++ b/cli/internal/api/client.go
@@ -18,16 +18,19 @@ const (
 	envCLIToken   = "CLOUDQUERY_CLI_TOKEN"
 )
 
+// NewClient creates a new client with the given token.
 func NewClient(token string) (*cloudquery_api.ClientWithResponses, error) {
 	return newClient(token, false)
 }
 
+// NewAnonymousClient creates a client that doesn't require authentication.
 func NewAnonymousClient() (*cloudquery_api.ClientWithResponses, error) {
 	return NewClient("")
 }
 
-func NewLocalGroupClient(token string) (*cloudquery_api.ClientWithResponses, error) {
-	return newClient(token, true)
+// NewLocalClient creates a client that connects to the local API if possible.
+func NewLocalClient() (*cloudquery_api.ClientWithResponses, error) {
+	return newClient("", true)
 }
 
 func ListAllPlugins(cl *cloudquery_api.ClientWithResponses) ([]cloudquery_api.ListPlugin, error) {
@@ -71,9 +74,9 @@ func GetPluginVersion(cl *cloudquery_api.ClientWithResponses, teamName string, k
 	return resp.JSON200, nil
 }
 
-func getAPIURL(preferLocalGroup bool) (apiURL string, isLocalGroup bool) {
+func getAPIURL(preferLocal bool) (apiURL string, isLocal bool) {
 	regularAPI := env.GetEnvOrDefault(envAPIURL, defaultAPIURL)
-	if !preferLocalGroup {
+	if !preferLocal {
 		return regularAPI, false
 	}
 
@@ -86,16 +89,16 @@ func getAPIURL(preferLocalGroup bool) (apiURL string, isLocalGroup bool) {
 	return val, val != regularAPI
 }
 
-func overrideToken(token string, getLocalGroup bool) string {
-	if !getLocalGroup {
+func overrideToken(token string, getLocal bool) string {
+	if !getLocal {
 		return token
 	}
 	return env.GetEnvOrDefault(envCLIToken, "")
 }
 
-func newClient(token string, localGroup bool) (*cloudquery_api.ClientWithResponses, error) {
-	endpoint, isLocalGroup := getAPIURL(localGroup)
-	token = overrideToken(token, isLocalGroup)
+func newClient(token string, local bool) (*cloudquery_api.ClientWithResponses, error) {
+	endpoint, isLocal := getAPIURL(local)
+	token = overrideToken(token, isLocal)
 
 	var opts []cloudquery_api.ClientOption
 	if token != "" {

--- a/cli/internal/api/client.go
+++ b/cli/internal/api/client.go
@@ -140,6 +140,6 @@ func tokenTypeFromValue(token string) auth.TokenType {
 	case token != "":
 		return auth.APIKey
 	default:
-		return auth.Undefined
+		return auth.BearerToken
 	}
 }

--- a/cli/internal/api/client.go
+++ b/cli/internal/api/client.go
@@ -140,6 +140,6 @@ func tokenTypeFromValue(token string) auth.TokenType {
 	case token != "":
 		return auth.APIKey
 	default:
-		return auth.BearerToken
+		return auth.Undefined
 	}
 }

--- a/cli/internal/api/client_test.go
+++ b/cli/internal/api/client_test.go
@@ -1,0 +1,80 @@
+package api
+
+import (
+	"context"
+	"net/http"
+	"testing"
+
+	cloudquery_api "github.com/cloudquery/cloudquery-api-go"
+	"github.com/stretchr/testify/require"
+)
+
+const (
+	testKey       = "testkey"
+	unexpectedKey = "whatkey"
+)
+
+func TestLocalClientDefaultAPI(t *testing.T) {
+	t.Setenv("CLOUDQUERY_API_KEY", testKey)
+	t.Setenv("CLOUDQUERY_API_URL", "")
+	t.Setenv("CQ_CLOUD", "")
+	t.Setenv("CLOUDQUERY_CLI_API_URL", "")
+	t.Setenv("CLOUDQUERY_CLI_KEY", "")
+
+	r := require.New(t)
+	c, err := NewLocalClient()
+	r.NoError(err)
+
+	cc := c.ClientInterface.(*cloudquery_api.Client)
+	r.Equal("https://api.cloudquery.io/", cc.Server)
+	r.Len(cc.RequestEditors, 1)
+	ensureRequestAuthHeader(t, cc.RequestEditors[0], "Bearer "+testKey)
+}
+
+func TestLocalClientLocalAPI(t *testing.T) {
+	// Both keys are set
+	t.Setenv("CLOUDQUERY_API_KEY", unexpectedKey)
+	t.Setenv("CLOUDQUERY_API_URL", "")
+	t.Setenv("CQ_CLOUD", "1")
+	t.Setenv("CLOUDQUERY_CLI_API_URL", "http://localhost:8080")
+	t.Setenv("CLOUDQUERY_CLI_KEY", testKey)
+
+	r := require.New(t)
+	c, err := NewLocalClient()
+	r.NoError(err)
+
+	cc := c.ClientInterface.(*cloudquery_api.Client)
+	r.Equal("http://localhost:8080/", cc.Server)
+	r.Len(cc.RequestEditors, 1)
+	ensureRequestAuthHeader(t, cc.RequestEditors[0], "Bearer "+testKey)
+}
+
+func TestLocalClientNotLocalAPI(t *testing.T) {
+	// Both env var pairs are set but CQ_CLOUD is falsy
+	t.Setenv("CLOUDQUERY_API_KEY", testKey)
+	t.Setenv("CLOUDQUERY_API_URL", "http://localhost:3333")
+	t.Setenv("CQ_CLOUD", "0")
+	t.Setenv("CLOUDQUERY_CLI_API_URL", "http://localhost:8080")
+	t.Setenv("CLOUDQUERY_CLI_KEY", unexpectedKey)
+
+	r := require.New(t)
+	c, err := NewLocalClient()
+	r.NoError(err)
+
+	cc := c.ClientInterface.(*cloudquery_api.Client)
+	r.Equal("http://localhost:3333/", cc.Server)
+	r.Len(cc.RequestEditors, 1)
+	ensureRequestAuthHeader(t, cc.RequestEditors[0], "Bearer "+testKey)
+}
+
+func ensureRequestAuthHeader(t *testing.T, f cloudquery_api.RequestEditorFn, expectedValue string) {
+	t.Helper()
+
+	req, err := http.NewRequest(http.MethodGet, "https://api.cloudquery.io", nil)
+	require.NoError(t, err)
+	err = f(context.TODO(), req)
+	require.NoError(t, err)
+
+	val := req.Header.Get("Authorization")
+	require.Equal(t, expectedValue, val)
+}


### PR DESCRIPTION
Enables `CLOUDQUERY_CLI_API_URL` and `CLOUDQUERY_CLI_KEY` env var handling, only activated when `CQ_CLOUD` is truthy.