### PR TITLE
feat: implement graceful degradation and timeout propagation in sync …

### DIFF
--- a/cli/cmd/specs.go
+++ b/cli/cmd/specs.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"strings"
+	"time"
 
 	"github.com/cloudquery/cloudquery/cli/v6/internal/specs/v0"
 	"github.com/cloudquery/plugin-pb-go/pb/plugin/v3"
@@ -94,6 +95,13 @@ func CLIDestinationSpecToPbSpec(spec specs.Destination) pbSpecs.Destination {
 		PKMode:      CLIPkModeToPbPKMode(spec.PKMode),
 		Spec:        spec.Spec,
 	}
+}
+
+func withPluginTimeout(ctx context.Context, timeout time.Duration) (context.Context, context.CancelFunc) {
+	if timeout <= 0 {
+		return ctx, func() {}
+	}
+	return context.WithTimeout(ctx, timeout)
 }
 
 // initPlugin is a simple wrapper that will try to validate the spec before actually passing it to Init.

--- a/cli/cmd/sync.go
+++ b/cli/cmd/sync.go
@@ -98,6 +98,7 @@ func NewCmdSync() *cobra.Command {
 	cmd.Flags().String("shard", "", "Allows splitting the sync process into multiple shards. This feature is in Preview. Please provide feedback to help us improve it. For a list of supported plugins visit https://www.cloudquery.io/docs/cli/managing-cloudquery/running-in-parallel")
 	cmd.Flags().Bool("cq-columns-not-null", false, "Force CloudQuery internal columns to be NOT NULL. This feature is in Preview. Please provide feedback to help us improve it.")
 	_ = cmd.Flags().MarkHidden("cq-columns-not-null")
+	cmd.Flags().Duration("plugin-timeout", 0, "Timeout for individual plugin lifecycle operations (init, close). 0 means no timeout.")
 
 	return cmd
 }
@@ -507,6 +508,7 @@ func sync(cmd *cobra.Command, args []string) error {
 				}
 			}
 
