### PR TITLE
fix: Update team internal metadata upon switch and login

### DIFF
--- a/cli/cmd/switch.go
+++ b/cli/cmd/switch.go
@@ -62,7 +62,8 @@ func runSwitch(cmd *cobra.Command, args []string) error {
 		} else {
 			cmd.Printf("Your current team is set to %v.\n\n", currentTeam)
 		}
-		cmd.Println("Teams available to you:", strings.Join(allTeams, ", ")+"\n")
+		teamNames := team.Names(allTeams)
+		cmd.Println("Teams available to you:", strings.Join(teamNames, ", ")+"\n")
 		cmd.Println("To switch teams, run `cloudquery switch <team>`")
 		return nil
 	}

--- a/cli/internal/auth/team.go
+++ b/cli/internal/auth/team.go
@@ -18,7 +18,7 @@ func getAvailableUserTeams(ctx context.Context, token auth.Token) []string {
 		return nil
 	}
 	teams, _ := cl.ListAllTeams(ctx)
-	return teams
+	return teamapi.Names(teams)
 }
 
 func configFileMissing(err error) bool {
@@ -60,9 +60,9 @@ func GetTeamForToken(ctx context.Context, token auth.Token) (string, error) {
 		case 0:
 			return "", errors.New("team api key has no assigned team")
 		case 1:
-			return teams[0], nil
+			return teams[0].Name, nil
 		default:
-			return "", fmt.Errorf("team api key has more than one team: %s", strings.Join(teams, ", "))
+			return "", fmt.Errorf("team api key has more than one team: %s", teamapi.Names(teams))
 		}
 	default:
 		return os.Getenv("_CQ_TEAM_NAME"), nil

--- a/cli/internal/team/team.go
+++ b/cli/internal/team/team.go
@@ -105,9 +105,9 @@ func (c *Client) GetTeam(ctx context.Context, team string) (*Team, error) {
 }
 
 func Names(teams []Team) []string {
-	names := make([]string, 0, len(teams))
-	for _, t := range teams {
-		names = append(names, t.Name)
+	names := make([]string, len(teams))
+	for i, t := range teams {
+		names[i] = t.Name
 	}
 	return names
 }


### PR DESCRIPTION
Fixes a bug whereby the `internal` value in the cached config didn't get updated between login / switch events, meaning that analytics events could get sent (or not sent) incorrectly. 

This was a rare bug that only affected CloudQuery team members doing testing on the analytics system itself.