### PR TITLE
fix: Update validation to include `add_primary_keys` kind

### DIFF
--- a/plugins/transformer/basic/client/spec/spec.go
+++ b/plugins/transformer/basic/client/spec/spec.go
@@ -43,7 +43,7 @@ func (s *Spec) Validate() error {
 	var err error
 	for _, t := range s.TransformationSpecs {
 		switch t.Kind {
-		case KindRemoveColumns:
+		case KindRemoveColumns, KindAddPrimaryKeys:
 			if len(t.Columns) == 0 {
 				err = errors.Join(err, fmt.Errorf("'%s' field must be specified for %s transformation", "columns", t.Kind))
 			}
@@ -91,6 +91,7 @@ func (s *Spec) Validate() error {
 			if len(t.Columns) > 0 {
 				err = errors.Join(err, fmt.Errorf("columns field must not be specified for %s transformation", t.Kind))
 			}
+
 		default:
 			err = errors.Join(err, fmt.Errorf("unknown transformation kind: %s", t.Kind))
 		}


### PR DESCRIPTION
Previous PR missed validating new transformer kind. This meant that an error was always thrown