### PR TITLE
feat: Support separate env vars for platform progress

### DIFF
--- a/cli/cmd/progress.go
+++ b/cli/cmd/progress.go
@@ -1,6 +1,16 @@
 package cmd
 
-import "io"
+import (
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+
+	cloudquery_api "github.com/cloudquery/cloudquery-api-go"
+	"github.com/cloudquery/cloudquery-api-go/auth"
+	"github.com/cloudquery/cloudquery/cli/v6/internal/api"
+)
 
 type progressBar interface {
 	io.Writer
@@ -19,4 +29,52 @@ func (noopProgressBar) Add(_ int) error {
 }
 func (noopProgressBar) Finish() error {
 	return nil
+}
+
+const (
+	envProgressURL    = "CLOUDQUERY_PROGRESS_URL"
+	envProgressApiKey = "CLOUDQUERY_PROGRESS_API_KEY"
+)
+
+func getFallbackProgressAPIClient(expectedTokenType auth.TokenType) (*cloudquery_api.ClientWithResponses, error) {
+	authClient := auth.NewTokenClient()
+	if authClient.GetTokenType() != expectedTokenType {
+		return nil, nil
+	}
+
+	token, err := authClient.GetToken()
+	if err != nil {
+		return nil, err
+	}
+	return api.NewClient(token.Value)
+}
+
+func getProgressAPIClient() (*cloudquery_api.ClientWithResponses, error) {
+	return getPlatformAPIClient(false)
+}
+
+func getPlatformAPIClient(testConn bool) (*cloudquery_api.ClientWithResponses, error) {
+	progressURL := os.Getenv(envProgressURL)
+	if progressURL == "" {
+		return getFallbackProgressAPIClient(
+			map[bool]auth.TokenType{
+				false: auth.SyncRunAPIKey,
+				true:  auth.SyncTestConnectionAPIKey,
+			}[testConn])
+	}
+
+	key := os.Getenv(envProgressApiKey)
+	if key == "" {
+		return nil, fmt.Errorf("missing %s environment variable", envProgressApiKey)
+	}
+
+	c, err := cloudquery_api.NewClientWithResponses(progressURL,
+		cloudquery_api.WithRequestEditorFn(func(ctx context.Context, req *http.Request) error {
+			req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", key))
+			return nil
+		}))
+	if err != nil {
+		return nil, fmt.Errorf("failed to create api client: %w", err)
+	}
+	return c, nil
 }

--- a/cli/cmd/sync_v3.go
+++ b/cli/cmd/sync_v3.go
@@ -13,7 +13,11 @@ import (
 	"time"
 
 	cloudquery_api "github.com/cloudquery/cloudquery-api-go"
-	"github.com/cloudquery/cloudquery-api-go/auth"
+	"github.com/cloudquery/cloudquery/cli/v6/internal/analytics"
+	"github.com/cloudquery/cloudquery/cli/v6/internal/specs/v0"
+	"github.com/cloudquery/cloudquery/cli/v6/internal/tablenamechanger"
+	"github.com/cloudquery/cloudquery/cli/v6/internal/transformer"
+	"github.com/cloudquery/cloudquery/cli/v6/internal/transformerpipeline"
 	"github.com/cloudquery/plugin-pb-go/managedplugin"
 	"github.com/cloudquery/plugin-pb-go/metrics"
 	"github.com/cloudquery/plugin-pb-go/pb/plugin/v3"
@@ -26,13 +30,6 @@ import (
 	"golang.org/x/sync/errgroup"
 	"google.golang.org/grpc"
 	"google.golang.org/protobuf/types/known/timestamppb"
-
-	"github.com/cloudquery/cloudquery/cli/v6/internal/analytics"
-	"github.com/cloudquery/cloudquery/cli/v6/internal/api"
-	"github.com/cloudquery/cloudquery/cli/v6/internal/specs/v0"
-	"github.com/cloudquery/cloudquery/cli/v6/internal/tablenamechanger"
-	"github.com/cloudquery/cloudquery/cli/v6/internal/transformer"
-	"github.com/cloudquery/cloudquery/cli/v6/internal/transformerpipeline"
 )
 
 type v3source struct {
@@ -81,19 +78,6 @@ func newSafeWriteClient(client grpc.ClientStreamingClient[plugin.Write_Request, 
 type shard struct {
 	num   int32
 	total int32
-}
-
-func getProgressAPIClient() (*cloudquery_api.ClientWithResponses, error) {
-	authClient := auth.NewTokenClient()
-	if authClient.GetTokenType() != auth.SyncRunAPIKey {
-		return nil, nil
-	}
-
-	token, err := authClient.GetToken()
-	if err != nil {
-		return nil, err
-	}
-	return api.NewClient(token.Value)
 }
 
 type syncV3Options struct {

--- a/cli/cmd/test_connection.go
+++ b/cli/cmd/test_connection.go
@@ -9,8 +9,6 @@ import (
 	"strings"
 
 	cloudquery_api "github.com/cloudquery/cloudquery-api-go"
-	apiAuth "github.com/cloudquery/cloudquery-api-go/auth"
-	"github.com/cloudquery/cloudquery/cli/v6/internal/api"
 	"github.com/cloudquery/cloudquery/cli/v6/internal/auth"
 	"github.com/cloudquery/cloudquery/cli/v6/internal/env"
 	"github.com/cloudquery/cloudquery/cli/v6/internal/specs/v0"
@@ -34,16 +32,7 @@ cloudquery test-connection ./directory ./aws.yml ./pg.yml
 )
 
 func getSyncTestConnectionAPIClient() (*cloudquery_api.ClientWithResponses, error) {
-	authClient := apiAuth.NewTokenClient()
-	if authClient.GetTokenType() != apiAuth.SyncTestConnectionAPIKey {
-		return nil, nil
-	}
-
-	token, err := authClient.GetToken()
-	if err != nil {
-		return nil, err
-	}
-	return api.NewClient(token.Value)
+	return getPlatformAPIClient(true)
 }
 
 func updateSyncTestConnectionStatus(ctx context.Context, logger zerolog.Logger, status cloudquery_api.SyncTestConnectionStatus, tcrs ...testConnectionResult) {


### PR DESCRIPTION
We could try this to separate sync and test conn requests from plugin download requests.