### PR TITLE
fix: Fix bug where basic interactive should apply.

### DIFF
--- a/cli/cmd/init.go
+++ b/cli/cmd/init.go
@@ -289,7 +289,7 @@ func initCmd(cmd *cobra.Command, args []string) (initCommandError error) {
 	}
 
 	// Check if user and team are set, and if so, run AI command
-	if user != nil && team != "" && !disableAI {
+	if user != nil && team != "" && !disableAI && source == "" && destination == "" {
 		err := api.NewConversation(ctx, apiClientWithoutRetries, team, resumeConversation)
 		if err != nil && err != api.ErrDisabled {
 			return err


### PR DESCRIPTION
Fixes a regression whereby setting any of the source/destination flags was not triggering basic interactive mode, instead sending you to AI Onboarding.

<img width="694" height="644" alt="Screenshot 2025-09-26 at 14 10 49" src="https://github.com/user-attachments/assets/881648c4-59e1-419b-860c-60decde5be53" />
