### PR TITLE
fix: Avoid panic during an empty write

### DIFF
--- a/plugins/destination/snowflake/client/write.go
+++ b/plugins/destination/snowflake/client/write.go
@@ -32,6 +32,12 @@ func (c *Client) Write(ctx context.Context, msgs <-chan message.WriteMessage) er
 }
 
 func (c *Client) WriteTableBatch(ctx context.Context, name string, msgs message.WriteInserts) error {
+	// if there are no messages, we can skip the write. Ideally this should be handled in the BatchWriter, but this is a good safeguard until the fix can be implemented
+	// upstream
+	if len(msgs) == 0 {
+		return nil
+	}
+
 	if err := c.setupWrite(ctx); err != nil {
 		return err
 	}


### PR DESCRIPTION
This happens when a single row is larger than 5 mb and the batch is empty
```
panic: runtime error: index out of range [0] with length 0

goroutine 221 [running]:
github.com/cloudquery/cloudquery/plugins/destination/snowflake/v4/client.(*Client).WriteTableBatch(0x2ddcc206270, {0x2375a20, 0x3904660}, {0x2ddccaa6a50, 0x25}, {0x2ddcd1d2000, 0x0, 0x2ddcc6ecdb0?})
	github.com/cloudquery/cloudquery/plugins/destination/snowflake/v4/client/write.go:76 +0x84a
github.com/cloudquery/plugin-sdk/v4/writers/batchwriter.(*BatchWriter).flushTable(0x2ddcc22c500, {0x2375a20, 0x3904660}, {0x2ddccaa6a50, 0x25}, {0x2ddcd1d2000, 0x0, 0x1388}, 0x0?)
	github.com/cloudquery/plugin-sdk/v4@v4.95.0/writers/batchwriter/batchwriter.go:201 +0xc4
github.com/cloudquery/plugin-sdk/v4/writers/batchwriter.(*BatchWriter).worker.func1(...)
	github.com/cloudquery/plugin-sdk/v4@v4.95.0/writers/batchwriter/batchwriter.go:137
github.com/cloudquery/plugin-sdk/v4/writers/batchwriter.(*BatchWriter).worker(0x2ddcc22c500, {0x2375a20, 0x3904660}, {0x2ddccaa6a50, 0x25}, 0x2ddcbeda3f0, 0x2ddcbeda460)
	github.com/cloudquery/plugin-sdk/v4@v4.95.0/writers/batchwriter/batchwriter.go:165 +0x5b1
github.com/cloudquery/plugin-sdk/v4/writers/batchwriter.(*BatchWriter).startWorker.func1()
	github.com/cloudquery/plugin-sdk/v4@v4.95.0/writers/batchwriter/batchwriter.go:375 +0x6b
created by github.com/cloudquery/plugin-sdk/v4/writers/batchwriter.(*BatchWriter).startWorker in goroutine 136
	github.com/cloudquery/plugin-sdk/v4@v4.95.0/writers/batchwriter/batchwriter.go:371 +0x3e8
```