### PR TITLE
chore: Fix permissions to publish CLI

### DIFF
--- a/.github/workflows/release_cli.yml
+++ b/.github/workflows/release_cli.yml
@@ -14,6 +14,8 @@ jobs:
     timeout-minutes: 30
     permissions:
       contents: write
+      packages: write
+      attestations: write
     runs-on: ubuntu-latest
     steps:
       # Tag format is cli-<version>


### PR DESCRIPTION
This is needed since we publish to GitHub packages docker images