### PR TITLE
feat: Implement text-embeddings support.

### DIFF
--- a/plugins/destination/bigquery/client/client.go
+++ b/plugins/destination/bigquery/client/client.go
@@ -22,6 +22,8 @@ type Client struct {
 	client *bigquery.Client
 	writer *batchwriter.BatchWriter
 
+	embeddingsClient EmbeddingsClient
+
 	batchwriter.UnimplementedDeleteStale
 	batchwriter.UnimplementedDeleteRecord
 }
@@ -62,6 +64,8 @@ func New(ctx context.Context, logger zerolog.Logger, specBytes []byte, opts plug
 	if err := validateCreds(ctx, c.client, c.spec.DatasetID, c.spec.ProjectID); err != nil {
 		return nil, fmt.Errorf("failed to validate credentials: %w", err)
 	}
+
+	c.embeddingsClient = NewEmbeddingsClient(c, &c.spec)
 
 	return c, nil
 }

--- a/plugins/destination/bigquery/client/embeddings_client.go
+++ b/plugins/destination/bigquery/client/embeddings_client.go
@@ -1,0 +1,50 @@
+package client
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/cloudquery/plugin-sdk/v4/message"
+)
+
+type EmbeddingsClient interface {
+	MigrateTables(ctx context.Context) error
+	WriteTableBatch(ctx context.Context, name string, msgs message.WriteInserts) error
+}
+
+func NewEmbeddingsClient(cl *Client, spec *Spec) EmbeddingsClient {
+	if spec.TextEmbeddings == nil {
+		return &NoOpEmbeddingsClient{}
+	}
+	c := &ConcreteEmbeddingsClient{
+		client:    cl,
+		spec:      spec.TextEmbeddings,
+		ProjectID: spec.ProjectID,
+		DatasetID: spec.DatasetID,
+	}
+	return c
+}
+
+type ConcreteEmbeddingsClient struct {
+	client *Client
+	spec   *TextEmbeddingsSpec
+
+	hasMigrated bool
+
+	// The id of the project where the destination BigQuery database resides.
+	ProjectID string `json:"project_id" jsonschema:"required,minLength=1"`
+
+	//  The name of the BigQuery dataset within the project, e.g. `my_dataset`.
+	//  This dataset needs to be created before running a sync or migration.
+	DatasetID string `json:"dataset_id" jsonschema:"required,minLength=1"`
+}
+
+// findTableConfig finds the table configuration by source table name
+func (c *ConcreteEmbeddingsClient) findTableConfig(name string) (*TableConfig, error) {
+	for _, table := range c.spec.Tables {
+		if table.SourceTableName == name {
+			return &table, nil
+		}
+	}
+	return nil, fmt.Errorf("table configuration not found for source table: %s", name)
+}

