### PR TITLE
chore: Pass `_CQ_INSTALLATION_ID` env var in plugin isolation mode

### DIFF
--- a/cli/cmd/sync.go
+++ b/cli/cmd/sync.go
@@ -500,6 +500,7 @@ func filterPluginEnv(environ []string, pluginName, kind string) []string {
 			k := getEnvKey(v)
 			globalEnvironmentVariables[k] = v
 		case strings.HasPrefix(v, "_CQ_TEAM_NAME="),
+			strings.HasPrefix(v, "_CQ_INSTALLATION_ID="),
 			strings.HasPrefix(v, "HOME="):
 			env = append(env, v)
 		case strings.HasPrefix(v, prefix):


### PR DESCRIPTION
To go with a certain PR on the private repo.