### PR TITLE
fix: Enable S3 destination test connections

### DIFF
--- a/plugins/destination/s3/client/test_connection.go
+++ b/plugins/destination/s3/client/test_connection.go
@@ -31,11 +31,13 @@ func NewConnectionTester(createClientFn NewClientFn) plugin.ConnectionTester {
 				return err
 			}
 			s.SetDefaults()
-			b := true
-			s.TestWrite = &b // Force test write to be enabled for connection testing
-			specBytes, err = json.Marshal(s)
-			if err != nil {
-				return fmt.Errorf("failed to marshal s3 spec: %w", err)
+			if !*s.TestWrite {
+				b := true
+				s.TestWrite = &b // Force test write to be enabled for connection testing
+				specBytes, err = json.Marshal(s)
+				if err != nil {
+					return fmt.Errorf("failed to marshal s3 spec: %w", err)
+				}
 			}
 		}
 

--- a/plugins/destination/s3/client/test_connection.go
+++ b/plugins/destination/s3/client/test_connection.go
@@ -2,9 +2,13 @@ package client
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
+	"fmt"
 
+	"github.com/cloudquery/cloudquery/plugins/destination/s3/v7/client/spec"
 	"github.com/cloudquery/plugin-sdk/v4/plugin"
+	"github.com/google/uuid"
 	"github.com/rs/zerolog"
 )
 
@@ -17,7 +21,27 @@ const (
 
 func NewConnectionTester(createClientFn NewClientFn) plugin.ConnectionTester {
 	return func(ctx context.Context, logger zerolog.Logger, specBytes []byte) error {
-		_, err := createClientFn(ctx, logger, specBytes, plugin.NewClientOptions{})
+		{
+			s := &spec.Spec{}
+			err := json.Unmarshal(specBytes, &s)
+			if err != nil {
+				return fmt.Errorf("failed to unmarshal s3 spec: %w", err)
+			}
+			if err := s.Validate(); err != nil {
+				return err
+			}
+			s.SetDefaults()
+			b := true
+			s.TestWrite = &b // Force test write to be enabled for connection testing
+			specBytes, err = json.Marshal(s)
+			if err != nil {
+				return fmt.Errorf("failed to marshal s3 spec: %w", err)
+			}
+		}
+
+		_, err := createClientFn(ctx, logger, specBytes, plugin.NewClientOptions{
+			InvocationID: uuid.NewString(),
+		})
 		if err == nil {
 			return nil
 		}

--- a/plugins/destination/s3/client/test_connection_test.go
+++ b/plugins/destination/s3/client/test_connection_test.go
@@ -35,6 +35,14 @@ func TestConnectionTester(t *testing.T) {
 			},
 		},
 		{
+			name: "error/unauthorized_with_test_write_false",
+			spec: []byte(`{"bucket": "test", "region": "test", "path": "test", "format": "csv", "test_write": false}`),
+			err:  plugin.NewTestConnError(codeUnauthorized, assert.AnError),
+			clientBuilder: func() (plugin.Client, error) {
+				return nil, errTestWriteFailed
+			},
+		},
+		{
 			name: "error/spec",
 			spec: []byte(`{null}`),
 			err:  plugin.NewTestConnError(codeInvalidSpec, assert.AnError),


### PR DESCRIPTION
S3 destination test connections didn't work on some cases:

- if `test_write` was explicitly set to `false` (the default value when unspecified is `true`)
- If `{{SYNC_ID}}` is set in the conn path (it always failed with: `path contains {{SYNC_ID}}. Upgrade your CLI to use this path variable`) due to invocation ID from the CLI not being set for test connections

This PR solves both issues, by forcing `test_write` to be `true` for test connections only, and force-generating an invocation ID (separate from what the CLI generated or was provided, which is a current shortcoming of the proto)