### PR TITLE
chore: Implement AI Onboarding improvements.

### DIFF
--- a/cli/cmd/ai.go
+++ b/cli/cmd/ai.go
@@ -40,6 +40,8 @@ func aiCmd(ctx context.Context, client *cloudquery_api.ClientWithResponses, team
 		}
 		return err
 	case <-ctx.Done():
+		// End the conversation when context is cancelled (e.g., Ctrl+C)
+		api.EndConversation(ctx, client, teamName)
 		fmt.Println("\nGoodbye! 👋")
 		return nil
 	}
@@ -53,10 +55,6 @@ func aiCmdInner(ctx context.Context, client *cloudquery_api.ClientWithResponses,
 	fmt.Println()
 	fmt.Println("What are you trying to build with CloudQuery?")
 	fmt.Println()
-
-	if _, err := client.AIOnboardingNewConversationWithResponse(ctx, teamName, cloudquery_api.AIOnboardingNewConversationJSONRequestBody{}); err != nil {
-		return fmt.Errorf("failed to start new conversation: %w", err)
-	}
 
 	scanner := bufio.NewScanner(os.Stdin)
 
@@ -76,6 +74,8 @@ func aiCmdInner(ctx context.Context, client *cloudquery_api.ClientWithResponses,
 
 		// Check for exit commands
 		if strings.ToLower(userInput) == "exit" || strings.ToLower(userInput) == "quit" {
+			// End the conversation before exiting
+			api.EndConversation(ctx, client, teamName)
 			break
 		}
 

--- a/cli/go.mod
+++ b/cli/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/apache/arrow-go/v18 v18.4.0
 	github.com/bradleyjkemp/cupaloy/v2 v2.8.0
 	github.com/cenkalti/backoff/v4 v4.3.0
-	github.com/cloudquery/cloudquery-api-go v1.14.3
+	github.com/cloudquery/cloudquery-api-go v1.14.4
 	github.com/cloudquery/codegen v0.3.31
 	github.com/cloudquery/plugin-pb-go v1.26.18
 	github.com/cloudquery/plugin-sdk/v4 v4.89.1

--- a/cli/go.sum
+++ b/cli/go.sum
@@ -42,8 +42,8 @@ github.com/chzyer/readline v0.0.0-20180603132655-2972be24d48e h1:fY5BOSpyZCqRo5O
 github.com/chzyer/readline v0.0.0-20180603132655-2972be24d48e/go.mod h1:nSuG5e5PlCu98SY8svDHJxuZscDgtXS6KTTbou5AhLI=
 github.com/chzyer/test v0.0.0-20180213035817-a1ea475d72b1 h1:q763qf9huN11kDQavWsoZXJNW3xEE4JJyHa5Q25/sd8=
 github.com/chzyer/test v0.0.0-20180213035817-a1ea475d72b1/go.mod h1:Q3SI9o4m/ZMnBNeIyt5eFwwo7qiLfzFZmjNmxjkiQlU=
-github.com/cloudquery/cloudquery-api-go v1.14.3 h1:f6nR5PsxGl932BMDzsjK6rXpHQbkQ7xL8DW2yBSUKn0=
-github.com/cloudquery/cloudquery-api-go v1.14.3/go.mod h1:KMcMIaX4l3C2QGHzlqeV7Ac9thX7L/sWXMM5wEmcKZI=
+github.com/cloudquery/cloudquery-api-go v1.14.4 h1:2uq0mNM58SGyX+vuCwqG9aeJXMbkxy5XXdnRT+YHAiA=
+github.com/cloudquery/cloudquery-api-go v1.14.4/go.mod h1:KMcMIaX4l3C2QGHzlqeV7Ac9thX7L/sWXMM5wEmcKZI=
 github.com/cloudquery/codegen v0.3.31 h1:YDqokUyWSECewoaISY4D2iIpFRTDnPtWmQOFgaQ60c0=
 github.com/cloudquery/codegen v0.3.31/go.mod h1:vU4G8lqQUPHF9ooUQY0RVbbjMPOD/6uqJDgMXfSgK8M=
 github.com/cloudquery/godebouncer v0.0.0-20230626172639-4b59d27e1b8c h1:o8Xwg6fiYnqCQuQVbt3YDvpgrB6Ipc0CNoBgAjvHp6s=

--- a/cli/internal/api/client.go
+++ b/cli/internal/api/client.go
@@ -152,8 +152,13 @@ func Chat(ctx context.Context, cl *cloudquery_api.ClientWithResponses, teamName 
 	return chatResp, nil
 }
 
-func NewConversation(ctx context.Context, cl *cloudquery_api.ClientWithResponses, teamName string) error {
-	resp, err := cl.AIOnboardingNewConversationWithResponse(ctx, teamName, cloudquery_api.AIOnboardingNewConversationJSONRequestBody{})
+func NewConversation(ctx context.Context, cl *cloudquery_api.ClientWithResponses, teamName string, resumeConversation bool) error {
+	requestBody := cloudquery_api.AIOnboardingNewConversationJSONRequestBody{}
+	if resumeConversation {
+		tryResume := any(true)
+		requestBody.TryResume = &tryResume
+	}
+	resp, err := cl.AIOnboardingNewConversationWithResponse(ctx, teamName, requestBody)
 	if err != nil {
 		return fmt.Errorf("failed to start new conversation: %w", err)
 	}
@@ -164,4 +169,9 @@ func NewConversation(ctx context.Context, cl *cloudquery_api.ClientWithResponses
 		return fmt.Errorf("failed to start new conversation: %s", resp.Status())
 	}
 	return nil
+}
+
+func EndConversation(ctx context.Context, cl *cloudquery_api.ClientWithResponses, teamName string) {
+	_, _ = cl.AIOnboardingEndConversationWithResponse(ctx, teamName)
+	// This call is best-effort, so we don't return an error
 }


### PR DESCRIPTION
Implements AI Onboarding improvements:

- Upon running SIGINT or typing `exit` or `quit` on AI Onboarding, an `EndConversation` API call is performed.
- `--resume-conversation` flag is added so that a new `conversation_id` is not created before starting the chat. This allows a web chat to continue on terminal.