### PR TITLE
feat: Add lower and upper case transformations to basic transformer

### DIFF
--- a/plugins/transformer/basic/client/spec/spec.go
+++ b/plugins/transformer/basic/client/spec/spec.go
@@ -15,6 +15,8 @@ const (
 	KindRenameColumn              = "rename_column"
 	KindAddPrimaryKeys            = "add_primary_keys"
 	KindObfuscateSensitiveColumns = "obfuscate_sensitive_columns"
+	KindUppercase                 = "uppercase"
+	KindLowercase                 = "lowercase"
 )
 
 type TransformationSpec struct {
@@ -99,7 +101,16 @@ func (s *Spec) Validate() error {
 			if len(t.Columns) > 0 {
 				err = errors.Join(err, fmt.Errorf("columns field must not be specified for %s transformation", t.Kind))
 			}
-
+		case KindLowercase, KindUppercase:
+			if t.Value != "" {
+				err = errors.Join(err, fmt.Errorf("value field must be empty for %s transformation", t.Kind))
+			}
+			if len(t.Columns) == 0 {
+				err = errors.Join(err, fmt.Errorf("'%s' field must be specified for %s transformation", "columns", t.Kind))
+			}
+			if t.Name != "" || t.NewTableNameTemplate != "" {
+				err = errors.Join(err, fmt.Errorf("name/new_table_name_template fields must not be specified for %s transformation", t.Kind))
+			}
 		default:
 			err = errors.Join(err, fmt.Errorf("unknown transformation kind: %s", t.Kind))
 		}

--- a/plugins/transformer/basic/client/spec/spec_test.go
+++ b/plugins/transformer/basic/client/spec/spec_test.go
@@ -176,6 +176,24 @@ func TestValidate(t *testing.T) {
 			},
 			wantErr: true,
 		},
