### PR TITLE
feat: Add relative time support to HackerNews plugin

### DIFF
--- a/plugins/source/hackernews/client/schema.json
+++ b/plugins/source/hackernews/client/schema.json
@@ -12,13 +12,18 @@
           "default": 100
         },
         "start_time": {
-          "type": "string",
-          "format": "date-time",
-          "description": "RFC3339 formatted timestamp. Syncing will begin with posts after this date. If not specified, the plugin will fetch all items."
+          "$ref": "#/$defs/Time",
+          "description": "RFC3339 formatted timestamp. Syncing will begin with posts after this date.\nRelative values like \"3 days ago\" are also supported.\nIf not specified, the plugin will default to 24 hours ago."
         }
       },
       "additionalProperties": false,
       "type": "object"
+    },
+    "Time": {
+      "type": "string",
+      "pattern": "(^now$|^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}(.(\\d{1,9}))?(Z|((-|\\+)\\d{2}:\\d{2}))$|^\\d{4}-\\d{2}-\\d{2}$|^[-+]?([0-9]*(\\.[0-9]*)?[a-z]+)+$|^(([0-9]+\\s+(nanoseconds?|ns|microseconds?|us|µs|μs|milliseconds?|ms|seconds?|s|minutes?|m|hours?|h|days?|d|months?|M|years?|Y)|[-+]?([0-9]*(\\.[0-9]*)?[a-z]+)+))(\\s+(([0-9]+\\s+(nanoseconds?|ns|microseconds?|us|µs|μs|milliseconds?|ms|seconds?|s|minutes?|m|hours?|h|days?|d|months?|M|years?|Y)|[-+]?([0-9]*(\\.[0-9]*)?[a-z]+)+)))*\\s+(ago|from\\s+now)$)",
+      "title": "CloudQuery configtype.Time",
+      "description": "Allows for defining timestamps in both absolute(RFC3339) and relative formats. Absolute timestamp example: `2024-01-01T12:00:00+00:00`.\nRelative timestamps can take this format:\n- `now`\n- `x seconds [ago|from now]`\n- `x minutes [ago|from now]`\n- `x hours [ago|from now]`\n- `x days [ago|from now]`\n`until` field usage:\n- `until: now`\n- `until: 2 days ago`\n- `until: 10 months 3 days 4h20m from now`\n- `until: 2024-01-01T12:00:00+00:00`"
     }
   }
 }

--- a/plugins/source/hackernews/client/spec.go
+++ b/plugins/source/hackernews/client/spec.go
@@ -2,15 +2,16 @@ package client
 
 import (
 	_ "embed"
-	"fmt"
-	"time"
+
+	"github.com/cloudquery/plugin-sdk/v4/configtype"
 )
 
 type Spec struct {
 	// The number of items to fetch concurrently
 	ItemConcurrency int `json:"item_concurrency" jsonschema:"minimum=1,default=100"`
 	// RFC3339 formatted timestamp. Syncing will begin with posts after this date. If not specified, the plugin will fetch all items.
-	StartTime string `json:"start_time" jsonschema:"format=date-time"`
+	// Relative values like "3 days ago" are also supported.
+	StartTime configtype.Time `json:"start_time" jsonschema:"format=date-time"`
 }
 
 type Backend struct {
@@ -26,12 +27,7 @@ func (s *Spec) SetDefaults() {
 }
 
 func (s *Spec) Validate() error {
-	if s.StartTime != "" {
-		_, err := time.Parse(time.RFC3339, s.StartTime)
-		if err != nil {
-			return fmt.Errorf("could not parse start_time: %v", err)
-		}
-	}
+	// validation for configtype.Time is done on unmarshalling
 	return nil
 }
 

--- a/plugins/source/hackernews/client/spec.go
+++ b/plugins/source/hackernews/client/spec.go
@@ -31,7 +31,7 @@ func (s *Spec) SetDefaults() {
 	}
 }
 
