### PR TITLE
chore: Track ghcr.io/gythialy/golang-cross via docker datasource

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -25,8 +25,8 @@
       matchStrings: [
         'image:\\s*ghcr\\.io/gythialy/golang-cross:(?<currentValue>\\d+\\.\\d+\\.\\d+)'
       ],
-      depNameTemplate: "golang-cross",
-      datasourceTemplate: "golang-version",
+      depNameTemplate: "ghcr.io/gythialy/golang-cross",
+      datasourceTemplate: "docker",
       versioningTemplate: "semver"
     }
   ],
@@ -96,6 +96,13 @@
     },
     {
       matchDatasources: ["golang-version"],
+      rangeStrategy: "bump",
+      addLabels: ["no automerge"],
+      schedule: ["before 3am on Saturday"],
+    },
+    {
+      matchDatasources: ["docker"],
+      matchPackageNames: ["ghcr.io/gythialy/golang-cross"],
       rangeStrategy: "bump",
       addLabels: ["no automerge"],
       schedule: ["before 3am on Saturday"],


### PR DESCRIPTION
Switches the Renovate custom manager for the `ghcr.io/gythialy/golang-cross` workflow image from the `golang-version` datasource (Go language releases on go.dev) to the `docker` datasource (actual GHCR tags), so Renovate only proposes image tags that exist — preventing repeats of the broken bump that blocked the snowflake plugin release ([ENG2-3291](https://linear.app/env-zero/issue/ENG2-3291), tactical revert in #22751).