### PR TITLE
fix: Update plugin docs to use current docs URLs

### DIFF
--- a/plugins/destination/azblob/docs/overview.md
+++ b/plugins/destination/azblob/docs/overview.md
@@ -18,7 +18,7 @@ This destination plugin lets you sync data from a CloudQuery source to remote Az
 
 This example configures an Azure blob storage destination, to create CSV files in `https://cqdestinationazblob.blob.core.windows.net/test/path/to/files`.
 
-The (top level) spec section is described in the [Destination Spec Reference](/docs/reference/destination-spec).
+The (top level) spec section is described in the [Destination Spec Reference](/docs/cli/integrations/destinations#complete-destination-spec-reference).
 
 :configuration
 

--- a/plugins/destination/bigquery/docs/overview.md
+++ b/plugins/destination/bigquery/docs/overview.md
@@ -26,7 +26,7 @@ Streaming is not available for the [Google Cloud free tier](https://cloud.google
 
 :configuration
 
-The BigQuery destination utilizes batching, and supports [`batch_size`](/docs/reference/destination-spec#batch_size) and [`batch_size_bytes`](/docs/reference/destination-spec#batch_size_bytes).
+The BigQuery destination utilizes batching, and supports [`batch_size`](/docs/cli/integrations/destinations#batch_size) and [`batch_size_bytes`](/docs/cli/integrations/destinations#batch_size_bytes).
 
 Note that the BigQuery plugin only supports the `append` write mode. 
 

--- a/plugins/destination/clickhouse/docs/_configuration.md
+++ b/plugins/destination/clickhouse/docs/_configuration.md
@@ -24,4 +24,4 @@ spec:
 
 This example configures a ClickHouse instance, located at `localhost:9000`.
 It expects `CH_USER`, `CH_PASSWORD` and `CH_DATABASE` environment variables to be set.
-The (top level) spec section is described in the [Destination Spec Reference](/docs/reference/destination-spec).
+The (top level) spec section is described in the [Destination Spec Reference](/docs/cli/integrations/destinations#complete-destination-spec-reference).

--- a/plugins/destination/clickhouse/docs/overview.md
+++ b/plugins/destination/clickhouse/docs/overview.md
@@ -11,7 +11,7 @@ description: CloudQuery ClickHouse destination plugin documentation
 This destination plugin lets you sync data from a CloudQuery source to [ClickHouse](https://clickhouse.com/) database.
 
 It supports `append` write mode only.
-Write mode selection is required through [`write_mode`](/docs/reference/destination-spec#write_mode).
+Write mode selection is required through [`write_mode`](/docs/cli/integrations/destinations#write_mode).
 
 Supported database versions: >= `24.8.1`
 

--- a/plugins/destination/elasticsearch/docs/overview.md
+++ b/plugins/destination/elasticsearch/docs/overview.md
@@ -13,7 +13,7 @@ The Elasticsearch plugin syncs data from any CloudQuery source plugin(s) to an E
 
 :configuration
 
-The Elasticsearch destination utilizes batching, and supports [`batch_size`](/docs/reference/destination-spec#batch_size) and [`batch_size_bytes`](/docs/reference/destination-spec#batch_size_bytes).
+The Elasticsearch destination utilizes batching, and supports [`batch_size`](/docs/cli/integrations/destinations#batch_size) and [`batch_size_bytes`](/docs/cli/integrations/destinations#batch_size_bytes).
 
 It supports `append`, `overwrite` and `overwrite-delete-stale` write modes. The default write mode is `overwrite-delete-stale`.
 

--- a/plugins/destination/file/docs/_configuration.md
+++ b/plugins/destination/file/docs/_configuration.md
@@ -29,4 +29,4 @@ spec:
     # batch_timeout: 30s
 ```
 
-Note that the file plugin only supports `append` `write_mode`. The (top level) spec section is described in the [Destination Spec Reference](/docs/reference/destination-spec).
+Note that the file plugin only supports `append` `write_mode`. The (top level) spec section is described in the [Destination Spec Reference](/docs/cli/integrations/destinations#complete-destination-spec-reference).

--- a/plugins/destination/firehose/docs/overview.md
+++ b/plugins/destination/firehose/docs/overview.md
@@ -18,9 +18,9 @@ This destination plugin lets you sync data from a CloudQuery source to Amazon Ki
 
 :configuration
 
-The (top level) spec section is described in the [Destination Spec Reference](/docs/reference/destination-spec).
+The (top level) spec section is described in the [Destination Spec Reference](/docs/cli/integrations/destinations#complete-destination-spec-reference).
 
-The Amazon Kinesis Firehose destination utilizes batching, and supports [`batch_size`](/docs/reference/destination-spec#batch_size) and [`batch_size_bytes`](/docs/reference/destination-spec#batch_size_bytes). 
+The Amazon Kinesis Firehose destination utilizes batching, and supports [`batch_size`](/docs/cli/integrations/destinations#batch_size) and [`batch_size_bytes`](/docs/cli/integrations/destinations#batch_size_bytes). 
 
 It is important to note that Amazon Kinesis Firehose has the following limitations that cannot be changed:
   - The maximum size of a record sent to Kinesis Data Firehose, before base64-encoding, is 1,000 KiB.

--- a/plugins/destination/firehose/docs/overview.md
+++ b/plugins/destination/firehose/docs/overview.md
@@ -20,7 +20,7 @@ This destination plugin lets you sync data from a CloudQuery source to Amazon Ki
 
 The (top level) spec section is described in the [Destination Spec Reference](/docs/cli/integrations/destinations#complete-destination-spec-reference).
 
-The Amazon Kinesis Firehose destination utilizes batching, and supports [`batch_size`](/docs/cli/integrations/destinations#batch_size) and [`batch_size_bytes`](/docs/cli/integrations/destinations#batch_size_bytes). 
+The Amazon Kinesis Firehose destination utilizes batching, and supports [`batch_size`](/docs/cli/integrations/destinations#batch_size) and [`batch_size_bytes`](/docs/cli/integrations/destinations#batch_size_bytes).
 
 It is important to note that Amazon Kinesis Firehose has the following limitations that cannot be changed:
   - The maximum size of a record sent to Kinesis Data Firehose, before base64-encoding, is 1,000 KiB.

--- a/plugins/destination/gcs/docs/_configuration.md
+++ b/plugins/destination/gcs/docs/_configuration.md
@@ -30,4 +30,4 @@ spec:
     # batch_timeout: 30s
 ```
 
-Note that the GCS plugin only supports `append` `write_mode`. The (top level) spec section is described in the [Destination Spec Reference](/docs/reference/destination-spec).
+Note that the GCS plugin only supports `append` `write_mode`. The (top level) spec section is described in the [Destination Spec Reference](/docs/cli/integrations/destinations#complete-destination-spec-reference).

--- a/plugins/destination/gremlin/docs/overview.md
+++ b/plugins/destination/gremlin/docs/overview.md
@@ -22,13 +22,13 @@ As a side note graph databases can be quite useful for various networking use-ca
 
 :configuration
 
-The (top level) spec section is described in the [Destination Spec Reference](/docs/reference/destination-spec).
+The (top level) spec section is described in the [Destination Spec Reference](/docs/cli/integrations/destinations#complete-destination-spec-reference).
 
 :::callout{type="info"}
 Make sure you use environment variable expansion in production instead of committing the credentials to the configuration file directly.
 :::
 
-The Gremlin destination utilizes batching, and supports [`batch_size`](/docs/reference/destination-spec#batch_size) and [`batch_size_bytes`](/docs/reference/destination-spec#batch_size_bytes).
+The Gremlin destination utilizes batching, and supports [`batch_size`](/docs/cli/integrations/destinations#batch_size) and [`batch_size_bytes`](/docs/cli/integrations/destinations#batch_size_bytes).
 
 ### Connecting to AWS Neptune
 

--- a/plugins/destination/kafka/docs/_configuration.md
+++ b/plugins/destination/kafka/docs/_configuration.md
@@ -1,6 +1,6 @@
 This example configures connects to a Kafka destination using SASL plain authentication and pushes messages in JSON format.
 
-The (top level) spec section is described in the [Destination Spec Reference](/docs/reference/destination-spec).
+The (top level) spec section is described in the [Destination Spec Reference](/docs/cli/integrations/destinations#complete-destination-spec-reference).
 
 ```yaml copy
 kind: destination
@@ -36,4 +36,4 @@ spec:
       # replication_factor: 1
 ```
 
-Note that the Kafka plugin only supports `append` `write_mode`. The (top level) spec section is described in the [Destination Spec Reference](/docs/reference/destination-spec).
+Note that the Kafka plugin only supports `append` `write_mode`. The (top level) spec section is described in the [Destination Spec Reference](/docs/cli/integrations/destinations#complete-destination-spec-reference).

--- a/plugins/destination/meilisearch/docs/overview.md
+++ b/plugins/destination/meilisearch/docs/overview.md
@@ -14,11 +14,11 @@ to a [Meilisearch](https://www.meilisearch.com) instance.
 
 :configuration
 
-The Meilisearch destination utilizes batching, and supports [`batch_size`](/docs/reference/destination-spec#batch_size)
-and [`batch_size_bytes`](/docs/reference/destination-spec#batch_size_bytes).
+The Meilisearch destination utilizes batching, and supports [`batch_size`](/docs/cli/integrations/destinations#batch_size)
+and [`batch_size_bytes`](/docs/cli/integrations/destinations#batch_size_bytes).
 
 It supports `append` and `overwrite` write modes. Write mode selection is required through
-[`write_mode`](/docs/reference/destination-spec#write_mode).
+[`write_mode`](/docs/cli/integrations/destinations#write_mode).
 
 ## Meilisearch Spec
 

--- a/plugins/destination/mongodb/docs/_configuration.md
+++ b/plugins/destination/mongodb/docs/_configuration.md
@@ -1,4 +1,4 @@
-This example configures a MongoDB destination, located at `localhost:27017`. The (top level) spec section is described in the [Destination Spec Reference](/docs/reference/destination-spec).
+This example configures a MongoDB destination, located at `localhost:27017`. The (top level) spec section is described in the [Destination Spec Reference](/docs/cli/integrations/destinations#complete-destination-spec-reference).
 
 ```yaml copy
 kind: destination

--- a/plugins/destination/mongodb/docs/overview.md
+++ b/plugins/destination/mongodb/docs/overview.md
@@ -24,7 +24,7 @@ Supported database versions:
 Make sure to use [environment variable substitution](/docs/advanced-topics/environment-variable-substitution) in production instead of committing the credentials to the configuration file directly.
 :::
 
-The MongoDB destination utilizes batching, and supports [`batch_size`](/docs/cli/integrations/destinations#batch_size) and [`batch_size_bytes`](/docs/cli/integrations/destinations#batch_size_bytes). 
+The MongoDB destination utilizes batching, and supports [`batch_size`](/docs/cli/integrations/destinations#batch_size) and [`batch_size_bytes`](/docs/cli/integrations/destinations#batch_size_bytes).
 
 ### MongoDB Spec
 

--- a/plugins/destination/mongodb/docs/overview.md
+++ b/plugins/destination/mongodb/docs/overview.md
@@ -24,7 +24,7 @@ Supported database versions:
 Make sure to use [environment variable substitution](/docs/advanced-topics/environment-variable-substitution) in production instead of committing the credentials to the configuration file directly.
 :::
 
-The MongoDB destination utilizes batching, and supports [`batch_size`](/docs/reference/destination-spec#batch_size) and [`batch_size_bytes`](/docs/reference/destination-spec#batch_size_bytes). 
+The MongoDB destination utilizes batching, and supports [`batch_size`](/docs/cli/integrations/destinations#batch_size) and [`batch_size_bytes`](/docs/cli/integrations/destinations#batch_size_bytes). 
 
 ### MongoDB Spec
 

--- a/plugins/destination/mssql/docs/configuration.md
+++ b/plugins/destination/mssql/docs/configuration.md
@@ -10,7 +10,7 @@
 Make sure you use [environment variable expansion](/docs/advanced-topics/environment-variable-substitution) in production instead of committing the credentials to the configuration file directly.
 :::
 
-The Microsoft SQL Server destination utilizes batching, and supports [`batch_size`](/docs/reference/destination-spec#batch_size) and [`batch_size_bytes`](/docs/reference/destination-spec#batch_size_bytes).
+The Microsoft SQL Server destination utilizes batching, and supports [`batch_size`](/docs/cli/integrations/destinations#batch_size) and [`batch_size_bytes`](/docs/cli/integrations/destinations#batch_size_bytes).
 
 ## Microsoft SQL Server spec
 

--- a/plugins/destination/mssql/docs/example.md
+++ b/plugins/destination/mssql/docs/example.md
@@ -54,7 +54,7 @@ via the following connection string:
 server=localhost;user id=SA;password=yourStrongP@ssword;port=1433;database=cloudquery;
 ```
 
-The (top level) spec section is described in the [Destination Spec Reference](/docs/reference/destination-spec).
+The (top level) spec section is described in the [Destination Spec Reference](/docs/cli/integrations/destinations#complete-destination-spec-reference).
 The full configuration for Microsoft SQL Server destination plugin will look like this:
 
 ```yaml copy

--- a/plugins/destination/mysql/docs/configuration.md
+++ b/plugins/destination/mysql/docs/configuration.md
@@ -10,7 +10,7 @@
 Make sure you use environment variable expansion in production instead of committing the credentials to the configuration file directly.
 :::
 
-The MySQL destination utilizes batching, and supports [`batch_size`](/docs/reference/destination-spec#batch_size) and [`batch_size_bytes`](/docs/reference/destination-spec#batch_size_bytes).
+The MySQL destination utilizes batching, and supports [`batch_size`](/docs/cli/integrations/destinations#batch_size) and [`batch_size_bytes`](/docs/cli/integrations/destinations#batch_size_bytes).
 
 ## MySQL spec
 

--- a/plugins/destination/mysql/docs/example.md
+++ b/plugins/destination/mysql/docs/example.md
@@ -28,7 +28,7 @@ Once you've completed the steps from previous sections you should be able to con
 root:password@/cloudquery
 ```
 
-The (top level) spec section is described in the [Destination Spec Reference](/docs/reference/destination-spec).
+The (top level) spec section is described in the [Destination Spec Reference](/docs/cli/integrations/destinations#complete-destination-spec-reference).
 The full configuration for the MySQL destination plugin should look like this:
 
 ```yaml copy

--- a/plugins/destination/neo4j/docs/overview.md
+++ b/plugins/destination/neo4j/docs/overview.md
@@ -27,7 +27,7 @@ The (top level) spec section is described in the [Destination Spec Reference](/d
 Make sure you use environment variable expansion in production instead of committing the credentials to the configuration file directly.
 :::
 
-The Neo4j destination utilizes batching, and supports [`batch_size`](/docs/cli/integrations/destinations#batch_size) and [`batch_size_bytes`](/docs/cli/integrations/destinations#batch_size_bytes). 
+The Neo4j destination utilizes batching, and supports [`batch_size`](/docs/cli/integrations/destinations#batch_size) and [`batch_size_bytes`](/docs/cli/integrations/destinations#batch_size_bytes).
 
 ### Plugin Spec
 

--- a/plugins/destination/neo4j/docs/overview.md
+++ b/plugins/destination/neo4j/docs/overview.md
@@ -21,13 +21,13 @@ As a side note graph databases can be quite useful for various networking use-ca
 
 :configuration
 
-The (top level) spec section is described in the [Destination Spec Reference](/docs/reference/destination-spec).
+The (top level) spec section is described in the [Destination Spec Reference](/docs/cli/integrations/destinations#complete-destination-spec-reference).
 
 :::callout{type="info"}
 Make sure you use environment variable expansion in production instead of committing the credentials to the configuration file directly.
 :::
 
-The Neo4j destination utilizes batching, and supports [`batch_size`](/docs/reference/destination-spec#batch_size) and [`batch_size_bytes`](/docs/reference/destination-spec#batch_size_bytes). 
+The Neo4j destination utilizes batching, and supports [`batch_size`](/docs/cli/integrations/destinations#batch_size) and [`batch_size_bytes`](/docs/cli/integrations/destinations#batch_size_bytes). 
 
 ### Plugin Spec
 

--- a/plugins/destination/postgresql/docs/overview.md
+++ b/plugins/destination/postgresql/docs/overview.md
@@ -22,13 +22,13 @@ Supported database versions:
 
 :configuration
 
-The (top level) spec section is described in the [Destination Spec Reference](/docs/reference/destination-spec).
+The (top level) spec section is described in the [Destination Spec Reference](/docs/cli/integrations/destinations#complete-destination-spec-reference).
 
 :::callout{type="info"}
 Make sure you use environment variable expansion in production instead of committing the credentials to the configuration file directly.
 :::
 
-The PostgreSQL destination utilizes batching, and supports [`batch_size`](/docs/reference/destination-spec#batch_size) and [`batch_size_bytes`](/docs/reference/destination-spec#batch_size_bytes).
+The PostgreSQL destination utilizes batching, and supports [`batch_size`](/docs/cli/integrations/destinations#batch_size) and [`batch_size_bytes`](/docs/cli/integrations/destinations#batch_size_bytes).
 
 ### PostgreSQL Spec
 

--- a/plugins/destination/s3/docs/_configuration.md
+++ b/plugins/destination/s3/docs/_configuration.md
@@ -1,6 +1,6 @@
 This example uses the parquet format, to create parquet files in `s3://bucket_name/path/to/files`, with each table placed in its own directory.
 
-The (top level) spec section is described in the [Destination Spec Reference](/docs/reference/destination-spec).
+The (top level) spec section is described in the [Destination Spec Reference](/docs/cli/integrations/destinations#complete-destination-spec-reference).
 
 ```yaml copy
 kind: destination
@@ -57,4 +57,4 @@ path: "path/to/files/{{TABLE}}/dt={{YEAR}}-{{MONTH}}-{{DAY}}/{{UUID}}.parquet"
 
 Other supported formats are `json` and `csv`.
 
-Note that the S3 plugin only supports `append` `write_mode`. The (top level) spec section is described in the [Destination Spec Reference](/docs/reference/destination-spec).
+Note that the S3 plugin only supports `append` `write_mode`. The (top level) spec section is described in the [Destination Spec Reference](/docs/cli/integrations/destinations#complete-destination-spec-reference).

--- a/plugins/destination/snowflake/docs/overview.md
+++ b/plugins/destination/snowflake/docs/overview.md
@@ -19,7 +19,7 @@ There are two ways to sync data to Snowflake:
 
 :configuration
 
-The Snowflake destination utilizes batching, and supports [`batch_size`](/docs/reference/destination-spec#batch_size) and [`batch_size_bytes`](/docs/reference/destination-spec#batch_size_bytes).
+The Snowflake destination utilizes batching, and supports [`batch_size`](/docs/cli/integrations/destinations#batch_size) and [`batch_size_bytes`](/docs/cli/integrations/destinations#batch_size_bytes).
 
 
 ## Authentication

--- a/plugins/source/airtable/docs/overview.md
+++ b/plugins/source/airtable/docs/overview.md
@@ -4,7 +4,7 @@ The plugin discover all bases and tables in your account and syncs them to the d
 
 ## Example Configuration
 
-This example syncs from Airtable to a Postgres destination. The (top level) source spec section is described in the [Source Spec Reference](/docs/reference/source-spec).
+This example syncs from Airtable to a Postgres destination. The (top level) source spec section is described in the [Source Spec Reference](/docs/cli/integrations/sources#complete-source-spec-reference).
 
 :configuration
 

--- a/plugins/source/bitbucket/docs/overview.md
+++ b/plugins/source/bitbucket/docs/overview.md
@@ -4,7 +4,7 @@ The plugin discover all workspaces and repositories in your account and syncs th
 
 ## Example Configuration
 
-This example syncs from Bitbucket to a Postgres destination. The (top level) source spec section is described in the [Source Spec Reference](/docs/reference/source-spec).
+This example syncs from Bitbucket to a Postgres destination. The (top level) source spec section is described in the [Source Spec Reference](/docs/cli/integrations/sources#complete-source-spec-reference).
 
 :configuration
 

--- a/plugins/source/hackernews/docs/overview.md
+++ b/plugins/source/hackernews/docs/overview.md
@@ -6,7 +6,7 @@ It can be used for real applications, but is mainly intended to serve as an exam
 
 The following configuration syncs from Hacker News to a Postgres destination, using a special table (`cq_hackernews_state`) to store the state of the last sync. It is also possible to any other CloudQuery destination as a state backend. For more on this, see [Managing Incremental Tables](/docs/advanced-topics/managing-incremental-tables).
 
-The (top level) source spec section is described in the [Source Spec Reference](/docs/reference/source-spec). The config for the `postgresql` destination is not shown here. See our [Quickstart](/docs/quickstart) if you need help setting up the destination.
+The (top level) source spec section is described in the [Source Spec Reference](/docs/cli/integrations/sources#complete-source-spec-reference). The config for the `postgresql` destination is not shown here. See our [Quickstart](/docs/cli/getting-started) if you need help setting up the destination.
 
 :configuration
 

--- a/plugins/source/square/docs/overview.md
+++ b/plugins/source/square/docs/overview.md
@@ -4,7 +4,7 @@ See [tables](/docs/plugins/sources/square/tables) for a list of resources suppor
 
 ## Example Configuration
 
-This example syncs from Square to a Postgres destination. The (top level) source spec section is described in the [Source Spec Reference](/docs/reference/source-spec).
+This example syncs from Square to a Postgres destination. The (top level) source spec section is described in the [Source Spec Reference](/docs/cli/integrations/sources#complete-source-spec-reference).
 
 :configuration
 

--- a/plugins/source/typeform/docs/overview.md
+++ b/plugins/source/typeform/docs/overview.md
@@ -8,7 +8,7 @@ See [tables](/docs/plugins/sources/typeform/tables) for a list of resources supp
 
 ## Example Configuration
 
-This example syncs from Typeform to a Postgres destination. The (top level) source spec section is described in the [Source Spec Reference](/docs/reference/source-spec).
+This example syncs from Typeform to a Postgres destination. The (top level) source spec section is described in the [Source Spec Reference](/docs/cli/integrations/sources#complete-source-spec-reference).
 
 :configuration
 

--- a/plugins/source/xkcd/README.md
+++ b/plugins/source/xkcd/README.md
@@ -7,12 +7,12 @@ It was originally developed as part of a live-coding tutorial on how to write yo
 ## Links
 
 - [Video Tutorial](https://www.youtube.com/watch?v=3Ka_Ob8E6P8)
-- [CloudQuery Quickstart Guide](https://www.cloudquery.io/docs/quickstart)
+- [CloudQuery Quickstart Guide](https://www.cloudquery.io/docs/cli/getting-started)
 - [Supported Tables](docs/tables/README.md)
 
 ## Configuration
 
-The following source configuration file will sync all comics to a local SQLite database. See [the CloudQuery Quickstart](https://www.cloudquery.io/docs/quickstart) for more information on how to configure the source and destination.
+The following source configuration file will sync all comics to a local SQLite database. See [the CloudQuery Quickstart](https://www.cloudquery.io/docs/cli/getting-started) for more information on how to configure the source and destination.
 
 ```yaml
 kind: source

--- a/plugins/source/xkcd/docs/overview.md
+++ b/plugins/source/xkcd/docs/overview.md
@@ -5,12 +5,12 @@ It was originally developed as part of a live-coding tutorial on how to write yo
 ## Links
 
  - [Video Tutorial](https://www.youtube.com/watch?v=3Ka_Ob8E6P8)
- - [CloudQuery Quickstart Guide](https://www.cloudquery.io/docs/quickstart)
+ - [CloudQuery Quickstart Guide](https://www.cloudquery.io/docs/cli/getting-started)
 
 ## Configuration
 
 The following configuration syncs from the XKCD API to a Postgres destination.
 
-The (top level) source spec section is described in the [Source Spec Reference](/docs/reference/source-spec). The config for the `postgresql` destination is not shown here. See our [Quickstart](/docs/quickstart) if you need help setting up the destination.
+The (top level) source spec section is described in the [Source Spec Reference](/docs/cli/integrations/sources#complete-source-spec-reference). The config for the `postgresql` destination is not shown here. See our [Quickstart](/docs/cli/getting-started) if you need help setting up the destination.
 
 :configuration


### PR DESCRIPTION
Replace stale redirect URLs in 28 plugin documentation files with their canonical destinations, eliminating redirect chains on hub plugin pages.