### PR TITLE
fix: Consistent multi-tenant platform-destination resolution (+ hint on ambiguity)

### DIFF
--- a/cli/internal/platform/inject.go
+++ b/cli/internal/platform/inject.go
@@ -107,12 +107,12 @@ func DetectTenant(ctx context.Context, token, teamName string) (apiURL string, o
 	if err != nil || len(tenants) == 0 {
 		return "", false
 	}
-	// Use the same selection as auto-injection (chooseTenant): the only active
-	// tenant, or the CQ_PLATFORM_TENANT_ID match. An ambiguous team (several
-	// active, no override) reports nothing rather than a tenant a real sync
-	// would skip.
-	tenant, ok := chooseTenant(tenants)
-	if !ok {
+	// Use the same selection as auto-injection (resolveTenant): the only active
+	// tenant, or the CQ_PLATFORM_TENANT_ID match. None or ambiguous (several
+	// active, no override) → report nothing; init is informational, so it never
+	// errors here, and it won't point at a tenant a real sync would skip.
+	tenant, err := resolveTenant(tenants)
+	if err != nil {
 		return "", false
 	}
 	return "https://" + tenant.Host, true
@@ -200,9 +200,15 @@ func MaybeInjectDestination(ctx context.Context, logger zerolog.Logger, token, t
 		logger.Debug().Err(err).Msg("platform destination: tenant discovery failed, skipping auto-injection")
 		return destinations, nil
 	}
-	tenant, ok := selectTenant(logger, tenants)
-	if !ok {
+	tenant, err := resolveTenant(tenants)
+	switch {
+	case errors.Is(err, errNoActiveTenant):
+		// No platform tenant for this team — nothing to inject; skip silently.
 		return destinations, nil
+	case err != nil:
+		// Several active tenants and no usable CQ_PLATFORM_TENANT_ID. A source
+		// opted into `platform`, so don't silently drop it — fail with the Hint.
+		return destinations, err
 	}
 
 	session, platformPluginVersion, err := mintSession(ctx, cl, tenant)
@@ -310,43 +316,39 @@ var resolveCredentials = func(ctx context.Context) (token, team string, err erro
 	return tok.Value, team, nil
 }
 
-// chooseTenant picks the single tenant to act on: the only active one, or the
-// CQ_PLATFORM_TENANT_ID match when several are active. ok is false when there
-// are none, or several with no (matching) override — the ambiguous case both
-// auto-injection and DetectTenant refuse rather than guess. Pure (no logging)
-// so both call sites share one decision.
-func chooseTenant(tenants []cloudquery_api.PlatformTenantSummary) (cloudquery_api.PlatformTenantSummary, bool) {
+var (
+	// errNoActiveTenant: the team has no active platform tenant to inject into.
+	// A no-op for auto-injection (skip silently) — not a user error.
+	errNoActiveTenant = errors.New("no active platform tenant")
+	// errAmbiguousTenant: several active tenants and CQ_PLATFORM_TENANT_ID isn't
+	// set to one of them. Surfaced to the user as a Hint (it's env-fixable) so an
+	// explicit `platform` opt-in isn't silently dropped. Callers match it with
+	// errors.Is to tell "ambiguous" apart from "none".
+	errAmbiguousTenant = errors.New("multiple active CloudQuery Platform tenants for this team")
+)
+
+// resolveTenant picks the single tenant to act on: the only active one, or the
+// CQ_PLATFORM_TENANT_ID match when several are active. Returns errNoActiveTenant
+// when there are none, and an errAmbiguousTenant-wrapped error (carrying an
+// actionable Hint) when several are active without a matching override. Pure (no
+// logging) so every call site shares one decision.
+func resolveTenant(tenants []cloudquery_api.PlatformTenantSummary) (cloudquery_api.PlatformTenantSummary, error) {
 	switch len(tenants) {
 	case 0:
-		return cloudquery_api.PlatformTenantSummary{}, false
+		return cloudquery_api.PlatformTenantSummary{}, errNoActiveTenant
 	case 1:
-		return tenants[0], true
+		return tenants[0], nil
 	}
 	want := os.Getenv(envTenantID)
 	if want == "" {
-		return cloudquery_api.PlatformTenantSummary{}, false
+		return cloudquery_api.PlatformTenantSummary{}, fmt.Errorf("%w. Hint: set %s to the tenant id you want to sync to", errAmbiguousTenant, envTenantID)
 	}
 	for _, t := range tenants {
 		if t.TenantId.String() == want {
-			return t, true
+			return t, nil
 		}
 	}
-	return cloudquery_api.PlatformTenantSummary{}, false
-}
-
-// selectTenant is chooseTenant plus the operator-facing warnings that explain
-// why an ambiguous multi-tenant team was skipped during auto-injection.
-func selectTenant(logger zerolog.Logger, tenants []cloudquery_api.PlatformTenantSummary) (cloudquery_api.PlatformTenantSummary, bool) {
-	tenant, ok := chooseTenant(tenants)
-	if ok || len(tenants) <= 1 {
-		return tenant, ok // resolved, or empty/none (no warning needed)
-	}
-	if want := os.Getenv(envTenantID); want == "" {
-		logger.Warn().Int("tenants", len(tenants)).Msgf("platform destination: team has multiple active tenants; set %s to choose one, skipping auto-injection", envTenantID)
-	} else {
-		logger.Warn().Str("tenant_id", want).Msgf("platform destination: %s does not match any active tenant, skipping auto-injection", envTenantID)
-	}
-	return cloudquery_api.PlatformTenantSummary{}, false
+	return cloudquery_api.PlatformTenantSummary{}, fmt.Errorf("%w: %s=%s matches none of them. Hint: set it to one of the team's active tenant ids", errAmbiguousTenant, envTenantID, want)
 }
 
 // YYYYMMDDhhmmssfff — same shape platform/syncs-transformer uses, so

--- a/cli/internal/platform/inject.go
+++ b/cli/internal/platform/inject.go
@@ -107,15 +107,13 @@ func DetectTenant(ctx context.Context, token, teamName string) (apiURL string, o
 	if err != nil || len(tenants) == 0 {
 		return "", false
 	}
-	// Match selectTenant: honor CQ_PLATFORM_TENANT_ID, else take the first.
-	tenant := tenants[0]
-	if want := os.Getenv(envTenantID); want != "" {
-		for _, c := range tenants {
-			if c.TenantId.String() == want {
-				tenant = c
-				break
-			}
-		}
+	// Use the same selection as auto-injection (chooseTenant): the only active
+	// tenant, or the CQ_PLATFORM_TENANT_ID match. An ambiguous team (several
+	// active, no override) reports nothing rather than a tenant a real sync
+	// would skip.
+	tenant, ok := chooseTenant(tenants)
+	if !ok {
+		return "", false
 	}
 	return "https://" + tenant.Host, true
 }
@@ -312,7 +310,12 @@ var resolveCredentials = func(ctx context.Context) (token, team string, err erro
 	return tok.Value, team, nil
 }
 
-func selectTenant(logger zerolog.Logger, tenants []cloudquery_api.PlatformTenantSummary) (cloudquery_api.PlatformTenantSummary, bool) {
+// chooseTenant picks the single tenant to act on: the only active one, or the
+// CQ_PLATFORM_TENANT_ID match when several are active. ok is false when there
+// are none, or several with no (matching) override — the ambiguous case both
+// auto-injection and DetectTenant refuse rather than guess. Pure (no logging)
+// so both call sites share one decision.
+func chooseTenant(tenants []cloudquery_api.PlatformTenantSummary) (cloudquery_api.PlatformTenantSummary, bool) {
 	switch len(tenants) {
 	case 0:
 		return cloudquery_api.PlatformTenantSummary{}, false
@@ -321,7 +324,6 @@ func selectTenant(logger zerolog.Logger, tenants []cloudquery_api.PlatformTenant
 	}
 	want := os.Getenv(envTenantID)
 	if want == "" {
-		logger.Warn().Int("tenants", len(tenants)).Msgf("platform destination: team has multiple active tenants; set %s to choose one, skipping auto-injection", envTenantID)
 		return cloudquery_api.PlatformTenantSummary{}, false
 	}
 	for _, t := range tenants {
@@ -329,7 +331,21 @@ func selectTenant(logger zerolog.Logger, tenants []cloudquery_api.PlatformTenant
 			return t, true
 		}
 	}
-	logger.Warn().Str("tenant_id", want).Msgf("platform destination: %s does not match any active tenant, skipping auto-injection", envTenantID)
+	return cloudquery_api.PlatformTenantSummary{}, false
+}
+
+// selectTenant is chooseTenant plus the operator-facing warnings that explain
+// why an ambiguous multi-tenant team was skipped during auto-injection.
+func selectTenant(logger zerolog.Logger, tenants []cloudquery_api.PlatformTenantSummary) (cloudquery_api.PlatformTenantSummary, bool) {
+	tenant, ok := chooseTenant(tenants)
+	if ok || len(tenants) <= 1 {
+		return tenant, ok // resolved, or empty/none (no warning needed)
+	}
+	if want := os.Getenv(envTenantID); want == "" {
+		logger.Warn().Int("tenants", len(tenants)).Msgf("platform destination: team has multiple active tenants; set %s to choose one, skipping auto-injection", envTenantID)
+	} else {
+		logger.Warn().Str("tenant_id", want).Msgf("platform destination: %s does not match any active tenant, skipping auto-injection", envTenantID)
+	}
 	return cloudquery_api.PlatformTenantSummary{}, false
 }
 

--- a/cli/internal/platform/inject_test.go
+++ b/cli/internal/platform/inject_test.go
@@ -167,6 +167,36 @@ func TestDetectTenant_CloudPath(t *testing.T) {
 	require.Equal(t, "https://acme.us.platform.cloudquery.io", url, "url is built from the active tenant's host")
 }
 
+// DetectTenant must make the SAME multi-tenant decision auto-injection does:
+// skip (report nothing) when a team has several active tenants and no
+// CQ_PLATFORM_TENANT_ID override — otherwise `init` would point the user at a
+// tenant a real sync would refuse to inject into.
+func TestDetectTenant_MultipleActiveTenants(t *testing.T) {
+	twoActive := func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{"items": []map[string]any{
+			{"tenant_id": "11111111-1111-1111-1111-111111111111", "status": "active", "team_name": "team-x", "host": "acme.us.platform.cloudquery.io", "subdomain": "acme"},
+			{"tenant_id": "22222222-2222-2222-2222-222222222222", "status": "active", "team_name": "team-x", "host": "beta.us.platform.cloudquery.io", "subdomain": "beta"},
+		}})
+	}
+
+	t.Run("ambiguous without override reports nothing", func(t *testing.T) {
+		srv := fakeCloud(t, twoActive, nil)
+		t.Setenv(envAPIURL, srv.URL)
+		_, ok := DetectTenant(context.Background(), "tok", "team-x")
+		require.False(t, ok, "several active tenants + no override is ambiguous; a sync would skip, so DetectTenant must too")
+	})
+
+	t.Run("override picks the matching tenant", func(t *testing.T) {
+		srv := fakeCloud(t, twoActive, nil)
+		t.Setenv(envAPIURL, srv.URL)
+		t.Setenv(envTenantID, "22222222-2222-2222-2222-222222222222")
+		url, ok := DetectTenant(context.Background(), "tok", "team-x")
+		require.True(t, ok)
+		require.Equal(t, "https://beta.us.platform.cloudquery.io", url)
+	})
+}
+
 func TestInject_DirectToken_InjectsWithoutCloud(t *testing.T) {
 	// A pre-minted cqpd_ token via env injects the destination with no cloud
 	// login, tenant discovery or session mint. No fake cloud is wired, so any

--- a/cli/internal/platform/inject_test.go
+++ b/cli/internal/platform/inject_test.go
@@ -307,11 +307,16 @@ func TestInject_MultipleTenants_RequiresEnvSelection(t *testing.T) {
 		)
 	}
 
-	t.Run("unset skips", func(t *testing.T) {
+	t.Run("unset errors with a hint", func(t *testing.T) {
 		srv := fakeCloud(t, tenants, nil)
 		t.Setenv(envAPIURL, srv.URL)
-		got := mustInject(t, "tok", "team-x", testSources(), testDestinations())
-		require.Len(t, got, 1)
+		// A source opted into `platform` but the tenant is ambiguous → fail with
+		// an actionable hint rather than silently dropping the opt-in.
+		got, err := MaybeInjectDestination(context.Background(), zerolog.Nop(), "tok", "team-x", testSources(), testDestinations())
+		require.ErrorIs(t, err, errAmbiguousTenant)
+		require.ErrorContains(t, err, "Hint:")
+		require.ErrorContains(t, err, envTenantID)
+		require.Len(t, got, 1, "destinations unchanged when injection errors")
 	})
 
 	t.Run("env picks", func(t *testing.T) {
@@ -329,12 +334,14 @@ func TestInject_MultipleTenants_RequiresEnvSelection(t *testing.T) {
 		require.Len(t, got, 2)
 	})
 
-	t.Run("env mismatch skips", func(t *testing.T) {
+	t.Run("env mismatch errors with a hint", func(t *testing.T) {
 		srv := fakeCloud(t, tenants, nil)
 		t.Setenv(envAPIURL, srv.URL)
 		t.Setenv(envTenantID, "99999999-9999-9999-9999-999999999999")
-		got := mustInject(t, "tok", "team-x", testSources(), testDestinations())
-		require.Len(t, got, 1)
+		got, err := MaybeInjectDestination(context.Background(), zerolog.Nop(), "tok", "team-x", testSources(), testDestinations())
+		require.ErrorIs(t, err, errAmbiguousTenant)
+		require.ErrorContains(t, err, "Hint:")
+		require.Len(t, got, 1, "destinations unchanged when injection errors")
 	})
 }
 


### PR DESCRIPTION
Two related fixes to how the CLI resolves which platform tenant to act on. Follow-up to #22945.

## 1. Align `DetectTenant` with auto-injection
`DetectTenant` (used by `init` to tell the user where data lands) took the first of several active tenants, while the actual sync injection skips an ambiguous multi-tenant team with no `CQ_PLATFORM_TENANT_ID`. So `init` could point a user at a tenant a real sync would refuse. Both now share one decision (`resolveTenant`) and treat ambiguity identically.

## 2. Fail an opt-in sync with a hint on an ambiguous tenant
`resolveTenant` distinguishes:
- **no active tenant** (`errNoActiveTenant`) → auto-injection skips silently (nothing to do).
- **several active, no matching `CQ_PLATFORM_TENANT_ID`** (`errAmbiguousTenant`) → user-fixable.

When a source opts into `platform` (lists it in `destinations`) but the tenant is ambiguous, `MaybeInjectDestination` now returns the `errAmbiguousTenant`-wrapped error carrying an actionable `Hint:` (e.g. "set `CQ_PLATFORM_TENANT_ID` to the tenant id you want to sync to") instead of silently dropping the opt-in — `sync.go` surfaces it and the sync fails with a clear message. Genuine-zero-tenants still skips silently. `init`'s `DetectTenant` stays informational (any error → report nothing, never fails `init`).

## Tests
- `TestDetectTenant_MultipleActiveTenants` — ambiguous → reports nothing; override → matching tenant.
- `TestInject_MultipleTenants_RequiresEnvSelection` — unset / mismatched env now assert the `errAmbiguousTenant` + `Hint:` error (was: silent skip); valid env still injects.

`go build` / `go vet` / `go test ./internal/platform/` clean.