### PR TITLE
fix: Fix bug on cloudquery-test argument.

### DIFF
--- a/cli/cmd/ai.go
+++ b/cli/cmd/ai.go
@@ -81,7 +81,7 @@ func aiCmd(ctx context.Context, client *cloudquery_api.ClientWithResponses, team
 						Name:      "cloudquery_test",
 						CallID:    response.FunctionCallID,
 						Arguments: response.FunctionCallArguments,
-						Output:    cloudqueryTest(response.FunctionCallArguments["filename"].(string)),
+						Output:    cloudqueryTest(response.FunctionCallArguments["filename_without_extension"].(string)),
 					},
 				})
 				if err != nil {


### PR DESCRIPTION
The `cloudquery-test` tool on AI Onboarding receives a named argument from the server. The argument name didn't coincide between the tool and the function.