### PR TITLE
chore: Comment on release PR after plugin published to Hub

### DIFF
--- a/.github/actions/release-pr-hub-comment/action.yml
+++ b/.github/actions/release-pr-hub-comment/action.yml
@@ -1,0 +1,72 @@
+name: Release PR Hub comment
+description: |
+  After a plugin is published to the CloudQuery Hub, comments once on the
+  release-please PR that shipped the version. The published tag points at the
+  release-please squash commit, whose subject carries the PR number
+  (`chore(main): Release <component> vX.Y.Z (#NNNN)`). A hidden marker makes
+  re-runs idempotent.
+
+  The calling job needs `pull-requests: write`.
+
+inputs:
+  plugin_kind:
+    description: Plugin kind (source/destination)
+    required: true
+  plugin_name:
+    description: Plugin name
+    required: true
+  plugin_version:
+    description: Plugin version (vX.Y.Z)
+    required: true
+  gh_token:
+    description: GitHub token (PR read + comment write)
+    required: true
+
+runs:
+  using: composite
+  steps:
+    - name: Comment on release PR
+      uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
+      env:
+        PLUGIN_KIND: ${{ inputs.plugin_kind }}
+        PLUGIN_NAME: ${{ inputs.plugin_name }}
+        PLUGIN_VERSION: ${{ inputs.plugin_version }}
+      with:
+        github-token: ${{ inputs.gh_token }}
+        script: |
+          const { PLUGIN_KIND, PLUGIN_NAME, PLUGIN_VERSION } = process.env;
+          const { owner, repo } = context.repo;
+
+          let subject;
+          try {
+            const { data } = await github.rest.repos.getCommit({ owner, repo, ref: context.sha });
+            subject = (data.commit.message || '').split('\n')[0].trim();
+          } catch (e) {
+            core.warning(`cannot read commit ${context.sha}: ${e.message}`);
+            return;
+          }
+          if (!/^chore(?:\([^)]+\))?:\s*Release\b/i.test(subject)) {
+            core.info(`"${subject}" is not a release commit; skipping`);
+            return;
+          }
+          const match = subject.match(/\(#(\d+)\)\s*$/);
+          if (!match) {
+            core.info(`no (#PR) in subject "${subject}"; skipping`);
+            return;
+          }
+          const issue_number = Number(match[1]);
+
+          const marker = `<!-- plugin-hub-publish:${PLUGIN_KIND}:${PLUGIN_NAME}:${PLUGIN_VERSION} -->`;
+          const existing = await github.paginate(github.rest.issues.listComments, { owner, repo, issue_number });
+          if (existing.some((c) => c.body && c.body.includes(marker))) {
+            core.info(`comment already present on #${issue_number}; skipping`);
+            return;
+          }
+
+          const hubUrl = `https://www.cloudquery.io/hub/plugins/${PLUGIN_KIND}/cloudquery/${PLUGIN_NAME}/${PLUGIN_VERSION}`;
+          await github.rest.issues.createComment({
+            owner,
+            repo,
+            issue_number,
+            body: `🚀 Published \`${PLUGIN_KIND}/${PLUGIN_NAME}\` \`${PLUGIN_VERSION}\` to the [CloudQuery Hub](${hubUrl}).\n${marker}`,
+          });

--- a/.github/actions/release-pr-hub-comment/action.yml
+++ b/.github/actions/release-pr-hub-comment/action.yml
@@ -2,9 +2,10 @@ name: Release PR Hub comment
 description: |
   After a plugin is published to the CloudQuery Hub, comments once on the
   release-please PR that shipped the version. The published tag points at the
-  release-please squash commit, whose subject carries the PR number
-  (`chore(main): Release <component> vX.Y.Z (#NNNN)`). A hidden marker makes
-  re-runs idempotent.
+  release-please squash commit; the PR is resolved via
+  `listPullRequestsAssociatedWithCommit`, falling back to parsing the PR number
+  from the commit subject (`chore(main): Release <component> vX.Y.Z (#NNNN)`).
+  A hidden marker makes re-runs idempotent.
 
   The calling job needs `pull-requests: write`.
 
@@ -37,24 +38,38 @@ runs:
           const { PLUGIN_KIND, PLUGIN_NAME, PLUGIN_VERSION } = process.env;
           const { owner, repo } = context.repo;
 
-          let subject;
+          // The tag commit is the release-please squash merge commit; prefer the
+          // API and fall back to parsing the PR number from the commit subject.
+          let issue_number;
           try {
-            const { data } = await github.rest.repos.getCommit({ owner, repo, ref: context.sha });
-            subject = (data.commit.message || '').split('\n')[0].trim();
+            const { data: prs } = await github.rest.repos.listPullRequestsAssociatedWithCommit({
+              owner,
+              repo,
+              commit_sha: context.sha,
+            });
+            const pr = prs.find((p) => p.merged_at) || prs[0];
+            if (pr) {
+              issue_number = pr.number;
+            }
           } catch (e) {
-            core.warning(`cannot read commit ${context.sha}: ${e.message}`);
-            return;
+            core.warning(`listPullRequestsAssociatedWithCommit failed: ${e.message}`);
           }
-          if (!/^chore(?:\([^)]+\))?:\s*Release\b/i.test(subject)) {
-            core.info(`"${subject}" is not a release commit; skipping`);
-            return;
+          if (!issue_number) {
+            let subject;
+            try {
+              const { data } = await github.rest.repos.getCommit({ owner, repo, ref: context.sha });
+              subject = (data.commit.message || '').split('\n')[0].trim();
+            } catch (e) {
+              core.warning(`cannot read commit ${context.sha}: ${e.message}`);
+              return;
+            }
+            const match = subject.match(/\(#(\d+)\)\s*$/);
+            if (!match) {
+              core.info(`no PR associated with ${context.sha} and no (#PR) in "${subject}"; skipping`);
+              return;
+            }
+            issue_number = Number(match[1]);
           }
-          const match = subject.match(/\(#(\d+)\)\s*$/);
-          if (!match) {
-            core.info(`no (#PR) in subject "${subject}"; skipping`);
-            return;
-          }
-          const issue_number = Number(match[1]);
 
           const marker = `<!-- plugin-hub-publish:${PLUGIN_KIND}:${PLUGIN_NAME}:${PLUGIN_VERSION} -->`;
           const existing = await github.paginate(github.rest.issues.listComments, { owner, repo, issue_number });

--- a/.github/workflows/publish_plugin_to_hub.yml
+++ b/.github/workflows/publish_plugin_to_hub.yml
@@ -12,6 +12,7 @@ env:
 
 permissions:
   contents: read
+  pull-requests: write
 
 jobs:
   prepare:
@@ -585,3 +586,46 @@ jobs:
           footer: "<{repo_url}|{repo}>"
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.ALERTS_INTEGRATIONS_SLACK_WEBHOOK_URL }}
+
+  comment-on-release-pr:
+    runs-on: ubuntu-latest
+    needs:
+      - prepare
+      - publish-plugin-to-hub-java
+      - publish-plugin-to-hub-python
+      - publish-plugin-to-hub-node
+      - publish-plugin-to-hub-go
+    if: |
+      always() &&
+      needs.prepare.outputs.prerelease == '' &&
+      (needs.publish-plugin-to-hub-java.result == 'success' ||
+       needs.publish-plugin-to-hub-python.result == 'success' ||
+       needs.publish-plugin-to-hub-node.result == 'success' ||
+       needs.publish-plugin-to-hub-go.result == 'success')
+    steps:
+      - name: Comment on release PR
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
+        env:
+          PLUGIN_KIND: ${{ needs.prepare.outputs.plugin_kind }}
+          PLUGIN_NAME: ${{ needs.prepare.outputs.plugin_name }}
+          PLUGIN_VERSION: ${{ needs.prepare.outputs.plugin_version }}
+        with:
+          script: |
+            const { PLUGIN_KIND, PLUGIN_NAME, PLUGIN_VERSION } = process.env;
+            const { data: prs } = await github.rest.repos.listPullRequestsAssociatedWithCommit({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              commit_sha: context.sha,
+            });
+            const pr = prs.find((p) => p.merged_at) || prs[0];
+            if (!pr) {
+              core.info(`No PR associated with commit ${context.sha}, skipping comment`);
+              return;
+            }
+            const hubUrl = `https://www.cloudquery.io/hub/plugins/${PLUGIN_KIND}/cloudquery/${PLUGIN_NAME}/${PLUGIN_VERSION}`;
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: pr.number,
+              body: `🚀 Published \`${PLUGIN_KIND}/${PLUGIN_NAME}\` \`${PLUGIN_VERSION}\` to the [CloudQuery Hub](${hubUrl}).`,
+            });

--- a/.github/workflows/publish_plugin_to_hub.yml
+++ b/.github/workflows/publish_plugin_to_hub.yml
@@ -12,7 +12,6 @@ env:
 
 permissions:
   contents: read
-  pull-requests: write
 
 jobs:
   prepare:
@@ -589,6 +588,9 @@ jobs:
 
   comment-on-release-pr:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
     needs:
       - prepare
       - publish-plugin-to-hub-java
@@ -603,29 +605,13 @@ jobs:
        needs.publish-plugin-to-hub-node.result == 'success' ||
        needs.publish-plugin-to-hub-go.result == 'success')
     steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       - name: Comment on release PR
-        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
-        env:
-          PLUGIN_KIND: ${{ needs.prepare.outputs.plugin_kind }}
-          PLUGIN_NAME: ${{ needs.prepare.outputs.plugin_name }}
-          PLUGIN_VERSION: ${{ needs.prepare.outputs.plugin_version }}
+        continue-on-error: true
+        uses: ./.github/actions/release-pr-hub-comment
         with:
-          script: |
-            const { PLUGIN_KIND, PLUGIN_NAME, PLUGIN_VERSION } = process.env;
-            const { data: prs } = await github.rest.repos.listPullRequestsAssociatedWithCommit({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              commit_sha: context.sha,
-            });
-            const pr = prs.find((p) => p.merged_at) || prs[0];
-            if (!pr) {
-              core.info(`No PR associated with commit ${context.sha}, skipping comment`);
-              return;
-            }
-            const hubUrl = `https://www.cloudquery.io/hub/plugins/${PLUGIN_KIND}/cloudquery/${PLUGIN_NAME}/${PLUGIN_VERSION}`;
-            await github.rest.issues.createComment({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              issue_number: pr.number,
-              body: `🚀 Published \`${PLUGIN_KIND}/${PLUGIN_NAME}\` \`${PLUGIN_VERSION}\` to the [CloudQuery Hub](${hubUrl}).`,
-            });
+          plugin_kind: ${{ needs.prepare.outputs.plugin_kind }}
+          plugin_name: ${{ needs.prepare.outputs.plugin_name }}
+          plugin_version: ${{ needs.prepare.outputs.plugin_version }}
+          gh_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/publish_plugin_to_hub_duckdb.yml
+++ b/.github/workflows/publish_plugin_to_hub_duckdb.yml
@@ -177,31 +177,13 @@ jobs:
 
       - name: Comment on release PR
         if: needs.prepare.outputs.prerelease == ''
-        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
-        env:
-          PLUGIN_KIND: ${{ needs.prepare.outputs.plugin_kind }}
-          PLUGIN_NAME: ${{ needs.prepare.outputs.plugin_name }}
-          PLUGIN_VERSION: ${{ needs.prepare.outputs.plugin_version }}
+        continue-on-error: true
+        uses: ./.github/actions/release-pr-hub-comment
         with:
-          script: |
-            const { PLUGIN_KIND, PLUGIN_NAME, PLUGIN_VERSION } = process.env;
-            const { data: prs } = await github.rest.repos.listPullRequestsAssociatedWithCommit({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              commit_sha: context.sha,
-            });
-            const pr = prs.find((p) => p.merged_at) || prs[0];
-            if (!pr) {
-              core.info(`No PR associated with commit ${context.sha}, skipping comment`);
-              return;
-            }
-            const hubUrl = `https://www.cloudquery.io/hub/plugins/${PLUGIN_KIND}/cloudquery/${PLUGIN_NAME}/${PLUGIN_VERSION}`;
-            await github.rest.issues.createComment({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              issue_number: pr.number,
-              body: `🚀 Published \`${PLUGIN_KIND}/${PLUGIN_NAME}\` \`${PLUGIN_VERSION}\` to the [CloudQuery Hub](${hubUrl}).`,
-            });
+          plugin_kind: ${{ needs.prepare.outputs.plugin_kind }}
+          plugin_name: ${{ needs.prepare.outputs.plugin_name }}
+          plugin_version: ${{ needs.prepare.outputs.plugin_version }}
+          gh_token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Slack Notify
         uses: ravsamhq/notify-slack-action@0670a0482d2a919531ba3b219e0c535fe4fcc791

--- a/.github/workflows/publish_plugin_to_hub_duckdb.yml
+++ b/.github/workflows/publish_plugin_to_hub_duckdb.yml
@@ -86,6 +86,7 @@ jobs:
     timeout-minutes: 60
     permissions:
       contents: write
+      pull-requests: write
     runs-on: ubuntu-latest
     container:
       image: ghcr.io/gythialy/golang-cross:1.26.4
@@ -173,6 +174,34 @@ jobs:
         if: needs.prepare.outputs.prerelease == ''
         run: |
           git tag ${{ needs.prepare.outputs.plugin_dir }}/${{ needs.prepare.outputs.plugin_version }} && git push origin ${{ needs.prepare.outputs.plugin_dir }}/${{ needs.prepare.outputs.plugin_version }}
+
+      - name: Comment on release PR
+        if: needs.prepare.outputs.prerelease == ''
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
+        env:
+          PLUGIN_KIND: ${{ needs.prepare.outputs.plugin_kind }}
+          PLUGIN_NAME: ${{ needs.prepare.outputs.plugin_name }}
+          PLUGIN_VERSION: ${{ needs.prepare.outputs.plugin_version }}
+        with:
+          script: |
+            const { PLUGIN_KIND, PLUGIN_NAME, PLUGIN_VERSION } = process.env;
+            const { data: prs } = await github.rest.repos.listPullRequestsAssociatedWithCommit({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              commit_sha: context.sha,
+            });
+            const pr = prs.find((p) => p.merged_at) || prs[0];
+            if (!pr) {
+              core.info(`No PR associated with commit ${context.sha}, skipping comment`);
+              return;
+            }
+            const hubUrl = `https://www.cloudquery.io/hub/plugins/${PLUGIN_KIND}/cloudquery/${PLUGIN_NAME}/${PLUGIN_VERSION}`;
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: pr.number,
+              body: `🚀 Published \`${PLUGIN_KIND}/${PLUGIN_NAME}\` \`${PLUGIN_VERSION}\` to the [CloudQuery Hub](${hubUrl}).`,
+            });
 
       - name: Slack Notify
         uses: ravsamhq/notify-slack-action@0670a0482d2a919531ba3b219e0c535fe4fcc791

