### PR TITLE
fix: Proper error join

### DIFF
--- a/plugins/destination/s3/client/write.go
+++ b/plugins/destination/s3/client/write.go
@@ -137,9 +137,7 @@ func (c *Client) MigrateTable(ctx context.Context, ch <-chan *message.WriteMigra
 			errs = append(errs, err)
 			continue
 		}
-		if err := s.Finish(); err != nil {
-			errs = append(errs, err)
-		}
+		errs = append(errs, s.Finish())
 	}
 	return errors.Join(errs...)
 }

--- a/plugins/destination/s3/client/write.go
+++ b/plugins/destination/s3/client/write.go
@@ -123,7 +123,7 @@ func (c *Client) Write(ctx context.Context, msgs <-chan message.WriteMessage) er
 }
 
 func (c *Client) MigrateTable(ctx context.Context, ch <-chan *message.WriteMigrateTable) error {
-	var errs error
+	var errs []error
 	for msg := range ch {
 		if !c.spec.GenerateEmptyObjects {
 			continue
@@ -134,12 +134,14 @@ func (c *Client) MigrateTable(ctx context.Context, ch <-chan *message.WriteMigra
 		c.initializedTables[table.Name] = objKey
 		s, err := c.createObject(ctx, table, objKey)
 		if err != nil {
-			errs = errors.Join(errs, err)
+			errs = append(errs, err)
 			continue
 		}
-		errs = errors.Join(errs, s.Finish())
+		if err := s.Finish(); err != nil {
+			errs = append(errs, err)
+		}
 	}
-	return errs
+	return errors.Join(errs...)
 }
 
 // sanitizeRecordJSONKeys replaces all invalid characters in JSON keys with underscores. This is required

--- a/plugins/destination/s3/client/write.go
+++ b/plugins/destination/s3/client/write.go
@@ -123,7 +123,9 @@ func (c *Client) Write(ctx context.Context, msgs <-chan message.WriteMessage) er
 }
 
 func (c *Client) MigrateTable(ctx context.Context, ch <-chan *message.WriteMigrateTable) error {
+	// nolint:prealloc
 	var errs []error
+
 	for msg := range ch {
 		if !c.spec.GenerateEmptyObjects {
 			continue
@@ -139,6 +141,7 @@ func (c *Client) MigrateTable(ctx context.Context, ch <-chan *message.WriteMigra
 		}
 		errs = append(errs, s.Finish())
 	}
+
 	return errors.Join(errs...)
 }
 


### PR DESCRIPTION
`errors.Join(errs, err)` doesn't check if `errs` is already a `joinError`, so it ends up creating error pairs with multiple levels of wrapping.

Follow-up to https://github.com/cloudquery/cloudquery/pull/20872