### PR TITLE
chore: Alert on failed plugin publish

### DIFF
--- a/.github/workflows/publish_plugin_to_hub.yml
+++ b/.github/workflows/publish_plugin_to_hub.yml
@@ -253,6 +253,17 @@ jobs:
         run: |
           cloudquery plugin publish --finalize ${{ needs.prepare.outputs.ui_dir_arg }}
 
+      - name: Slack Notify
+        uses: ravsamhq/notify-slack-action@be814b201e233b2dc673608aa46e5447c8ab13f2
+        if: always()
+        with:
+          status: ${{ job.status }}
+          notify_when: 'failure'
+          notification_title: 'Failed to publish to hub ${{ needs.prepare.outputs.plugin_kind }}-${{ needs.prepare.outputs.plugin_name }}@${{ needs.prepare.outputs.plugin_version }}'
+          footer: '<{repo_url}|{repo}>'
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.ALERTS_INTEGRATIONS_SLACK_WEBHOOK_URL }}
+
   publish-plugin-to-hub-python:
     timeout-minutes: 60
     runs-on: ubuntu-latest
@@ -343,6 +354,17 @@ jobs:
         run: |
           cloudquery plugin publish --finalize ${{ needs.prepare.outputs.ui_dir_arg }}
 
+      - name: Slack Notify
+        uses: ravsamhq/notify-slack-action@be814b201e233b2dc673608aa46e5447c8ab13f2
+        if: always()
+        with:
+          status: ${{ job.status }}
+          notify_when: 'failure'
+          notification_title: 'Failed to publish to hub ${{ needs.prepare.outputs.plugin_kind }}-${{ needs.prepare.outputs.plugin_name }}@${{ needs.prepare.outputs.plugin_version }}'
+          footer: '<{repo_url}|{repo}>'
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.ALERTS_INTEGRATIONS_SLACK_WEBHOOK_URL }}
+
   publish-plugin-to-hub-node:
     timeout-minutes: 60
     runs-on: ubuntu-latest
@@ -426,6 +448,17 @@ jobs:
           CLOUDQUERY_API_KEY: ${{ secrets.CLOUDQUERY_API_KEY }}
         run: |
           cloudquery plugin publish --finalize ${{ needs.prepare.outputs.ui_dir_arg }}
+
+      - name: Slack Notify
+        uses: ravsamhq/notify-slack-action@be814b201e233b2dc673608aa46e5447c8ab13f2
+        if: always()
+        with:
+          status: ${{ job.status }}
+          notify_when: 'failure'
+          notification_title: 'Failed to publish to hub ${{ needs.prepare.outputs.plugin_kind }}-${{ needs.prepare.outputs.plugin_name }}@${{ needs.prepare.outputs.plugin_version }}'
+          footer: '<{repo_url}|{repo}>'
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.ALERTS_INTEGRATIONS_SLACK_WEBHOOK_URL }}
 
   publish-plugin-to-hub-go:
     timeout-minutes: 60
@@ -521,3 +554,14 @@ jobs:
         if: needs.prepare.outputs.prerelease == ''
         run: |
           git tag ${{ needs.prepare.outputs.plugin_dir }}/${{ needs.prepare.outputs.plugin_version }} && git push origin ${{ needs.prepare.outputs.plugin_dir }}/${{ needs.prepare.outputs.plugin_version }}
+
+      - name: Slack Notify
+        uses: ravsamhq/notify-slack-action@be814b201e233b2dc673608aa46e5447c8ab13f2
+        if: always()
+        with:
+          status: ${{ job.status }}
+          notify_when: 'failure'
+          notification_title: 'Failed to publish to hub ${{ needs.prepare.outputs.plugin_kind }}-${{ needs.prepare.outputs.plugin_name }}@${{ needs.prepare.outputs.plugin_version }}'
+          footer: '<{repo_url}|{repo}>'
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.ALERTS_INTEGRATIONS_SLACK_WEBHOOK_URL }}

--- a/.github/workflows/publish_plugin_to_hub_duckdb.yml
+++ b/.github/workflows/publish_plugin_to_hub_duckdb.yml
@@ -167,3 +167,14 @@ jobs:
         if: needs.prepare.outputs.prerelease == ''
         run: |
           git tag ${{ needs.prepare.outputs.plugin_dir }}/${{ needs.prepare.outputs.plugin_version }} && git push origin ${{ needs.prepare.outputs.plugin_dir }}/${{ needs.prepare.outputs.plugin_version }}
