### PR TITLE
feat: Cloud-API-based AI Onboarding command.

### DIFF
--- a/cli/cmd/ai.go
+++ b/cli/cmd/ai.go
@@ -1,0 +1,122 @@
+package cmd
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	"strings"
+
+	cloudquery_api "github.com/cloudquery/cloudquery-api-go"
+	"github.com/cloudquery/cloudquery/cli/v6/internal/api"
+
+	"github.com/fatih/color"
+)
+
+var (
+	aiBold    = color.New(color.Bold)
+	aiSuccess = color.New(color.Bold, color.FgGreen)
+	aiInfo    = color.New(color.Bold, color.FgCyan)
+)
+
+func aiCmd(ctx context.Context, client *cloudquery_api.ClientWithResponses, teamName string) error {
+
+	// Track AI session start
+	TrackAISessionStarted(ctx, invocationUUID.UUID)
+
+	fmt.Println()
+	aiSuccess.Println("🤖 CloudQuery AI Assistant")
+	fmt.Println("I'm here to help you set up CloudQuery syncs!")
+	fmt.Println("Type 'exit' or 'quit' to end the conversation.")
+	fmt.Println()
+	fmt.Println("What are you trying to build with CloudQuery?")
+	fmt.Println()
+
+	if _, err := client.AIOnboardingNewConversationWithResponse(ctx, teamName, cloudquery_api.AIOnboardingNewConversationJSONRequestBody{}); err != nil {
+		return fmt.Errorf("failed to start new conversation: %w", err)
+	}
+
+	scanner := bufio.NewScanner(os.Stdin)
+
+	for {
+		fmt.Print(aiInfo.Sprint("You: "))
+		if !scanner.Scan() {
+			break
+		}
+
+		userInput := strings.TrimSpace(scanner.Text())
+		if userInput == "" {
+			continue
+		}
+
+		// Check for exit commands
+		if strings.ToLower(userInput) == "exit" || strings.ToLower(userInput) == "quit" {
+			fmt.Println("Goodbye! 👋")
+			break
+		}
+
+		response, err := api.Chat(ctx, client, teamName, &userInput, nil)
+		if err != nil {
+			return fmt.Errorf("failed to chat: %w", err)
+		}
+		for response.FunctionCall != nil {
+			switch *response.FunctionCall {
+			case "create_spec_file":
+				err := createSpecFile(response.FunctionCallArguments["filename_without_extension"].(string), response.FunctionCallArguments["content"].(string))
+				if err != nil {
+					return fmt.Errorf("failed to create spec file: %w", err)
+				}
+				response, err = api.Chat(ctx, client, teamName, nil, &[]api.FunctionCallOutput{
+					{
+						Name:      "create_spec_file",
+						CallID:    response.FunctionCallID,
+						Arguments: response.FunctionCallArguments,
+						Output:    "Spec file created",
+					},
+				})
+				if err != nil {
+					return fmt.Errorf("failed to chat: %w", err)
+				}
+			case "cloudquery_test":
+				response, err = api.Chat(ctx, client, teamName, nil, &[]api.FunctionCallOutput{
+					{
+						Name:      "cloudquery_test",
+						CallID:    response.FunctionCallID,
+						Arguments: response.FunctionCallArguments,
+						Output:    cloudqueryTest(response.FunctionCallArguments["filename"].(string)),
+					},
+				})
+				if err != nil {
+					return fmt.Errorf("failed to chat: %w", err)
+				}
+			default:
+				return fmt.Errorf("unsupported function call: %s", *response.FunctionCall)
+			}
+		}
+
+		fmt.Printf("\n%s %s\n\n", aiBold.Sprint("AI:"), *response.Message)
+	}
+
+	// Track AI session end
+	TrackAISessionEnded(ctx, invocationUUID.UUID)
+
+	return nil
+}
+
+func createSpecFile(filenameWithoutExtension, content string) error {
+	return os.WriteFile(filenameWithoutExtension+".yaml", []byte(content), 0644)
+}
+
+func cloudqueryTest(filenameWithoutExtension string) string {
+	cmd := exec.Command("cloudquery", "test", filenameWithoutExtension+".yaml")
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	if err != nil {
+		return fmt.Sprintf("cloudquery test failed: %v\nOutput:\n%s", err, out.String())
+	}
+	return fmt.Sprintf("Result of cloudquery test:\n%s", out.String())
+}