+		{
+			name: "InvalidLowercaseEmptyColumns",
+			input: Spec{
+				TransformationSpecs: []TransformationSpec{
+					{Kind: KindLowercase, Columns: []string{}},
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "ValidLowercase",
+			input: Spec{
+				TransformationSpecs: []TransformationSpec{
+					{Kind: KindLowercase, Columns: []string{"col1"}},
+				},
+			},
+			wantErr: false,
+		},
 	}
 
 	for _, tt := range tests {

--- a/plugins/transformer/basic/client/transformers/transformers.go
+++ b/plugins/transformer/basic/client/transformers/transformers.go
@@ -40,6 +40,10 @@ func NewFromSpec(sp spec.TransformationSpec) (*Transformer, error) {
 		tr.fn = RenameColumn(sp.Name, sp.Value)
 	case spec.KindObfuscateSensitiveColumns:
 		tr.fn = ObfuscateSensitiveColumns(sp.Columns)
+	case spec.KindUppercase:
+		tr.fn = ChangeCase(sp.Kind, sp.Columns)
+	case spec.KindLowercase:
+		tr.fn = ChangeCase(sp.Kind, sp.Columns)
 	default:
 		return nil, fmt.Errorf("unknown transformation kind: %s", sp.Kind)
 	}
@@ -123,6 +127,12 @@ func ChangeTableName(newTableNamePattern string) TransformationFn {
 func RenameColumn(oldName, newName string) TransformationFn {
 	return func(record arrow.Record) (arrow.Record, error) {
 		return recordupdater.New(record).RenameColumn(oldName, newName)
+	}
+}
+
+func ChangeCase(caseType string, columnNames []string) TransformationFn {
+	return func(record arrow.Record) (arrow.Record, error) {
+		return recordupdater.New(record).ChangeCase(caseType, columnNames)
 	}
 }
 

--- a/plugins/transformer/basic/client/transformers/transformers_test.go
+++ b/plugins/transformer/basic/client/transformers/transformers_test.go
@@ -143,6 +143,36 @@ func TestTransform(t *testing.T) {
 			},
 		},
 		{
+			name: "UppercaseColumns",
+			spec: spec.TransformationSpec{
+				Kind:    spec.KindUppercase,
+				Columns: []string{"col1"},
+				Tables:  []string{"*"},
+			},
+			record: createTestRecord(),
+			validate: func(t *testing.T, record arrow.Record) {
+				require.Equal(t, "VAL1", record.Column(0).(*array.String).Value(0), "Expected uppercase value in col1 column")
+				require.Equal(t, "VAL2", record.Column(0).(*array.String).Value(1), "Expected uppercase value in col1 column")
+				require.Equal(t, int64(2), record.NumCols(), "Expected 2 columns")
+				require.Equal(t, int64(2), record.NumRows(), "Expected 2 rows")
+			},
+		},
+		{
+			name: "LowercaseColumns",
+			spec: spec.TransformationSpec{
+				Kind:    spec.KindLowercase,
+				Columns: []string{"col1"},
+				Tables:  []string{"*"},
+			},
+			record: createUppercaseTestRecord(),
+			validate: func(t *testing.T, record arrow.Record) {
+				require.Equal(t, "val1", record.Column(0).(*array.String).Value(0), "Expected lowercase value in col1 column")
+				require.Equal(t, "val2", record.Column(0).(*array.String).Value(1), "Expected lowercase value in col1 column")
+				require.Equal(t, int64(2), record.NumCols(), "Expected 2 columns")
+				require.Equal(t, int64(2), record.NumRows(), "Expected 2 rows")
+			},
+		},
+		{
 			name: "ChangeTableName",
 			spec: spec.TransformationSpec{
 				Kind:                 spec.KindChangeTableNames,
@@ -184,6 +214,23 @@ func createTestRecord() arrow.Record {
 	defer bld.Release()
 
 	bld.Field(0).(*array.StringBuilder).AppendValues([]string{"val1", "val2"}, nil)
+	bld.Field(1).(*array.StringBuilder).AppendValues([]string{"val3", "val4"}, nil)
+
+	return bld.NewRecord()
+}
+
+func createUppercaseTestRecord() arrow.Record {
+	md := arrow.NewMetadata([]string{schema.MetadataTableName}, []string{"table1"})
+	bld := array.NewRecordBuilder(memory.DefaultAllocator, arrow.NewSchema(
+		[]arrow.Field{
+			{Name: "col1", Type: arrow.BinaryTypes.String},
+			{Name: "col2", Type: arrow.BinaryTypes.String},
+		},
+		&md,
+	))
+	defer bld.Release()
+
+	bld.Field(0).(*array.StringBuilder).AppendValues([]string{"VAL1", "VAL2"}, nil)
 	bld.Field(1).(*array.StringBuilder).AppendValues([]string{"val3", "val4"}, nil)
 
 	return bld.NewRecord()

--- a/plugins/transformer/basic/docs/_configuration.md
+++ b/plugins/transformer/basic/docs/_configuration.md
@@ -30,5 +30,11 @@ spec:
         tables: ["xkcd_comics"]
         name: img
         value: img_url
+      - kind: uppercase
+        tables: ["xkcd_comics"]
+        columns: ["title"]
+      - kind: lowercase
+        tables: ["xkcd_comics"]
+        columns: ["title"]
 
 ```

--- a/plugins/transformer/basic/docs/overview.md
+++ b/plugins/transformer/basic/docs/overview.md
@@ -5,6 +5,7 @@ This CloudQuery transformer plugin provides basic transformation capabilities:
 - Adding a column with the timestamp that the record was processed by the transformer
 - Obfuscating string columns
 - Renaming tables using a name template (use `{{.OldName}}` to refer to the original name, see example below)
+- Normalizing column values to all-upper/lowercase
 
 ## Configuration
 
@@ -32,7 +33,7 @@ Then, add your transformer spec. Here's an example that transforms the XKCD sour
 
 :configuration
 
-JSON is supported for removing paths and obfuscating string values. Array indexes are supported in both cases. For example, with a JSON column named `tags`:
+JSON is supported for removing paths and obfuscating string values, as well as lower/uppercasing field values. Array indexes are supported in both cases. For example, with a JSON column named `tags`:
 ```json
 {"foo":{"bar":["a","b","c"]},"hello":"world","kubectl.kubernetes.io/last-applied-configuration":"secrets"}
 ```


### PR DESCRIPTION
Adds two transformations to help users normalize data. Has json path handling like `obfuscate` transformations.
<!--
Use the following steps to ensure your PR is ready to be reviewed

- [x] Read the [contribution guidelines](https://github.com/cloudquery/cloudquery/blob/main/CONTRIBUTING.md) 🧑‍🎓
- [x] Run `make lint` to ensure the proposed changes follow the coding style 🚨 (install golangci-lint [here](https://golangci-lint.run/usage/install/#local-installation))
- [x] Run `make test` to ensure the proposed changes pass the tests 🧪
- [x] If changing a source plugin run `make gen` to ensure docs are up to date 📝
- [x] Ensure the status checks below are successful ✅
--->