-func (s *Spec) Validate() error {
+func (*Spec) Validate() error {
 	// validation for configtype.Time is done on unmarshalling
 	return nil
 }

--- a/plugins/source/hackernews/client/spec.go
+++ b/plugins/source/hackernews/client/spec.go
@@ -9,8 +9,9 @@ import (
 type Spec struct {
 	// The number of items to fetch concurrently
 	ItemConcurrency int `json:"item_concurrency" jsonschema:"minimum=1,default=100"`
-	// RFC3339 formatted timestamp. Syncing will begin with posts after this date. If not specified, the plugin will fetch all items.
+	// RFC3339 formatted timestamp. Syncing will begin with posts after this date.
 	// Relative values like "3 days ago" are also supported.
+	// If not specified, the plugin will default to 24 hours ago.
 	StartTime configtype.Time `json:"start_time" jsonschema:"format=date-time"`
 }
 
@@ -23,6 +24,10 @@ func (s *Spec) SetDefaults() {
 	if s.ItemConcurrency <= 0 {
 		// Default to loading 100 concurrent items
 		s.ItemConcurrency = 100
+	}
+	if s.StartTime.IsZero() {
+		// Default to 24 hours ago
+		s.StartTime, _ = configtype.ParseTime("24 hours ago")
 	}
 }
 

--- a/plugins/source/hackernews/client/spec_test.go
+++ b/plugins/source/hackernews/client/spec_test.go
@@ -13,9 +13,14 @@ func TestJSONSchema(t *testing.T) {
 			Spec: `{}`,
 		},
 		{
-			Name: "invalid start_time",
+			Name: "relative start_time",
 			Spec: `{"start_time":"now"}`,
-			Err:  true,
+			Err:  false,
+		},
+		{
+			Name: "relative start_time days ago",
+			Spec: `{"start_time":"3 days ago"}`,
+			Err:  false,
 		},
 		{
 			Name: "valid start_time",

--- a/plugins/source/hackernews/client/spec_test.go
+++ b/plugins/source/hackernews/client/spec_test.go
@@ -23,6 +23,11 @@ func TestJSONSchema(t *testing.T) {
 			Err:  false,
 		},
 		{
+			Name: "invalid relative start_time",
+			Spec: `{"start_time":"3 flumps ago"}`,
+			Err:  true,
+		},
+		{
 			Name: "valid start_time",
 			Spec: `{"start_time":"2000-01-01T00:00:01Z"}`,
 		},

--- a/plugins/source/hackernews/client/testing.go
+++ b/plugins/source/hackernews/client/testing.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/cloudquery/cloudquery/plugins/source/hackernews/v3/client/services"
+	"github.com/cloudquery/plugin-sdk/v4/configtype"
 	"github.com/cloudquery/plugin-sdk/v4/plugin"
 	"github.com/cloudquery/plugin-sdk/v4/scheduler"
 	"github.com/cloudquery/plugin-sdk/v4/schema"
@@ -28,9 +29,9 @@ func MockTestHelper(t *testing.T, table *schema.Table, builder func(*testing.T, 
 		zerolog.ConsoleWriter{Out: os.Stderr, TimeFormat: time.StampMicro},
 	).Level(zerolog.DebugLevel).With().Timestamp().Logger()
 
-	startTimeStr := ""
-	if !opts.StartTime.IsZero() {
-		startTimeStr = opts.StartTime.Format(time.RFC3339)
+	startTime, err := configtype.ParseTime(opts.StartTime.Format(time.RFC3339))
+	if err != nil {
+		t.Fatalf("failed to parse start time: %v", err)
 	}
 	c := &Client{
 		logger:     l,
@@ -40,7 +41,7 @@ func MockTestHelper(t *testing.T, table *schema.Table, builder func(*testing.T, 
 		backoff:    1 * time.Millisecond,
 		Spec: Spec{
 			ItemConcurrency: 10,
-			StartTime:       startTimeStr,
+			StartTime:       startTime,
 		},
 	}
 	tables := schema.Tables{table}

--- a/plugins/source/hackernews/docs/_configuration.md
+++ b/plugins/source/hackernews/docs/_configuration.md
@@ -14,4 +14,5 @@ spec:
   # Learn more about the configuration options at https://cql.ink/hackernews_source
   spec:
     item_concurrency: 100
+    start_time: 3 hours ago
 ```

--- a/plugins/source/hackernews/docs/_licenses.md
+++ b/plugins/source/hackernews/docs/_licenses.md
@@ -7,8 +7,8 @@ The following tools / packages are used in this plugin:
 | Name | License |
 |------|---------|
 | github.com/adrg/xdg | MIT |
-| github.com/apache/arrow/go/v13 | Apache-2.0 |
 | github.com/apache/arrow-go/v18 | Apache-2.0 |
+| github.com/apache/arrow/go/v13 | Apache-2.0 |
 | github.com/apapsch/go-jsonmerge/v2 | MIT |
 | github.com/aws/aws-sdk-go-v2 | Apache-2.0 |
 | github.com/aws/aws-sdk-go-v2/config | Apache-2.0 |
@@ -29,8 +29,9 @@ The following tools / packages are used in this plugin:
 | github.com/aws/smithy-go/internal/sync/singleflight | BSD-3-Clause |
 | github.com/bahlo/generic-list-go | BSD-3-Clause |
 | github.com/buger/jsonparser | MIT |
-| github.com/cenkalti/backoff/v4 | MIT |
+| github.com/cenkalti/backoff/v5 | MIT |
 | github.com/cloudquery/cloudquery-api-go | MPL-2.0 |
+| github.com/cloudquery/codegen/jsonschema/docs | MPL-2.0 |
 | github.com/cloudquery/plugin-pb-go | MPL-2.0 |
 | github.com/cloudquery/plugin-sdk/v2/internal/glob | MIT |
 | github.com/cloudquery/plugin-sdk/v2/schema | MIT |
@@ -70,6 +71,7 @@ The following tools / packages are used in this plugin:
 | github.com/thoas/go-funk | MIT |
 | github.com/wk8/go-ordered-map/v2 | Apache-2.0 |
 | github.com/zeebo/xxh3 | BSD-2-Clause |
+| go.opentelemetry.io/auto/sdk | Apache-2.0 |
 | go.opentelemetry.io/otel | Apache-2.0 |
 | go.opentelemetry.io/otel/exporters/otlp/otlplog/otlploghttp | Apache-2.0 |
 | go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetrichttp | Apache-2.0 |

--- a/plugins/source/hackernews/docs/overview.md
+++ b/plugins/source/hackernews/docs/overview.md
@@ -25,7 +25,8 @@ For more information about managing state for incremental tables, see [Managing 
 
   A date-time string in `RFC3339` format.
   For example, `"2023-01-01T00:00:00Z"` will sync all items created on or after January 1, 2023.
-  If not specified, the plugin will fetch all items.
+  It is also possible to use relative time strings, such as `"3 hours ago"` or `"1 day ago"`.
+  If not specified, the plugin will fetch all items in the last 24 hours.
 
   Note that because this is an incremental table, a previous cursor position will take precedence over this setting, unless the given start time is after the last cursor position.
 

--- a/plugins/source/hackernews/resources/services/items/items_fetch.go
+++ b/plugins/source/hackernews/resources/services/items/items_fetch.go
@@ -56,11 +56,8 @@ func fetchItems(ctx context.Context, meta schema.ClientMeta, _ *schema.Resource,
 	c.Logger().Info().Int("max_id", maxID).Msg("Found max ID")
 
 	// we allow the user to specify a start time for posts, so we need to find the first post after that time
-	if c.Spec.StartTime != "" {
-		startTime, err := time.Parse(time.RFC3339, c.Spec.StartTime)
-		if err != nil {
-			return fmt.Errorf("failed to parse start time: %w", err)
-		}
+	if !c.Spec.StartTime.IsZero() {
+		startTime := c.Spec.StartTime.AsTime(time.Now())
 		c.Logger().Info().Time("start_time", startTime).Msg("Finding first post after start_time")
 		startItemID, err := findFirstPostAfter(ctx, c, startTime, maxID)
 		if err != nil {


### PR DESCRIPTION
This adds relative time support to the Hackernews plugin, and changes the default behavior to sync the last 24 hours. The default generated config (`cloudquery init`) will use 3 hours, which takes a few minutes to sync on my machine.

I've chosen not to mark this as a breaking change, because:
 - the previous timestamp format (RFC3339) is still supported, and
 - if a user has been syncing without the start time specified, the state store would make them immune to the default changing

