### PR TITLE
fix: Skip redacting environment variables injected by cloud providers or the CLI

### DIFF
--- a/cli/internal/secrets/secrets.go
+++ b/cli/internal/secrets/secrets.go
@@ -3,8 +3,21 @@ package secrets
 import (
 	"bytes"
 	"io"
+	"slices"
 	"strings"
 )
+
+var skippedEnvironmentVariables = []string{
+	// injected by Kubernetes
+	"JOB_COMPLETION_INDEX",
+
+	// injected by the CloudQuery CLI
+	"CQ_CLOUD",
+
+	// injected by EKS, do not contain any sensitive information regardless
+	"AWS_STS_REGIONAL_ENDPOINTS", "AWS_DEFAULT_REGION", "AWS_REGION",
+	"AWS_WEB_IDENTITY_TOKEN_FILE", "AWS_ROLE_ARN", "AWS_ROLE_SESSION_NAME",
+}
 
 type SecretAwareRedactor struct {
 	secrets map[string]string
@@ -28,9 +41,13 @@ func (s *SecretAwareRedactor) RedactBytes(msg []byte) []byte {
 func (s *SecretAwareRedactor) AddSecretEnv(env []string) {
 	for _, v := range env {
 		parts := strings.SplitN(v, "=", 2)
-		if len(parts) == 2 && len(parts[1]) > 0 {
-			s.secrets[parts[1]] = parts[0]
+		if len(parts) != 2 || len(parts[1]) == 0 {
+			continue
 		}
+		if slices.Contains(skippedEnvironmentVariables, parts[0]) {
+			continue
+		}
+		s.secrets[parts[1]] = parts[0]
 	}
 }
 

--- a/cli/internal/secrets/secrets.go
+++ b/cli/internal/secrets/secrets.go
@@ -7,17 +7,14 @@ import (
 	"strings"
 )
 
-var skippedEnvironmentVariables = []string{
-	// injected by Kubernetes
-	"JOB_COMPLETION_INDEX",
-
-	// injected by the CloudQuery CLI
-	"CQ_CLOUD",
-
-	// injected by EKS, do not contain any sensitive information regardless
-	"AWS_STS_REGIONAL_ENDPOINTS", "AWS_DEFAULT_REGION", "AWS_REGION",
-	"AWS_WEB_IDENTITY_TOKEN_FILE", "AWS_ROLE_ARN", "AWS_ROLE_SESSION_NAME",
+var allowedEnvPrefixes = []string{
+	"HOME=",
+	"AWS_",
+	"_CQ_TEAM_NAME=",
 }
+
+// minRedactingLength is the minimum length of an environment variable value for it to be redacted
+const minRedactingLength = 4
 
 type SecretAwareRedactor struct {
 	secrets map[string]string
@@ -38,15 +35,17 @@ func (s *SecretAwareRedactor) RedactBytes(msg []byte) []byte {
 	return msg
 }
 
-func (s *SecretAwareRedactor) AddSecretEnv(env []string) {
-	for _, v := range env {
+func (s *SecretAwareRedactor) AddSecretEnv(envs []string) {
+	for _, v := range envs {
+		if slices.ContainsFunc(allowedEnvPrefixes, func(prefix string) bool { return strings.HasPrefix(v, prefix) }) {
+			continue
+		}
+
 		parts := strings.SplitN(v, "=", 2)
-		if len(parts) != 2 || len(parts[1]) == 0 {
+		if len(parts) != 2 || len(parts[1]) < minRedactingLength {
 			continue
 		}
-		if slices.Contains(skippedEnvironmentVariables, parts[0]) {
-			continue
-		}
+
 		s.secrets[parts[1]] = parts[0]
 	}
 }

--- a/cli/internal/secrets/secrets.go
+++ b/cli/internal/secrets/secrets.go
@@ -8,9 +8,12 @@ import (
 )
 
 var allowedEnvPrefixes = []string{
-	"HOME=",
-	"AWS_",
 	"_CQ_TEAM_NAME=",
+	"HOME=",
+
+	// injected by EKS, do not contain any sensitive information regardless
+	"AWS_STS_REGIONAL_ENDPOINTS", "AWS_DEFAULT_REGION", "AWS_REGION",
+	"AWS_WEB_IDENTITY_TOKEN_FILE", "AWS_ROLE_ARN", "AWS_ROLE_SESSION_NAME",
 }
 
 // minRedactingLength is the minimum length of an environment variable value for it to be redacted

--- a/cli/internal/secrets/secrets_test.go
+++ b/cli/internal/secrets/secrets_test.go
@@ -39,6 +39,12 @@ func TestRedaction(t *testing.T) {
 			msg:  "wrong password foobar123",
 			want: "wrong password foobar123",
 		},
+		{
+			name: "does not redact skipped env variables",
+			env:  []string{"AWS_REGION=us-west-1", "CQ_CLOUD=1"},
+			msg:  "us-west-1: sample log",
+			want: "us-west-1: sample log",
+		},
 	}
 	for _, tt := range tests {
 		redactor := NewSecretAwareRedactor()

--- a/cli/internal/secrets/secrets_test.go
+++ b/cli/internal/secrets/secrets_test.go
@@ -40,10 +40,34 @@ func TestRedaction(t *testing.T) {
 			want: "wrong password foobar123",
 		},
 		{
-			name: "does not redact skipped env variables",
-			env:  []string{"AWS_REGION=us-west-1", "CQ_CLOUD=1"},
+			name: "does not redact skipped env variables - AWS",
+			env:  []string{"AWS_REGION=us-west-1"},
 			msg:  "us-west-1: sample log",
 			want: "us-west-1: sample log",
+		},
+		{
+			name: "does not redact skipped env variables - HOME",
+			env:  []string{"HOME=/root"},
+			msg:  "sample log /root",
+			want: "sample log /root",
+		},
+		{
+			name: "does not redact skipped env variables - _CQ_TEAM_NAME",
+			env:  []string{"_CQ_TEAM_NAME=team"},
+			msg:  "wrong api key for team",
+			want: "wrong api key for team",
+		},
+		{
+			name: "does not redact variables with values of less than 4 characters",
+			env:  []string{"DB_PASS=123"},
+			msg:  "wrong password foobar123",
+			want: "wrong password foobar123",
+		},
+		{
+			name: "does redact CLOUDQUERY_API_KEY",
+			env:  []string{"CLOUDQUERY_API_KEY=cqtk_test"},
+			msg:  "wrong api key cqtk_test",
+			want: "wrong api key CLOUDQUERY_API_KEY",
 		},
 	}
 	for _, tt := range tests {


### PR DESCRIPTION
This PR skips redacting environment variables injected by EKS and some allowed by our plugin isolation logic. Moreso, it also skips redacting environment variables whose values are less than 4 characters in length.