### PR TITLE
fix!: Correct nullability for map items

### DIFF
--- a/plugins/destination/clickhouse/typeconv/arrow/types/map.go
+++ b/plugins/destination/clickhouse/typeconv/arrow/types/map.go
@@ -34,5 +34,5 @@ func mapType(name string, col *column.Map) (*arrow.Field, error) {
 		return nil, err
 	}
 
-	return &arrow.Field{Name: name, Type: arrow.MapOf(keyType.Type, itemType.Type)}, nil
+	return &arrow.Field{Name: name, Type: arrow.MapOfFields(*keyType, *itemType)}, nil
 }

--- a/plugins/destination/clickhouse/typeconv/arrow/types/map_test.go
+++ b/plugins/destination/clickhouse/typeconv/arrow/types/map_test.go
@@ -8,7 +8,14 @@ import (
 )
 
 func Test_mapType(t *testing.T) {
+	mapWithNonNullableItem := arrow.MapOf(new(arrow.StringType), new(arrow.BooleanType))
+	mapWithNonNullableItem.SetItemNullable(false)
+
 	for _, tc := range []testCase{
+		{
+			columnType: "Map(String, Bool)",
+			expected:   mapWithNonNullableItem,
+		},
 		{
 			columnType: "Map(String, Nullable(Bool))",
 			expected:   arrow.MapOf(new(arrow.StringType), new(arrow.BooleanType)),


### PR DESCRIPTION
<!-- 🎉 Thank you for making CloudQuery awesome by submitting a PR 🎉 -->

#### Summary

`MapOf` always sets items to `Nullable: true` https://github.com/apache/arrow-go/blob/2d0962ed55074f050193b82aaf80f8b5995a2ffc/arrow/datatype_nested.go#L536

<!--
Use the following steps to ensure your PR is ready to be reviewed

- [ ] Read the [contribution guidelines](https://github.com/cloudquery/cloudquery/blob/main/CONTRIBUTING.md) 🧑‍🎓
- [ ] Run `make lint` to ensure the proposed changes follow the coding style 🚨 (install golangci-lint [here](https://golangci-lint.run/usage/install/#local-installation))
- [ ] Run `make test` to ensure the proposed changes pass the tests 🧪
- [ ] If changing a source plugin run `make gen` to ensure docs are up to date 📝
- [ ] Ensure the status checks below are successful ✅
--->
