### PR TITLE
doc: Set `send_sync_summary: true` for all destinations

### DIFF
--- a/plugins/destination/azblob/docs/_configuration.md
+++ b/plugins/destination/azblob/docs/_configuration.md
@@ -5,6 +5,7 @@ spec:
   path: "cloudquery/azblob"
   registry: "cloudquery"
   version: "VERSION_DESTINATION_AZBLOB"
+  send_sync_summary: true
   spec:
     storage_account: "cqdestinationazblob"
     container: "test"

--- a/plugins/destination/bigquery/docs/_configuration.md
+++ b/plugins/destination/bigquery/docs/_configuration.md
@@ -6,6 +6,7 @@ spec:
   registry: cloudquery
   version: "VERSION_DESTINATION_BIGQUERY"
   write_mode: "append"
+  send_sync_summary: true
   # Learn more about the configuration options at https://cql.ink/bigquery_destination
   spec:
     project_id: ${PROJECT_ID}

--- a/plugins/destination/clickhouse/docs/_configuration.md
+++ b/plugins/destination/clickhouse/docs/_configuration.md
@@ -6,6 +6,7 @@ spec:
   registry: "cloudquery"
   version: "VERSION_DESTINATION_CLICKHOUSE"
   write_mode: "append"
+  send_sync_summary: true
   # Learn more about the configuration options at https://cql.ink/clickhouse_destination
   spec:
     connection_string: "clickhouse://${CH_USER}:${CH_PASSWORD}@localhost:9000/${CH_DATABASE}"

--- a/plugins/destination/clickhouse/docs/overview.md
+++ b/plugins/destination/clickhouse/docs/overview.md
@@ -98,6 +98,7 @@ spec:
   registry:   "cloudquery"
   version:    "VERSION_DESTINATION_CLICKHOUSE"
   write_mode: "append"
+  send_sync_summary: true
 
   spec:
     connection_string: "clickhouse://${CH_USER}:${CH_PASSWORD}@localhost:9000/${CH_DATABASE}"
@@ -252,6 +253,7 @@ spec:
   registry:   "cloudquery"
   version:    "VERSION_DESTINATION_CLICKHOUSE"
   write_mode: "append"
+  send_sync_summary: true
 
   spec:
     connection_string: "clickhouse://${CH_USER}:${CH_PASSWORD}@localhost:9000/${CH_DATABASE}?debug=true"

--- a/plugins/destination/duckdb/docs/_configuration.md
+++ b/plugins/destination/duckdb/docs/_configuration.md
@@ -8,6 +8,7 @@ spec:
   registry: cloudquery
   version: "VERSION_DESTINATION_DUCKDB"
   write_mode: "overwrite-delete-stale"
+  send_sync_summary: true
   # Learn more about the configuration options at https://cql.ink/duckdb_destination
   spec:
     connection_string: ./database.db

--- a/plugins/destination/elasticsearch/docs/_configuration.md
+++ b/plugins/destination/elasticsearch/docs/_configuration.md
@@ -8,6 +8,7 @@ spec:
   registry: cloudquery
   version: "VERSION_DESTINATION_ELASTICSEARCH"
   write_mode: "overwrite-delete-stale"
+  send_sync_summary: true
   spec:
     # Elastic Cloud configuration parameters
     cloud_id: "${ELASTICSEARCH_CLOUD_ID}"

--- a/plugins/destination/file/docs/_configuration.md
+++ b/plugins/destination/file/docs/_configuration.md
@@ -8,6 +8,7 @@ spec:
   registry: "cloudquery"
   version: "VERSION_DESTINATION_FILE"
   write_mode: "append"
+  send_sync_summary: true
   # Learn more about the configuration options at https://cql.ink/file_destination
   spec:
     path: "path/to/files/{{TABLE}}/{{UUID}}.{{FORMAT}}"

--- a/plugins/destination/firehose/docs/_configuration.md
+++ b/plugins/destination/firehose/docs/_configuration.md
@@ -6,6 +6,7 @@ spec:
   registry: "cloudquery"
   version: "VERSION_DESTINATION_FIREHOSE"
   write_mode: "append" # this plugin only supports 'append' mode
+  send_sync_summary: true
   spec:
     # Required parameters e.g. arn:aws:firehose:us-east-1:111122223333:deliverystream/TestRedshiftStream
     stream_arn: "${FIREHOSE_STREAM_ARN}"

--- a/plugins/destination/gcs/docs/_configuration.md
+++ b/plugins/destination/gcs/docs/_configuration.md
@@ -8,6 +8,7 @@ spec:
   registry: "cloudquery"
   version: "VERSION_DESTINATION_GCS"
   write_mode: "append"
+  send_sync_summary: true
   spec:
     bucket: "bucket_name"
     path: "path/to/files/{{TABLE}}/{{UUID}}.{{FORMAT}}"

