### PR TITLE
fix: Replace internal columns if exist on Cloud syncs

### DIFF
--- a/cli/cmd/sync.go
+++ b/cli/cmd/sync.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 
 	"github.com/cloudquery/cloudquery/cli/v6/internal/auth"
+	"github.com/cloudquery/cloudquery/cli/v6/internal/env"
 	"github.com/cloudquery/cloudquery/cli/v6/internal/otel"
 	"github.com/cloudquery/cloudquery/cli/v6/internal/specs/v0"
 	"github.com/cloudquery/plugin-pb-go/managedplugin"
@@ -148,7 +149,7 @@ func sync(cmd *cobra.Command, args []string) error {
 	}
 
 	// in the cloud sync environment, we pass only the relevant environment variables to the plugin
-	_, isolatePluginEnvironment := os.LookupEnv("CQ_CLOUD")
+	isolatePluginEnvironment := env.IsCloud()
 
 	ctx := cmd.Context()
 	log.Info().Strs("args", args).Msg("Loading spec(s)")

--- a/cli/cmd/sync.go
+++ b/cli/cmd/sync.go
@@ -487,7 +487,7 @@ func sync(cmd *cobra.Command, args []string) error {
 }
 
 func filterPluginEnv(environ []string, pluginName, kind string) []string {
-	env := make([]string, 0, len(environ))
+	pluginEnv := make([]string, 0, len(environ))
 	cleanName := strings.ReplaceAll(pluginName, "-", "_")
 	prefix := strings.ToUpper("__" + kind + "_" + cleanName + "__")
 
@@ -502,10 +502,10 @@ func filterPluginEnv(environ []string, pluginName, kind string) []string {
 			globalEnvironmentVariables[k] = v
 		case strings.HasPrefix(v, "_CQ_TEAM_NAME="),
 			strings.HasPrefix(v, "HOME="):
-			env = append(env, v)
+			pluginEnv = append(pluginEnv, v)
 		case strings.HasPrefix(v, prefix):
 			cleanEnv := strings.TrimPrefix(v, prefix)
-			env = append(env, cleanEnv)
+			pluginEnv = append(pluginEnv, cleanEnv)
 			if strings.HasPrefix(cleanEnv, "CLOUDQUERY_API_KEY=") ||
 				strings.HasPrefix(cleanEnv, "AWS_") {
 				k := getEnvKey(cleanEnv)
@@ -515,10 +515,10 @@ func filterPluginEnv(environ []string, pluginName, kind string) []string {
 	}
 	for k, v := range globalEnvironmentVariables {
 		if _, ok := specificEnvironmentVariables[k]; !ok {
-			env = append(env, v)
+			pluginEnv = append(pluginEnv, v)
 		}
 	}
-	return env
+	return pluginEnv
 }
 
 func getEnvKey(v string) string {

--- a/cli/go.mod
+++ b/cli/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/cloudquery/cloudquery-api-go v1.13.7
 	github.com/cloudquery/codegen v0.3.23
 	github.com/cloudquery/plugin-pb-go v1.26.8
-	github.com/cloudquery/plugin-sdk/v4 v4.74.3-0.20250331102814-6f83cacbae46
+	github.com/cloudquery/plugin-sdk/v4 v4.75.0
 	github.com/distribution/reference v0.6.0
 	github.com/docker/distribution v2.8.3+incompatible
 	github.com/docker/docker v26.1.5+incompatible

--- a/cli/go.mod
+++ b/cli/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/cloudquery/cloudquery-api-go v1.13.7
 	github.com/cloudquery/codegen v0.3.23
 	github.com/cloudquery/plugin-pb-go v1.26.8
-	github.com/cloudquery/plugin-sdk/v4 v4.74.2
+	github.com/cloudquery/plugin-sdk/v4 v4.74.3-0.20250331102814-6f83cacbae46
 	github.com/distribution/reference v0.6.0
 	github.com/docker/distribution v2.8.3+incompatible
 	github.com/docker/docker v26.1.5+incompatible

--- a/cli/go.sum
+++ b/cli/go.sum
@@ -50,8 +50,8 @@ github.com/cloudquery/jsonschema v0.0.0-20240220124159-92878faa2a66 h1:OZLPSIBYE
 github.com/cloudquery/jsonschema v0.0.0-20240220124159-92878faa2a66/go.mod h1:0SoZ/U7yJlNOR+fWsBSeTvTbGXB6DK01tzJ7m2Xfg34=
 github.com/cloudquery/plugin-pb-go v1.26.8 h1:mHNyOyG/MW/rjDVR0OR8DdezXmyoD4drphyHlYmnJoY=
 github.com/cloudquery/plugin-pb-go v1.26.8/go.mod h1:orruK+wdIP3kOvmEQhCcFND2bVVH7o0fFSGrqZYMt7k=
-github.com/cloudquery/plugin-sdk/v4 v4.74.2 h1:AHQZ9zxm0kLummKrT+dBYAvI6zf4j4DxfFXypg7kblw=
-github.com/cloudquery/plugin-sdk/v4 v4.74.2/go.mod h1:dDLB0XrS3R+nIWh4X8J8/ZQcsJ+lmjxUxoBxhAq8iCA=
+github.com/cloudquery/plugin-sdk/v4 v4.74.3-0.20250331102814-6f83cacbae46 h1:VqVMoP4orUdC1una/R64+/emHIu7QGWlHN1L+rfwiTQ=
+github.com/cloudquery/plugin-sdk/v4 v4.74.3-0.20250331102814-6f83cacbae46/go.mod h1:dDLB0XrS3R+nIWh4X8J8/ZQcsJ+lmjxUxoBxhAq8iCA=
 github.com/containerd/log v0.1.0 h1:TCJt7ioM2cr/tfR8GPbGf9/VRAX8D2B4PjzCpfX540I=
 github.com/containerd/log v0.1.0/go.mod h1:VRRf09a7mHDIRezVKTRCrOq78v577GXq3bSa3EhrzVo=
 github.com/coreos/go-systemd/v22 v22.5.0/go.mod h1:Y58oyj3AT4RCenI/lSvhwexgC+NSVTIJ3seZv2GcEnc=

--- a/cli/go.sum
+++ b/cli/go.sum
@@ -50,8 +50,8 @@ github.com/cloudquery/jsonschema v0.0.0-20240220124159-92878faa2a66 h1:OZLPSIBYE
 github.com/cloudquery/jsonschema v0.0.0-20240220124159-92878faa2a66/go.mod h1:0SoZ/U7yJlNOR+fWsBSeTvTbGXB6DK01tzJ7m2Xfg34=
 github.com/cloudquery/plugin-pb-go v1.26.8 h1:mHNyOyG/MW/rjDVR0OR8DdezXmyoD4drphyHlYmnJoY=
 github.com/cloudquery/plugin-pb-go v1.26.8/go.mod h1:orruK+wdIP3kOvmEQhCcFND2bVVH7o0fFSGrqZYMt7k=
-github.com/cloudquery/plugin-sdk/v4 v4.74.3-0.20250331102814-6f83cacbae46 h1:VqVMoP4orUdC1una/R64+/emHIu7QGWlHN1L+rfwiTQ=
-github.com/cloudquery/plugin-sdk/v4 v4.74.3-0.20250331102814-6f83cacbae46/go.mod h1:dDLB0XrS3R+nIWh4X8J8/ZQcsJ+lmjxUxoBxhAq8iCA=
+github.com/cloudquery/plugin-sdk/v4 v4.75.0 h1:N/edo8VA+YzfjIC+bQ3y7AAUHQEYzF6y+ZFYLyHKFMI=
+github.com/cloudquery/plugin-sdk/v4 v4.75.0/go.mod h1:dDLB0XrS3R+nIWh4X8J8/ZQcsJ+lmjxUxoBxhAq8iCA=
 github.com/containerd/log v0.1.0 h1:TCJt7ioM2cr/tfR8GPbGf9/VRAX8D2B4PjzCpfX540I=
 github.com/containerd/log v0.1.0/go.mod h1:VRRf09a7mHDIRezVKTRCrOq78v577GXq3bSa3EhrzVo=
 github.com/coreos/go-systemd/v22 v22.5.0/go.mod h1:Y58oyj3AT4RCenI/lSvhwexgC+NSVTIJ3seZv2GcEnc=

--- a/cli/internal/analytics/client.go
+++ b/cli/internal/analytics/client.go
@@ -2,7 +2,6 @@ package analytics
 
 import (
 	"context"
-	"os"
 	"time"
 
 	cqapi "github.com/cloudquery/cloudquery-api-go"
@@ -46,8 +45,7 @@ func InitClient() {
 }
 
 func getEnvironment() string {
-	_, ok := os.LookupEnv("CQ_CLOUD")
-	if ok {
+	if env.IsCloud() {
 		return "cloud"
 	}
 	return "cli"

--- a/cli/internal/env/env.go
+++ b/cli/internal/env/env.go
@@ -8,3 +8,8 @@ func GetEnvOrDefault(env, def string) string {
 	}
 	return def
 }
+
+func IsCloud() bool {
+	_, ok := os.LookupEnv("CQ_CLOUD")
+	return ok
+}


### PR DESCRIPTION
<!-- 🎉 Thank you for making CloudQuery awesome by submitting a PR 🎉 -->

#### Summary

Goes with https://github.com/cloudquery/plugin-sdk/pull/2105

For Cloud syncs we should replace the internal columns if exist so we can trace back the synced data to the correct source name, sync time and sync group id (otherwise we'd get the ones of the original sync, e.g. `AWS->S3`)

<!--
Use the following steps to ensure your PR is ready to be reviewed

- [ ] Read the [contribution guidelines](https://github.com/cloudquery/cloudquery/blob/main/CONTRIBUTING.md) 🧑‍🎓
- [ ] Run `make lint` to ensure the proposed changes follow the coding style 🚨 (install golangci-lint [here](https://golangci-lint.run/usage/install/#local-installation))
- [ ] Run `make test` to ensure the proposed changes pass the tests 🧪
- [ ] If changing a source plugin run `make gen` to ensure docs are up to date 📝
- [ ] Ensure the status checks below are successful ✅
--->