--- a/.github/workflows/publish_plugin_to_hub_snowflake.yml
+++ b/.github/workflows/publish_plugin_to_hub_snowflake.yml
@@ -86,6 +86,7 @@ jobs:
     timeout-minutes: 60
     permissions:
       contents: write
+      pull-requests: write
     runs-on: ubuntu-latest
     container:
       image: ghcr.io/gythialy/golang-cross:1.26.4
@@ -175,6 +176,34 @@ jobs:
         if: needs.prepare.outputs.prerelease == ''
         run: |
           git tag ${{ needs.prepare.outputs.plugin_dir }}/${{ needs.prepare.outputs.plugin_version }} && git push origin ${{ needs.prepare.outputs.plugin_dir }}/${{ needs.prepare.outputs.plugin_version }}
+
+      - name: Comment on release PR
+        if: needs.prepare.outputs.prerelease == ''
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
+        env:
+          PLUGIN_KIND: ${{ needs.prepare.outputs.plugin_kind }}
+          PLUGIN_NAME: ${{ needs.prepare.outputs.plugin_name }}
+          PLUGIN_VERSION: ${{ needs.prepare.outputs.plugin_version }}
+        with:
+          script: |
+            const { PLUGIN_KIND, PLUGIN_NAME, PLUGIN_VERSION } = process.env;
+            const { data: prs } = await github.rest.repos.listPullRequestsAssociatedWithCommit({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              commit_sha: context.sha,
+            });
+            const pr = prs.find((p) => p.merged_at) || prs[0];
+            if (!pr) {
+              core.info(`No PR associated with commit ${context.sha}, skipping comment`);
+              return;
+            }
+            const hubUrl = `https://www.cloudquery.io/hub/plugins/${PLUGIN_KIND}/cloudquery/${PLUGIN_NAME}/${PLUGIN_VERSION}`;
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: pr.number,
+              body: `🚀 Published \`${PLUGIN_KIND}/${PLUGIN_NAME}\` \`${PLUGIN_VERSION}\` to the [CloudQuery Hub](${hubUrl}).`,
+            });
 
       - name: Slack Notify
         uses: ravsamhq/notify-slack-action@0670a0482d2a919531ba3b219e0c535fe4fcc791

