### PR TITLE
fix: Fix checking user's email while they may not be logged in.

### DIFF
--- a/cli/cmd/init.go
+++ b/cli/cmd/init.go
@@ -276,8 +276,14 @@ func initCmd(cmd *cobra.Command, args []string) (initCommandError error) {
 		}
 	}
 
+	// TODO: Temporarily, while we have the @cloudquery.io-only command, let's make sure there's a user before we check their email.
+	userEmail := ""
+	if user != nil {
+		userEmail = user.Email
+	}
+
 	// TODO: For now, this is enabled only for @cloudquery.io users
-	if strings.HasSuffix(user.Email, "@cloudquery.io") {
+	if strings.HasSuffix(userEmail, "@cloudquery.io") {
 		// Check if user and team are set, and if so, run AI command
 		if user != nil && team != "" && !disableAI {
 			err := api.NewConversation(ctx, apiClient, team)


### PR DESCRIPTION
The AI Onboarding tool is on private beta for CloudQuery staff. The check for this was not taking into account that the user may not be logged in, causing a panic if not.