--- a/cli/cmd/analytics.go
+++ b/cli/cmd/analytics.go
@@ -12,6 +12,7 @@ import (
 	"github.com/cloudquery/cloudquery/cli/v6/internal/specs/v0"
 	"github.com/cloudquery/plugin-pb-go/metrics"
 	"github.com/cloudquery/plugin-pb-go/pb/analytics/v0"
+	guuid "github.com/google/uuid"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials"
 	"google.golang.org/grpc/credentials/insecure"
@@ -110,4 +111,24 @@ func (c *AnalyticsClient) Close() error {
 		return c.conn.Close()
 	}
 	return nil
+}
+
+// TrackAISessionStarted tracks when an AI session begins
+func TrackAISessionStarted(ctx context.Context, invocationUUID guuid.UUID) {
+	// This is a mock implementation - in a real implementation, you would send to analytics
+	if oldAnalyticsClient != nil {
+		// Send AI session started event
+		// For now, we'll just log it
+		fmt.Printf("[ANALYTICS] AI session started: %s\n", invocationUUID.String())
+	}
+}
+
+// TrackAISessionEnded tracks when an AI session ends
+func TrackAISessionEnded(ctx context.Context, invocationUUID guuid.UUID) {
+	// This is a mock implementation - in a real implementation, you would send to analytics
+	if oldAnalyticsClient != nil {
+		// Send AI session ended event
+		// For now, we'll just log it
+		fmt.Printf("[ANALYTICS] AI session ended: %s\n", invocationUUID.String())
+	}
 }

--- a/cli/cmd/root.go
+++ b/cli/cmd/root.go
@@ -212,6 +212,7 @@ func NewCmdRoot() *cobra.Command {
 		pluginCmd,
 		addonCmd,
 		newCmdInit(),
+		newCmdAI(),
 	)
 
 	cmd.CompletionOptions.HiddenDefaultCmd = true

--- a/cli/go.mod
+++ b/cli/go.mod
@@ -179,3 +179,6 @@ replace github.com/invopop/jsonschema => github.com/cloudquery/jsonschema v0.0.0
 
 // github.com/cloudquery/godebouncer @ fix-race
 replace github.com/vnteamopen/godebouncer => github.com/cloudquery/godebouncer v0.0.0-20230626172639-4b59d27e1b8c
+
+// github.com/cloudquery/cloudquery-api-go @ specific commit
+replace github.com/cloudquery/cloudquery-api-go => github.com/cloudquery/cloudquery-api-go v0.0.0-20250915105902-f1c24ed37ec2

--- a/cli/go.sum
+++ b/cli/go.sum
@@ -42,8 +42,8 @@ github.com/chzyer/readline v0.0.0-20180603132655-2972be24d48e h1:fY5BOSpyZCqRo5O
 github.com/chzyer/readline v0.0.0-20180603132655-2972be24d48e/go.mod h1:nSuG5e5PlCu98SY8svDHJxuZscDgtXS6KTTbou5AhLI=
 github.com/chzyer/test v0.0.0-20180213035817-a1ea475d72b1 h1:q763qf9huN11kDQavWsoZXJNW3xEE4JJyHa5Q25/sd8=
 github.com/chzyer/test v0.0.0-20180213035817-a1ea475d72b1/go.mod h1:Q3SI9o4m/ZMnBNeIyt5eFwwo7qiLfzFZmjNmxjkiQlU=
-github.com/cloudquery/cloudquery-api-go v1.14.2 h1:fo65yti2EPM+mM+fkO4do3WesSug3T97wts0RwlTEZY=
-github.com/cloudquery/cloudquery-api-go v1.14.2/go.mod h1:KMcMIaX4l3C2QGHzlqeV7Ac9thX7L/sWXMM5wEmcKZI=
+github.com/cloudquery/cloudquery-api-go v0.0.0-20250915105902-f1c24ed37ec2 h1:ysQB97O36hRfcyObiE1dE/43L3a7r3wLdgAr98EGids=
+github.com/cloudquery/cloudquery-api-go v0.0.0-20250915105902-f1c24ed37ec2/go.mod h1:KMcMIaX4l3C2QGHzlqeV7Ac9thX7L/sWXMM5wEmcKZI=
 github.com/cloudquery/codegen v0.3.31 h1:YDqokUyWSECewoaISY4D2iIpFRTDnPtWmQOFgaQ60c0=
 github.com/cloudquery/codegen v0.3.31/go.mod h1:vU4G8lqQUPHF9ooUQY0RVbbjMPOD/6uqJDgMXfSgK8M=
 github.com/cloudquery/godebouncer v0.0.0-20230626172639-4b59d27e1b8c h1:o8Xwg6fiYnqCQuQVbt3YDvpgrB6Ipc0CNoBgAjvHp6s=