--- a/.github/workflows/publish_plugin_to_hub_snowflake.yml
+++ b/.github/workflows/publish_plugin_to_hub_snowflake.yml
@@ -179,31 +179,13 @@ jobs:
 
       - name: Comment on release PR
         if: needs.prepare.outputs.prerelease == ''
-        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
-        env:
-          PLUGIN_KIND: ${{ needs.prepare.outputs.plugin_kind }}
-          PLUGIN_NAME: ${{ needs.prepare.outputs.plugin_name }}
-          PLUGIN_VERSION: ${{ needs.prepare.outputs.plugin_version }}
+        continue-on-error: true
+        uses: ./.github/actions/release-pr-hub-comment
         with:
-          script: |
-            const { PLUGIN_KIND, PLUGIN_NAME, PLUGIN_VERSION } = process.env;
-            const { data: prs } = await github.rest.repos.listPullRequestsAssociatedWithCommit({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              commit_sha: context.sha,
-            });
-            const pr = prs.find((p) => p.merged_at) || prs[0];
-            if (!pr) {
-              core.info(`No PR associated with commit ${context.sha}, skipping comment`);
-              return;
-            }
-            const hubUrl = `https://www.cloudquery.io/hub/plugins/${PLUGIN_KIND}/cloudquery/${PLUGIN_NAME}/${PLUGIN_VERSION}`;
-            await github.rest.issues.createComment({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              issue_number: pr.number,
-              body: `🚀 Published \`${PLUGIN_KIND}/${PLUGIN_NAME}\` \`${PLUGIN_VERSION}\` to the [CloudQuery Hub](${hubUrl}).`,
-            });
+          plugin_kind: ${{ needs.prepare.outputs.plugin_kind }}
+          plugin_name: ${{ needs.prepare.outputs.plugin_name }}
+          plugin_version: ${{ needs.prepare.outputs.plugin_version }}
+          gh_token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Slack Notify
         uses: ravsamhq/notify-slack-action@0670a0482d2a919531ba3b219e0c535fe4fcc791

