### PR TITLE
fix: Support compound types migrations

### DIFF
--- a/plugins/destination/clickhouse/client/client_test.go
+++ b/plugins/destination/clickhouse/client/client_test.go
@@ -139,3 +139,87 @@ func TestMigrateCQClientIDColumnWhenSortKeyIsAlreadySet(t *testing.T) {
 		t.Fatal(fmt.Errorf("failed to insert record: %w", err))
 	}
 }
+
+func TestMigrateNewArrayAndMapColumns(t *testing.T) {
+	ctx := context.Background()
+	p := plugin.NewPlugin("clickhouse",
+		internalPlugin.Version,
+		New,
+		plugin.WithJSONSchema(spec.JSONSchema),
+	)
+	s := &spec.Spec{ConnectionString: getTestConnection()}
+	b, err := json.Marshal(s)
+	require.NoError(t, err)
+	err = p.Init(ctx, b, plugin.NewClientOptions{})
+	require.NoError(t, err)
+
+	tableName := fmt.Sprintf("cq_test_migrate_new_array_and_map_columns_%d", time.Now().UnixNano())
+	table := &schema.Table{
+		Name: tableName,
+		Columns: []schema.Column{
+			schema.CqIDColumn,
+			schema.CqSourceNameColumn,
+			schema.CqSyncTimeColumn,
+			schema.CqClientIDColumn,
+			{
+				Name:       "_cq_sync_group_id",
+				Type:       arrow.BinaryTypes.String,
+				NotNull:    true,
+				PrimaryKey: true,
+			},
+		},
+	}
+	if err := p.WriteAll(ctx, []message.WriteMessage{&message.WriteMigrateTable{Table: table}}); err != nil {
+		t.Fatal(fmt.Errorf("failed to create table: %w", err))
+	}
+
+	bldr := array.NewRecordBuilder(memory.DefaultAllocator, table.ToArrowSchema())
+	bldr.Field(0).(*sdkTypes.UUIDBuilder).Append(uuid.MustParse("123e4567-e89b-12d3-a456-426614174000"))
+	bldr.Field(1).(*array.StringBuilder).Append("foo")
+	bldr.Field(2).(*array.TimestampBuilder).Append(arrow.Timestamp(time.Now().UnixMicro()))
+	bldr.Field(3).(*array.StringBuilder).Append("cq-sync-group-id")
+	bldr.Field(4).(*array.StringBuilder).Append("cq-client-id")
+	record := bldr.NewRecord()
+
+	if err := p.WriteAll(ctx, []message.WriteMessage{&message.WriteInsert{
+		Record: record,
+	}}); err != nil {
+		t.Fatal(fmt.Errorf("failed to insert record: %w", err))
+	}
+
+	newColumns := schema.ColumnList{
+		{
+			Name: "array_column",
+			Type: arrow.ListOf(arrow.BinaryTypes.String),
+		},
+		{
+			Name: "map_column",
+			Type: arrow.MapOf(arrow.BinaryTypes.String, arrow.BinaryTypes.String),
+		},
+	}
+	tableWithCQClientIDColumn := &schema.Table{
+		Name:    tableName,
+		Columns: append(table.Columns, newColumns...),
+	}
+
+	if err := p.WriteAll(ctx, []message.WriteMessage{&message.WriteMigrateTable{Table: tableWithCQClientIDColumn}}); err != nil {
+		t.Fatal(fmt.Errorf("failed to migrate table: %w", err))
+	}
+
+	bldr = array.NewRecordBuilder(memory.DefaultAllocator, tableWithCQClientIDColumn.ToArrowSchema())
+	bldr.Field(0).(*sdkTypes.UUIDBuilder).Append(uuid.MustParse("123e4567-e89b-12d3-a456-426614174000"))
+	bldr.Field(1).(*array.StringBuilder).Append("foo")
+	bldr.Field(2).(*array.TimestampBuilder).Append(arrow.Timestamp(time.Now().UnixMicro()))
+	bldr.Field(3).(*array.StringBuilder).Append("cq-sync-group-id")
+	bldr.Field(4).(*array.StringBuilder).Append("cq-client-id")
+	bldr.Field(5).(*array.ListBuilder).Append(true)
+	bldr.Field(5).(*array.ListBuilder).ValueBuilder().(*array.StringBuilder).Append("foo")
+	bldr.Field(6).(*array.MapBuilder).Append(true)
+	record = bldr.NewRecord()
+
+	if err := p.WriteAll(ctx, []message.WriteMessage{&message.WriteInsert{
+		Record: record,
+	}}); err != nil {
+		t.Fatal(fmt.Errorf("failed to insert record: %w", err))
+	}
+}

