### PR TITLE
fix: Handle SnakeCasing for Initialisms

### DIFF
--- a/plugins/transformer/jsonflattener/client/recordupdater/record_updater.go
+++ b/plugins/transformer/jsonflattener/client/recordupdater/record_updater.go
@@ -8,6 +8,7 @@ import (
 	"github.com/apache/arrow-go/v18/arrow/array"
 	"github.com/cloudquery/cloudquery/plugins/transformer/jsonflattener/client/schemaupdater"
 	"github.com/cloudquery/cloudquery/plugins/transformer/jsonflattener/client/util"
+	"github.com/cloudquery/plugin-sdk/v4/caser"
 	"github.com/cloudquery/plugin-sdk/v4/schema"
 	"github.com/cloudquery/plugin-sdk/v4/types"
 	"github.com/rs/zerolog"
@@ -166,7 +167,9 @@ func (*RecordUpdater) preprocessRow(colName string, rowIndex int, rawRow any) (m
 
 func preprocessTypeSchema(unprocessedTypeSchema map[string]any) map[string]string {
 	typeSchema := make(map[string]string)
+	customCaser := caser.New()
 	for key, typ := range unprocessedTypeSchema {
+		key = customCaser.ToSnake(key)
 		// Edge case: if the key is utf8, we don't process it, because utf8 is a special
 		// string that means that there can be many keys with any name.
 		if key == "utf8" {


### PR DESCRIPTION
Our caser automatically handles TLS differently than normal words because it is included in our common initialisms

https://github.com/cloudquery/plugin-sdk/blob/b3be1b67a1b72a85424488eff7d931ae9007f686/caser/initialisms.go#L36

Before:
![Screenshot 2025-01-29 at 12 53 19 PM](https://github.com/user-attachments/assets/ded360a3-f385-4483-b369-520f2b9850f3)

After:
![Screenshot 2025-01-29 at 12 54 23 PM](https://github.com/user-attachments/assets/7124d885-1819-4a31-8fef-279651a91532)
