### PR TITLE
fix: Better handling of error messages from API

### DIFF
--- a/cli/cmd/switch.go
+++ b/cli/cmd/switch.go
@@ -54,7 +54,7 @@ func runSwitch(cmd *cobra.Command, args []string) error {
 
 		allTeams, err := cl.ListAllTeams(cmd.Context())
 		if err != nil {
-			return fmt.Errorf("failed to list all teams: %w", err)
+			return fmt.Errorf("failed to list teams: %w", err)
 		}
 
 		if currentTeam == "" {

--- a/cli/internal/auth/team.go
+++ b/cli/internal/auth/team.go
@@ -17,10 +17,7 @@ func getAvailableUserTeams(ctx context.Context, token auth.Token) []string {
 	if err != nil {
 		return nil
 	}
-	teams, err := cl.ListAllTeams(ctx)
-	if err != nil {
-		return nil
-	}
+	teams, _ := cl.ListAllTeams(ctx)
 	return teams
 }
 

--- a/cli/internal/team/team.go
+++ b/cli/internal/team/team.go
@@ -9,6 +9,7 @@ import (
 
 	cloudquery_api "github.com/cloudquery/cloudquery-api-go"
 	"github.com/cloudquery/cloudquery/cli/v6/internal/api"
+	"github.com/cloudquery/cloudquery/cli/v6/internal/hub"
 )
 
 type Team = cloudquery_api.Team
@@ -61,7 +62,7 @@ func (c *Client) ListAllTeams(ctx context.Context) ([]string, error) {
 			return nil, err
 		}
 		if resp.StatusCode() != http.StatusOK || resp.JSON200 == nil {
-			return nil, fmt.Errorf("failed to list teams: %s", resp.Status())
+			return nil, fmt.Errorf("failed to list teams: %w", hub.ErrorFromHTTPResponse(resp.HTTPResponse, resp))
 		}
 		for _, team := range resp.JSON200.Items {
 			teams = append(teams, team.Name)
@@ -81,7 +82,7 @@ func (c *Client) GetTeam(ctx context.Context, team string) (*Team, error) {
 	}
 
 	if resp.StatusCode() != http.StatusOK || resp.JSON200 == nil {
-		return nil, fmt.Errorf("failed to get team %q: %s", team, resp.Status())
+		return nil, fmt.Errorf("failed to get team %q: %w", team, hub.ErrorFromHTTPResponse(resp.HTTPResponse, resp))
 	}
 
 	return resp.JSON200, nil

--- a/cli/internal/team/team.go
+++ b/cli/internal/team/team.go
@@ -37,7 +37,7 @@ func NewClientFromAPI(apiClient *cloudquery_api.ClientWithResponses) *Client {
 func (c *Client) ValidateTeam(ctx context.Context, name string) error {
 	teams, err := c.ListAllTeams(ctx)
 	if err != nil {
-		return err
+		return fmt.Errorf("failed to list teams: %w", err)
 	}
 	return c.ValidateTeamAgainstTeams(name, teams)
 }
@@ -62,7 +62,7 @@ func (c *Client) ListAllTeams(ctx context.Context) ([]string, error) {
 			return nil, err
 		}
 		if resp.StatusCode() != http.StatusOK || resp.JSON200 == nil {
-			return nil, fmt.Errorf("failed to list teams: %w", hub.ErrorFromHTTPResponse(resp.HTTPResponse, resp))
+			return nil, hub.ErrorFromHTTPResponse(resp.HTTPResponse, resp)
 		}
 		for _, team := range resp.JSON200.Items {
 			teams = append(teams, team.Name)


### PR DESCRIPTION
```
CLOUDQUERY_API_KEY=invalidkey ./cli switch
Error: failed to list teams: 401: Invalid authentication token
```