### PR TITLE
fix: S3 destination avoid hang on migrate errors

### DIFF
--- a/plugins/destination/s3/client/write.go
+++ b/plugins/destination/s3/client/write.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"io"
 	"regexp"
 	"time"
@@ -122,6 +123,7 @@ func (c *Client) Write(ctx context.Context, msgs <-chan message.WriteMessage) er
 }
 
 func (c *Client) MigrateTable(ctx context.Context, ch <-chan *message.WriteMigrateTable) error {
+	var errs error
 	for msg := range ch {
 		if !c.spec.GenerateEmptyObjects {
 			continue
@@ -132,14 +134,12 @@ func (c *Client) MigrateTable(ctx context.Context, ch <-chan *message.WriteMigra
 		c.initializedTables[table.Name] = objKey
 		s, err := c.createObject(ctx, table, objKey)
 		if err != nil {
-			return err
+			errs = errors.Join(errs, err)
+			continue
 		}
-		err = s.Finish()
-		if err != nil {
-			return err
-		}
+		errs = errors.Join(errs, s.Finish())
 	}
-	return nil
+	return errs
 }
 
 // sanitizeRecordJSONKeys replaces all invalid characters in JSON keys with underscores. This is required


### PR DESCRIPTION
When `write_empty_objects_for_empty_tables` option is used, if migration (writing empty object to the bucket) fails, the method returns early without closing the channel. This produces a hang in [StreamingBatchWriter](https://github.com/cloudquery/plugin-sdk/blob/main/writers/streamingbatchwriter/) (`clientCh <- r`)