### PR TITLE
chore: Update permissions to allow writing issues

### DIFF
--- a/.github/workflows/manual_commands.yml
+++ b/.github/workflows/manual_commands.yml
@@ -6,6 +6,7 @@ on:
 
 permissions:
   contents: read
+  issues: write
 
 jobs:
   gen:


### PR DESCRIPTION
Otherwise the workflow can't add reactions (e.g. 👀 ) when you run the `/gen` command