--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,17 @@ module github.com/cloudquery/cloudquery/v6
 
 go 1.25.0
 
-require github.com/cloudquery/cloudquery/cli/v6 v6.27.0
+require (
+	github.com/cloudquery/cloudquery-api-go v1.14.1
+	github.com/cloudquery/cloudquery/cli/v6 v6.27.0
+	github.com/hashicorp/golang-lru/v2 v2.0.7
+	github.com/openai/openai-go v1.12.0
+	github.com/openai/openai-go/v2 v2.4.0
+	github.com/rs/zerolog v1.34.0
+	github.com/samber/lo v1.49.1
+)
+
+require github.com/tidwall/sjson v1.2.5 // indirect
 
 require (
 	github.com/Masterminds/semver v1.5.0 // indirect
@@ -18,7 +28,6 @@ require (
 	github.com/cenkalti/backoff/v5 v5.0.2 // indirect
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
 	github.com/chzyer/readline v0.0.0-20180603132655-2972be24d48e // indirect
-	github.com/cloudquery/cloudquery-api-go v1.14.1 // indirect
 	github.com/cloudquery/plugin-pb-go v1.26.18 // indirect
 	github.com/cloudquery/plugin-sdk/v4 v4.88.1 // indirect
 	github.com/containerd/errdefs v1.0.0 // indirect
@@ -84,10 +93,8 @@ require (
 	github.com/prometheus/procfs v0.15.0 // indirect
 	github.com/rivo/uniseg v0.4.7 // indirect
 	github.com/rs/cors v1.11.1 // indirect
-	github.com/rs/zerolog v1.34.0 // indirect
 	github.com/rudderlabs/analytics-go/v4 v4.2.1 // indirect
 	github.com/russross/blackfriday/v2 v2.1.0 // indirect
-	github.com/samber/lo v1.49.1 // indirect
 	github.com/santhosh-tekuri/jsonschema/v5 v5.3.1 // indirect
 	github.com/schollz/progressbar/v3 v3.14.6 // indirect
 	github.com/segmentio/backo-go v1.1.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -145,6 +145,8 @@ github.com/hashicorp/go-retryablehttp v0.7.8 h1:ylXZWnqa7Lhqpk0L1P1LzDtGcCR0rPVU
 github.com/hashicorp/go-retryablehttp v0.7.8/go.mod h1:rjiScheydd+CxvumBsIrFKlx3iS0jrZ7LvzFGFmuKbw=
 github.com/hashicorp/go-version v1.7.0 h1:5tqGy27NaOTB8yJKUZELlFAS/LTKJkrmONwQKeRZfjY=
 github.com/hashicorp/go-version v1.7.0/go.mod h1:fltr4n8CU8Ke44wwGCBoEymUuxUHl09ZGVZPK5anwXA=
+github.com/hashicorp/golang-lru/v2 v2.0.7 h1:a+bsQ5rvGLjzHuww6tVxozPZFVghXaHOwFs4luLUK2k=
+github.com/hashicorp/golang-lru/v2 v2.0.7/go.mod h1:QeFd9opnmA6QUJc5vARoKUSoFhyfM2/ZepoAG6RGpeM=
 github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=
 github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
 github.com/invopop/jsonschema v0.13.0 h1:KvpoAJWEjR3uD9Kbm2HWJmqsEaHt8lBUpd0qHcIi21E=
@@ -226,6 +228,10 @@ github.com/mostynb/go-grpc-compression v1.2.3/go.mod h1:AghIxF3P57umzqM9yz795+y1
 github.com/mwitkow/go-conntrack v0.0.0-20161129095857-cc309e4a2223/go.mod h1:qRWi+5nqEBWmkhHvq77mSJWrCKwh8bxhgT7d/eI7P4U=
 github.com/oapi-codegen/runtime v1.1.2 h1:P2+CubHq8fO4Q6fV1tqDBZHCwpVpvPg7oKiYzQgXIyI=
 github.com/oapi-codegen/runtime v1.1.2/go.mod h1:SK9X900oXmPWilYR5/WKPzt3Kqxn/uS/+lbpREv+eCg=
+github.com/openai/openai-go v1.12.0 h1:NBQCnXzqOTv5wsgNC36PrFEiskGfO5wccfCWDo9S1U0=
+github.com/openai/openai-go v1.12.0/go.mod h1:g461MYGXEXBVdV5SaR/5tNzNbSfwTBBefwc+LlDCK0Y=
+github.com/openai/openai-go/v2 v2.4.0 h1:ufc/Qf6SEeRLn6xpxHy6hnK6Ip1xXmM4FOne4QnEzo4=
+github.com/openai/openai-go/v2 v2.4.0/go.mod h1:sIUkR+Cu/PMUVkSKhkk742PRURkQOCFhiwJ7eRSBqmk=
 github.com/opencontainers/go-digest v1.0.0 h1:apOUWs51W5PlhuyGyz9FCeeBIOUDA/6nW8Oi/yOhh5U=
 github.com/opencontainers/go-digest v1.0.0/go.mod h1:0JzlMkj0TRzQZfJkVvzbP0HBR3IKzErnv2BNG4W4MAM=
 github.com/opencontainers/image-spec v1.1.1 h1:y0fUlFfIZhPF1W537XOLg0/fcx6zcHCJwooC2xJA040=
@@ -301,6 +307,7 @@ github.com/stretchr/testify v1.10.0 h1:Xv5erBjTwe/5IxqUQTdXv5kgmIvbHo3QQyRwhJsOf
 github.com/stretchr/testify v1.10.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
 github.com/thoas/go-funk v0.9.3 h1:7+nAEx3kn5ZJcnDm2Bh23N2yOtweO14bi//dvRtgLpw=
 github.com/thoas/go-funk v0.9.3/go.mod h1:+IWnUfUmFO1+WVYQWQtIJHeRRdaIyyYglZN7xzUPe4Q=
+github.com/tidwall/gjson v1.14.2/go.mod h1:/wbyibRr2FHMks5tjHJ5F8dMZh3AcwJEMf5vlfC0lxk=
 github.com/tidwall/gjson v1.14.4 h1:uo0p8EbA09J7RQaflQ1aBRffTR7xedD2bcIVSYxLnkM=
 github.com/tidwall/gjson v1.14.4/go.mod h1:/wbyibRr2FHMks5tjHJ5F8dMZh3AcwJEMf5vlfC0lxk=
 github.com/tidwall/match v1.1.1 h1:+Ho715JplO36QYgwN9PGYNhgZvoUSc9X2c80KVTi+GA=
@@ -308,6 +315,8 @@ github.com/tidwall/match v1.1.1/go.mod h1:eRSPERbgtNPcGhD8UCthc6PmLEQXEWd3PRB5JT
 github.com/tidwall/pretty v1.2.0/go.mod h1:ITEVvHYasfjBbM0u2Pg8T2nJnzm8xPwvNhhsoaGGjNU=
 github.com/tidwall/pretty v1.2.1 h1:qjsOFOWWQl+N3RsoF5/ssm1pHmJJwhjlSbZ51I6wMl4=
 github.com/tidwall/pretty v1.2.1/go.mod h1:ITEVvHYasfjBbM0u2Pg8T2nJnzm8xPwvNhhsoaGGjNU=
+github.com/tidwall/sjson v1.2.5 h1:kLy8mja+1c9jlljvWTlSazM7cKDRfJuR/bOJhcY5NcY=
+github.com/tidwall/sjson v1.2.5/go.mod h1:Fvgq9kS/6ociJEDnK0Fk1cpYF4FIW6ZF7LAe+6jwd28=
 github.com/vnteamopen/godebouncer v1.1.1-0.20230626172639-4b59d27e1b8c h1:md2xztL1PUgRdAUnI6TwoCw9sny3Pm0a74UwObvJw+c=
 github.com/vnteamopen/godebouncer v1.1.1-0.20230626172639-4b59d27e1b8c/go.mod h1:0Rxvtp9fhnRCt+k4QrpXY0OPUyyjF0zVO7wCrnsqsCU=
 github.com/wk8/go-ordered-map/v2 v2.1.8 h1:5h/BUHu93oj4gIdvHHHGsScSTMijfx5PeYkE/fJgbpc=


### PR DESCRIPTION
This PR enables the Open AI-based chat onboarding mode on `cloudquery init`.

The Cloud API chat endpoints are already merged and functional but the client API changes haven't been released yet, so this is a WIP simply because I cannot pull that dependency yet, but the code itself should we final minus any bugs.

Upon merging, the `cloudquery init` command will start an AI chat to help the user set up the first sync.

This behaviour can be prevented in the following ways:
- Call `cloudquery init` with the `-source` and `-destination` flags already.
- Use the `-offline` flag to force the existing simple interactive mode.

Chats are per-user and may be subject to per team-day token limits.

Here's an example chat:
<img width="975" height="736" alt="Screenshot 2025-09-15 at 16 04 47" src="https://github.com/user-attachments/assets/334a24fb-42ae-4ee2-92db-32efa6c5143e" />
