### PR TITLE
fix: Change fips mode to on, prevent panic from crypto.

### DIFF
--- a/plugins/source/test/main_fips.go
+++ b/plugins/source/test/main_fips.go
@@ -1,6 +1,6 @@
 //go:build fipsEnabled
 
-//go:debug fips140=only
+//go:debug fips140=on
 
 package main
 


### PR DESCRIPTION
We have the fips debug mode set to `only`, which causes panics or errors when certain crypto functions are run. This was not the intention of us setting that mode, so this PR sets it to `on`.