+
+      - name: Slack Notify
+        uses: ravsamhq/notify-slack-action@be814b201e233b2dc673608aa46e5447c8ab13f2
+        if: always()
+        with:
+          status: ${{ job.status }}
+          notify_when: 'failure'
+          notification_title: 'Failed to publish to hub ${{ needs.prepare.outputs.plugin_kind }}-${{ needs.prepare.outputs.plugin_name }}@${{ needs.prepare.outputs.plugin_version }}'
+          footer: '<{repo_url}|{repo}>'
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.ALERTS_INTEGRATIONS_SLACK_WEBHOOK_URL }}

--- a/.github/workflows/publish_plugin_to_hub_fips.yml
+++ b/.github/workflows/publish_plugin_to_hub_fips.yml
@@ -127,3 +127,14 @@ jobs:
           CLOUDQUERY_API_KEY: ${{ secrets.CLOUDQUERY_API_KEY }}
         run: |
           cloudquery plugin publish --finalize
+
+      - name: Slack Notify
+        uses: ravsamhq/notify-slack-action@be814b201e233b2dc673608aa46e5447c8ab13f2
+        if: always()
+        with:
+          status: ${{ job.status }}
+          notify_when: 'failure'
+          notification_title: 'Failed to publish to hub ${{ needs.prepare.outputs.plugin_kind }}-${{ needs.prepare.outputs.plugin_name }}@${{ needs.prepare.outputs.plugin_version }}'
+          footer: '<{repo_url}|{repo}>'
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.ALERTS_INTEGRATIONS_SLACK_WEBHOOK_URL }}

--- a/.github/workflows/publish_plugin_to_hub_snowflake.yml
+++ b/.github/workflows/publish_plugin_to_hub_snowflake.yml
@@ -168,3 +168,14 @@ jobs:
         if: needs.prepare.outputs.prerelease == ''
         run: |
           git tag ${{ needs.prepare.outputs.plugin_dir }}/${{ needs.prepare.outputs.plugin_version }} && git push origin ${{ needs.prepare.outputs.plugin_dir }}/${{ needs.prepare.outputs.plugin_version }}
+
+      - name: Slack Notify
+        uses: ravsamhq/notify-slack-action@be814b201e233b2dc673608aa46e5447c8ab13f2
+        if: always()
+        with:
+          status: ${{ job.status }}
+          notify_when: 'failure'
+          notification_title: 'Failed to publish to hub ${{ needs.prepare.outputs.plugin_kind }}-${{ needs.prepare.outputs.plugin_name }}@${{ needs.prepare.outputs.plugin_version }}'
+          footer: '<{repo_url}|{repo}>'
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.ALERTS_INTEGRATIONS_SLACK_WEBHOOK_URL }}

--- a/.github/workflows/publish_plugin_to_hub_sqlite.yml
+++ b/.github/workflows/publish_plugin_to_hub_sqlite.yml
@@ -167,3 +167,14 @@ jobs:
         if: needs.prepare.outputs.prerelease == ''
         run: |
           git tag ${{ needs.prepare.outputs.plugin_dir }}/${{ needs.prepare.outputs.plugin_version }} && git push origin ${{ needs.prepare.outputs.plugin_dir }}/${{ needs.prepare.outputs.plugin_version }}
+
+      - name: Slack Notify
+        uses: ravsamhq/notify-slack-action@be814b201e233b2dc673608aa46e5447c8ab13f2
+        if: always()
+        with:
+          status: ${{ job.status }}
+          notify_when: 'failure'
+          notification_title: 'Failed to publish to hub ${{ needs.prepare.outputs.plugin_kind }}-${{ needs.prepare.outputs.plugin_name }}@${{ needs.prepare.outputs.plugin_version }}'
+          footer: '<{repo_url}|{repo}>'
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.ALERTS_INTEGRATIONS_SLACK_WEBHOOK_URL }}


### PR DESCRIPTION
<!-- 🎉 Thank you for making CloudQuery awesome by submitting a PR 🎉 -->

#### Summary

Plugins failing to publish doesn't happen very often but when it does it's easy to miss.

This PR will result in sending an alert to [#alerts-integrations](https://cloudqueryio.slack.com/archives/C044XR4FDEK) when it happens

<!--
Use the following steps to ensure your PR is ready to be reviewed

- [ ] Read the [contribution guidelines](https://github.com/cloudquery/cloudquery/blob/main/CONTRIBUTING.md) 🧑‍🎓
- [ ] Run `make lint` to ensure the proposed changes follow the coding style 🚨 (install golangci-lint [here](https://golangci-lint.run/usage/install/#local-installation))
- [ ] Run `make test` to ensure the proposed changes pass the tests 🧪
- [ ] If changing a source plugin run `make gen` to ensure docs are up to date 📝
- [ ] Ensure the status checks below are successful ✅
--->
