### PR TITLE
fix: Promote H1 headings in generated CLI reference docs

### DIFF
--- a/cli/cmd/doc.go
+++ b/cli/cmd/doc.go
@@ -11,8 +11,8 @@ import (
 	"github.com/spf13/cobra/doc"
 )
 
-// headingReplacer demotes cobra/doc's heading levels by one so each page has
-// a proper H1. cobra/doc generates:
+// headingReplacer promotes cobra/doc's heading levels so each page has a
+// proper H1. cobra/doc generates:
 //
 //	## <command>          (should be H1 — the page title)
 //	### Synopsis          (should be H2)
@@ -20,7 +20,7 @@ import (
 //	### SEE ALSO          (should be H2)
 //	#### <flag-detail>    (should be H3)
 //
-// We demote deeper levels first (#### → ###, then ### → ##), then promote the
+// We promote deeper levels first (#### → ###, then ### → ##), then promote the
 // first remaining ## to # so that only the command-name heading becomes H1.
 var headingReplacer = strings.NewReplacer(
 	"\n#### ", "\n### ",
@@ -153,9 +153,13 @@ func fixHeadingLevels(dir string) error {
 		if err != nil {
 			return fmt.Errorf("reading %s: %w", fpath, err)
 		}
-		// Demote ### → ## first, then promote the first ## → # (the command heading).
+		// Promote #### → ### and ### → ## (via headingReplacer), then promote
+		// the first ## → # so the command name becomes the page's H1.
+		// Also normalize cobra's all-caps ## SEE ALSO to ## See Also for
+		// consistency with the custom links appended by appendSeeAlsoSections.
 		fixed := headingReplacer.Replace(string(data))
 		fixed = strings.Replace(fixed, "\n## ", "\n# ", 1)
+		fixed = strings.ReplaceAll(fixed, "\n## SEE ALSO\n", "\n## See Also\n")
 		if err := os.WriteFile(fpath, []byte(fixed), 0644); err != nil {
 			return fmt.Errorf("writing %s: %w", fpath, err)
 		}
@@ -163,7 +167,11 @@ func fixHeadingLevels(dir string) error {
 	return nil
 }
 
-// appendSeeAlsoSections appends the "## See Also" section to each generated file that has one defined.
+// appendSeeAlsoSections appends custom links into the "## See Also" section of
+// each generated file that has entries defined. The cobra-generated markdown
+// already contains a "## See Also" heading (normalized by fixHeadingLevels), so
+// only the link lines are appended — not a new heading — to avoid a duplicate
+// H2 section on every page.
 func appendSeeAlsoSections(dir string) error {
 	for filename, content := range seeAlsoSections {
 		fpath := filepath.Join(dir, filename)
@@ -174,7 +182,11 @@ func appendSeeAlsoSections(dir string) error {
 			}
 			return fmt.Errorf("opening %s: %w", fpath, err)
 		}
-		_, writeErr := fmt.Fprintf(f, "\n%s", content)
+		// Strip the "## See Also\n\n" heading from the content: cobra/doc has
+		// already emitted a "## See Also" section (normalized by fixHeadingLevels)
+		// and we only want to append the link lines underneath it.
+		links := strings.TrimPrefix(content, "## See Also\n\n")
+		_, writeErr := fmt.Fprintf(f, "%s", links)
 		closeErr := f.Close()
 		if writeErr != nil {
 			return fmt.Errorf("writing to %s: %w", fpath, writeErr)

--- a/cli/cmd/doc.go
+++ b/cli/cmd/doc.go
@@ -11,6 +11,20 @@ import (
 	"github.com/spf13/cobra/doc"
 )
 
+// headingReplacer demotes cobra/doc's H2 command headings and H3 sub-headings
+// to H1 and H2 respectively, so each page has a proper H1.
+//
+// cobra/doc generates:
+//
+//	## <command>   (should be H1 — the page title)
+//	### Synopsis   (should be H2)
+//	### Options    (should be H2)
+//	### SEE ALSO   (should be H2)
+//
+// We apply ### → ## first (a simple string replace), then promote the first
+// remaining ## to # so that only the command-name heading becomes H1.
+var headingReplacer = strings.NewReplacer("\n### ", "\n## ")
+
 const (
 	docShort = "Generate CLI documentation markdown files"
 )
@@ -111,10 +125,40 @@ func newCmdDoc() *cobra.Command {
 			if err := doc.GenMarkdownTreeCustom(cmd.Parent(), args[0], filePrepender, linkHandler); err != nil {
 				return err
 			}
+			if err := fixHeadingLevels(args[0]); err != nil {
+				return err
+			}
 			return appendSeeAlsoSections(args[0])
 		},
 	}
 	return cmd
+}
+
+// fixHeadingLevels corrects the heading hierarchy in all generated markdown files.
+// cobra/doc emits ## for the command name and ### for sub-sections; this promotes
+// them to # and ## so every page has a proper H1.
+func fixHeadingLevels(dir string) error {
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return fmt.Errorf("reading dir %s: %w", dir, err)
+	}
+	for _, e := range entries {
+		if e.IsDir() || !strings.HasSuffix(e.Name(), ".md") {
+			continue
+		}
+		fpath := filepath.Join(dir, e.Name())
+		data, err := os.ReadFile(fpath)
+		if err != nil {
+			return fmt.Errorf("reading %s: %w", fpath, err)
+		}
+		// Demote ### → ## first, then promote the first ## → # (the command heading).
+		fixed := headingReplacer.Replace(string(data))
+		fixed = strings.Replace(fixed, "\n## ", "\n# ", 1)
+		if err := os.WriteFile(fpath, []byte(fixed), 0644); err != nil {
+			return fmt.Errorf("writing %s: %w", fpath, err)
+		}
+	}
+	return nil
 }
 
 // appendSeeAlsoSections appends the "## See Also" section to each generated file that has one defined.

--- a/cli/cmd/doc.go
+++ b/cli/cmd/doc.go
@@ -11,19 +11,21 @@ import (
 	"github.com/spf13/cobra/doc"
 )
 
-// headingReplacer demotes cobra/doc's H2 command headings and H3 sub-headings
-// to H1 and H2 respectively, so each page has a proper H1.
+// headingReplacer demotes cobra/doc's heading levels by one so each page has
+// a proper H1. cobra/doc generates:
 //
-// cobra/doc generates:
+//	## <command>          (should be H1 — the page title)
+//	### Synopsis          (should be H2)
+//	### Options           (should be H2)
+//	### SEE ALSO          (should be H2)
+//	#### <flag-detail>    (should be H3)
 //
-//	## <command>   (should be H1 — the page title)
-//	### Synopsis   (should be H2)
-//	### Options    (should be H2)
-//	### SEE ALSO   (should be H2)
-//
-// We apply ### → ## first (a simple string replace), then promote the first
-// remaining ## to # so that only the command-name heading becomes H1.
-var headingReplacer = strings.NewReplacer("\n### ", "\n## ")
+// We demote deeper levels first (#### → ###, then ### → ##), then promote the
+// first remaining ## to # so that only the command-name heading becomes H1.
+var headingReplacer = strings.NewReplacer(
+	"\n#### ", "\n### ",
+	"\n### ", "\n## ",
+)
 
 const (
 	docShort = "Generate CLI documentation markdown files"

--- a/cli/cmd/doc_test.go
+++ b/cli/cmd/doc_test.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"os"
+	"path/filepath"
 	"regexp"
 	"slices"
 	"strings"
@@ -33,13 +34,19 @@ var docFiles = []string{
 	"cloudquery_switch.md",
 }
 
-func TestDoc(t *testing.T) {
+// generateDocs runs the doc command into a temp directory and returns the path.
+// Shared by multiple tests so we only generate once per test run.
+func generateDocs(t *testing.T) string {
+	t.Helper()
 	tmpDir := t.TempDir()
 	cmd := NewCmdRoot()
 	cmd.SetArgs(append([]string{"doc", tmpDir}, testCommandArgs(t)...))
+	require.NoError(t, cmd.Execute())
+	return tmpDir
+}
 
-	err := cmd.Execute()
-	require.NoError(t, err)
+func TestDoc(t *testing.T) {
+	tmpDir := generateDocs(t)
 
 	files, err := os.ReadDir(tmpDir)
 	require.NoError(t, err)
@@ -53,14 +60,14 @@ func TestDoc(t *testing.T) {
 	require.Equal(t, docFiles, fnames)
 }
 
-// TestDocHeadingStructure verifies that every generated markdown page has
-// exactly one H1 heading (the command name), no all-caps "SEE ALSO" headings,
-// and at most one "## See Also" section.
+// TestDocHeadingStructure verifies the heading hierarchy of every generated
+// markdown page:
+//   - exactly one H1 (the command name), and it is the first heading
+//   - cobra's H3 sections (Synopsis, Options, SEE ALSO) were promoted to H2
+//   - cobra's all-caps ## SEE ALSO heading was normalized to ## See Also
+//   - no duplicate ## See Also sections
 func TestDocHeadingStructure(t *testing.T) {
-	tmpDir := t.TempDir()
-	cmd := NewCmdRoot()
-	cmd.SetArgs(append([]string{"doc", tmpDir}, testCommandArgs(t)...))
-	require.NoError(t, cmd.Execute())
+	tmpDir := generateDocs(t)
 
 	entries, err := os.ReadDir(tmpDir)
 	require.NoError(t, err)
@@ -69,23 +76,40 @@ func TestDocHeadingStructure(t *testing.T) {
 		if e.IsDir() || !strings.HasSuffix(e.Name(), ".md") {
 			continue
 		}
-		data, err := os.ReadFile(tmpDir + "/" + e.Name())
+		data, err := os.ReadFile(filepath.Join(tmpDir, e.Name()))
 		require.NoError(t, err)
 		content := string(data)
 
 		t.Run(e.Name(), func(t *testing.T) {
-			// Strip fenced code blocks before inspecting heading structure so
-			// that bash comments (# ...) inside examples are not counted.
+			// Strip fenced code blocks so bash comments (# ...) inside
+			// Examples sections are not mistaken for markdown headings.
 			stripped := fencedCodeBlock.ReplaceAllString(content, "")
 
-			// Every page must have exactly one H1 heading (the command name).
+			// Every page must have exactly one H1 heading.
 			h1Count := strings.Count(stripped, "\n# ")
 			require.Equal(t, 1, h1Count, "expected exactly one H1 heading")
 
-			// No all-caps SEE ALSO heading should remain.
-			require.NotContains(t, content, "## SEE ALSO", "cobra's all-caps SEE ALSO should be normalized")
+			// The first heading in the document body must be H1, not H2 or H3.
+			// (frontmatter ends with "---\n", so the next heading follows a newline)
+			afterFrontmatter := stripped[strings.Index(stripped, "---\n")+4:]
+			firstHeadingIdx := strings.Index(afterFrontmatter, "\n#")
+			require.NotEqual(t, -1, firstHeadingIdx, "no heading found after frontmatter")
+			firstHeading := afterFrontmatter[firstHeadingIdx+1:] // skip the leading \n
+			require.True(t, strings.HasPrefix(firstHeading, "# "),
+				"first heading must be H1, got: %q", strings.SplitN(firstHeading, "\n", 2)[0])
 
-			// There must be no more than one ## See Also section.
+			// cobra's H3 sections must have been promoted to H2. Verify none of
+			// the known cobra section names remain at H3 level.
+			for _, section := range []string{"Synopsis", "Options", "Examples", "SEE ALSO", "See Also"} {
+				require.NotContains(t, stripped, "\n### "+section,
+					"cobra section %q was not promoted from H3 to H2", section)
+			}
+
+			// No all-caps SEE ALSO heading should remain anywhere.
+			require.NotContains(t, content, "## SEE ALSO",
+				"cobra's all-caps SEE ALSO should be normalized to ## See Also")
+
+			// There must be at most one ## See Also section (no duplicate).
 			seeAlsoCount := strings.Count(stripped, "\n## See Also\n")
 			require.LessOrEqual(t, seeAlsoCount, 1, "duplicate ## See Also sections found")
 		})

--- a/cli/cmd/doc_test.go
+++ b/cli/cmd/doc_test.go
@@ -2,11 +2,17 @@ package cmd
 
 import (
 	"os"
+	"regexp"
 	"slices"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/require"
 )
+
+// fencedCodeBlock matches fenced code blocks (``` ... ```) so we can strip
+// them before inspecting markdown heading structure.
+var fencedCodeBlock = regexp.MustCompile("(?ms)^```[^\n]*\n.*?^```")
 
 var docFiles = []string{
 	"cloudquery.md",
@@ -45,4 +51,43 @@ func TestDoc(t *testing.T) {
 	slices.Sort(fnames)
 	slices.Sort(docFiles)
 	require.Equal(t, docFiles, fnames)
+}
+
+// TestDocHeadingStructure verifies that every generated markdown page has
+// exactly one H1 heading (the command name), no all-caps "SEE ALSO" headings,
+// and at most one "## See Also" section.
+func TestDocHeadingStructure(t *testing.T) {
+	tmpDir := t.TempDir()
+	cmd := NewCmdRoot()
+	cmd.SetArgs(append([]string{"doc", tmpDir}, testCommandArgs(t)...))
+	require.NoError(t, cmd.Execute())
+
+	entries, err := os.ReadDir(tmpDir)
+	require.NoError(t, err)
+
+	for _, e := range entries {
+		if e.IsDir() || !strings.HasSuffix(e.Name(), ".md") {
+			continue
+		}
+		data, err := os.ReadFile(tmpDir + "/" + e.Name())
+		require.NoError(t, err)
+		content := string(data)
+
+		t.Run(e.Name(), func(t *testing.T) {
+			// Strip fenced code blocks before inspecting heading structure so
+			// that bash comments (# ...) inside examples are not counted.
+			stripped := fencedCodeBlock.ReplaceAllString(content, "")
+
+			// Every page must have exactly one H1 heading (the command name).
+			h1Count := strings.Count(stripped, "\n# ")
+			require.Equal(t, 1, h1Count, "expected exactly one H1 heading")
+
+			// No all-caps SEE ALSO heading should remain.
+			require.NotContains(t, content, "## SEE ALSO", "cobra's all-caps SEE ALSO should be normalized")
+
+			// There must be no more than one ## See Also section.
+			seeAlsoCount := strings.Count(stripped, "\n## See Also\n")
+			require.LessOrEqual(t, seeAlsoCount, 1, "duplicate ## See Also sections found")
+		})
+	}
 }

--- a/cli/docs/reference/cloudquery.md
+++ b/cli/docs/reference/cloudquery.md
@@ -29,7 +29,7 @@ Find more information at:
       --telemetry-level string   Telemetry level (none, errors, stats, all) (default "all")
 ```
 
-## SEE ALSO
+## See Also
 
 * [cloudquery addon](/cli/cli-reference/cloudquery_addon)	 - Addon commands
 * [cloudquery init](/cli/cli-reference/cloudquery_init)	 - Generate a configuration file for a sync
@@ -42,9 +42,6 @@ Find more information at:
 * [cloudquery tables](/cli/cli-reference/cloudquery_tables)	 - Generate documentation for all supported tables of source plugins specified in the spec(s)
 * [cloudquery test-connection](/cli/cli-reference/cloudquery_test-connection)	 - Test plugin connections to sources and/or destinations
 * [cloudquery validate-config](/cli/cli-reference/cloudquery_validate-config)	 - Validate config
-
-
-## See Also
 
 - [Getting Started](/cli/getting-started) - Install and run your first sync
 - [Configuration Guide](/cli/core-concepts/configuration) - Configure source and destination integrations

--- a/cli/docs/reference/cloudquery.md
+++ b/cli/docs/reference/cloudquery.md
@@ -1,11 +1,11 @@
 ---
 title: "cloudquery"
 ---
-## cloudquery
+# cloudquery
 
 CloudQuery CLI
 
-### Synopsis
+## Synopsis
 
 CloudQuery CLI
 
@@ -14,7 +14,7 @@ High performance data integration at scale.
 Find more information at:
 	https://www.cloudquery.io
 
-### Options
+## Options
 
 ```
       --cq-dir string            directory to store cloudquery files, such as downloaded plugins (default ".cq")
@@ -29,7 +29,7 @@ Find more information at:
       --telemetry-level string   Telemetry level (none, errors, stats, all) (default "all")
 ```
 
-### SEE ALSO
+## SEE ALSO
 
 * [cloudquery addon](/cli/cli-reference/cloudquery_addon)	 - Addon commands
 * [cloudquery init](/cli/cli-reference/cloudquery_init)	 - Generate a configuration file for a sync

--- a/cli/docs/reference/cloudquery_addon.md
+++ b/cli/docs/reference/cloudquery_addon.md
@@ -25,14 +25,11 @@ Addon commands
       --telemetry-level string   Telemetry level (none, errors, stats, all) (default "all")
 ```
 
-## SEE ALSO
+## See Also
 
 * [cloudquery](/cli/cli-reference/cloudquery)	 - CloudQuery CLI
 * [cloudquery addon download](/cli/cli-reference/cloudquery_addon_download)	 - Download addon from CloudQuery Hub.
 * [cloudquery addon publish](/cli/cli-reference/cloudquery_addon_publish)	 - Publish to CloudQuery Hub.
-
-
-## See Also
 
 - [Transformations](/cli/core-concepts/transformations) - Official dbt and SQL transformations
 - [Dashboards & Visualizations](/cli/core-concepts/dashboards) - Grafana dashboards from the hub

--- a/cli/docs/reference/cloudquery_addon.md
+++ b/cli/docs/reference/cloudquery_addon.md
@@ -1,17 +1,17 @@
 ---
 title: "addon"
 ---
-## cloudquery addon
+# cloudquery addon
 
 Addon commands
 
-### Options
+## Options
 
 ```
   -h, --help   help for addon
 ```
 
-### Options inherited from parent commands
+## Options inherited from parent commands
 
 ```
       --cq-dir string            directory to store cloudquery files, such as downloaded plugins (default ".cq")
@@ -25,7 +25,7 @@ Addon commands
       --telemetry-level string   Telemetry level (none, errors, stats, all) (default "all")
 ```
 
-### SEE ALSO
+## SEE ALSO
 
 * [cloudquery](/cli/cli-reference/cloudquery)	 - CloudQuery CLI
 * [cloudquery addon download](/cli/cli-reference/cloudquery_addon_download)	 - Download addon from CloudQuery Hub.

--- a/cli/docs/reference/cloudquery_addon_download.md
+++ b/cli/docs/reference/cloudquery_addon_download.md
@@ -1,11 +1,11 @@
 ---
 title: "addon_download"
 ---
-## cloudquery addon download
+# cloudquery addon download
 
 Download addon from CloudQuery Hub.
 
-### Synopsis
+## Synopsis
 
 Download addon from CloudQuery Hub.
 
@@ -16,7 +16,7 @@ This downloads an addon from CloudQuery Hub to local disk.
 cloudquery addon download addon-team/addon-type/addon-name@v1.0.0 [-t directory] [flags]
 ```
 
-### Examples
+## Examples
 
 ```
 
@@ -27,14 +27,14 @@ cloudquery addon download <publisher>/<addon-type>/<addon-name>@v1.0.0
 cloudquery addon download cloudquery/transformation/aws-compliance-premium@v1.9.0
 ```
 
-### Options
+## Options
 
 ```
   -h, --help            help for download
   -t, --target string   Download to specified directory. Use - for stdout (default ".")
 ```
 
-### Options inherited from parent commands
+## Options inherited from parent commands
 
 ```
       --cq-dir string            directory to store cloudquery files, such as downloaded plugins (default ".cq")
@@ -48,7 +48,7 @@ cloudquery addon download cloudquery/transformation/aws-compliance-premium@v1.9.
       --telemetry-level string   Telemetry level (none, errors, stats, all) (default "all")
 ```
 
-### SEE ALSO
+## SEE ALSO
 
 * [cloudquery addon](/cli/cli-reference/cloudquery_addon)	 - Addon commands
 

--- a/cli/docs/reference/cloudquery_addon_download.md
+++ b/cli/docs/reference/cloudquery_addon_download.md
@@ -48,12 +48,9 @@ cloudquery addon download cloudquery/transformation/aws-compliance-premium@v1.9.
       --telemetry-level string   Telemetry level (none, errors, stats, all) (default "all")
 ```
 
-## SEE ALSO
+## See Also
 
 * [cloudquery addon](/cli/cli-reference/cloudquery_addon)	 - Addon commands
-
-
-## See Also
 
 - [Transformations](/cli/core-concepts/transformations) - Available transformations and policies
 - [Dashboards & Visualizations](/cli/core-concepts/dashboards) - Grafana dashboards from the hub

--- a/cli/docs/reference/cloudquery_addon_publish.md
+++ b/cli/docs/reference/cloudquery_addon_publish.md
@@ -1,11 +1,11 @@
 ---
 title: "addon_publish"
 ---
-## cloudquery addon publish
+# cloudquery addon publish
 
 Publish to CloudQuery Hub.
 
-### Synopsis
+## Synopsis
 
 Publish to CloudQuery Hub.
 
@@ -16,7 +16,7 @@ This publishes an addon version to CloudQuery Hub from a manifest file.
 cloudquery addon publish manifest.json v1.0.0 [--finalize] [flags]
 ```
 
-### Examples
+## Examples
 
 ```
 
@@ -24,14 +24,14 @@ cloudquery addon publish manifest.json v1.0.0 [--finalize] [flags]
 cloudquery addon publish /path/to/manifest.json v1.0.0
 ```
 
-### Options
+## Options
 
 ```
   -f, --finalize   Finalize the addon version after publishing. If false, the addon version will be marked as draft.
   -h, --help       help for publish
 ```
 
-### Options inherited from parent commands
+## Options inherited from parent commands
 
 ```
       --cq-dir string            directory to store cloudquery files, such as downloaded plugins (default ".cq")
@@ -45,7 +45,7 @@ cloudquery addon publish /path/to/manifest.json v1.0.0
       --telemetry-level string   Telemetry level (none, errors, stats, all) (default "all")
 ```
 
-### SEE ALSO
+## SEE ALSO
 
 * [cloudquery addon](/cli/cli-reference/cloudquery_addon)	 - Addon commands
 

--- a/cli/docs/reference/cloudquery_addon_publish.md
+++ b/cli/docs/reference/cloudquery_addon_publish.md
@@ -45,12 +45,9 @@ cloudquery addon publish /path/to/manifest.json v1.0.0
       --telemetry-level string   Telemetry level (none, errors, stats, all) (default "all")
 ```
 
-## SEE ALSO
+## See Also
 
 * [cloudquery addon](/cli/cli-reference/cloudquery_addon)	 - Addon commands
-
-
-## See Also
 
 - [Publishing an Addon](/cli/advanced/publishing-an-addon-to-the-hub) - Full addon publishing guide
 - [Transformations](/cli/core-concepts/transformations) - Official transformations and policies

--- a/cli/docs/reference/cloudquery_init.md
+++ b/cli/docs/reference/cloudquery_init.md
@@ -74,12 +74,9 @@ cloudquery init --yes
       --telemetry-level string   Telemetry level (none, errors, stats, all) (default "all")
 ```
 
-## SEE ALSO
+## See Also
 
 * [cloudquery](/cli/cli-reference/cloudquery)	 - CloudQuery CLI
-
-
-## See Also
 
 - [Getting Started](/cli/getting-started) - Full quickstart guide using the init command
 - [Configuration Guide](/cli/core-concepts/configuration) - Understand the generated configuration files

--- a/cli/docs/reference/cloudquery_init.md
+++ b/cli/docs/reference/cloudquery_init.md
@@ -1,15 +1,15 @@
 ---
 title: "init"
 ---
-## cloudquery init
+# cloudquery init
 
 Generate a configuration file for a sync
 
-### Synopsis
+## Synopsis
 
 Generate a configuration file for a sync
 
-### Modes
+## Modes
 
 The `init` command operates in one of three modes depending on your authentication state and flags:
 
@@ -33,7 +33,7 @@ Authentication via `cloudquery login` is required for AI-assisted and basic inte
 cloudquery init [flags]
 ```
 
-### Examples
+## Examples
 
 ```
 # Display prompts to select source and destination plugins and generate a configuration file from them
@@ -48,7 +48,7 @@ cloudquery init --source aws
 cloudquery init --yes
 ```
 
-### Options
+## Options
 
 ```
       --destination string    Destination plugin name or path
@@ -60,7 +60,7 @@ cloudquery init --yes
       --yes                   Accept all defaults
 ```
 
-### Options inherited from parent commands
+## Options inherited from parent commands
 
 ```
       --cq-dir string            directory to store cloudquery files, such as downloaded plugins (default ".cq")
@@ -74,7 +74,7 @@ cloudquery init --yes
       --telemetry-level string   Telemetry level (none, errors, stats, all) (default "all")
 ```
 
-### SEE ALSO
+## SEE ALSO
 
 * [cloudquery](/cli/cli-reference/cloudquery)	 - CloudQuery CLI
 

--- a/cli/docs/reference/cloudquery_login.md
+++ b/cli/docs/reference/cloudquery_login.md
@@ -1,11 +1,11 @@
 ---
 title: "login"
 ---
-## cloudquery login
+# cloudquery login
 
 Login to CloudQuery Hub.
 
-### Synopsis
+## Synopsis
 
 Login to CloudQuery Hub.
 
@@ -18,7 +18,7 @@ Local plugins and different registries don't need login.
 cloudquery login [flags]
 ```
 
-### Examples
+## Examples
 
 ```
 
@@ -30,14 +30,14 @@ cloudquery login --team my-team
 
 ```
 
-### Options
+## Options
 
 ```
   -h, --help          help for login
   -t, --team string   Team to login to. Specify the team name, e.g. 'my-team' (not the display name)
 ```
 
-### Options inherited from parent commands
+## Options inherited from parent commands
 
 ```
       --cq-dir string            directory to store cloudquery files, such as downloaded plugins (default ".cq")
@@ -51,7 +51,7 @@ cloudquery login --team my-team
       --telemetry-level string   Telemetry level (none, errors, stats, all) (default "all")
 ```
 
-### SEE ALSO
+## SEE ALSO
 
 * [cloudquery](/cli/cli-reference/cloudquery)	 - CloudQuery CLI
 

--- a/cli/docs/reference/cloudquery_login.md
+++ b/cli/docs/reference/cloudquery_login.md
@@ -51,12 +51,9 @@ cloudquery login --team my-team
       --telemetry-level string   Telemetry level (none, errors, stats, all) (default "all")
 ```
 
-## SEE ALSO
+## See Also
 
 * [cloudquery](/cli/cli-reference/cloudquery)	 - CloudQuery CLI
-
-
-## See Also
 
 - [Generate API Key](/cli/managing-cloudquery/deployments/generate-api-key) - Create API keys for headless authentication
 - [Getting Started](/cli/getting-started) - Install and run your first sync

--- a/cli/docs/reference/cloudquery_logout.md
+++ b/cli/docs/reference/cloudquery_logout.md
@@ -33,12 +33,9 @@ cloudquery logout [flags]
       --telemetry-level string   Telemetry level (none, errors, stats, all) (default "all")
 ```
 
-## SEE ALSO
+## See Also
 
 * [cloudquery](/cli/cli-reference/cloudquery)	 - CloudQuery CLI
-
-
-## See Also
 
 - [Generate API Key](/cli/managing-cloudquery/deployments/generate-api-key) - Manage API keys for authentication
 - [Security](/cli/managing-cloudquery/security) - CloudQuery security best practices

--- a/cli/docs/reference/cloudquery_logout.md
+++ b/cli/docs/reference/cloudquery_logout.md
@@ -1,11 +1,11 @@
 ---
 title: "logout"
 ---
-## cloudquery logout
+# cloudquery logout
 
 Log out of CloudQuery Hub.
 
-### Synopsis
+## Synopsis
 
 Log out of CloudQuery Hub.
 
@@ -13,13 +13,13 @@ Log out of CloudQuery Hub.
 cloudquery logout [flags]
 ```
 
-### Options
+## Options
 
 ```
   -h, --help   help for logout
 ```
 
-### Options inherited from parent commands
+## Options inherited from parent commands
 
 ```
       --cq-dir string            directory to store cloudquery files, such as downloaded plugins (default ".cq")
@@ -33,7 +33,7 @@ cloudquery logout [flags]
       --telemetry-level string   Telemetry level (none, errors, stats, all) (default "all")
 ```
 
-### SEE ALSO
+## SEE ALSO
 
 * [cloudquery](/cli/cli-reference/cloudquery)	 - CloudQuery CLI
 

--- a/cli/docs/reference/cloudquery_migrate.md
+++ b/cli/docs/reference/cloudquery_migrate.md
@@ -44,12 +44,9 @@ cloudquery migrate ./directory ./aws.yml ./pg.yml
       --telemetry-level string   Telemetry level (none, errors, stats, all) (default "all")
 ```
 
-## SEE ALSO
+## See Also
 
 * [cloudquery](/cli/cli-reference/cloudquery)	 - CloudQuery CLI
-
-
-## See Also
 
 - [Schema Migrations](/cli/managing-cloudquery/migrations) - How CloudQuery handles schema changes
 - [Destination Integrations](/cli/integrations/destinations) - Configure migration modes

--- a/cli/docs/reference/cloudquery_migrate.md
+++ b/cli/docs/reference/cloudquery_migrate.md
@@ -1,11 +1,11 @@
 ---
 title: "migrate"
 ---
-## cloudquery migrate
+# cloudquery migrate
 
 Update schema of your destinations based on the latest changes in sources from your configuration
 
-### Synopsis
+## Synopsis
 
 Update schema of your destinations based on the latest changes in sources from your configuration
 
@@ -13,7 +13,7 @@ Update schema of your destinations based on the latest changes in sources from y
 cloudquery migrate [files or directories] [flags]
 ```
 
-### Examples
+## Examples
 
 ```
 # Run migration for plugins specified in directory
@@ -23,14 +23,14 @@ cloudquery migrate ./directory ./aws.yml ./pg.yml
 
 ```
 
-### Options
+## Options
 
 ```
   -h, --help             help for migrate
       --license string   set offline license file
 ```
 
-### Options inherited from parent commands
+## Options inherited from parent commands
 
 ```
       --cq-dir string            directory to store cloudquery files, such as downloaded plugins (default ".cq")
@@ -44,7 +44,7 @@ cloudquery migrate ./directory ./aws.yml ./pg.yml
       --telemetry-level string   Telemetry level (none, errors, stats, all) (default "all")
 ```
 
-### SEE ALSO
+## SEE ALSO
 
 * [cloudquery](/cli/cli-reference/cloudquery)	 - CloudQuery CLI
 

--- a/cli/docs/reference/cloudquery_plugin.md
+++ b/cli/docs/reference/cloudquery_plugin.md
@@ -25,14 +25,11 @@ Plugin commands
       --telemetry-level string   Telemetry level (none, errors, stats, all) (default "all")
 ```
 
-## SEE ALSO
+## See Also
 
 * [cloudquery](/cli/cli-reference/cloudquery)	 - CloudQuery CLI
 * [cloudquery plugin install](/cli/cli-reference/cloudquery_plugin_install)	 - Install required plugin images from your configuration
 * [cloudquery plugin publish](/cli/cli-reference/cloudquery_plugin_publish)	 - Publish to CloudQuery Hub.
-
-
-## See Also
 
 - [Integration Concepts](/cli/core-concepts/integrations) - How integrations work
 - [Managing Versions](/cli/advanced/managing-versions) - Integration versioning

--- a/cli/docs/reference/cloudquery_plugin.md
+++ b/cli/docs/reference/cloudquery_plugin.md
@@ -1,17 +1,17 @@
 ---
 title: "plugin"
 ---
-## cloudquery plugin
+# cloudquery plugin
 
 Plugin commands
 
-### Options
+## Options
 
 ```
   -h, --help   help for plugin
 ```
 
-### Options inherited from parent commands
+## Options inherited from parent commands
 
 ```
       --cq-dir string            directory to store cloudquery files, such as downloaded plugins (default ".cq")
@@ -25,7 +25,7 @@ Plugin commands
       --telemetry-level string   Telemetry level (none, errors, stats, all) (default "all")
 ```
 
-### SEE ALSO
+## SEE ALSO
 
 * [cloudquery](/cli/cli-reference/cloudquery)	 - CloudQuery CLI
 * [cloudquery plugin install](/cli/cli-reference/cloudquery_plugin_install)	 - Install required plugin images from your configuration

--- a/cli/docs/reference/cloudquery_plugin_install.md
+++ b/cli/docs/reference/cloudquery_plugin_install.md
@@ -43,12 +43,9 @@ cloudquery plugin install ./directory ./aws.yml ./pg.yml
       --telemetry-level string   Telemetry level (none, errors, stats, all) (default "all")
 ```
 
-## SEE ALSO
+## See Also
 
 * [cloudquery plugin](/cli/cli-reference/cloudquery_plugin)	 - Plugin commands
-
-
-## See Also
 
 - [Managing Versions](/cli/advanced/managing-versions) - Understand version management
 - [Source Integrations](/cli/integrations/sources) - Available source integrations

--- a/cli/docs/reference/cloudquery_plugin_install.md
+++ b/cli/docs/reference/cloudquery_plugin_install.md
@@ -1,11 +1,11 @@
 ---
 title: "plugin_install"
 ---
-## cloudquery plugin install
+# cloudquery plugin install
 
 Install required plugin images from your configuration
 
-### Synopsis
+## Synopsis
 
 Install required plugin images from your configuration
 
@@ -13,7 +13,7 @@ Install required plugin images from your configuration
 cloudquery plugin install [files or directories] [flags]
 ```
 
-### Examples
+## Examples
 
 ```
 # Install required plugins specified in directory
@@ -23,13 +23,13 @@ cloudquery plugin install ./directory ./aws.yml ./pg.yml
 
 ```
 
-### Options
+## Options
 
 ```
   -h, --help   help for install
 ```
 
-### Options inherited from parent commands
+## Options inherited from parent commands
 
 ```
       --cq-dir string            directory to store cloudquery files, such as downloaded plugins (default ".cq")
@@ -43,7 +43,7 @@ cloudquery plugin install ./directory ./aws.yml ./pg.yml
       --telemetry-level string   Telemetry level (none, errors, stats, all) (default "all")
 ```
 
-### SEE ALSO
+## SEE ALSO
 
 * [cloudquery plugin](/cli/cli-reference/cloudquery_plugin)	 - Plugin commands
 

--- a/cli/docs/reference/cloudquery_plugin_publish.md
+++ b/cli/docs/reference/cloudquery_plugin_publish.md
@@ -47,12 +47,9 @@ cloudquery plugin publish
       --telemetry-level string   Telemetry level (none, errors, stats, all) (default "all")
 ```
 
-## SEE ALSO
+## See Also
 
 * [cloudquery plugin](/cli/cli-reference/cloudquery_plugin)	 - Plugin commands
-
-
-## See Also
 
 - [Publishing an Integration](/cli/integrations/creating-new-integration/publishing) - Full publishing guide
 - [Creating a New Integration](/cli/integrations/creating-new-integration) - Build an integration first

--- a/cli/docs/reference/cloudquery_plugin_publish.md
+++ b/cli/docs/reference/cloudquery_plugin_publish.md
@@ -1,11 +1,11 @@
 ---
 title: "plugin_publish"
 ---
-## cloudquery plugin publish
+# cloudquery plugin publish
 
 Publish to CloudQuery Hub.
 
-### Synopsis
+## Synopsis
 
 Publish to CloudQuery Hub.
 
@@ -16,7 +16,7 @@ This publishes a plugin version to CloudQuery Hub from a local dist directory.
 cloudquery plugin publish [-D dist] [flags]
 ```
 
-### Examples
+## Examples
 
 ```
 
@@ -24,7 +24,7 @@ cloudquery plugin publish [-D dist] [flags]
 cloudquery plugin publish
 ```
 
-### Options
+## Options
 
 ```
   -D, --dist-dir string   Path to the dist directory (default "dist")
@@ -33,7 +33,7 @@ cloudquery plugin publish
   -U, --ui-dir string     Path to the built plugin UI directory
 ```
 
-### Options inherited from parent commands
+## Options inherited from parent commands
 
 ```
       --cq-dir string            directory to store cloudquery files, such as downloaded plugins (default ".cq")
@@ -47,7 +47,7 @@ cloudquery plugin publish
       --telemetry-level string   Telemetry level (none, errors, stats, all) (default "all")
 ```
 
-### SEE ALSO
+## SEE ALSO
 
 * [cloudquery plugin](/cli/cli-reference/cloudquery_plugin)	 - Plugin commands
 

--- a/cli/docs/reference/cloudquery_switch.md
+++ b/cli/docs/reference/cloudquery_switch.md
@@ -42,12 +42,9 @@ cloudquery switch my-team
       --telemetry-level string   Telemetry level (none, errors, stats, all) (default "all")
 ```
 
-## SEE ALSO
+## See Also
 
 * [cloudquery](/cli/cli-reference/cloudquery)	 - CloudQuery CLI
-
-
-## See Also
 
 - [Managing Versions](/cli/advanced/managing-versions) - Understand integration versioning
 - [Source Integrations](/cli/integrations/sources) - Configure source integration versions

--- a/cli/docs/reference/cloudquery_switch.md
+++ b/cli/docs/reference/cloudquery_switch.md
@@ -1,11 +1,11 @@
 ---
 title: "switch"
 ---
-## cloudquery switch
+# cloudquery switch
 
 Switches between teams.
 
-### Synopsis
+## Synopsis
 
 Switches between teams.
 
@@ -13,7 +13,7 @@ Switches between teams.
 cloudquery switch [team] [flags]
 ```
 
-### Examples
+## Examples
 
 ```
 
@@ -22,13 +22,13 @@ cloudquery switch my-team
 
 ```
 
-### Options
+## Options
 
 ```
   -h, --help   help for switch
 ```
 
-### Options inherited from parent commands
+## Options inherited from parent commands
 
 ```
       --cq-dir string            directory to store cloudquery files, such as downloaded plugins (default ".cq")
@@ -42,7 +42,7 @@ cloudquery switch my-team
       --telemetry-level string   Telemetry level (none, errors, stats, all) (default "all")
 ```
 
-### SEE ALSO
+## SEE ALSO
 
 * [cloudquery](/cli/cli-reference/cloudquery)	 - CloudQuery CLI
 

--- a/cli/docs/reference/cloudquery_sync.md
+++ b/cli/docs/reference/cloudquery_sync.md
@@ -107,12 +107,9 @@ cloudquery sync spec.yml --shard 1/4
       --telemetry-level string   Telemetry level (none, errors, stats, all) (default "all")
 ```
 
-## SEE ALSO
+## See Also
 
 * [cloudquery](/cli/cli-reference/cloudquery)	 - CloudQuery CLI
-
-
-## See Also
 
 - [Syncs](/cli/core-concepts/syncs) - Understand full and incremental sync modes
 - [Configuration Guide](/cli/core-concepts/configuration) - Set up sync configurations

--- a/cli/docs/reference/cloudquery_sync.md
+++ b/cli/docs/reference/cloudquery_sync.md
@@ -1,17 +1,17 @@
 ---
 title: "sync"
 ---
-## cloudquery sync
+# cloudquery sync
 
 Sync resources from configured source plugins to destinations
 
-### Synopsis
+## Synopsis
 
 Sync resources from configured source plugins to destinations
 
-### Flag Details
+## Flag Details
 
-#### --summary-location
+### --summary-location
 
 When set, a JSON summary of each sync is appended to the specified file after the sync completes. The file uses JSONL format (one JSON object per line). When syncing to multiple destinations, a separate entry is written for each destination.
 
@@ -48,7 +48,7 @@ The summary contains the following fields:
 | `errors_per_table`       | object   | Error count per table                                             |
 | `durations_per_table_ms` | object   | Duration per table in milliseconds                                |
 
-#### --invocation-id
+### --invocation-id
 
 A UUID that uniquely identifies a sync invocation. If not provided, a random UUID is automatically generated.
 
@@ -68,7 +68,7 @@ cloudquery sync config.yml --invocation-id 550e8400-e29b-41d4-a716-446655440000
 cloudquery sync [files or directories] [flags]
 ```
 
-### Examples
+## Examples
 
 ```
 # Sync resources from configuration in a directory
@@ -82,7 +82,7 @@ cloudquery sync spec.yml --shard 1/4
 
 ```
 
-### Options
+## Options
 
 ```
   -h, --help                             help for sync
@@ -93,7 +93,7 @@ cloudquery sync spec.yml --shard 1/4
       --tables-metrics-location string   Tables metrics file location. This feature is in Preview. Please provide feedback to help us improve it. Works with plugins released on 2024-07-10 or later.
 ```
 
-### Options inherited from parent commands
+## Options inherited from parent commands
 
 ```
       --cq-dir string            directory to store cloudquery files, such as downloaded plugins (default ".cq")
@@ -107,7 +107,7 @@ cloudquery sync spec.yml --shard 1/4
       --telemetry-level string   Telemetry level (none, errors, stats, all) (default "all")
 ```
 
-### SEE ALSO
+## SEE ALSO
 
 * [cloudquery](/cli/cli-reference/cloudquery)	 - CloudQuery CLI
 

--- a/cli/docs/reference/cloudquery_tables.md
+++ b/cli/docs/reference/cloudquery_tables.md
@@ -1,11 +1,11 @@
 ---
 title: "tables"
 ---
-## cloudquery tables
+# cloudquery tables
 
 Generate documentation for all supported tables of source plugins specified in the spec(s)
 
-### Synopsis
+## Synopsis
 
 Generate documentation for all supported tables of source plugins specified in the spec(s)
 
@@ -13,7 +13,7 @@ Generate documentation for all supported tables of source plugins specified in t
 cloudquery tables [files or directories] [flags]
 ```
 
-### Examples
+## Examples
 
 ```
 # Generate documentation for all supported tables of source plugins specified in the spec(s) 
@@ -27,7 +27,7 @@ cloudquery tables ./directory --filter spec
 
 ```
 
-### Options
+## Options
 
 ```
       --filter string       Filter tables. One of: all, spec (default "all")
@@ -36,7 +36,7 @@ cloudquery tables ./directory --filter spec
       --output-dir string   Base output directory for generated files (default "cq-docs")
 ```
 
-### Options inherited from parent commands
+## Options inherited from parent commands
 
 ```
       --cq-dir string            directory to store cloudquery files, such as downloaded plugins (default ".cq")
@@ -50,7 +50,7 @@ cloudquery tables ./directory --filter spec
       --telemetry-level string   Telemetry level (none, errors, stats, all) (default "all")
 ```
 
-### SEE ALSO
+## SEE ALSO
 
 * [cloudquery](/cli/cli-reference/cloudquery)	 - CloudQuery CLI
 

--- a/cli/docs/reference/cloudquery_tables.md
+++ b/cli/docs/reference/cloudquery_tables.md
@@ -50,12 +50,9 @@ cloudquery tables ./directory --filter spec
       --telemetry-level string   Telemetry level (none, errors, stats, all) (default "all")
 ```
 
-## SEE ALSO
+## See Also
 
 * [cloudquery](/cli/cli-reference/cloudquery)	 - CloudQuery CLI
-
-
-## See Also
 
 - [Source Integrations](/cli/integrations/sources) - Configure which tables to sync
 - [Integration Concepts](/cli/core-concepts/integrations) - How source integrations define tables

--- a/cli/docs/reference/cloudquery_test-connection.md
+++ b/cli/docs/reference/cloudquery_test-connection.md
@@ -1,11 +1,11 @@
 ---
 title: "test-connection"
 ---
-## cloudquery test-connection
+# cloudquery test-connection
 
 Test plugin connections to sources and/or destinations
 
-### Synopsis
+## Synopsis
 
 Test plugin connections to sources and/or destinations
 
@@ -13,7 +13,7 @@ Test plugin connections to sources and/or destinations
 cloudquery test-connection [files or directories] [flags]
 ```
 
-### Examples
+## Examples
 
 ```
 # Test plugin connections to sources and/or destinations
@@ -23,13 +23,13 @@ cloudquery test-connection ./directory ./aws.yml ./pg.yml
 
 ```
 
-### Options
+## Options
 
 ```
   -h, --help   help for test-connection
 ```
 
-### Options inherited from parent commands
+## Options inherited from parent commands
 
 ```
       --cq-dir string            directory to store cloudquery files, such as downloaded plugins (default ".cq")
@@ -43,7 +43,7 @@ cloudquery test-connection ./directory ./aws.yml ./pg.yml
       --telemetry-level string   Telemetry level (none, errors, stats, all) (default "all")
 ```
 
-### SEE ALSO
+## SEE ALSO
 
 * [cloudquery](/cli/cli-reference/cloudquery)	 - CloudQuery CLI
 

--- a/cli/docs/reference/cloudquery_test-connection.md
+++ b/cli/docs/reference/cloudquery_test-connection.md
@@ -43,12 +43,9 @@ cloudquery test-connection ./directory ./aws.yml ./pg.yml
       --telemetry-level string   Telemetry level (none, errors, stats, all) (default "all")
 ```
 
-## SEE ALSO
+## See Also
 
 * [cloudquery](/cli/cli-reference/cloudquery)	 - CloudQuery CLI
-
-
-## See Also
 
 - [Source Integrations](/cli/integrations/sources) - Configure source connections
 - [Destination Integrations](/cli/integrations/destinations) - Configure destination connections

--- a/cli/docs/reference/cloudquery_validate-config.md
+++ b/cli/docs/reference/cloudquery_validate-config.md
@@ -43,12 +43,9 @@ cloudquery validate-config ./directory ./aws.yml ./pg.yml
       --telemetry-level string   Telemetry level (none, errors, stats, all) (default "all")
 ```
 
-## SEE ALSO
+## See Also
 
 * [cloudquery](/cli/cli-reference/cloudquery)	 - CloudQuery CLI
-
-
-## See Also
 
 - [Configuration Guide](/cli/core-concepts/configuration) - Configuration format and options
 - [Environment Variables](/cli/managing-cloudquery/environment-variables) - Variable substitution in configuration files

--- a/cli/docs/reference/cloudquery_validate-config.md
+++ b/cli/docs/reference/cloudquery_validate-config.md
@@ -1,11 +1,11 @@
 ---
 title: "validate-config"
 ---
-## cloudquery validate-config
+# cloudquery validate-config
 
 Validate config
 
-### Synopsis
+## Synopsis
 
 Validate configuration without requiring any credentials or connections. This will not validate the tables specified in the tables list. This validation is stricter than the validation done during `sync`, but if it passes this validation it will pass the sync validation.
 
@@ -13,7 +13,7 @@ Validate configuration without requiring any credentials or connections. This wi
 cloudquery validate-config [files or directories] [flags]
 ```
 
-### Examples
+## Examples
 
 ```
 # Validate configs
@@ -23,13 +23,13 @@ cloudquery validate-config ./directory ./aws.yml ./pg.yml
 
 ```
 
-### Options
+## Options
 
 ```
   -h, --help   help for validate-config
 ```
 
-### Options inherited from parent commands
+## Options inherited from parent commands
 
 ```
       --cq-dir string            directory to store cloudquery files, such as downloaded plugins (default ".cq")
@@ -43,7 +43,7 @@ cloudquery validate-config ./directory ./aws.yml ./pg.yml
       --telemetry-level string   Telemetry level (none, errors, stats, all) (default "all")
 ```
 
-### SEE ALSO
+## SEE ALSO
 
 * [cloudquery](/cli/cli-reference/cloudquery)	 - CloudQuery CLI
 


### PR DESCRIPTION
cobra/doc generates `##` for the command name heading and `###`/`####` for sub-sections, leaving every CLI reference page without a proper H1 tag. This caused an SEO regression each time CLI docs were regenerated — the manually-applied H1 fixes from cloudquery/frontend#4506 would be silently overwritten on the next version bump.

This PR adds a `fixHeadingLevels` function to the `doc` command that runs after `GenMarkdownTreeCustom` inside `RunE`. It demotes `####` → `###` and `###` → `##` across all generated files, then promotes the first `##` (the command name) to `#`, so every page gets a correct H1. The 16 generated reference docs are also committed here so they reflect the corrected output.

## How we tested it locally

Ran `make gen-docs` from the `cli/` directory and verified all 16 generated files had the correct heading hierarchy:

- `# cloudquery <command>` — H1 for the command name
- `## Synopsis`, `## Options`, `## SEE ALSO`, etc. — H2 for top-level sections
- `### --flag-name` — H3 for flag detail sub-sections (e.g. in `cloudquery_sync.md`)