### PR TITLE
fix: Pass `invocationID` when initializing test connection

### DIFF
--- a/plugins/destination/s3/client/test_connection.go
+++ b/plugins/destination/s3/client/test_connection.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 
 	"github.com/cloudquery/plugin-sdk/v4/plugin"
+	"github.com/google/uuid"
 	"github.com/rs/zerolog"
 )
 
@@ -17,7 +18,11 @@ const (
 
 func NewConnectionTester(createClientFn NewClientFn) plugin.ConnectionTester {
 	return func(ctx context.Context, logger zerolog.Logger, specBytes []byte) error {
-		_, err := createClientFn(ctx, logger, specBytes, plugin.NewClientOptions{})
+		invocationID, err := uuid.NewRandom()
+		if err != nil {
+			return err
+		}
+		_, err = createClientFn(ctx, logger, specBytes, plugin.NewClientOptions{InvocationID: invocationID.String()})
 		if err == nil {
 			return nil
 		}


### PR DESCRIPTION
<!-- 🎉 Thank you for making CloudQuery awesome by submitting a PR 🎉 -->

#### Summary

Otherwise if the path contains `{{SYNC_ID}}` the test connection fails here https://github.com/cloudquery/cloudquery/blob/983062b2210f6a269743afda4c56c5df9e0cdc77/plugins/destination/s3/client/client.go#L66

A better solution would be to get the invocation id from the CLI but the current signature of `NewConnectionTester` doesn't allow for it.

<!--
Use the following steps to ensure your PR is ready to be reviewed

- [ ] Read the [contribution guidelines](https://github.com/cloudquery/cloudquery/blob/main/CONTRIBUTING.md) 🧑‍🎓
- [ ] Run `make lint` to ensure the proposed changes follow the coding style 🚨 (install golangci-lint [here](https://golangci-lint.run/usage/install/#local-installation))
- [ ] Run `make test` to ensure the proposed changes pass the tests 🧪
- [ ] If changing a source plugin run `make gen` to ensure docs are up to date 📝
- [ ] Ensure the status checks below are successful ✅
--->
