### PR TITLE
chore: Remove types header

### DIFF
--- a/plugins/destination/mysql/docs/types.md
+++ b/plugins/destination/mysql/docs/types.md
@@ -1,5 +1,3 @@
-# MySQL Types
-
 The MySQL destination (MySQL 8.0 and later) supports most [Apache Arrow](https://arrow.apache.org/docs/index.html)
 types. The following table shows the supported types and how they are mapped
 to [MySQL data types](https://dev.mysql.com/doc/refman/8.0/en/data-types.html).


### PR DESCRIPTION
<!-- 🎉 Thank you for making CloudQuery awesome by submitting a PR 🎉 -->

#### Summary

Small follow up to https://github.com/cloudquery/cloudquery/pull/21220 to remove the duplicated header

<img width="1188" height="474" alt="image" src="https://github.com/user-attachments/assets/ab5606d5-ce4b-4f7c-b169-dbb587b53f84" />


<!--
Use the following steps to ensure your PR is ready to be reviewed

- [ ] Read the [contribution guidelines](https://github.com/cloudquery/cloudquery/blob/main/CONTRIBUTING.md) 🧑‍🎓
- [ ] Run `make lint` to ensure the proposed changes follow the coding style 🚨 (install golangci-lint [here](https://golangci-lint.run/usage/install/#local-installation))
- [ ] Run `make test` to ensure the proposed changes pass the tests 🧪
- [ ] If changing a source plugin run `make gen` to ensure docs are up to date 📝
- [ ] Ensure the status checks below are successful ✅
--->