--- a/plugins/destination/bigquery/client/embeddings_migrate.go
+++ b/plugins/destination/bigquery/client/embeddings_migrate.go
@@ -1,0 +1,64 @@
+package client
+
+import (
+	"context"
+	"fmt"
+
+	"cloud.google.com/go/bigquery"
+	pluginSchema "github.com/cloudquery/plugin-sdk/v4/schema"
+)
+
+func (c *ConcreteEmbeddingsClient) MigrateTables(ctx context.Context) error {
+	for _, tableConfig := range c.spec.Tables {
+		schema, err := c.buildSchemaForEmbeddingsTable(ctx, tableConfig)
+		if err != nil {
+			return err
+		}
+		tm := bigquery.TableMetadata{
+			Name:             tableConfig.TargetTableName,
+			Location:         "",
+			Description:      fmt.Sprintf("Embeddings for table %s", tableConfig.SourceTableName),
+			Schema:           schema,
+			TimePartitioning: c.client.timePartitioning(),
+		}
+
+		if ok, err := c.client.doesTableExist(ctx, c.client.client, tableConfig.TargetTableName); err != nil {
+			return err
+		} else if ok {
+			continue
+		}
+
+		if err := c.client.client.DatasetInProject(c.ProjectID, c.DatasetID).Table(tableConfig.TargetTableName).Create(ctx, &tm); err != nil {
+			return err
+		}
+		if err := c.client.waitForTableToExist(ctx, c.client.client, &pluginSchema.Table{Name: tableConfig.TargetTableName}); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (c *ConcreteEmbeddingsClient) buildSchemaForEmbeddingsTable(ctx context.Context, tableConfig TableConfig) ([]*bigquery.FieldSchema, error) {
+	md, err := c.client.client.DatasetInProject(c.ProjectID, c.DatasetID).Table(tableConfig.SourceTableName).Metadata(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	metadataColumnSet := sliceToSet(tableConfig.MetadataColumns)
+	columns := baseColumns()
+	for _, column := range md.Schema {
+		if _, ok := metadataColumnSet[column.Name]; ok {
+			columns = append(columns, column)
+		}
+	}
+
+	return columns, nil
+}
+
+func baseColumns() []*bigquery.FieldSchema {
+	return []*bigquery.FieldSchema{
+		{Name: "chunk_id", Type: bigquery.IntegerFieldType, Required: true},
+		{Name: "chunk_text", Type: bigquery.StringFieldType, Required: true},
+		{Name: "embedding", Type: bigquery.FloatFieldType, Repeated: true, Required: true},
+	}
+}

--- a/plugins/destination/bigquery/client/embeddings_no_op.go
+++ b/plugins/destination/bigquery/client/embeddings_no_op.go
@@ -1,0 +1,18 @@
+package client
+
+import (
+	"context"
+
+	"github.com/cloudquery/plugin-sdk/v4/message"
+)
+
+type NoOpEmbeddingsClient struct {
+}
+
+func (*NoOpEmbeddingsClient) WriteTableBatch(ctx context.Context, name string, msgs message.WriteInserts) error {
+	return nil
+}
+
+func (*NoOpEmbeddingsClient) MigrateTables(ctx context.Context) error {
+	return nil
+}

--- a/plugins/destination/bigquery/client/embeddings_util.go
+++ b/plugins/destination/bigquery/client/embeddings_util.go
@@ -1,0 +1,48 @@
+package client
+
+import (
+	"fmt"
+
+	"github.com/apache/arrow-go/v18/arrow"
+	"github.com/cloudquery/plugin-sdk/v4/message"
+	"github.com/samber/lo"
+)
+
+func sliceToSet(slice []string) map[string]struct{} {
+	return lo.Associate(slice, func(s string) (string, struct{}) {
+		return s, struct{}{}
+	})
+}
+
+func extractCqIDs(msgs message.WriteInserts) ([]string, error) {
+	cqIDs := make([]string, 0)
+	for _, msg := range msgs {
+		batchCQIDs, err := getCQIDs(msg.Record)
+		if err != nil {
+			return nil, err
+		}
+		cqIDs = append(cqIDs, batchCQIDs...)
+	}
+	return cqIDs, nil
+}
+
+func getCQIDs(r arrow.Record) ([]string, error) {
+	cqIDColIndex, err := getColumnIndexWithName(r, CQIDColumn)
+	if err != nil {
+		return nil, err
+	}
+	results := make([]string, r.NumRows())
+	for i := range int(r.NumRows()) {
+		results[i] = r.Column(cqIDColIndex).ValueStr(i)
+	}
+	return results, nil
+}
+
+func getColumnIndexWithName(r arrow.Record, name string) (int, error) {
+	for i := range int(r.NumCols()) {
+		if r.Schema().Field(i).Name == name {
+			return i, nil
+		}
+	}
+	return -1, fmt.Errorf("column %s not found", name) // should never happen
+}

--- a/plugins/destination/bigquery/client/embeddings_write.go
+++ b/plugins/destination/bigquery/client/embeddings_write.go
@@ -1,0 +1,161 @@
+package client
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"strings"
+	"text/template"
+
+	"github.com/cloudquery/plugin-sdk/v4/message"
+)
+
+const (
+	CQIDColumn = "_cq_id"
+)
+
+func (c *ConcreteEmbeddingsClient) WriteTableBatch(ctx context.Context, name string, msgs message.WriteInserts) error {
+	if !c.hasMigrated {
+		if err := c.MigrateTables(ctx); err != nil {
+			return err
+		}
+		c.hasMigrated = true
+	}
+
+	tableConfig, err := c.findTableConfig(name)
+	if err != nil {
+		return err
+	}
+
+	cqIDs, err := extractCqIDs(msgs)
+	if err != nil {
+		return fmt.Errorf("failed to extract CQ IDs: %w", err)
+	}
+
+	query, err := c.buildEmbeddingQuery(tableConfig, cqIDs)
+	if err != nil {
+		return fmt.Errorf("failed to build embedding query: %w", err)
+	}
+
+	job, err := c.client.client.Query(query).Run(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to execute embedding query: %w", err)
+	}
+
+	status, err := job.Wait(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to wait for embedding query: %w", err)
+	}
+
+	if status.Err() != nil {
+		return fmt.Errorf("embedding query failed: %w", status.Err())
+	}
+
+	return nil
+}
+
+func (c *ConcreteEmbeddingsClient) buildEmbeddingQuery(tableConfig *TableConfig, cqIDs []string) (string, error) {
+	// Build embed columns concatenated with newlines
+	embedColumnsExpr := strings.Join(tableConfig.EmbedColumns, " || '\\n' || ")
+
+	// Build metadata columns for SELECT
+	metadataColumns := make([]string, len(tableConfig.MetadataColumns))
+	copy(metadataColumns, tableConfig.MetadataColumns)
+	metadataColumnsStr := strings.Join(metadataColumns, ", ")
+
+	// Build WHERE clause for CQ IDs
+	cqIDList := "'" + strings.Join(cqIDs, "', '") + "'"
+
+	// Build the query template
+	queryTemplate := `
+INSERT INTO ` + "`{{.ProjectID}}.{{.DatasetID}}.{{.TargetTableName}}`" + ` ({{.MetadataColumns}}, chunk_id, chunk_text, embedding)
+WITH docs AS (
+  SELECT 
+    {{.MetadataColumns}},
+    {{.EmbedColumnsExpr}} AS content
+  FROM ` + "`{{.ProjectID}}.{{.DatasetID}}.{{.SourceTableName}}`" + `
+  WHERE _cq_id IN ({{.CqIDList}})
+),
+params AS (
+  SELECT 
+    {{.ChunkSize}} AS chunk_size,
+    {{.ChunkOverlap}} AS overlap
+),
+offsets AS (
+  SELECT 
+    {{.MetadataColumns}},
+    GENERATE_ARRAY(0, LENGTH(d.content) - 1, p.chunk_size - p.overlap) AS starts,
+    d.content,
+    p.chunk_size
+  FROM docs d, params p
+),
+chunks AS (
+  SELECT
+    {{.MetadataColumns}},
+    i AS chunk_id,
+    SUBSTR(content, start + 1, chunk_size) AS chunk_text
+  FROM offsets, UNNEST(starts) AS start WITH OFFSET i
+),
+embeddings AS (
+  SELECT
+    {{.MetadataColumns}},
+    chunk_id,
+    chunk_text,
+    ml_generate_embedding_result AS embedding
+  FROM ML.GENERATE_EMBEDDING(
+    MODEL ` + "`{{.ProjectID}}.{{.DatasetID}}.{{.RemoteModelName}}`" + `,
+    (
+      SELECT 
+        {{.MetadataColumns}},
+        chunk_id,
+        chunk_text,
+        chunk_text AS content
+      FROM chunks
+    )
+  )
+)
+SELECT
+  {{.MetadataColumns}},
+  chunk_id,
+  chunk_text,
+  embedding
+FROM embeddings`
+
+	// Prepare template data
+	tmplData := struct {
+		ProjectID        string
+		DatasetID        string
+		SourceTableName  string
+		TargetTableName  string
+		MetadataColumns  string
+		EmbedColumnsExpr string
+		CqIDList         string
+		ChunkSize        int
+		ChunkOverlap     int
+		RemoteModelName  string
+	}{
+		ProjectID:        c.ProjectID,
+		DatasetID:        c.DatasetID,
+		SourceTableName:  tableConfig.SourceTableName,
+		TargetTableName:  tableConfig.TargetTableName,
+		MetadataColumns:  metadataColumnsStr,
+		EmbedColumnsExpr: embedColumnsExpr,
+		CqIDList:         cqIDList,
+		ChunkSize:        c.spec.TextSplitter.RecursiveText.ChunkSize,
+		ChunkOverlap:     c.spec.TextSplitter.RecursiveText.ChunkOverlap,
+		RemoteModelName:  c.spec.RemoteModelName,
+	}
+
+	// Execute template
+	tmpl, err := template.New("embedding_query").Parse(queryTemplate)
+	if err != nil {
+		return "", fmt.Errorf("failed to parse query template: %w", err)
+	}
+
+	var buf bytes.Buffer
+	if err := tmpl.Execute(&buf, tmplData); err != nil {
+		return "", fmt.Errorf("failed to execute query template: %w", err)
+	}
+
+	return buf.String(), nil
+}

--- a/plugins/destination/bigquery/client/schema.json
+++ b/plugins/destination/bigquery/client/schema.json
@@ -8,6 +8,24 @@
       "pattern": "^[-+]?([0-9]*(\\.[0-9]*)?[a-z]+)+$",
       "title": "CloudQuery configtype.Duration"
     },
+    "RecursiveText": {
+      "properties": {
+        "chunk_size": {
+          "type": "integer",
+          "minimum": 1
+        },
+        "chunk_overlap": {
+          "type": "integer",
+          "minimum": 0
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "chunk_size",
+        "chunk_overlap"
+      ]
+    },
     "Spec": {
       "properties": {
         "project_id": {
@@ -62,6 +80,17 @@
         "client_project_id": {
           "type": "string",
           "description": "Identifies the project context bq client should execute in. Defaults to the project_id. You can set it to *detect-project-id* to automatically detect project id from credentials in the environment."
+        },
+        "text_embeddings": {
+          "oneOf": [
+            {
+              "$ref": "#/$defs/TextEmbeddingsSpec",
+              "description": "Optional: Configuration for creating text embeddings for certain tables"
+            },
+            {
+              "type": "null"
+            }
+          ]
         }
       },
       "additionalProperties": false,
@@ -70,6 +99,95 @@
         "project_id",
         "dataset_id"
       ]
+    },
+    "TableConfig": {
+      "properties": {
+        "source_table_name": {
+          "type": "string",
+          "minLength": 1
+        },
+        "target_table_name": {
+          "type": "string",
+          "minLength": 1
+        },
+        "embed_columns": {
+          "oneOf": [
+            {
+              "items": {
+                "type": "string"
+              },
+              "type": "array",
+              "minItems": 1
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "metadata_columns": {
+          "oneOf": [
+            {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "source_table_name",
+        "target_table_name",
+        "embed_columns"
+      ],
+      "description": "TableConfig defines per-source-table embedding configuration."
+    },
+    "TextEmbeddingsSpec": {
+      "properties": {
+        "remote_model_name": {
+          "type": "string",
+          "minLength": 1
+        },
+        "tables": {
+          "oneOf": [
+            {
+              "items": {
+                "$ref": "#/$defs/TableConfig"
+              },
+              "type": "array"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "text_splitter": {
+          "$ref": "#/$defs/TextSplitter"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "remote_model_name"
+      ]
+    },
+    "TextSplitter": {
+      "properties": {
+        "recursive_text": {
+          "$ref": "#/$defs/RecursiveText"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "recursive_text"
+      ],
+      "description": "TextSplitter defines how source text should be split into chunks for embedding."
     }
   }
 }

--- a/plugins/destination/bigquery/client/write.go
+++ b/plugins/destination/bigquery/client/write.go
@@ -94,7 +94,7 @@ func (c *Client) WriteTableBatch(ctx context.Context, name string, msgs message.
 		return fmt.Errorf("failed to put item into BigQuery table %s: %w", name, err)
 	}
 
-	return nil
+	return c.embeddingsClient.WriteTableBatch(ctx, name, msgs)
 }
 
 func getValueForBigQuery(col arrow.Array, i int) any {

--- a/plugins/destination/bigquery/docs/_licenses.md
+++ b/plugins/destination/bigquery/docs/_licenses.md
@@ -13,9 +13,9 @@ The following tools / packages are used in this plugin:
 | cloud.google.com/go/compute/metadata | Apache-2.0 |
 | cloud.google.com/go/iam | Apache-2.0 |
 | github.com/adrg/xdg | MIT |
+| github.com/apache/arrow-go/v18 | Apache-2.0 |
 | github.com/apache/arrow/go/v13 | Apache-2.0 |
 | github.com/apache/arrow/go/v15 | Apache-2.0 |
-| github.com/apache/arrow-go/v18 | Apache-2.0 |
 | github.com/apapsch/go-jsonmerge/v2 | MIT |
 | github.com/aws/aws-sdk-go-v2 | Apache-2.0 |
 | github.com/aws/aws-sdk-go-v2/config | Apache-2.0 |
@@ -36,8 +36,9 @@ The following tools / packages are used in this plugin:
 | github.com/aws/smithy-go/internal/sync/singleflight | BSD-3-Clause |
 | github.com/bahlo/generic-list-go | BSD-3-Clause |
 | github.com/buger/jsonparser | MIT |
-| github.com/cenkalti/backoff/v4 | MIT |
+| github.com/cenkalti/backoff/v5 | MIT |
 | github.com/cloudquery/cloudquery-api-go | MPL-2.0 |
+| github.com/cloudquery/codegen/jsonschema/docs | MPL-2.0 |
 | github.com/cloudquery/plugin-pb-go | MPL-2.0 |
 | github.com/cloudquery/plugin-sdk/v2/internal/glob | MIT |
 | github.com/cloudquery/plugin-sdk/v2/schema | MIT |
@@ -51,7 +52,6 @@ The following tools / packages are used in this plugin:
 | github.com/go-logr/logr | Apache-2.0 |
 | github.com/go-logr/stdr | Apache-2.0 |
 | github.com/goccy/go-json | MIT |
-| github.com/golang/groupcache/lru | Apache-2.0 |
 | github.com/google/flatbuffers/go | Apache-2.0 |
 | github.com/google/s2a-go | Apache-2.0 |
 | github.com/google/uuid | BSD-3-Clause |
@@ -61,7 +61,6 @@ The following tools / packages are used in this plugin:
 | github.com/grpc-ecosystem/grpc-gateway/v2 | BSD-3-Clause |
 | github.com/hashicorp/go-cleanhttp | MPL-2.0 |
 | github.com/hashicorp/go-retryablehttp | MPL-2.0 |
-| github.com/huandu/xstrings | MIT |
 | github.com/invopop/jsonschema | MIT |
 | github.com/klauspost/compress | Apache-2.0 |
 | github.com/klauspost/compress/internal/snapref | BSD-3-Clause |
@@ -73,14 +72,16 @@ The following tools / packages are used in this plugin:
 | github.com/pierrec/lz4/v4 | BSD-3-Clause |
 | github.com/pmezard/go-difflib/difflib | BSD-3-Clause |
 | github.com/rs/zerolog | MIT |
+| github.com/samber/lo | MIT |
 | github.com/santhosh-tekuri/jsonschema/v6 | Apache-2.0 |
 | github.com/spf13/cobra | Apache-2.0 |
 | github.com/spf13/pflag | BSD-3-Clause |
+| github.com/stoewer/go-strcase | MIT |
 | github.com/stretchr/testify | MIT |
 | github.com/thoas/go-funk | MIT |
 | github.com/wk8/go-ordered-map/v2 | Apache-2.0 |
 | github.com/zeebo/xxh3 | BSD-2-Clause |
-| go.opencensus.io | Apache-2.0 |
+| go.opentelemetry.io/auto/sdk | Apache-2.0 |
 | go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc | Apache-2.0 |
 | go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp | Apache-2.0 |
 | go.opentelemetry.io/otel | Apache-2.0 |

--- a/plugins/destination/bigquery/docs/overview.md
+++ b/plugins/destination/bigquery/docs/overview.md
@@ -81,6 +81,50 @@ This is the top-level spec used by the BigQuery destination plugin.
 
   Maximum interval between batch writes.
 
+- `text_embeddings` (`object`) (optional)
+
+  Configuration for creating text embeddings for certain tables using a Vertex AI model.
+
+  A remote model must be attached to the dataset before using this feature, and its name supplied in the `remote_model_name` field.
+  
+  - `remote_model_name` (`string`) (required)
+
+    The name of the remote model to use for text embeddings.
+
+  - `tables` (`array`) (required)
+
+    The tables to create text embeddings for. Each one must have its own configuration.
+
+    - `source_table_name` (`string`) (required)
+      
+      The name of the source table to create text embeddings for.
+
+    - `target_table_name` (`string`) (required)
+      
+      The name of the target table in which to store the embeddings.
+
+    - `embed_columns` (`array`) (required)
+
+      The columns to use as content for the embeddings generation function. They will be concatenated in the order they are provided.
+
+    - `metadata_columns` (`array`) (optional)
+      
+      Which columns to copy as-is from the source table to the target table. `_cq_id` is always included.
+
+  - `text_splitter` (`object`) (optional)
+
+    The text splitter configuration to use for text embeddings. Currently only `recursive_text` is supported.
+
+    - `recursive_text` (`object`) (required)
+
+      - `chunk_size` (`integer`) (required)
+
+        The size of the chunks in characters (not tokens). Defaults to `1000`.
+
+      - `chunk_overlap` (`integer`) (required)
+      
+        The overlap between chunks in characters (not tokens). Defaults to `100`.
+
 ## Underlying library
 
 We use the official [cloud.google.com/go/bigquery](https://pkg.go.dev/cloud.google.com/go/bigquery) package for database connection.


### PR DESCRIPTION
Implements text embedding generation via Vertex AI models at insertion time.

The new optional spec object looks like this:

```

- `text_embeddings` (`object`) (optional)

  Configuration for creating text embeddings for certain tables using a Vertex AI model.

  A remote model must be attached to the dataset before using this feature, and its name supplied in the `remote_model_name` field.
  
  - `remote_model_name` (`string`) (required)

    The name of the remote model to use for text embeddings.

  - `tables` (`array`) (required)

    The tables to create text embeddings for. Each one must have its own configuration.

    - `source_table_name` (`string`) (required)
      
      The name of the source table to create text embeddings for.

    - `target_table_name` (`string`) (required)
      
      The name of the target table in which to store the embeddings.

    - `embed_columns` (`array`) (required)

      The columns to use as content for the embeddings generation function. They will be concatenated in the order they are provided.

    - `metadata_columns` (`array`) (optional)
      
      Which columns to copy as-is from the source table to the target table. `_cq_id` is always included.

  - `text_splitter` (`object`) (optional)

    The text splitter configuration to use for text embeddings. Currently only `recursive_text` is supported.

    - `recursive_text` (`object`) (required)

      - `chunk_size` (`integer`) (required)

        The size of the chunks in characters (not tokens). Defaults to `1000`.

      - `chunk_overlap` (`integer`) (required)
      
        The overlap between chunks in characters (not tokens). Defaults to `100`.
```

This is an example that runs `cloudquery sync` from Github to BigQuery and generates embeddings for all open Github Issues onto a `github_issues_embeddings` table as part of the sync, ready to be used by a RAG model or any other use case (like search, anomaly detection, classification, etc).

```
$ cloudquery sync github_to_bigquery.yaml
Loading spec(s) from github_to_bigquery.yaml
Starting sync for: github (cloudquery/github@v14.1.1) -> [bigquery (grpc@localhost:7777)]
Sync completed successfully. Resources: 157, Errors: 0, Warnings: 0, Time: 31s
```

Note that the dataset must already have a connected remote model, linking a Vertex AI text embedding model at the time where the sync runs, and its name must be supplied in the spec.

<img width="1234" height="718" alt="Screenshot 2025-09-02 at 17 23 12" src="https://github.com/user-attachments/assets/1098bafe-6ff1-41f9-ac79-d07fa100c3f0" />
