### PR TITLE
feat: Add skip_incremental_tables suboption for partition_by.

### DIFF
--- a/plugins/destination/clickhouse/client/migrate.go
+++ b/plugins/destination/clickhouse/client/migrate.go
@@ -177,7 +177,7 @@ func (c *Client) checkPartitionOrOrderByChanged(ctx context.Context, table *sche
 		return err
 	}
 
-	resolvedPartitionBy, err := queries.ResolvePartitionBy(table.Name, partition)
+	resolvedPartitionBy, err := queries.ResolvePartitionBy(table, partition)
 	if err != nil {
 		return err
 	}

--- a/plugins/destination/clickhouse/client/spec/schema.json
+++ b/plugins/destination/clickhouse/client/spec/schema.json
@@ -121,6 +121,10 @@
         "partition_by": {
           "type": "string",
           "description": "Partitioning strategy to use, e.g. `toYYYYMM(_cq_sync_time)`,\nthe string is passed as is after \"PARTITION BY\" clause with no validation or quoting.\n\nAn unset partition_by is not valid."
+        },
+        "skip_incremental_tables": {
+          "type": "boolean",
+          "description": "Skip incremental tables from partitioning."
         }
       },
       "additionalProperties": false,

--- a/plugins/destination/clickhouse/client/spec/spec.go
+++ b/plugins/destination/clickhouse/client/spec/spec.go
@@ -78,6 +78,9 @@ type PartitionStrategy struct {
 	//
 	// An unset partition_by is not valid.
 	PartitionBy string `json:"partition_by"`
+
+	// Skip incremental tables from partitioning.
+	SkipIncrementalTables bool `json:"skip_incremental_tables,omitempty"`
 }
 
 type OrderByStrategy struct {

--- a/plugins/destination/clickhouse/docs/_licenses.md
+++ b/plugins/destination/clickhouse/docs/_licenses.md
@@ -10,8 +10,8 @@ The following tools / packages are used in this plugin:
 | github.com/ClickHouse/clickhouse-go/v2 | Apache-2.0 |
 | github.com/adrg/xdg | MIT |
 | github.com/andybalholm/brotli | MIT |
-| github.com/apache/arrow/go/v13 | Apache-2.0 |
 | github.com/apache/arrow-go/v18 | Apache-2.0 |
+| github.com/apache/arrow/go/v13 | Apache-2.0 |
 | github.com/apapsch/go-jsonmerge/v2 | MIT |
 | github.com/aws/aws-sdk-go-v2 | Apache-2.0 |
 | github.com/aws/aws-sdk-go-v2/config | Apache-2.0 |
@@ -54,7 +54,6 @@ The following tools / packages are used in this plugin:
 | github.com/grpc-ecosystem/grpc-gateway/v2 | BSD-3-Clause |
 | github.com/hashicorp/go-cleanhttp | MPL-2.0 |
 | github.com/hashicorp/go-retryablehttp | MPL-2.0 |
-| github.com/huandu/xstrings | MIT |
 | github.com/invopop/jsonschema | MIT |
 | github.com/klauspost/compress | Apache-2.0 |
 | github.com/klauspost/compress/internal/snapref | BSD-3-Clause |
@@ -73,10 +72,12 @@ The following tools / packages are used in this plugin:
 | github.com/shopspring/decimal | MIT |
 | github.com/spf13/cobra | Apache-2.0 |
 | github.com/spf13/pflag | BSD-3-Clause |
+| github.com/stoewer/go-strcase | MIT |
 | github.com/stretchr/testify | MIT |
 | github.com/thoas/go-funk | MIT |
 | github.com/wk8/go-ordered-map/v2 | Apache-2.0 |
 | github.com/zeebo/xxh3 | BSD-2-Clause |
+| go.opentelemetry.io/auto/sdk | Apache-2.0 |
 | go.opentelemetry.io/otel | Apache-2.0 |
 | go.opentelemetry.io/otel/exporters/otlp/otlplog/otlploghttp | Apache-2.0 |
 | go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetrichttp | Apache-2.0 |

--- a/plugins/destination/clickhouse/docs/overview.md
+++ b/plugins/destination/clickhouse/docs/overview.md
@@ -130,6 +130,10 @@ Each object has the following fields:
 
   Partition strategy table patterns should be disjointed sets: if a table matches two partition strategies, an error will be raised at runtime.
 
+- `skip_incremental_tables` (boolean) (optional) (default: `false`)
+
+  If set to `true`, incremental tables will not be partitioned by this strategy.
+
 - `partition_by` (string) (required)
 
   Partitioning strategy to use, e.g. `toYYYYMM(_cq_sync_time)`, the string is passed as is after "PARTITION BY" clause with no validation or quoting.

--- a/plugins/destination/clickhouse/queries/tables_test.go
+++ b/plugins/destination/clickhouse/queries/tables_test.go
@@ -97,6 +97,28 @@ func TestCreateTableWithPartitionBySkipsIfNoMatch(t *testing.T) {
 	ensureContents(t, query, "create_table.sql")
 }
 
+func TestCreateTableWithPartitionBySkipsIfIncremental(t *testing.T) {
+	query, err := CreateTable(&schema.Table{
+		Name: "table_name",
+		Columns: schema.ColumnList{
+			schema.CqIDColumn,
+			schema.CqParentIDColumn,
+			schema.CqSourceNameColumn,
+			schema.CqSyncTimeColumn,
+			schema.Column{
+				Name:    "extra_col",
+				Type:    arrow.PrimitiveTypes.Float64,
+				NotNull: true,
+			},
+			schema.Column{Name: "extra_inet_col", Type: types.NewInetType()},
+			schema.Column{Name: "extra_inet_arr_col", Type: arrow.ListOf(types.NewInetType())},
+		},
+		IsIncremental: true,
+	}, "", spec.DefaultEngine(), []spec.PartitionStrategy{{Tables: []string{"*"}, SkipIncrementalTables: true, PartitionBy: "toYYYYMM(`_cq_sync_time`)"}}, nil)
+	require.NoError(t, err)
+	ensureContents(t, query, "create_table.sql")
+}
+
 func TestCreateTableWithOrderBy(t *testing.T) {
 	query, err := CreateTable(&schema.Table{
 		Name: "table_name",


### PR DESCRIPTION
This PR adds a `skip_incremental_tables` boolean sub-option to the `partition_by` strategies of the ClickHouse destination.

The reasoning is that it is a common use case that incremental/non-incremental changes have to be partitioned differently, but since tables can migrate from being non-incremental to becoming incremental, the "list of incremental tables" can change over time, and so maintaining this list in the spec up to date can be an error-prone operational burden.

By adding the `skip_incremental_tables` options on a partitioning strategy, a partitioning strategy can be applied specifically to non-incremental tables, without needing to list the tables.