--- a/.github/workflows/publish_plugin_to_hub_sqlite.yml
+++ b/.github/workflows/publish_plugin_to_hub_sqlite.yml
@@ -177,31 +177,13 @@ jobs:
 
       - name: Comment on release PR
         if: needs.prepare.outputs.prerelease == ''
-        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
-        env:
-          PLUGIN_KIND: ${{ needs.prepare.outputs.plugin_kind }}
-          PLUGIN_NAME: ${{ needs.prepare.outputs.plugin_name }}
-          PLUGIN_VERSION: ${{ needs.prepare.outputs.plugin_version }}
+        continue-on-error: true
+        uses: ./.github/actions/release-pr-hub-comment
         with:
-          script: |
-            const { PLUGIN_KIND, PLUGIN_NAME, PLUGIN_VERSION } = process.env;
-            const { data: prs } = await github.rest.repos.listPullRequestsAssociatedWithCommit({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              commit_sha: context.sha,
-            });
-            const pr = prs.find((p) => p.merged_at) || prs[0];
-            if (!pr) {
-              core.info(`No PR associated with commit ${context.sha}, skipping comment`);
-              return;
-            }
-            const hubUrl = `https://www.cloudquery.io/hub/plugins/${PLUGIN_KIND}/cloudquery/${PLUGIN_NAME}/${PLUGIN_VERSION}`;
-            await github.rest.issues.createComment({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              issue_number: pr.number,
-              body: `🚀 Published \`${PLUGIN_KIND}/${PLUGIN_NAME}\` \`${PLUGIN_VERSION}\` to the [CloudQuery Hub](${hubUrl}).`,
-            });
+          plugin_kind: ${{ needs.prepare.outputs.plugin_kind }}
+          plugin_name: ${{ needs.prepare.outputs.plugin_name }}
+          plugin_version: ${{ needs.prepare.outputs.plugin_version }}
+          gh_token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Slack Notify
         uses: ravsamhq/notify-slack-action@0670a0482d2a919531ba3b219e0c535fe4fcc791

