### PR TITLE
fix: Remove requirement for index.html for plugin UI assets

### DIFF
--- a/cli/internal/publish/pluginui.go
+++ b/cli/internal/publish/pluginui.go
@@ -52,10 +52,6 @@ func UploadPluginUIAssets(ctx context.Context, c *cloudquery_api.ClientWithRespo
 		return fmt.Errorf("%s is a reserved name and cannot be used as an asset name", uiAssetBundleTarName)
 	}
 
-	if _, ok := urlPathVsDetails["index.html"]; !ok {
-		return errors.New("index.html is required in the UI directory")
-	}
-
 	assets = append(assets, cloudquery_api.PluginUIAssetUploadRequest{
 		Name:        uiAssetBundleTarName,
 		ContentType: lo.ToPtr("application/gzip"),


### PR DESCRIPTION
<!-- 🎉 Thank you for making CloudQuery awesome by submitting a PR 🎉 -->

#### Summary

⚠️ **If you're contributing to a plugin please read this section of the [contribution guidelines](https://github.com/cloudquery/cloudquery/blob/main/CONTRIBUTING.md#open-core-vs-open-source) 🧑‍🎓 before submitting this PR** ⚠️

<!--
Explain what problem this PR addresses
-->

<!--
Use the following steps to ensure your PR is ready to be reviewed

- [ ] Read the [contribution guidelines](https://github.com/cloudquery/cloudquery/blob/main/CONTRIBUTING.md) 🧑‍🎓
- [ ] Run `make lint` to ensure the proposed changes follow the coding style 🚨 (install golangci-lint [here](https://golangci-lint.run/usage/install/#local-installation))
- [ ] Run `make test` to ensure the proposed changes pass the tests 🧪
- [ ] If changing a source plugin run `make gen` to ensure docs are up to date 📝
- [ ] Ensure the status checks below are successful ✅
--->
