### PR TITLE
fix: Bring back client side rate limiter

### DIFF
--- a/plugins/destination/s3/client/client.go
+++ b/plugins/destination/s3/client/client.go
@@ -12,7 +12,6 @@ import (
 	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
-	"github.com/aws/aws-sdk-go-v2/aws/ratelimit"
 	"github.com/aws/aws-sdk-go-v2/aws/retry"
 	awshttp "github.com/aws/aws-sdk-go-v2/aws/transport/http"
 	"github.com/aws/aws-sdk-go-v2/config"
@@ -82,7 +81,6 @@ func New(ctx context.Context, logger zerolog.Logger, s []byte, opts plugin.NewCl
 			return retry.NewStandard(func(so *retry.StandardOptions) {
 				so.MaxAttempts = *c.spec.MaxRetries
 				so.MaxBackoff = time.Duration(*c.spec.MaxBackoff) * time.Second
-				so.RateLimiter = ratelimit.None
 			})
 		}),
 	}


### PR DESCRIPTION
<!-- 🎉 Thank you for making CloudQuery awesome by submitting a PR 🎉 -->

#### Summary

Instead of https://github.com/cloudquery/cloudquery/pull/21732.

https://github.com/cloudquery/cloudquery/pull/20400 has 2 slight changes in behavior
1. Disabled client side rate limiting
2. Increased `MaxBackoff` from `20` to `30`.

While I think 2. is ok, 1. can have unwanted effects such as https://github.com/cloudquery/cloudquery/pull/21732#issuecomment-3675267462

<!--
Use the following steps to ensure your PR is ready to be reviewed

- [ ] Read the [contribution guidelines](https://github.com/cloudquery/cloudquery/blob/main/CONTRIBUTING.md) 🧑‍🎓
- [ ] Run `make lint` to ensure the proposed changes follow the coding style 🚨 (install golangci-lint [here](https://golangci-lint.run/usage/install/#local-installation))
- [ ] Run `make test` to ensure the proposed changes pass the tests 🧪
- [ ] If changing a source plugin run `make gen` to ensure docs are up to date 📝
- [ ] Ensure the status checks below are successful ✅
--->
