### PR TITLE
fix: Allow empty destinations in spec during test connection

### DIFF
--- a/cli/cmd/test_connection_test.go
+++ b/cli/cmd/test_connection_test.go
@@ -26,6 +26,10 @@ func TestTestConnection(t *testing.T) {
 			config: "test-connection-bad-connection.yml",
 			errors: []string{"cloudflare (cloudquery/cloudflare@v", "postgresql (cloudquery/postgresql@v"},
 		},
+		{
+			name:   "source with no destination should pass validation",
+			config: "source-no-destination.yml",
+		},
 	}
 	_, filename, _, _ := runtime.Caller(0)
 	currentDir := path.Dir(filename)

--- a/cli/cmd/testdata/source-no-destination.yml
+++ b/cli/cmd/testdata/source-no-destination.yml
@@ -1,0 +1,7 @@
+kind: "source"
+spec:
+  name: "test"
+  path: "cloudquery/test"
+  destinations: []
+  version: "v4.5.1" # latest version of source test plugin
+  tables: ["*"]

--- a/cli/internal/specs/v0/source.go
+++ b/cli/internal/specs/v0/source.go
@@ -110,7 +110,7 @@ func (Source) JSONSchemaExtend(sc *jsonschema.Schema) {
 	Metadata{}.JSONSchemaExtend(sc) // have to call manually
 }
 
-func (s *Source) Validate() error {
+func (s *Source) Validate(relaxed bool) error {
 	if err := s.Metadata.Validate(); err != nil {
 		return err
 	}
@@ -119,7 +119,7 @@ func (s *Source) Validate() error {
 		return errors.New("tables configuration is required. Hint: set the tables you want to sync by adding `tables: [...]` or use `cloudquery tables` to list available tables")
 	}
 
-	if len(s.Destinations) == 0 {
+	if !relaxed && len(s.Destinations) == 0 {
 		return errors.New("at least one destination is required")
 	}
 

--- a/cli/internal/specs/v0/source_test.go
+++ b/cli/internal/specs/v0/source_test.go
@@ -192,7 +192,7 @@ func TestSourceUnmarshalSpecValidate(t *testing.T) {
 			}
 			source := spec.Spec.(*Source)
 			source.SetDefaults()
-			err = source.Validate()
+			err = source.Validate(false)
 			if err != nil {
 				if err.Error() != tc.err {
 					t.Fatalf("expected:%s got:%s", tc.err, err.Error())


### PR DESCRIPTION
Follow-up to
https://github.com/cloudquery/cloudquery/pull/17993
https://github.com/cloudquery/cloudquery/pull/18542
