### PR TITLE
chore: Alert on failed CLI and Scaffold releases

### DIFF
--- a/.github/workflows/release_cli.yml
+++ b/.github/workflows/release_cli.yml
@@ -128,3 +128,13 @@ jobs:
           body: Updates the CLI latest version to ${{steps.split.outputs.version}}
           labels: automerge
           author: cq-bot <cq-bot@users.noreply.github.com>
+      - name: Slack Notify
+        uses: ravsamhq/notify-slack-action@be814b201e233b2dc673608aa46e5447c8ab13f2
+        if: always()
+        with:
+          status: ${{ job.status }}
+          notify_when: "failure"
+          notification_title: "Failed to release CLI ${{ steps.split.outputs.version }}"
+          footer: "<{repo_url}|{repo}>"
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.ALERTS_INTEGRATIONS_SLACK_WEBHOOK_URL }}

--- a/.github/workflows/release_scaffold.yml
+++ b/.github/workflows/release_scaffold.yml
@@ -108,3 +108,13 @@ jobs:
           body: Updates Scaffold latest version to ${{steps.split.outputs.version}}
           labels: automerge
           author: cq-bot <cq-bot@users.noreply.github.com>
+      - name: Slack Notify
+        uses: ravsamhq/notify-slack-action@be814b201e233b2dc673608aa46e5447c8ab13f2
+        if: always()
+        with:
+          status: ${{ job.status }}
+          notify_when: "failure"
+          notification_title: "Failed to release Scaffold ${{ steps.split.outputs.version }}"
+          footer: "<{repo_url}|{repo}>"
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.ALERTS_INTEGRATIONS_SLACK_WEBHOOK_URL }}


### PR DESCRIPTION
We do this for plugins already https://github.com/cloudquery/cloudquery/blob/f1b82a2cd291a47b912b3e9d745672692e0b20c8/.github/workflows/publish_plugin_to_hub.yml#L360

Should help catch https://github.com/cloudquery/cloudquery/pull/21639 sooner