### PR TITLE
chore: Fix PR cache delete action

### DIFF
--- a/.github/workflows/clean_actions_cache.yml
+++ b/.github/workflows/clean_actions_cache.yml
@@ -12,9 +12,6 @@ jobs:
   cleanup:
     runs-on: ubuntu-latest
     steps:
-      - name: Check out code
-        uses: actions/checkout@v5
-
       - name: Cleanup
         run: |
           REPO=${{ github.repository }}

--- a/.github/workflows/clean_actions_cache.yml
+++ b/.github/workflows/clean_actions_cache.yml
@@ -1,33 +1,35 @@
 name: Cleanup caches by a branch
 on:
-  pull_request_target:
+  pull_request:
     types:
       - closed
 
 permissions:
   contents: read
+  actions: write
 
 jobs:
   cleanup:
     runs-on: ubuntu-latest
     steps:
+      - name: Check out code
+        uses: actions/checkout@v5
+
       - name: Cleanup
         run: |
-          gh extension install actions/gh-actions-cache
-
           REPO=${{ github.repository }}
           BRANCH="refs/pull/${{ github.event.pull_request.number }}/merge"
 
           echo "Fetching list of cache key"
-          cacheKeysForPR=$(gh api /repos/$REPO/actions/caches?ref=$BRANCH --paginate | jq -r '.actions_caches[].key' )
+          cacheKeysForPR=$(gh cache list --repo $REPO --ref $BRANCH --json key | jq -r '.[].key')
 
-          ## Setting this to not fail the workflow while deleting cache keys. 
+          ## Setting this to not fail the workflow while deleting cache keys.
           set +e
           echo "Deleting caches..."
           for cacheKey in $cacheKeysForPR
           do
-              gh actions-cache delete $cacheKey -R $REPO -B $BRANCH --confirm
+              gh cache delete $cacheKey --repo $REPO --ref $BRANCH
           done
           echo "Done"
         env:
-          GH_TOKEN: ${{ secrets.GH_CQ_BOT }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
The workflow to delete PR's cache after they are merged stopped working due to the permissions changes I did.
This PR fixes it and also updates the workflow to use the built in `gh` CLI `cache` command since the `extension` is now deprecated