### PR TITLE
fix: Don't re-use scan destination between rows scan

### DIFF
--- a/plugins/destination/clickhouse/client/retry_helpers.go
+++ b/plugins/destination/clickhouse/client/retry_helpers.go
@@ -110,9 +110,10 @@ func retryRead(ctx context.Context, logger zerolog.Logger, conn clickhouse.Conn,
 			}
 			defer rows.Close()
 
-			row := rowArr(rows.ColumnTypes())
+			columnsTypes := rows.ColumnTypes()
 			builder := array.NewRecordBuilder(memory.DefaultAllocator, table.ToArrowSchema())
 			for rows.Next() {
+				row := rowArr(columnsTypes)
 				if err = rows.Scan(row...); err != nil {
 					return nil, err
 				}


### PR DESCRIPTION
<!-- 🎉 Thank you for making CloudQuery awesome by submitting a PR 🎉 -->

#### Summary

I believe this should fix the flaky ClickHouse destination tests we've been seeing for a long while.

We were re-using the scan destination between scans which caused under some conditions to keep the previous read value instead of overwriting (I saw this happen when we first read a non null value, then supposed to read a null value, but I guess ClickHouse has some optimization so skip reading the null value) 

<!--
Use the following steps to ensure your PR is ready to be reviewed

- [ ] Read the [contribution guidelines](https://github.com/cloudquery/cloudquery/blob/main/CONTRIBUTING.md) 🧑‍🎓
- [ ] Run `make lint` to ensure the proposed changes follow the coding style 🚨 (install golangci-lint [here](https://golangci-lint.run/usage/install/#local-installation))
- [ ] Run `make test` to ensure the proposed changes pass the tests 🧪
- [ ] If changing a source plugin run `make gen` to ensure docs are up to date 📝
- [ ] Ensure the status checks below are successful ✅
--->
