### PR TITLE
fix: Allow overriding API key per plugin in isolated env setting

### DIFF
--- a/cli/cmd/sync.go
+++ b/cli/cmd/sync.go
@@ -495,7 +495,7 @@ func filterPluginEnv(environ []string, pluginName, kind string) []string {
 	for _, v := range environ {
 		switch {
 		case strings.HasPrefix(v, "CLOUDQUERY_API_KEY="):
-			lowerPriority[v[:strings.Index(v, "=")]] = v
+			lowerPriority["CLOUDQUERY_API_KEY"] = v
 		case strings.HasPrefix(v, "_CQ_TEAM_NAME="),
 			strings.HasPrefix(v, "HOME="):
 			env = append(env, v)

--- a/cli/cmd/sync.go
+++ b/cli/cmd/sync.go
@@ -490,25 +490,25 @@ func filterPluginEnv(environ []string, pluginName, kind string) []string {
 	cleanName := strings.ReplaceAll(pluginName, "-", "_")
 	prefix := strings.ToUpper("__" + kind + "_" + cleanName + "__")
 
-	lowerPriority := map[string]string{}
-	dupes := map[string]struct{}{}
+	foundPluginSpecificAPIKey := false
+	globalAPIKey := ""
 	for _, v := range environ {
 		switch {
 		case strings.HasPrefix(v, "CLOUDQUERY_API_KEY="):
-			lowerPriority["CLOUDQUERY_API_KEY"] = v
+			globalAPIKey = v
 		case strings.HasPrefix(v, "_CQ_TEAM_NAME="),
 			strings.HasPrefix(v, "HOME="):
 			env = append(env, v)
 		case strings.HasPrefix(v, prefix):
 			cleanEnv := strings.TrimPrefix(v, prefix)
 			env = append(env, cleanEnv)
-			dupes[strings.SplitN(cleanEnv, "=", 2)[0]] = struct{}{}
+			if strings.HasPrefix(cleanEnv, "CLOUDQUERY_API_KEY=") {
+				foundPluginSpecificAPIKey = true
+			}
 		}
 	}
-	for k, v := range lowerPriority {
-		if _, ok := dupes[k]; !ok {
-			env = append(env, v)
-		}
+	if !foundPluginSpecificAPIKey {
+		env = append(env, globalAPIKey)
 	}
 	return env
 }


### PR DESCRIPTION
Without this fix, two env vars of the same name would be returned.