--- a/plugins/destination/gremlin/docs/_configuration.md
+++ b/plugins/destination/gremlin/docs/_configuration.md
@@ -7,6 +7,7 @@ spec:
   path: "cloudquery/gremlin"
   registry: "cloudquery"
   version: "VERSION_DESTINATION_GREMLIN"
+  send_sync_summary: true
   spec:
     endpoint: "ws://localhost:8182"
     # Optional parameters

--- a/plugins/destination/kafka/docs/_configuration.md
+++ b/plugins/destination/kafka/docs/_configuration.md
@@ -10,6 +10,7 @@ spec:
   registry: "cloudquery"
   version: "VERSION_DESTINATION_KAFKA"
   write_mode: "append"
+  send_sync_summary: true
   spec:
     # required - list of brokers to connect to
     brokers: ["<broker-host>:<broker-port>"]

--- a/plugins/destination/kafka/docs/confluent_cloud.md
+++ b/plugins/destination/kafka/docs/confluent_cloud.md
@@ -19,6 +19,7 @@ spec:
   registry: "cloudquery"
   version: "VERSION_DESTINATION_KAFKA"
   write_mode: "append"
+  send_sync_summary: true
   spec:
     # required - list of brokers to connect to
     brokers: ["${CONFLUENT_BOOTSTRAP_SERVER}"]

--- a/plugins/destination/meilisearch/docs/_configuration.md
+++ b/plugins/destination/meilisearch/docs/_configuration.md
@@ -8,6 +8,7 @@ spec:
   registry: cloudquery
   version: "VERSION_DESTINATION_MEILISEARCH"
   write_mode: "overwrite"
+  send_sync_summary: true
   # Learn more about the configuration options at https://cql.ink/meilisearch_destination
   spec:
     # meilisearch plugin spec

--- a/plugins/destination/mongodb/docs/_configuration.md
+++ b/plugins/destination/mongodb/docs/_configuration.md
@@ -7,6 +7,7 @@ spec:
   path: "cloudquery/mongodb"
   registry: "cloudquery"
   version: "VERSION_DESTINATION_MONGODB"
+  send_sync_summary: true
   spec:
     # required, a connection string in the format mongodb://localhost:27017
     connection_string: "${MONGODB_CONNECTION_STRING}"

--- a/plugins/destination/mssql/docs/_configuration.md
+++ b/plugins/destination/mssql/docs/_configuration.md
@@ -5,6 +5,7 @@ spec:
   path: "cloudquery/mssql"
   registry: "cloudquery"
   version: "VERSION_DESTINATION_MSSQL"
+  send_sync_summary: true
   spec:
     # Connection string in the format `server=localhost;user id=SA;password=yourStrongP@ssword;port=1433;database=cloudquery;`
     connection_string: "${MSSQL_CONNECTION_STRING}"

--- a/plugins/destination/mssql/docs/configuration.md
+++ b/plugins/destination/mssql/docs/configuration.md
@@ -69,6 +69,7 @@ spec:
   path:     "cloudquery/mssql"
   registry:   "cloudquery"
   version:  "VERSION_DESTINATION_MSSQL"
+  send_sync_summary: true
 
   spec:
     connection_string: "${MSSQL_CONNECTION_STRING};log=255"

--- a/plugins/destination/mssql/docs/example.md
+++ b/plugins/destination/mssql/docs/example.md
@@ -64,6 +64,7 @@ spec:
   path: "cloudquery/mssql"
   registry: "cloudquery"
   version: "VERSION_DESTINATION_MSSQL"
+  send_sync_summary: true
 
   spec:
     connection_string: "server=localhost;user id=SA;password=yourStrongP@ssword;port=1433;database=cloudquery;"

--- a/plugins/destination/mysql/docs/_configuration.md
+++ b/plugins/destination/mysql/docs/_configuration.md
@@ -5,6 +5,7 @@ spec:
   path: "cloudquery/mysql"
   registry: "cloudquery"
   version: "VERSION_DESTINATION_MYSQL"
+  send_sync_summary: true
   # Learn more about the configuration options at https://cql.ink/mysql_destination
   spec:
     connection_string: "user:password@/dbname"

--- a/plugins/destination/mysql/docs/example.md
+++ b/plugins/destination/mysql/docs/example.md
@@ -38,6 +38,7 @@ spec:
   path: "cloudquery/mysql"
   registry: "cloudquery"
   version: "VERSION_DESTINATION_MYSQL"
+  send_sync_summary: true
 
   spec:
     connection_string: "root:password@/cloudquery"

--- a/plugins/destination/neo4j/docs/_configuration.md
+++ b/plugins/destination/neo4j/docs/_configuration.md
@@ -7,6 +7,7 @@ spec:
   path: "cloudquery/neo4j"
   registry: "cloudquery"
   version: "VERSION_DESTINATION_NEO4J"
