### PR TITLE
feat: Publish multiplatform images for Ubuntu

### DIFF
--- a/cli/.goreleaser.yaml
+++ b/cli/.goreleaser.yaml
@@ -80,6 +80,21 @@ docker_manifests:
   - "ghcr.io/cloudquery/cloudquery:{{ .Major }}.{{ .Minor }}-linux-amd64"
   - "ghcr.io/cloudquery/cloudquery:{{ .Major }}.{{ .Minor }}-linux-arm64"
 
+- name_template: "ghcr.io/cloudquery/cloudquery:{{.Version}}-ubuntu"
+  image_templates:
+  - "ghcr.io/cloudquery/cloudquery:{{.Version}}-ubuntu-amd64"
+  - "ghcr.io/cloudquery/cloudquery:{{.Version}}-ubuntu-arm64"
+
+- name_template: "ghcr.io/cloudquery/cloudquery:latest-ubuntu"
+  image_templates:
+  - "ghcr.io/cloudquery/cloudquery:latest-ubuntu-amd64"
+  - "ghcr.io/cloudquery/cloudquery:latest-ubuntu-arm64"
+
+- name_template: "ghcr.io/cloudquery/cloudquery:{{ .Major }}.{{ .Minor }}-ubuntu"
+  image_templates:
+  - "ghcr.io/cloudquery/cloudquery:{{ .Major }}.{{ .Minor }}-ubuntu-amd64"
+  - "ghcr.io/cloudquery/cloudquery:{{ .Major }}.{{ .Minor }}-ubuntu-arm64"
+
 
 brews:
   -


### PR DESCRIPTION
<!-- 🎉 Thank you for making CloudQuery awesome by submitting a PR 🎉 -->

#### Summary

Follow up to https://github.com/cloudquery/cloudquery/pull/16989.

While we have Ubuntu CLI images we don't publish them as multi platform ones (see https://github.com/cloudquery/cloudquery/pkgs/container/cloudquery):
![image](https://github.com/user-attachments/assets/d7b0a0d2-fdad-4f94-94bf-388ca5103095)
making them harder to consume.

This PR adds that feature

<!--
Use the following steps to ensure your PR is ready to be reviewed

- [ ] Read the [contribution guidelines](https://github.com/cloudquery/cloudquery/blob/main/CONTRIBUTING.md) 🧑‍🎓
- [ ] Run `make lint` to ensure the proposed changes follow the coding style 🚨 (install golangci-lint [here](https://golangci-lint.run/usage/install/#local-installation))
- [ ] Run `make test` to ensure the proposed changes pass the tests 🧪
- [ ] If changing a source plugin run `make gen` to ensure docs are up to date 📝
- [ ] Ensure the status checks below are successful ✅
--->
