### PR TITLE
feat: Support the new OTEL metric format removing the client_id metric point granularity

### DIFF
--- a/cli/internal/otel/receiver.go
+++ b/cli/internal/otel/receiver.go
@@ -133,10 +133,7 @@ func newMetricConsumer(metricsFile *os.File, quit chan any, wg *sync.WaitGroup) 
 
 	return func(ctx context.Context, metric pluginMetric) {
 		table := metric.Attributes["sync.table.name"].(string)
-		clientId, ok := metric.Attributes["sync.table.client_id"].(string)
-		if !ok {
-			clientId = ""
-		}
+		clientId, _ := metric.Attributes["sync.table.client_id"].(string)
 
 		tableLock.Lock()
 		defer tableLock.Unlock()


### PR DESCRIPTION
Should go with https://github.com/cloudquery/plugin-sdk/pull/2185 in order to allow the CLI to read metrics without the client_id metric point.

[old CLI, old SDK](https://github.com/user-attachments/files/21236264/before.txt)
[old CLI, new SDK](https://github.com/user-attachments/files/21289151/after.txt)
[updated CLI, old SDK](https://github.com/user-attachments/files/21289612/after.txt)
[updated CLI, new SDK](https://github.com/user-attachments/files/21236263/after.txt)

The above showcase that Duration metrics are unavailable if using an old CLI version with newer plugin versions, but that's a downside we have to work with.