### PR TITLE
fix: Test PostgreSQL pool connections before use

### DIFF
--- a/plugins/destination/postgresql/client/client.go
+++ b/plugins/destination/postgresql/client/client.go
@@ -94,6 +94,10 @@ func New(ctx context.Context, logger zerolog.Logger, specBytes []byte, opts plug
 	}
 	// maybe expose this to the user?
 	pgxConfig.ConnConfig.RuntimeParams["timezone"] = "UTC"
+	// If the connection is dead (server outage, network split etc.) drop it from the pool
+	pgxConfig.BeforeAcquire = func(ctx context.Context, conn *pgx.Conn) bool {
+		return conn.Ping(ctx) == nil
+	}
 	c.conn, err = pgxpool.NewWithConfig(ctx, pgxConfig)
 	if err != nil {
 		return nil, fmt.Errorf("failed to connect to postgresql: %w", err)


### PR DESCRIPTION
If a PostgreSQL server becomes unreachable after a sync has started, connections from the pgx pool can hang indefinitely. As per upstream, the only way to know for sure if a connection is still valid is to try using it.

This commit adds a BeforeAcquire hook to ping the database before any query. If it fails, the connection is dropped from the pool.