### PR TITLE
fix: Add more verbose error for when partition and sorting key changes

### DIFF
--- a/plugins/destination/clickhouse/client/migrate.go
+++ b/plugins/destination/clickhouse/client/migrate.go
@@ -200,7 +200,7 @@ func (c *Client) allTablesChanges(ctx context.Context, want schema.Tables, have 
 	return result, nil
 }
 
-func (c *Client) forceMigrationNeeded(changes []schema.TableColumnChange, tableChanges []tableSchemaChange) (bool, error) {
+func (*Client) forceMigrationNeeded(changes []schema.TableColumnChange, tableChanges []tableSchemaChange) (bool, error) {
 	if unsafe := unsafeChanges(changes); len(unsafe) > 0 {
 		return true, nil
 	}

--- a/plugins/destination/clickhouse/client/migrate.go
+++ b/plugins/destination/clickhouse/client/migrate.go
@@ -179,11 +179,7 @@ func (c *Client) allTablesChanges(ctx context.Context, want schema.Tables, have 
 		}
 		tableSchemaChanges = slices.Clip(tableSchemaChanges)
 
-		forcedMigrationNeeded, err := c.forceMigrationNeeded(changes, tableSchemaChanges)
-		if err != nil {
-			return nil, err
-		}
-
+		forcedMigrationNeeded := c.forceMigrationNeeded(changes, tableSchemaChanges)
 		oldTTL, newTTL, err := c.checkTTLChanged(ctx, t)
 		if err != nil {
 			return nil, fmt.Errorf("failed to check TTL changes for table %s: %w", t.Name, err)
@@ -200,16 +196,16 @@ func (c *Client) allTablesChanges(ctx context.Context, want schema.Tables, have 
 	return result, nil
 }
 
-func (*Client) forceMigrationNeeded(changes []schema.TableColumnChange, tableChanges []tableSchemaChange) (bool, error) {
+func (*Client) forceMigrationNeeded(changes []schema.TableColumnChange, tableChanges []tableSchemaChange) bool {
 	if unsafe := unsafeChanges(changes); len(unsafe) > 0 {
-		return true, nil
+		return true
 	}
 
 	if len(tableChanges) > 0 {
-		return true, nil
+		return true
 	}
 
-	return false, nil
+	return false
 }
 
 func unsafeChanges(changes []schema.TableColumnChange) []schema.TableColumnChange {


### PR DESCRIPTION
This improves the error message when migrating between plugin versions where sorting key or partition keys have changed. Before, the user was left guessing what changes were needed for certain tables.


### Before

```bash
cloudquery sync aws_to_clickhouse.yaml
Loading spec(s) from aws_to_clickhouse.yaml
Starting sync for: aws (cloudquery/aws@v32.37.1) -> [clickhouse (cloudquery/clickhouse@v7.3.1)]
Error: failed to sync v3 source aws: write client returned error (insert): plugin returned error:
Can't migrate tables automatically, migrate manually or consider using 'migrate_mode: forced'. Non auto migratable tables changes:

aws_ec2_instance_types:
  - Column "placement_group_info" added with type "utf8"
  - Column "test_column" with type "utf8" removed
  - Not null constraint removed from column "v_cpu_info"

aws_eks_cluster_node_groups:


aws_elasticache_replication_groups:


aws_elbv1_load_balancers:


aws_elbv2_load_balancers:


aws_rds_clusters:


aws_rds_instances:

```

### After:

```bash
cloudquery sync aws_to_clickhouse.yaml
Loading spec(s) from aws_to_clickhouse.yaml
Starting sync for: aws (cloudquery/aws@v32.37.1) -> [clickhouse (local@/Users/herman/code/cloudquery/cloudquery/plugins/destination/clickhouse/clickhouse)]
Error: failed to sync v3 source aws: write client returned error (insert): plugin returned error:

Can't migrate tables automatically, migrate manually or consider using 'migrate_mode: forced'.

Non auto-migratable tables:

aws_ec2_instance_types:
  - Column "placement_group_info" added with type "utf8"
  - Column "test_column" with type "utf8" removed
  - Not null constraint removed from column "v_cpu_info"
  - Sorting key changed (was [supported_boot_modes,supported_root_device_types,supported_usage_classes,supported_virtualization_types,_cq_id] and would become [_cq_id])

aws_eks_cluster_node_groups:
  - Sorting key changed (was [instance_types,subnets,_cq_id] and would become [_cq_id])

aws_elasticache_replication_groups:
  - Sorting key changed (was [member_clusters,member_clusters_outpost_arns,user_group_ids,_cq_id] and would become [_cq_id])

aws_elbv1_load_balancers:
  - Sorting key changed (was [availability_zones,security_groups,subnets,_cq_id] and would become [_cq_id])

aws_elbv2_load_balancers:
  - Sorting key changed (was [security_groups,_cq_id] and would become [_cq_id])

aws_rds_clusters:
  - Sorting key changed (was [availability_zones,custom_endpoints,enabled_cloudwatch_logs_exports,read_replica_identifiers,_cq_id] and would become [_cq_id])

aws_rds_instances:
  - Sorting key changed (was [enabled_cloudwatch_logs_exports,read_replica_db_cluster_identifiers,read_replica_db_instance_identifiers,_cq_id] and would become [_cq_id])
```