### PR TITLE
fix: Add AI-assisted setup data collection notice

### DIFF
--- a/cli/cmd/ai.go
+++ b/cli/cmd/ai.go
@@ -24,6 +24,7 @@ var (
 	aiBold    = color.New(color.Bold)
 	aiSuccess = color.New(color.Bold, color.FgGreen)
 	aiInfo    = color.New(color.Bold, color.FgCyan)
+	aiMuted   = color.New(color.Faint, color.FgWhite)
 )
 
 // Spinner messages for different operations
@@ -173,7 +174,7 @@ func aiCmd(ctx context.Context, client *cloudquery_api.ClientWithResponses, team
 }
 
 func aiCmdInner(ctx context.Context, client *cloudquery_api.ClientWithResponses, teamName string, resumeConversation bool) error {
-	fmt.Println(`Your conversation with the AI may be recorded for quality assurance purposes. If you prefer not to use AI-assisted setup, run cloudquery init --disable-ai.`)
+	aiMuted.Println(`Your conversation with the AI may be recorded for quality assurance purposes. If you prefer not to use AI-assisted setup, run cloudquery init --disable-ai.`)
 	fmt.Println()
 	aiSuccess.Println("🤖 CloudQuery AI Assistant")
 	fmt.Println("I'm here to help you set up CloudQuery syncs!")


### PR DESCRIPTION
Fixes https://linear.app/cloudquery/issue/ENG-2222/notify-users-about-data-collection-when-running-the-init-command


<img width="1261" height="77" alt="Screenshot 2025-12-29 at 09 35 14" src="https://github.com/user-attachments/assets/e676f823-e0bb-430c-acad-752ace3beaa7" />
