### PR TITLE
fix: Table with PK components should upsert.

### DIFF
--- a/plugins/destination/postgresql/client/insert.go
+++ b/plugins/destination/postgresql/client/insert.go
@@ -67,7 +67,7 @@ func (c *Client) InsertBatch(ctx context.Context, messages message.WriteInserts)
 		if !ok {
 			// cache the query
 			table := c.normalizeTable(msg.GetTable())
-			if len(table.PrimaryKeysIndexes()) > 0 {
+			if len(table.PrimaryKeysIndexes())+len(table.PrimaryKeyComponents()) > 0 {
 				sql = c.upsert(table)
 			} else {
 				sql = c.insert(table)


### PR DESCRIPTION
`schema.Column` defines both `PrimaryKey` and `PrimaryKeyComponent` for a column, and certain plugin's tables use one of the two but not the other.

The Postgres destination decides whether to insert or upsert based on the existence of PK columns on the table, but ignores PK components.

This causes tables with PK component only columns to fail with constraint violations on inserts, when the rows already exist on the DB side.