### PR TITLE
chore: Use different Go version update logic for plugins

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -58,6 +58,12 @@
       commitMessagePrefix: 'chore(deps): ',
       groupName: 'CloudQuery Plugin Config UI packages',
     },
+    {
+      matchDatasources: ["golang-version"],
+      rangeStrategy: "bump",
+      addLabels: ["no automerge"],
+      schedule: ["before 3am on Saturday"],
+    },
   ],
   ignorePaths: [
     'plugins/source/aws/**',


### PR DESCRIPTION
<!-- 🎉 Thank you for making CloudQuery awesome by submitting a PR 🎉 -->

#### Summary

This should open Go version update PRs for newer versions than our default (defined in https://github.com/cloudquery/.github/blob/7a408435c94677e30963ea808287a82e0de31bb5/.github/renovate-go-default.json5#L11).
The default is there since some of our Go modules (like the SDK) are publicly consumed so we don't want to force consumers to upgrade their go version 

<!--
Use the following steps to ensure your PR is ready to be reviewed

- [ ] Read the [contribution guidelines](https://github.com/cloudquery/cloudquery/blob/main/CONTRIBUTING.md) 🧑‍🎓
- [ ] Run `make lint` to ensure the proposed changes follow the coding style 🚨 (install golangci-lint [here](https://golangci-lint.run/usage/install/#local-installation))
- [ ] Run `make test` to ensure the proposed changes pass the tests 🧪
- [ ] If changing a source plugin run `make gen` to ensure docs are up to date 📝
- [ ] Ensure the status checks below are successful ✅
--->