+  send_sync_summary: true
   # Learn more about the configuration options at https://cql.ink/neo4j_destination
   spec:
     connection_string: "${NEO4J_CONNECTION_STRING}"

--- a/plugins/destination/postgresql/docs/_configuration.md
+++ b/plugins/destination/postgresql/docs/_configuration.md
@@ -8,6 +8,7 @@ spec:
   registry: "cloudquery"
   version: "VERSION_DESTINATION_POSTGRESQL"
   write_mode: "overwrite-delete-stale"
+  send_sync_summary: true
   # Learn more about the configuration options at https://cql.ink/postgresql_destination
   spec:
     # set the environment variable in DSN format like "user=postgres password=pass+0-[word host=localhost port=5432 dbname=postgres sslmode=disable"

--- a/plugins/destination/postgresql/docs/overview.md
+++ b/plugins/destination/postgresql/docs/overview.md
@@ -139,6 +139,7 @@ spec:
   path: cloudquery/postgresql
   registry: cloudquery
   version: "VERSION_DESTINATION_POSTGRESQL"
+  send_sync_summary: true
   spec:
     connection_string: ${PG_CONNECTION_STRING}
     pgx_log_level: debug # Available: error, warn, info, debug, trace. Default: "error"

--- a/plugins/destination/s3/docs/_configuration.md
+++ b/plugins/destination/s3/docs/_configuration.md
@@ -10,6 +10,7 @@ spec:
   registry: "cloudquery"
   version: "VERSION_DESTINATION_S3"
   write_mode: "append"
+  send_sync_summary: true
   # Learn more about the configuration options at https://cql.ink/s3_destination
   spec:
     bucket: "bucket_name"

--- a/plugins/destination/snowflake/docs/_configuration.md
+++ b/plugins/destination/snowflake/docs/_configuration.md
@@ -8,6 +8,7 @@ spec:
   registry: cloudquery
   version: "VERSION_DESTINATION_SNOWFLAKE"
   write_mode: "append"
+  send_sync_summary: true
   # Learn more about the configuration options at https://cql.ink/snowflake_destination
   spec:
     connection_string: "${SNOWFLAKE_CONNECTION_STRING}"

--- a/plugins/destination/snowflake/docs/overview.md
+++ b/plugins/destination/snowflake/docs/overview.md
@@ -32,6 +32,7 @@ Authentication of the connection to Snowflake can be specified using:
   kind: destination
   spec:
     name: snowflake
+    send_sync_summary: true
     ...
     spec:
       connection_string: "user:pass@account/db/schema?warehouse=wh"
@@ -43,6 +44,7 @@ Authentication of the connection to Snowflake can be specified using:
   kind: destination
   spec:
     name: snowflake
+    send_sync_summary: true
     ...
     spec:
       connection_string: "user@account/database/schema?warehouse=wh"
@@ -62,6 +64,7 @@ Authentication of the connection to Snowflake can be specified using:
   kind: destination
   spec:
     name: snowflake
+    send_sync_summary: true
     ...
     spec:
       connection_string: "user@account/database/schema?warehouse=wh"
@@ -86,6 +89,7 @@ Authentication of the connection to Snowflake can be specified using:
   kind: destination
   spec:
     name: snowflake
+    send_sync_summary: true
     ...
     spec:
       connection_string: "user:pass@account/db/schema?warehouse=wh&authenticator=oauth&token=token"

--- a/plugins/destination/sqlite-python/docs/_configuration.md
+++ b/plugins/destination/sqlite-python/docs/_configuration.md
@@ -7,6 +7,7 @@ spec:
   path: cloudquery/sqlite-python
   registry: cloudquery
   version: "VERSION_DESTINATION_SQLITE_PYTHON"
+  send_sync_summary: true
   # Learn more about the configuration options at https://cql.ink/sqlite-python_destination
   spec:
     connection_string: ./db.sql

--- a/plugins/destination/sqlite/docs/configuration.md
+++ b/plugins/destination/sqlite/docs/configuration.md
@@ -11,6 +11,7 @@ spec:
   path: cloudquery/sqlite
   registry: cloudquery
   version: "VERSION_DESTINATION_SQLITE"
+  send_sync_summary: true
   # Learn more about the configuration options at https://cql.ink/sqlite_destination
   spec:
     connection_string: ./db.sql


### PR DESCRIPTION
The `cloudquery_sync_summary` table is a powerful to tool that users usually don't know about until they run into an issue where they wish they had it enabled. By setting it in the docs, hopefully more people will have it enabled before they run into the issue where they wish they already had it.


In a future release of plugins/cli we should make it default to enabled, but this doc change is a good first step