### PR TITLE
fix: Remove fmt.Println from sqlite unpackArray

### DIFF
--- a/plugins/destination/sqlite/client/delete.go
+++ b/plugins/destination/sqlite/client/delete.go
@@ -2,7 +2,6 @@ package client
 
 import (
 	"context"
-	"fmt"
 	"reflect"
 	"strings"
 
@@ -83,7 +82,6 @@ func extractPredicateValues(where message.PredicateGroups) ([]any, error) {
 
 func unpackArray(s any) []any {
 	v := reflect.ValueOf(s)
-	fmt.Println(v.Kind(), v.Len())
 	r := make([]any, v.Len())
 	for i := range v.Len() {
 		r[i] = v.Index(i).Interface()


### PR DESCRIPTION
<!-- 🎉 Thank you for making CloudQuery awesome by submitting a PR 🎉 -->

#### Summary

Following up on https://github.com/cloudquery/cloudquery/pull/21102
There was a leftover from the debugging session that got merged into the release.
This removes a `fmt.Println(...)` left in the `unpackArray` function from the SQLite plugin, used when sending DeleteRecord messages.

<!--
Explain what problem this PR addresses
-->

<!--
Use the following steps to ensure your PR is ready to be reviewed

- [ ] Read the [contribution guidelines](https://github.com/cloudquery/cloudquery/blob/main/CONTRIBUTING.md) 🧑‍🎓
- [ ] Run `make lint` to ensure the proposed changes follow the coding style 🚨 (install golangci-lint [here](https://golangci-lint.run/usage/install/#local-installation))
- [ ] Run `make test` to ensure the proposed changes pass the tests 🧪
- [ ] If changing a source plugin run `make gen` to ensure docs are up to date 📝
- [ ] Ensure the status checks below are successful ✅
--->
