### PR TITLE
chore: Drop -- from pnpm run dev package in publish workflow

### DIFF
--- a/.github/workflows/publish_plugin_to_hub.yml
+++ b/.github/workflows/publish_plugin_to_hub.yml
@@ -452,7 +452,7 @@ jobs:
         working-directory: ${{ needs.prepare.outputs.plugin_dir }}
         run: |
           rm -rf docs/tables.md
-          pnpm run dev -- package -m ${{ steps.release-notes.outputs.result }} ${{ needs.prepare.outputs.plugin_version }} .
+          pnpm run dev package -m ${{ steps.release-notes.outputs.result }} ${{ needs.prepare.outputs.plugin_version }} .
 
       - name: Setup CloudQuery
         uses: cloudquery/setup-cloudquery@b7f7ea62cfec9774ad44a0d9307d0f6c5573bcb6 # v5.0.2


### PR DESCRIPTION
pnpm 10 forwards the literal `--` into the script argv, causing yargs to treat every following token as positional and fail with "Too many non-option arguments: got 5, maximum of 1". Removing `--` restores correct arg forwarding.