### PR TITLE
chore: Refactor Spec to use `*string` instead of `string` for value

### DIFF
--- a/plugins/transformer/basic/client/spec/spec.go
+++ b/plugins/transformer/basic/client/spec/spec.go
@@ -50,11 +50,11 @@ func (s *Spec) Validate() error {
 			if len(t.Columns) == 0 {
 				err = errors.Join(err, fmt.Errorf("'%s' field must be specified for %s transformation", "columns", t.Kind))
 			}
-			if t.Name != "" || t.Value != "" || t.NewTableNameTemplate != "" {
+			if t.Name != "" || (t.Value != nil && *t.Value != "") || t.NewTableNameTemplate != "" {
 				err = errors.Join(err, fmt.Errorf("name/value/new_table_name_template fields must not be specified for %s transformation", t.Kind))
 			}
 		case KindAddColumn:
-			if t.Name == "" || t.Value == "" {
+			if t.Name == "" || t.Value == nil || *t.Value == "" {
 				err = errors.Join(err, fmt.Errorf("'%s' and '%s' fields must be specified for %s transformation", "name", "value", t.Kind))
 			}
 			if t.NewTableNameTemplate != "" {
@@ -64,7 +64,7 @@ func (s *Spec) Validate() error {
 			if t.Name == "" {
 				err = errors.Join(err, fmt.Errorf("'%s' field must be specified for %s transformation", "name", t.Kind))
 			}
-			if t.Value != "" || len(t.Columns) > 0 || t.NewTableNameTemplate != "" {
+			if (t.Value != nil && *t.Value != "") || len(t.Columns) > 0 || t.NewTableNameTemplate != "" {
 				err = errors.Join(err, fmt.Errorf("value/columns/new_table_name_template fields must not be specified for %s transformation", t.Kind))
 			}
 			if t.NewTableNameTemplate != "" {
@@ -74,25 +74,25 @@ func (s *Spec) Validate() error {
 			if len(t.Columns) == 0 {
 				err = errors.Join(err, fmt.Errorf("'%s' field must be specified for %s transformation", "columns", t.Kind))
 			}
-			if t.Name != "" || t.Value != "" || t.NewTableNameTemplate != "" {
+			if t.Name != "" || (t.Value != nil && *t.Value != "") || t.NewTableNameTemplate != "" {
 				err = errors.Join(err, fmt.Errorf("name/value/new_table_name_template fields must not be specified for %s transformation", t.Kind))
 			}
 		case KindObfuscateSensitiveColumns:
 			if len(t.Columns) != 0 {
 				err = errors.Join(err, fmt.Errorf("'%s' field must not be specified for %s transformation", "columns", t.Kind))
 			}
-			if t.Name != "" || t.Value != "" || t.NewTableNameTemplate != "" {
+			if t.Name != "" || (t.Value != nil && *t.Value != "") || t.NewTableNameTemplate != "" {
 				err = errors.Join(err, fmt.Errorf("name/value/new_table_name_template fields must not be specified for %s transformation", t.Kind))
 			}
 		case KindChangeTableNames:
 			if t.NewTableNameTemplate == "" {
 				err = errors.Join(err, fmt.Errorf("'%s' field must be specified for %s transformation", "new_table_name_template", t.Kind))
 			}
-			if t.Name != "" || t.Value != "" || len(t.Columns) > 0 {
+			if t.Name != "" || (t.Value != nil && *t.Value != "") || len(t.Columns) > 0 {
 				err = errors.Join(err, fmt.Errorf("name/value/columns fields must not be specified for %s transformation", t.Kind))
 			}
 		case KindRenameColumn:
-			if t.Name == "" || t.Value == "" {
+			if t.Name == "" || t.Value == nil || *t.Value == "" {
 				err = errors.Join(err, fmt.Errorf("'%s' and '%s' fields must be specified for %s transformation", "name", "value", t.Kind))
 			}
 			if t.NewTableNameTemplate != "" {
@@ -102,7 +102,7 @@ func (s *Spec) Validate() error {
 				err = errors.Join(err, fmt.Errorf("columns field must not be specified for %s transformation", t.Kind))
 			}
 		case KindLowercase, KindUppercase:
-			if t.Value != "" {
+			if t.Value != nil && *t.Value != "" {
 				err = errors.Join(err, fmt.Errorf("value field must be empty for %s transformation", t.Kind))
 			}
 			if len(t.Columns) == 0 {

--- a/plugins/transformer/basic/client/spec/spec.go
+++ b/plugins/transformer/basic/client/spec/spec.go
@@ -24,7 +24,7 @@ type TransformationSpec struct {
 	Tables  []string `json:"tables"` // per-transformation table glob patterns
 	Columns []string `json:"columns"`
 	Name    string   `json:"name"`
-	Value   string   `json:"value"`
+	Value   *string  `json:"value"`
 
 	// For change_table_names transformation
 	NewTableNameTemplate string `json:"new_table_name_template"`

--- a/plugins/transformer/basic/client/spec/spec_test.go
+++ b/plugins/transformer/basic/client/spec/spec_test.go
@@ -81,7 +81,7 @@ func TestValidate(t *testing.T) {
 			name: "ValidAddColumn",
 			input: Spec{
 				TransformationSpecs: []TransformationSpec{
-					{Kind: KindAddColumn, Name: "new_col", Value: "default"},
+					{Kind: KindAddColumn, Name: "new_col", Value: &[]string{"default"}[0]},
 				},
 			},
 			wantErr: false,
@@ -90,7 +90,7 @@ func TestValidate(t *testing.T) {
 			name: "InvalidAddColumnNoName",
 			input: Spec{
 				TransformationSpecs: []TransformationSpec{
-					{Kind: KindAddColumn, Value: "default"},
+					{Kind: KindAddColumn, Value: &[]string{"default"}[0]},
 				},
 			},
 			wantErr: true,
@@ -117,7 +117,7 @@ func TestValidate(t *testing.T) {
 			name: "InvalidAddTimestampColumnValue",
 			input: Spec{
 				TransformationSpecs: []TransformationSpec{
-					{Kind: KindAddTimestampColumn, Value: "default"},
+					{Kind: KindAddTimestampColumn, Value: &[]string{"default"}[0]},
 				},
 			},
 			wantErr: true,
@@ -144,7 +144,7 @@ func TestValidate(t *testing.T) {
 			name: "ValidRenameColumn",
 			input: Spec{
 				TransformationSpecs: []TransformationSpec{
-					{Kind: KindRenameColumn, Name: "old_col", Value: "new_col"},
+					{Kind: KindRenameColumn, Name: "old_col", Value: &[]string{"new_col"}[0]},
 				},
 			},
 			wantErr: false,

--- a/plugins/transformer/basic/client/transformers/transformers.go
+++ b/plugins/transformer/basic/client/transformers/transformers.go
@@ -25,7 +25,7 @@ func NewFromSpec(sp spec.TransformationSpec) (*Transformer, error) {
 
 	switch sp.Kind {
 	case spec.KindAddColumn:
-		tr.fn = AddLiteralStringColumnAsLastColumn(sp.Name, sp.Value)
+		tr.fn = AddLiteralStringColumnAsLastColumn(sp.Name, *sp.Value)
 	case spec.KindAddTimestampColumn:
 		tr.fn = AddTimestampColumnAsLastColumn(sp.Name)
 	case spec.KindRemoveColumns:
@@ -37,7 +37,7 @@ func NewFromSpec(sp spec.TransformationSpec) (*Transformer, error) {
 	case spec.KindChangeTableNames:
 		tr.fn = ChangeTableName(sp.NewTableNameTemplate)
 	case spec.KindRenameColumn:
-		tr.fn = RenameColumn(sp.Name, sp.Value)
+		tr.fn = RenameColumn(sp.Name, *sp.Value)
 	case spec.KindObfuscateSensitiveColumns:
 		tr.fn = ObfuscateSensitiveColumns(sp.Columns)
 	case spec.KindUppercase:

--- a/plugins/transformer/basic/client/transformers/transformers_test.go
+++ b/plugins/transformer/basic/client/transformers/transformers_test.go
@@ -22,7 +22,7 @@ func TestNewFromSpec(t *testing.T) {
 			spec: spec.TransformationSpec{
 				Kind:  spec.KindAddColumn,
 				Name:  "new_col",
-				Value: "default",
+				Value: &[]string{"default"}[0],
 			},
 			wantErr: false,
 		},
@@ -90,7 +90,7 @@ func TestTransform(t *testing.T) {
 			spec: spec.TransformationSpec{
 				Kind:   spec.KindAddColumn,
 				Name:   "new_col",
-				Value:  "default",
+				Value:  &[]string{"default"}[0],
 				Tables: []string{"*"},
 			},
 			record: createTestRecord(),


### PR DESCRIPTION
<!-- 🎉 Thank you for making CloudQuery awesome by submitting a PR 🎉 -->

#### Summary

⚠️ **If you're contributing to a plugin please read this section of the [contribution guidelines](https://github.com/cloudquery/cloudquery/blob/main/CONTRIBUTING.md#open-core-vs-open-source) 🧑‍🎓 before submitting this PR** ⚠️

<!--
Explain what problem this PR addresses
-->

<!--
Use the following steps to ensure your PR is ready to be reviewed

- [ ] Read the [contribution guidelines](https://github.com/cloudquery/cloudquery/blob/main/CONTRIBUTING.md) 🧑‍🎓
- [ ] Run `make lint` to ensure the proposed changes follow the coding style 🚨 (install golangci-lint [here](https://golangci-lint.run/usage/install/#local-installation))
- [ ] Run `make test` to ensure the proposed changes pass the tests 🧪
- [ ] If changing a source plugin run `make gen` to ensure docs are up to date 📝
- [ ] Ensure the status checks below are successful ✅
--->