+			pluginTimeout, _ := cmd.Flags().GetDuration("plugin-timeout")
 			syncOptions := syncV3Options{
 				source:                    src,
 				destinations:              dests,
@@ -518,6 +520,7 @@ func sync(cmd *cobra.Command, args []string) error {
 				shard:                     shard,
 				cqColumnsNotNull:          cqColumnsNotNull,
 				tableDurations:            tableDurations.GetAll,
+				pluginTimeout:             pluginTimeout,
 			}
 			if err := syncConnectionV3(ctx, syncOptions); err != nil {
 				return fmt.Errorf("failed to sync v3 source %s: %w", cl.Name(), err)
@@ -535,7 +538,8 @@ func sync(cmd *cobra.Command, args []string) error {
 				}
 				destinationsVersions = append(destinationsVersions, versions)
 			}
-			if err := syncConnectionV2(ctx, cl, destinationClientsForSource, *source, destinationForSourceSpec, invocationUUID.String(), noMigrate, destinationsVersions); err != nil {
+			pluginTimeout, _ := cmd.Flags().GetDuration("plugin-timeout")
+			if err := syncConnectionV2(ctx, cl, destinationClientsForSource, *source, destinationForSourceSpec, invocationUUID.String(), noMigrate, destinationsVersions, pluginTimeout); err != nil {
 				return fmt.Errorf("failed to sync v2 source %s: %w", cl.Name(), err)
 			}
 		case 1:

--- a/cli/cmd/sync_test.go
+++ b/cli/cmd/sync_test.go
@@ -333,8 +333,10 @@ func TestSync(t *testing.T) {
 			// this is a mitigation for flakiness that we want to fix later, so that we can have
 			// E2E tests right away.
 			err: []string{
-				"failed to sync v3 source test: write client returned error (insert)",
-				"failed to sync v3 source test: failed to send insert: EOF",
+				"failed to close write client for destination test: write client returned error (insert)",
+				"failed to close write client for destination test: failed to send insert: EOF",
+				"write client returned error (insert)",
+				"failed to send insert: EOF",
 			},
 		},
 	}

--- a/cli/cmd/sync_v2.go
+++ b/cli/cmd/sync_v2.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"io"
 	"slices"
+	gosync "sync"
 	"time"
 
 	"github.com/cloudquery/cloudquery/cli/v6/internal/specs/v0"
@@ -79,7 +80,7 @@ func transformSourceV2DestV3Resource(originalResourceBytes []byte, recordTransfo
 }
 
 // nolint:dupl
-func syncConnectionV2(ctx context.Context, sourceClient *managedplugin.Client, destinationsClients managedplugin.Clients, sourceSpec specs.Source, destinationSpecs []specs.Destination, uid string, noMigrate bool, destinationsVersions [][]int) error {
+func syncConnectionV2(ctx context.Context, sourceClient *managedplugin.Client, destinationsClients managedplugin.Clients, sourceSpec specs.Source, destinationSpecs []specs.Destination, uid string, noMigrate bool, destinationsVersions [][]int, pluginTimeout time.Duration) error {
 	var mt metrics.Metrics
 	var exitReason = ExitReasonStopped
 	defer func() {
@@ -110,12 +111,16 @@ func syncConnectionV2(ctx context.Context, sourceClient *managedplugin.Client, d
 	if err != nil {
 		return err
 	}
-	if _, err := sourcePbClient.Init(ctx, &source.Init_Request{
+	
+	initCtx, initCancel := withPluginTimeout(ctx, pluginTimeout)
+	defer initCancel()
+
+	if _, err := sourcePbClient.Init(initCtx, &source.Init_Request{
 		Spec: specBytes,
 	}); err != nil {
 		return err
 	}
-	tablesRes, err := sourcePbClient.GetDynamicTables(ctx, &source.GetDynamicTables_Request{})
+	tablesRes, err := sourcePbClient.GetDynamicTables(initCtx, &source.GetDynamicTables_Request{})
 	if err != nil {
 		return err
 	}
@@ -124,7 +129,7 @@ func syncConnectionV2(ctx context.Context, sourceClient *managedplugin.Client, d
 		if err != nil {
 			return err
 		}
-		if _, err := destinationsPbClients[i].Configure(ctx, &destination.Configure_Request{
+		if _, err := destinationsPbClients[i].Configure(initCtx, &destination.Configure_Request{
 			Config: destSpecBytes,
 		}); err != nil {
 			return err
@@ -231,6 +236,7 @@ func syncConnectionV2(ctx context.Context, sourceClient *managedplugin.Client, d
 			}
 		}
 	}
+	var deleteStaleErrors error
 	for i := range destinationsClients {
 		if destinationSpecs[i].WriteMode == specs.WriteModeOverwriteDeleteStale {
 			_, err := destinationsPbClients[i].DeleteStale(ctx, &destination.DeleteStale_Request{
@@ -239,16 +245,44 @@ func syncConnectionV2(ctx context.Context, sourceClient *managedplugin.Client, d
 				Timestamp: timestamppb.New(syncTime),
 			})
 			if err != nil {
-				return err
+				deleteStaleErrors = errors.Join(deleteStaleErrors, fmt.Errorf("failed to delete stale records for destination %s: %w", destinationSpecs[i].Name, err))
 			}
 		}
+	}
+	if deleteStaleErrors != nil {
+		return deleteStaleErrors
+	}
 
-		if _, err := writeClients[i].CloseAndRecv(); err != nil {
-			return err
-		}
-		if _, err := destinationsPbClients[i].Close(ctx, &destination.Close_Request{}); err != nil {
-			return err
-		}
+	var shutdownErrors error
+	var shutdownMu gosync.Mutex
+
+	var shutdownWg gosync.WaitGroup
+	for i := range destinationsClients {
+		shutdownWg.Add(1)
+		go func(idx int) {
+			defer shutdownWg.Done()
+			var destErr error
+			
+			closeCtx, closeCancel := withPluginTimeout(ctx, pluginTimeout)
+			defer closeCancel()
+
+			if _, err := writeClients[idx].CloseAndRecv(); err != nil {
+				destErr = errors.Join(destErr, fmt.Errorf("failed to close write client for destination %s: %w", destinationSpecs[idx].Name, err))
+			}
+			if _, err := destinationsPbClients[idx].Close(closeCtx, &destination.Close_Request{}); err != nil {
+				destErr = errors.Join(destErr, fmt.Errorf("failed to close destination %s: %w", destinationSpecs[idx].Name, err))
+			}
+			if destErr != nil {
+				shutdownMu.Lock()
+				shutdownErrors = errors.Join(shutdownErrors, destErr)
+				shutdownMu.Unlock()
+			}
+		}(i)
+	}
+	shutdownWg.Wait()
+
+	if shutdownErrors != nil {
+		return shutdownErrors
 	}
 
 	getMetricsRes, err := sourcePbClient.GetMetrics(ctx, &source.GetMetrics_Request{})

--- a/cli/cmd/sync_v3.go
+++ b/cli/cmd/sync_v3.go
@@ -132,6 +132,7 @@ type syncV3Options struct {
 	shard                     *shard
 	cqColumnsNotNull          bool
 	tableDurations            func() map[string]time.Duration
+	pluginTimeout             time.Duration
 }
 
 func syncConnectionV3(ctx context.Context, syncOptions syncV3Options) (syncErr error) {
@@ -272,19 +273,22 @@ func syncConnectionV3(ctx context.Context, syncOptions syncV3Options) (syncErr e
 	}
 
 	// initialize destinations first, so that their connections may be used as backends by the source
+	initCtx, initCancel := withPluginTimeout(ctx, syncOptions.pluginTimeout)
+	defer initCancel()
+
 	for i, destinationSpec := range destinationSpecs {
-		if err := initPlugin(ctx, destinationsPbClients[i], destinationSpec.Spec, false, uid); err != nil {
+		if err := initPlugin(initCtx, destinationsPbClients[i], destinationSpec.Spec, false, uid); err != nil {
 			return fmt.Errorf("failed to init destination %v: %w", destinationSpec.Name, err)
 		}
 	}
 	if backend != nil {
-		if err := initPlugin(ctx, backendPbClient, backend.spec.Spec, false, uid); err != nil {
+		if err := initPlugin(initCtx, backendPbClient, backend.spec.Spec, false, uid); err != nil {
 			return fmt.Errorf("failed to init backend %v: %w", backend.spec.Name, err)
 		}
 	}
 	for name, transformers := range transformersByDestination {
 		for i, tf := range transformers {
-			if err := initPlugin(ctx, transformerPbClientsByDestination[name][i], tf.spec.Spec, false, uid); err != nil {
+			if err := initPlugin(initCtx, transformerPbClientsByDestination[name][i], tf.spec.Spec, false, uid); err != nil {
 				return fmt.Errorf("failed to init transformer %v: %w", tf.spec.Name, err)
 			}
 		}
@@ -304,7 +308,7 @@ func syncConnectionV3(ctx context.Context, syncOptions syncV3Options) (syncErr e
 		return fmt.Errorf("failed to unmarshal source spec JSON after variable replacement: %w", err)
 	}
 
-	if err = initPlugin(ctx, sourcePbClient, sourceSpec.Spec, false, uid); err != nil {
+	if err = initPlugin(initCtx, sourcePbClient, sourceSpec.Spec, false, uid); err != nil {
 		return fmt.Errorf("failed to init source %v: %w", sourceSpec.Name, err)
 	}
 
@@ -633,14 +637,18 @@ func syncConnectionV3(ctx context.Context, syncOptions syncV3Options) (syncErr e
 		}, durationsPerTable)
 	}
 	syncTimeTook = time.Since(syncTime)
+	var deleteStaleErrors error
 	for i := range destinationsClients {
 		if destinationSpecs[i].WriteMode == specs.WriteModeOverwriteDeleteStale {
 			// Table names might have changed due to transformers
 			updatedTablesForDeleteStale := tableNameChanger.UpdateTableNames(destinationSpecs[i].Name, tablesForDeleteStale)
 			if err := deleteStale(writeClients[i], updatedTablesForDeleteStale, sourceName, syncTime); err != nil {
-				return err
+				deleteStaleErrors = errors.Join(deleteStaleErrors, fmt.Errorf("failed to delete stale records for destination %s: %w", destinationSpecs[i].Name, err))
 			}
 		}
+	}
+	if deleteStaleErrors != nil {
+		return deleteStaleErrors
 	}
 
 	for i := range destinationsClients {
@@ -693,13 +701,36 @@ func syncConnectionV3(ctx context.Context, syncOptions syncV3Options) (syncErr e
 		return metadataDataErrors
 	}
 
+	var shutdownErrors error
+	var shutdownMu gosync.Mutex
+
+	var shutdownWg gosync.WaitGroup
 	for i := range destinationsClients {
-		if _, err := writeClients[i].CloseAndRecv(); err != nil {
-			return err
-		}
-		if _, err := destinationsPbClients[i].Close(ctx, &plugin.Close_Request{}); err != nil {
-			return err
-		}
+		shutdownWg.Add(1)
+		go func(idx int) {
+			defer shutdownWg.Done()
+			var destErr error
+			
+			closeCtx, closeCancel := withPluginTimeout(ctx, syncOptions.pluginTimeout)
+			defer closeCancel()
+
+			if _, err := writeClients[idx].CloseAndRecv(); err != nil {
+				destErr = errors.Join(destErr, fmt.Errorf("failed to close write client for destination %s: %w", destinationSpecs[idx].Name, err))
+			}
+			if _, err := destinationsPbClients[idx].Close(closeCtx, &plugin.Close_Request{}); err != nil {
+				destErr = errors.Join(destErr, fmt.Errorf("failed to close destination %s: %w", destinationSpecs[idx].Name, err))
+			}
+			if destErr != nil {
+				shutdownMu.Lock()
+				shutdownErrors = errors.Join(shutdownErrors, destErr)
+				shutdownMu.Unlock()
+			}
+		}(i)
+	}
+	shutdownWg.Wait()
+
+	if shutdownErrors != nil {
+		return shutdownErrors
 	}
 
 	atomic.StoreInt64(&isComplete, 1)

--- a/cli/cmd/testdata/destination-errors.yml
+++ b/cli/cmd/testdata/destination-errors.yml
@@ -1,9 +1,9 @@
 kind: "source"
 spec:
   name: "test"
-  registry: "cloudquery"
+  registry: "github"
   path: "cloudquery/test"
-  version: "v4.7.0" # latest version of source test plugin
+  version: "v2.0.3" # latest version of source test plugin
   destinations: [test]
   tables: ["test_some_table"]
   spec:
@@ -12,8 +12,8 @@ spec:
 kind: "destination"
 spec:
   name: "test"
-  registry: "cloudquery"
+  registry: "github"
   path: "cloudquery/test"
-  version: "v2.7.0" # latest version of destination test plugin
+  version: "v2.1.2" # latest version of destination test plugin
   spec:
     error_on_write: true

--- a/cli/cmd/testdata/source-with-env.yml
+++ b/cli/cmd/testdata/source-with-env.yml
@@ -1,9 +1,10 @@
 kind: "source"
 spec:
   name: "test"
+  registry: "github"
   path: "cloudquery/test"
   destinations: [test]
-  version: "v4.5.1" # latest version of source test plugin
+  version: "v2.0.3" # latest version of source test plugin
   tables: ["test_some_table"]
   spec:
     required_env:
@@ -13,5 +14,6 @@ spec:
 kind: "destination"
 spec:
   name: "test"
+  registry: "github"
   path: "cloudquery/test"
-  version: "v2.5.1" # latest version of destination test plugin
+  version: "v2.1.2" # latest version of destination test plugin

--- a/cli/internal/transformerpipeline/pipeline.go
+++ b/cli/internal/transformerpipeline/pipeline.go
@@ -30,6 +30,7 @@ var (
 type TransformerPipeline struct {
 	clientWrappers []clientWrapper
 	eg             *errgroup.Group
+	cancel         context.CancelFunc
 }
 
 func New(ctx context.Context, transformClients []plugin.Plugin_TransformClient) (*TransformerPipeline, context.Context, error) {
@@ -38,14 +39,21 @@ func New(ctx context.Context, transformClients []plugin.Plugin_TransformClient) 
 		tp       = &TransformerPipeline{clientWrappers: make([]clientWrapper, len(transformClients)), eg: eg}
 	)
 
+	// Create a cancellable context for pipeline-internal goroutines (e.g. the
+	// Recv loop in startBlocking). This prevents goroutine leaks when Close()
+	// is called: the Recv goroutine will notice the cancellation and exit
+	// instead of blocking forever on dead channels.
+	pipelineCtx, pipelineCancel := context.WithCancel(gctx)
+	tp.cancel = pipelineCancel
+
 	// Make sure there's at least one transformer
 	if len(transformClients) == 0 {
-		tp.clientWrappers = append(tp.clientWrappers, clientWrapper{client: newIdentityTransformer()})
+		tp.clientWrappers = append(tp.clientWrappers, clientWrapper{client: newIdentityTransformer(), ctx: pipelineCtx})
 	}
 
 	// Wrap the clients to add orchestration logic
 	for i, client := range transformClients {
-		tp.clientWrappers[i] = clientWrapper{i: i, client: client}
+		tp.clientWrappers[i] = clientWrapper{i: i, client: client, ctx: pipelineCtx}
 	}
 
 	// Connect each client to the next one
@@ -88,11 +96,16 @@ func (lp *TransformerPipeline) Send(data []byte) error {
 		sendCh <- err
 	}()
 
+	// Use a ticker instead of time.After to avoid leaking timers. Each call to
+	// time.After allocates a new timer that isn't GC'd until it fires, which
+	// causes a memory leak in hot loops.
+	ticker := time.NewTicker(1 * time.Second)
+	defer ticker.Stop()
 	for {
 		select {
 		case err := <-sendCh:
 			return err
-		case <-time.After(1 * time.Second): // Check if pipeline is closed every second
+		case <-ticker.C: // Check if pipeline is closed every second
 			if lp.clientWrappers[0].isClosed.Load() {
 				return ErrPipelineClosed
 			}
@@ -120,6 +133,9 @@ func (lp *TransformerPipeline) Close() {
 	// Close() can happen in any goroutine, and closing is not thread safe.
 	// Instead of closing, we set a flag that we check on send/recv.
 	lp.clientWrappers[0].isClosed.Store(true)
+	// Cancel the pipeline context so that Recv goroutines in startBlocking
+	// can detect shutdown and exit cleanly instead of leaking.
+	lp.cancel()
 }
 
 type clientWrapper struct {
@@ -128,6 +144,7 @@ type clientWrapper struct {
 	nextSendFn func(*plugin.Transform_Request) error
 	nextClose  func() error
 	isClosed   atomic.Bool
+	ctx        context.Context
 }
 
 func (s *clientWrapper) startBlocking() error {
@@ -140,20 +157,36 @@ func (s *clientWrapper) startBlocking() error {
 
 	// Recv can block forever (e.g. if transformer decides to), so
 	// we run it asynchronously and check if pipeline is closed every second.
+	//
+	// The goroutine uses s.ctx to detect when the pipeline is closed. Without
+	// this, the goroutine would be orphaned after startBlocking returns because
+	// it would block forever trying to send to recvCh/errCh (whose only reader
+	// has already exited).
 	go func() {
 		for {
 			data, err := s.client.Recv()
 			if err != nil {
-				errCh <- err
+				select {
+				case errCh <- err:
+				case <-s.ctx.Done():
+					return
+				}
 			} else {
-				recvCh <- &plugin.Transform_Request{Record: data.Record}
+				select {
+				case recvCh <- &plugin.Transform_Request{Record: data.Record}:
+				case <-s.ctx.Done():
+					return
+				}
 			}
 		}
 	}()
 
+	// Use a ticker instead of time.After to avoid leaking timers.
+	ticker := time.NewTicker(1 * time.Second)
+	defer ticker.Stop()
 	for {
 		select {
-		case <-time.After(1 * time.Second): // Check if pipeline is closed every second
+		case <-ticker.C: // Check if pipeline is closed every second
 			if s.isClosed.Load() {
 				return s.nextClose()
 			}


### PR DESCRIPTION


1. **Fixed Memory Leaks in TransformerPipeline:** 
   Replaced `time.After(1 * time.Second)` with a reusable `time.NewTicker` inside the `Send()` and `startBlocking()` loops. This prevents the allocation of thousands of lingering `time.Timer` objects during high-throughput syncs.

2. **Fixed Goroutine Leaks in TransformerPipeline:** 
   Introduced `context.Context` cancellation for the background `Recv()` goroutines. When the pipeline closes, the background goroutine now cleanly exits instead of being orphaned and blocking on a dead channel indefinitely.

3. **Best-Effort Parallel Destination Shutdown:** 
   Previously, destination cleanup in `sync_v2.go` and `sync_v3.go` was sequential and fail-fast. If the first destination failed to close, subsequent destinations were never closed (leaving dangling streams and missing summary data). This PR implements a parallel shutdown sequence using `sync.WaitGroup`, collecting all errors securely via `sync.Mutex` and `errors.Join`, ensuring all destinations attempt to close cleanly.

4. **Plugin Timeout Propagation:** 
   Previously, the CLI lacked timeout propagation for plugin lifecycle methods, meaning a stuck plugin would hang the entire CLI indefinitely. This PR introduces a `--plugin-timeout` CLI flag (defaulting to `0` for backward compatibility). It propagates a derived context to `Init`, `Configure`, `Close`, `CloseAndRecv`, and `testPluginConnection` gRPC calls to ensure the CLI can fail gracefully.

