### PR TITLE
fix: Set unique=false on all columns when adding PKs.

### DIFF
--- a/plugins/transformer/basic/client/schemaupdater/schema_updater.go
+++ b/plugins/transformer/basic/client/schemaupdater/schema_updater.go
@@ -110,5 +110,13 @@ func (s *SchemaUpdater) AddPrimaryKeys(newPks []string) (*arrow.Schema, error) {
 		}
 		newCol.PrimaryKey = true
 	}
+
+	// When adding PK components, if we retain unique columns this will result in more than one
+	// unique constraint on the destination (if such constraints are supported). We'd fail upserts
+	// if enabled. Therefore, we must set Unique = false on all columns.
+	for i := range table.Columns {
+		table.Columns[i].Unique = false
+	}
+
 	return table.ToArrowSchema(), nil
 }


### PR DESCRIPTION
`_cq_id` column is usually the PK on a table, and has the `unique: true` setting.

When adding PK components via the basic transformer function, this results in two separate uniqueness constraints on the database side (if supported).

For overwrite-delete-stale mode, PostgreSQL and likely other databases that support `UPSERT` cannot deal with multiple uniqueness constraints. This is seldom what the user is expecting when they add a PK component, since they'd expect a single, composite constraint.

Thus, this PR simply removes any `Unique` schema properties upon adding PK components.

This was a reported bug which caused:

```
Key (_cq_source_name)=(aws) already exists., hint: , position: 0, internal_position: 0, internal_query: , where: , schema_name: public, table_name: aws_inspector2_findings, column_name: , data_type_name: , constraint_name: aws_inspector2_findings__cq_source_name_key, file: nbtinsert.c, line: 664, routine: _bt_check_unique: ERROR: duplicate key value violates unique constraint "aws_inspector2_findings__cq_source_name_key"
```

And upon this fix, the sync now works (testing a table synced twice with different source names):

```
Starting sync for: aws (cloudquery/aws@v32.6.0) -> [aurora (cloudquery/postgresql@v8.12.0)]
Sync completed successfully. Resources: 39, Errors: 0, Warnings: 0, Time: 5s
Starting sync for: aws2 (cloudquery/aws@v32.6.0) -> [aurora (cloudquery/postgresql@v8.12.0)]
Sync completed successfully. Resources: 39, Errors: 0, Warnings: 0, Time: 4s
```