--- a/plugins/destination/clickhouse/client/client_test.go
+++ b/plugins/destination/clickhouse/client/client_test.go
@@ -177,8 +177,8 @@ func TestMigrateNewArrayAndMapColumns(t *testing.T) {
 	bldr.Field(0).(*sdkTypes.UUIDBuilder).Append(uuid.MustParse("123e4567-e89b-12d3-a456-426614174000"))
 	bldr.Field(1).(*array.StringBuilder).Append("foo")
 	bldr.Field(2).(*array.TimestampBuilder).Append(arrow.Timestamp(time.Now().UnixMicro()))
-	bldr.Field(3).(*array.StringBuilder).Append("cq-sync-group-id")
 	bldr.Field(4).(*array.StringBuilder).Append("cq-client-id")
+	bldr.Field(3).(*array.StringBuilder).Append("cq-sync-group-id")
 	record := bldr.NewRecord()
 
 	if err := p.WriteAll(ctx, []message.WriteMessage{&message.WriteInsert{
@@ -210,8 +210,8 @@ func TestMigrateNewArrayAndMapColumns(t *testing.T) {
 	bldr.Field(0).(*sdkTypes.UUIDBuilder).Append(uuid.MustParse("123e4567-e89b-12d3-a456-426614174000"))
 	bldr.Field(1).(*array.StringBuilder).Append("foo")
 	bldr.Field(2).(*array.TimestampBuilder).Append(arrow.Timestamp(time.Now().UnixMicro()))
-	bldr.Field(3).(*array.StringBuilder).Append("cq-sync-group-id")
 	bldr.Field(4).(*array.StringBuilder).Append("cq-client-id")
+	bldr.Field(3).(*array.StringBuilder).Append("cq-sync-group-id")
 	bldr.Field(5).(*array.ListBuilder).Append(true)
 	bldr.Field(5).(*array.ListBuilder).ValueBuilder().(*array.StringBuilder).Append("foo")
 	bldr.Field(6).(*array.MapBuilder).Append(true)

--- a/plugins/destination/clickhouse/client/migrate.go
+++ b/plugins/destination/clickhouse/client/migrate.go
@@ -128,8 +128,9 @@ func needsTableDrop(change schema.TableColumnChange) bool {
 		return false
 	}
 
-	// We can safely add a nullable column without dropping the table
-	if change.Type == schema.TableColumnChangeTypeAdd && !change.Current.NotNull {
+	// We can add new nullable columns or non-nullable columns that are not part of the sort key
+	isCompoundType := queries.IsCompoundType(change.Current)
+	if change.Type == schema.TableColumnChangeTypeAdd && (isCompoundType || !change.Current.NotNull) {
 		return false
 	}
 

--- a/plugins/destination/clickhouse/queries/tables.go
+++ b/plugins/destination/clickhouse/queries/tables.go
@@ -16,7 +16,7 @@ import (
 func SortKeys(table *schema.Table) []string {
 	keys := make([]string, 0, len(table.Columns))
 	for _, col := range table.Columns {
-		if (col.NotNull || col.PrimaryKey) && !isCompoundType(col) {
+		if (col.NotNull || col.PrimaryKey) && !IsCompoundType(col) {
 			keys = append(keys, col.Name)
 		}
 	}
@@ -30,7 +30,7 @@ func SortKeys(table *schema.Table) []string {
 	return slices.Clip(keys)
 }
 
-func isCompoundType(col schema.Column) bool {
+func IsCompoundType(col schema.Column) bool {
 	switch col.Type.(type) {
 	case *arrow.StructType:
 		return true


### PR DESCRIPTION
<!-- 🎉 Thank you for making CloudQuery awesome by submitting a PR 🎉 -->

#### Summary

Fixes a bug in ClickHouse migration where is would require forced migration for new lists and maps columns.

<!--
Use the following steps to ensure your PR is ready to be reviewed

- [ ] Read the [contribution guidelines](https://github.com/cloudquery/cloudquery/blob/main/CONTRIBUTING.md) 🧑‍🎓
- [ ] Run `make lint` to ensure the proposed changes follow the coding style 🚨 (install golangci-lint [here](https://golangci-lint.run/usage/install/#local-installation))
- [ ] Run `make test` to ensure the proposed changes pass the tests 🧪
- [ ] If changing a source plugin run `make gen` to ensure docs are up to date 📝
- [ ] Ensure the status checks below are successful ✅
--->
