### PR TITLE
Revert "fix: Table with PK components should upsert."

### DIFF
--- a/plugins/destination/postgresql/client/insert.go
+++ b/plugins/destination/postgresql/client/insert.go
@@ -67,7 +67,7 @@ func (c *Client) InsertBatch(ctx context.Context, messages message.WriteInserts)
 		if !ok {
 			// cache the query
 			table := c.normalizeTable(msg.GetTable())
-			if len(table.PrimaryKeysIndexes())+len(table.PrimaryKeyComponents()) > 0 {
+			if len(table.PrimaryKeysIndexes()) > 0 {
 				sql = c.upsert(table)
 			} else {
 				sql = c.insert(table)


### PR DESCRIPTION
This reverts commit 2a26f3254d9916c8910c7b7dd84a5ab83fac391d.

My bugfix for the supposed Postgres bug would break append mode (would always upsert). Moreover, the fix is likely not possible, because `_cq_id` would be set as `PrimaryKey` by the `schema.AddCqIDs` function.