### PR TITLE
fix: Only validate version when Cloudquery Registry is used

### DIFF
--- a/cli/internal/specs/v0/version.go
+++ b/cli/internal/specs/v0/version.go
@@ -23,7 +23,8 @@ func WarnOnOutdatedVersions(ctx context.Context, p *managedplugin.PluginVersionW
 			continue
 		}
 		// N.B.: warning is best-effort; we ignore errors, but the function still logs errors with Debug logs
-		if source.Registry == RegistryCloudQuery {
+		// We only check for outdated plugins if the registry is cloudquery or github and the org is cloudquery
+		if source.Registry == RegistryCloudQuery || (source.Registry == RegistryGitHub && org == "cloudquery") {
 			_, _ = p.WarnIfOutdated(ctx, org, name, managedplugin.PluginSource.String(), source.Version)
 		}
 	}
@@ -34,7 +35,8 @@ func WarnOnOutdatedVersions(ctx context.Context, p *managedplugin.PluginVersionW
 			continue
 		}
 		// N.B.: warning is best-effort; we ignore errors, but the function still logs errors with Debug logs
-		if destination.Registry == RegistryCloudQuery {
+		// We only check for outdated plugins if the registry is cloudquery or github and the org is cloudquery
+		if destination.Registry == RegistryCloudQuery || (destination.Registry == RegistryGitHub && org == "cloudquery") {
 			_, _ = p.WarnIfOutdated(ctx, org, name, managedplugin.PluginDestination.String(), destination.Version)
 		}
 	}
@@ -45,7 +47,8 @@ func WarnOnOutdatedVersions(ctx context.Context, p *managedplugin.PluginVersionW
 			continue
 		}
 		// N.B.: warning is best-effort; we ignore errors, but the function still logs errors with Debug logs
-		if transformer.Registry == RegistryCloudQuery {
+		// We only check for outdated plugins if the registry is cloudquery or github and the org is cloudquery
+		if transformer.Registry == RegistryCloudQuery || (transformer.Registry == RegistryGitHub && org == "cloudquery") {
 			_, _ = p.WarnIfOutdated(ctx, org, name, managedplugin.PluginTransformer.String(), transformer.Version)
 		}
 	}

--- a/cli/internal/specs/v0/version.go
+++ b/cli/internal/specs/v0/version.go
@@ -37,7 +37,6 @@ func WarnOnOutdatedVersions(ctx context.Context, p *managedplugin.PluginVersionW
 		if destination.Registry == RegistryCloudQuery {
 			_, _ = p.WarnIfOutdated(ctx, org, name, managedplugin.PluginDestination.String(), destination.Version)
 		}
-
 	}
 	for _, transformer := range transformers {
 		org, name, err := pluginPathToOrgName(transformer.Path)

--- a/cli/internal/specs/v0/version.go
+++ b/cli/internal/specs/v0/version.go
@@ -23,7 +23,9 @@ func WarnOnOutdatedVersions(ctx context.Context, p *managedplugin.PluginVersionW
 			continue
 		}
 		// N.B.: warning is best-effort; we ignore errors, but the function still logs errors with Debug logs
-		_, _ = p.WarnIfOutdated(ctx, org, name, managedplugin.PluginSource.String(), source.Version)
+		if source.Registry == RegistryCloudQuery {
+			_, _ = p.WarnIfOutdated(ctx, org, name, managedplugin.PluginSource.String(), source.Version)
+		}
 	}
 	for _, destination := range destinations {
 		org, name, err := pluginPathToOrgName(destination.Path)
@@ -32,7 +34,10 @@ func WarnOnOutdatedVersions(ctx context.Context, p *managedplugin.PluginVersionW
 			continue
 		}
 		// N.B.: warning is best-effort; we ignore errors, but the function still logs errors with Debug logs
-		_, _ = p.WarnIfOutdated(ctx, org, name, managedplugin.PluginDestination.String(), destination.Version)
+		if destination.Registry == RegistryCloudQuery {
+			_, _ = p.WarnIfOutdated(ctx, org, name, managedplugin.PluginDestination.String(), destination.Version)
+		}
+
 	}
 	for _, transformer := range transformers {
 		org, name, err := pluginPathToOrgName(transformer.Path)
@@ -41,7 +46,9 @@ func WarnOnOutdatedVersions(ctx context.Context, p *managedplugin.PluginVersionW
 			continue
 		}
 		// N.B.: warning is best-effort; we ignore errors, but the function still logs errors with Debug logs
-		_, _ = p.WarnIfOutdated(ctx, org, name, managedplugin.PluginTransformer.String(), transformer.Version)
+		if transformer.Registry == RegistryCloudQuery {
+			_, _ = p.WarnIfOutdated(ctx, org, name, managedplugin.PluginTransformer.String(), transformer.Version)
+		}
 	}
 }
 


### PR DESCRIPTION
<!-- 🎉 Thank you for making CloudQuery awesome by submitting a PR 🎉 -->

#### Summary

⚠️ **If you're contributing to a plugin please read this section of the [contribution guidelines](https://github.com/cloudquery/cloudquery/blob/main/CONTRIBUTING.md#open-core-vs-open-source) 🧑‍🎓 before submitting this PR** ⚠️

<!--
Explain what problem this PR addresses
-->

<!--
Use the following steps to ensure your PR is ready to be reviewed

- [ ] Read the [contribution guidelines](https://github.com/cloudquery/cloudquery/blob/main/CONTRIBUTING.md) 🧑‍🎓
- [ ] Run `make lint` to ensure the proposed changes follow the coding style 🚨 (install golangci-lint [here](https://golangci-lint.run/usage/install/#local-installation))
- [ ] Run `make test` to ensure the proposed changes pass the tests 🧪
- [ ] If changing a source plugin run `make gen` to ensure docs are up to date 📝
- [ ] Ensure the status checks below are successful ✅
--->