--- a/.github/workflows/publish_plugin_to_hub_sqlite.yml
+++ b/.github/workflows/publish_plugin_to_hub_sqlite.yml
@@ -86,6 +86,7 @@ jobs:
     timeout-minutes: 60
     permissions:
       contents: write
+      pull-requests: write
     runs-on: ubuntu-latest
     container:
       image: ghcr.io/gythialy/golang-cross:1.26.4
@@ -173,6 +174,34 @@ jobs:
         if: needs.prepare.outputs.prerelease == ''
         run: |
           git tag ${{ needs.prepare.outputs.plugin_dir }}/${{ needs.prepare.outputs.plugin_version }} && git push origin ${{ needs.prepare.outputs.plugin_dir }}/${{ needs.prepare.outputs.plugin_version }}
+
+      - name: Comment on release PR
+        if: needs.prepare.outputs.prerelease == ''
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
+        env:
+          PLUGIN_KIND: ${{ needs.prepare.outputs.plugin_kind }}
+          PLUGIN_NAME: ${{ needs.prepare.outputs.plugin_name }}
+          PLUGIN_VERSION: ${{ needs.prepare.outputs.plugin_version }}
+        with:
+          script: |
+            const { PLUGIN_KIND, PLUGIN_NAME, PLUGIN_VERSION } = process.env;
+            const { data: prs } = await github.rest.repos.listPullRequestsAssociatedWithCommit({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              commit_sha: context.sha,
+            });
+            const pr = prs.find((p) => p.merged_at) || prs[0];
+            if (!pr) {
+              core.info(`No PR associated with commit ${context.sha}, skipping comment`);
+              return;
+            }
+            const hubUrl = `https://www.cloudquery.io/hub/plugins/${PLUGIN_KIND}/cloudquery/${PLUGIN_NAME}/${PLUGIN_VERSION}`;
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: pr.number,
+              body: `🚀 Published \`${PLUGIN_KIND}/${PLUGIN_NAME}\` \`${PLUGIN_VERSION}\` to the [CloudQuery Hub](${hubUrl}).`,
+            });
 
       - name: Slack Notify
         uses: ravsamhq/notify-slack-action@0670a0482d2a919531ba3b219e0c535fe4fcc791


### PR DESCRIPTION
Posts a comment on the merged release PR once a plugin is published to the CloudQuery Hub. Runs only for non-prerelease versions and only after a successful publish.

The release PR is resolved via `listPullRequestsAssociatedWithCommit` on the tag commit, falling back to parsing the PR number from the release commit subject (`chore(main): Release <component> vX.Y.Z (#NNNN)`). A hidden marker keeps re-runs idempotent, and the step is `continue-on-error` so it never fails a publish.

Shared logic lives in a composite action (`.github/actions/release-pr-hub-comment`), used by the main publish workflow plus the DuckDB, SQLite, and Snowflake destination workflows. `pull-requests: write` is scoped to the commenting job.