### PR TITLE
test: Set `x509negativeserial=1` in test

### DIFF
--- a/plugins/destination/mssql/client/client_test.go
+++ b/plugins/destination/mssql/client/client_test.go
@@ -1,3 +1,4 @@
+//go:debug x509negativeserial=1
 package client
 
 import (


### PR DESCRIPTION
<!-- 🎉 Thank you for making CloudQuery awesome by submitting a PR 🎉 -->

#### Summary

This PR fixes intermediate CI failures in our tests that started happening when we upgraded to Go 1.23.. See https://github.com/cloudquery/cloudquery/pull/20087#issuecomment-2606728207 and https://github.com/cloudquery/cloudquery/actions/runs/12892739493/job/35947615181?pr=20087#step:11:18 


If we want to support certificates with negative serial numbers we should do:

```go.mod
go 1.23

godebug (
	x509negativeserial=1
)
```

In our `go.mod` file, but I don't think we should as it's not RFC compliant

<!--
Use the following steps to ensure your PR is ready to be reviewed

- [ ] Read the [contribution guidelines](https://github.com/cloudquery/cloudquery/blob/main/CONTRIBUTING.md) 🧑‍🎓
- [ ] Run `make lint` to ensure the proposed changes follow the coding style 🚨 (install golangci-lint [here](https://golangci-lint.run/usage/install/#local-installation))
- [ ] Run `make test` to ensure the proposed changes pass the tests 🧪
- [ ] If changing a source plugin run `make gen` to ensure docs are up to date 📝
- [ ] Ensure the status checks below are successful ✅
--->
