### PR TITLE
feat: Guard env-credential overrides — warn on mismatch, fail init on a rejected platform token

### DIFF
--- a/cli/cmd/credential_warnings.go
+++ b/cli/cmd/credential_warnings.go
@@ -1,0 +1,32 @@
+package cmd
+
+import (
+	"os"
+
+	cqapiauth "github.com/cloudquery/cloudquery-api-go/auth"
+	"github.com/cloudquery/cloudquery/cli/v6/internal/platform"
+	"github.com/spf13/cobra"
+)
+
+// Env credentials silently outrank the on-disk login: GetToken prefers
+// CLOUDQUERY_API_KEY over the saved refresh token, and the platform paths
+// prefer CQ_PLATFORM_TOKEN. login/logout call these so the user learns when
+// the login state they just changed is not what will actually authenticate.
+
+func warnEnvCredentialsOverrideLogin(cmd *cobra.Command) {
+	if os.Getenv(cqapiauth.EnvVarCloudQueryAPIKey) != "" {
+		cmd.Printf("Warning: %s is set in your environment and takes precedence over this login.\n", cqapiauth.EnvVarCloudQueryAPIKey)
+	}
+	if os.Getenv(platform.EnvPlatformToken) != "" {
+		cmd.Printf("Warning: %s is set in your environment; platform syncs and plugin downloads will use it instead of this login.\n", platform.EnvPlatformToken)
+	}
+}
+
+func warnEnvCredentialsSurviveLogout(cmd *cobra.Command) {
+	if os.Getenv(cqapiauth.EnvVarCloudQueryAPIKey) != "" {
+		cmd.Printf("Warning: %s is still set in your environment and will continue to authenticate CLI commands.\n", cqapiauth.EnvVarCloudQueryAPIKey)
+	}
+	if os.Getenv(platform.EnvPlatformToken) != "" {
+		cmd.Printf("Warning: %s is still set in your environment and will continue to authenticate platform syncs and plugin downloads.\n", platform.EnvPlatformToken)
+	}
+}

--- a/cli/cmd/credential_warnings_test.go
+++ b/cli/cmd/credential_warnings_test.go
@@ -1,0 +1,50 @@
+package cmd
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/cloudquery/cloudquery/cli/v6/internal/platform"
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/require"
+)
+
+func captureWarnings(t *testing.T, warn func(*cobra.Command)) string {
+	t.Helper()
+	var buf bytes.Buffer
+	cmd := &cobra.Command{}
+	cmd.SetOut(&buf)
+	warn(cmd)
+	return buf.String()
+}
+
+func TestWarnEnvCredentialsOverrideLogin(t *testing.T) {
+	t.Run("no env credentials -> silent", func(t *testing.T) {
+		t.Setenv("CLOUDQUERY_API_KEY", "")
+		t.Setenv(platform.EnvPlatformToken, "")
+		require.Empty(t, captureWarnings(t, warnEnvCredentialsOverrideLogin))
+	})
+	t.Run("both set -> warns about each", func(t *testing.T) {
+		t.Setenv("CLOUDQUERY_API_KEY", "cqt_x")
+		t.Setenv(platform.EnvPlatformToken, "cqpd_x.y")
+		out := captureWarnings(t, warnEnvCredentialsOverrideLogin)
+		require.Contains(t, out, "CLOUDQUERY_API_KEY")
+		require.Contains(t, out, platform.EnvPlatformToken)
+		require.Contains(t, out, "takes precedence over this login")
+	})
+}
+
+func TestWarnEnvCredentialsSurviveLogout(t *testing.T) {
+	t.Run("no env credentials -> silent", func(t *testing.T) {
+		t.Setenv("CLOUDQUERY_API_KEY", "")
+		t.Setenv(platform.EnvPlatformToken, "")
+		require.Empty(t, captureWarnings(t, warnEnvCredentialsSurviveLogout))
+	})
+	t.Run("both set -> warns each still authenticates", func(t *testing.T) {
+		t.Setenv("CLOUDQUERY_API_KEY", "cqt_x")
+		t.Setenv(platform.EnvPlatformToken, "cqpd_x.y")
+		out := captureWarnings(t, warnEnvCredentialsSurviveLogout)
+		require.Contains(t, out, "CLOUDQUERY_API_KEY is still set")
+		require.Contains(t, out, platform.EnvPlatformToken+" is still set")
+	})
+}

--- a/cli/cmd/credential_warnings_test.go
+++ b/cli/cmd/credential_warnings_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"testing"
 
+	cqapiauth "github.com/cloudquery/cloudquery-api-go/auth"
 	"github.com/cloudquery/cloudquery/cli/v6/internal/platform"
 	"github.com/spf13/cobra"
 	"github.com/stretchr/testify/require"
@@ -20,15 +21,15 @@ func captureWarnings(t *testing.T, warn func(*cobra.Command)) string {
 
 func TestWarnEnvCredentialsOverrideLogin(t *testing.T) {
 	t.Run("no env credentials -> silent", func(t *testing.T) {
-		t.Setenv("CLOUDQUERY_API_KEY", "")
+		t.Setenv(cqapiauth.EnvVarCloudQueryAPIKey, "")
 		t.Setenv(platform.EnvPlatformToken, "")
 		require.Empty(t, captureWarnings(t, warnEnvCredentialsOverrideLogin))
 	})
 	t.Run("both set -> warns about each", func(t *testing.T) {
-		t.Setenv("CLOUDQUERY_API_KEY", "cqt_x")
+		t.Setenv(cqapiauth.EnvVarCloudQueryAPIKey, "cqt_x")
 		t.Setenv(platform.EnvPlatformToken, "cqpd_x.y")
 		out := captureWarnings(t, warnEnvCredentialsOverrideLogin)
-		require.Contains(t, out, "CLOUDQUERY_API_KEY")
+		require.Contains(t, out, cqapiauth.EnvVarCloudQueryAPIKey)
 		require.Contains(t, out, platform.EnvPlatformToken)
 		require.Contains(t, out, "takes precedence over this login")
 	})
@@ -36,15 +37,15 @@ func TestWarnEnvCredentialsOverrideLogin(t *testing.T) {
 
 func TestWarnEnvCredentialsSurviveLogout(t *testing.T) {
 	t.Run("no env credentials -> silent", func(t *testing.T) {
-		t.Setenv("CLOUDQUERY_API_KEY", "")
+		t.Setenv(cqapiauth.EnvVarCloudQueryAPIKey, "")
 		t.Setenv(platform.EnvPlatformToken, "")
 		require.Empty(t, captureWarnings(t, warnEnvCredentialsSurviveLogout))
 	})
 	t.Run("both set -> warns each still authenticates", func(t *testing.T) {
-		t.Setenv("CLOUDQUERY_API_KEY", "cqt_x")
+		t.Setenv(cqapiauth.EnvVarCloudQueryAPIKey, "cqt_x")
 		t.Setenv(platform.EnvPlatformToken, "cqpd_x.y")
 		out := captureWarnings(t, warnEnvCredentialsSurviveLogout)
-		require.Contains(t, out, "CLOUDQUERY_API_KEY is still set")
+		require.Contains(t, out, cqapiauth.EnvVarCloudQueryAPIKey+" is still set")
 		require.Contains(t, out, platform.EnvPlatformToken+" is still set")
 	})
 }

--- a/cli/cmd/login.go
+++ b/cli/cmd/login.go
@@ -202,6 +202,7 @@ func runLogin(ctx context.Context, cmd *cobra.Command) (err error) {
 	analytics.TrackLoginSuccess(ctx, invocationUUID.UUID)
 
 	cmd.Println("✅ CLI successfully authenticated.")
+	warnEnvCredentialsOverrideLogin(cmd)
 	cmd.Println("Next, initialize your sync configuration:")
 	cmd.Println(bold.Sprint("cloudquery init"))
 

--- a/cli/cmd/logout.go
+++ b/cli/cmd/logout.go
@@ -48,6 +48,7 @@ func runLogout(_ context.Context, cmd *cobra.Command) error {
 	}
 
 	cmd.Println("CLI successfully logged out.")
+	warnEnvCredentialsSurviveLogout(cmd)
 
 	return nil
 }

--- a/cli/internal/platform/inject.go
+++ b/cli/internal/platform/inject.go
@@ -14,6 +14,7 @@ import (
 	"slices"
 	"strconv"
 	"strings"
+	gosync "sync"
 	"time"
 
 	"github.com/Masterminds/semver"
@@ -25,6 +26,7 @@ import (
 	"github.com/cloudquery/cloudquery/cli/v6/internal/env"
 	specs "github.com/cloudquery/cloudquery/cli/v6/internal/specs/v0"
 	"github.com/rs/zerolog"
+	zlog "github.com/rs/zerolog/log"
 	"google.golang.org/grpc/status"
 )
 
@@ -231,12 +233,29 @@ func apiURLFromToken(token string) string {
 // helper so download, injection, and tenant detection treat both envs alike.
 func platformToken() string {
 	if t := os.Getenv(EnvPlatformToken); t != "" {
+		warnTeamMismatchOnce(t)
 		return t
 	}
 	if k := os.Getenv("CLOUDQUERY_API_KEY"); strings.HasPrefix(k, cqpdPrefix) {
+		warnTeamMismatchOnce(k)
 		return k
 	}
 	return ""
+}
+
+// warnTeamMismatchOnce surfaces the team mismatch at the platformToken()
+// chokepoint so every consumer (init, validate-config, sync, migrate) warns
+// without each entry point remembering to — and only once per run, since
+// several of them read the token during a single command.
+var teamMismatchOnce gosync.Once
+
+func warnTeamMismatchOnce(token string) {
+	teamMismatchOnce.Do(func() {
+		if msg := teamMismatchWarning(TeamFromToken(token)); msg != "" {
+			zlog.Warn().Msg(msg)
+			fmt.Fprintln(os.Stderr, msg)
+		}
+	})
 }
 
 // PropagatePluginCredential makes a headless cqpd_ token available to spawned
@@ -466,12 +485,7 @@ func GateSources(ctx context.Context, logger zerolog.Logger, cloudToken, teamNam
 // env read keeps sync and migrate from drifting.
 func DownloadAuth(ctx context.Context, logger zerolog.Logger, sources []*specs.Source, destinations []*specs.Destination, transformers []*specs.Transformer) (token, team string, err error) {
 	if t := platformToken(); t != "" {
-		tokenTeam := TeamFromToken(t)
-		if msg := teamMismatchWarning(tokenTeam); msg != "" {
-			logger.Warn().Msg(msg)
-			fmt.Fprintln(os.Stderr, msg)
-		}
-		return t, tokenTeam, nil
+		return t, TeamFromToken(t), nil
 	}
 	authToken, err := cqauth.GetAuthTokenIfNeeded(logger, sources, destinations, transformers)
 	if err != nil {

--- a/cli/internal/platform/inject.go
+++ b/cli/internal/platform/inject.go
@@ -127,9 +127,17 @@ func DetectTenantForInit(ctx context.Context, logger zerolog.Logger, cloudToken,
 		if u == "" {
 			return &TenantInit{}, nil // tenant present, but no url to reach endpoints
 		}
+		// This same call validates the token: an explicit env token that the tenant
+		// rejects (expired/revoked/wrong tenant) means the platform sync can't run,
+		// so fail now rather than scaffold a spec that 401s at sync time. Other
+		// failures stay best-effort (nil pins → hub latest).
+		pins, err := fetchSupportedSourceVersions(ctx, logger, t, u)
+		if errors.Is(err, errPlatformUnauthorized) {
+			return nil, fmt.Errorf("the platform token in your environment (%s, or a %s CLOUDQUERY_API_KEY) is invalid or expired — mint a fresh token, unset it, or pass --disable-platform", EnvPlatformToken, cqpdPrefix)
+		}
 		return &TenantInit{
 			APIURL:               u,
-			PinnedSourceVersions: fetchSupportedSourceVersions(ctx, logger, t, u),
+			PinnedSourceVersions: pins,
 			token:                t,
 			endpointBase:         u,
 		}, nil
@@ -145,9 +153,12 @@ func DetectTenantForInit(ctx context.Context, logger zerolog.Logger, cloudToken,
 	if err != nil {
 		return nil, fmt.Errorf("mint platform destination session for tenant %s: %w", tenant.TenantId.String(), err)
 	}
+	// The session was just minted, so a 401 here would be a server anomaly, not
+	// user-fixable — keep pins best-effort rather than failing init.
+	pins, _ := fetchSupportedSourceVersions(ctx, logger, session.Token, session.ApiUrl)
 	return &TenantInit{
 		APIURL:               "https://" + tenant.Host,
-		PinnedSourceVersions: fetchSupportedSourceVersions(ctx, logger, session.Token, session.ApiUrl),
+		PinnedSourceVersions: pins,
 		token:                session.Token,
 		endpointBase:         session.ApiUrl,
 	}, nil
@@ -371,15 +382,25 @@ func PinnedSourceVersions(ctx context.Context, logger zerolog.Logger, cloudToken
 	if !ok {
 		return nil, false
 	}
-	versions := fetchSupportedSourceVersions(ctx, logger, token, apiURL)
+	// Best-effort (fail-open) even on an auth rejection: the version gate is a UX
+	// check, not a security boundary.
+	versions, _ := fetchSupportedSourceVersions(ctx, logger, token, apiURL)
 	return versions, versions != nil
 }
 
+// errPlatformUnauthorized means the platform rejected the token (401/403) —
+// expired, revoked, secret-rotated, or scoped to a dead tenant. Distinguished
+// from other failures so an explicit CQ_PLATFORM_TOKEN can fail init early rather
+// than silently degrade; every other failure stays best-effort (nil, nil).
+var errPlatformUnauthorized = errors.New("platform rejected the token")
+
 // fetchSupportedSourceVersions GETs /external-syncs/supported-source-versions
-// with an already-minted cqpd_ token and returns the pinned path->version map, or
-// nil on any failure (best-effort). Shared by PinnedSourceVersions and the init
-// tenant-detection path, which resolve the token/apiURL differently.
-func fetchSupportedSourceVersions(ctx context.Context, logger zerolog.Logger, cqpdToken, apiURL string) map[string]string {
+// with an already-minted cqpd_ token and returns the pinned path->version map.
+// Returns errPlatformUnauthorized on a 401/403; (nil, nil) on any other failure
+// (best-effort). Shared by PinnedSourceVersions and the init tenant-detection
+// path, which resolve the token/apiURL differently and treat the auth error
+// differently.
+func fetchSupportedSourceVersions(ctx context.Context, logger zerolog.Logger, cqpdToken, apiURL string) (map[string]string, error) {
 	url := externalSyncsURL(apiURL, "/external-syncs/supported-source-versions")
 
 	ctx, cancel := context.WithTimeout(ctx, requestTimeout)
@@ -387,25 +408,29 @@ func fetchSupportedSourceVersions(ctx context.Context, logger zerolog.Logger, cq
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
 	if err != nil {
 		logger.Debug().Err(err).Str("url", url).Msg("platform: failed to build supported-source-versions request")
-		return nil
+		return nil, nil
 	}
 	req.Header.Set("Authorization", "Bearer "+cqpdToken)
 	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
 		logger.Debug().Err(err).Str("url", url).Msg("platform: supported-source-versions lookup failed")
-		return nil
+		return nil, nil
 	}
 	defer resp.Body.Close()
+	if resp.StatusCode == http.StatusUnauthorized || resp.StatusCode == http.StatusForbidden {
+		logger.Debug().Int("status", resp.StatusCode).Str("url", url).Msg("platform: supported-source-versions rejected the token")
+		return nil, errPlatformUnauthorized
+	}
 	if resp.StatusCode != http.StatusOK {
 		logger.Debug().Int("status", resp.StatusCode).Str("url", url).Msg("platform: supported-source-versions returned non-200")
-		return nil
+		return nil, nil
 	}
 	var versions map[string]string
 	if err := json.NewDecoder(resp.Body).Decode(&versions); err != nil {
 		logger.Debug().Err(err).Msg("platform: failed to decode supported-source-versions")
-		return nil
+		return nil, nil
 	}
-	return versions
+	return versions, nil
 }
 
 // AnySourceTargetsPlatform reports whether any source opts into the platform

--- a/cli/internal/platform/inject.go
+++ b/cli/internal/platform/inject.go
@@ -19,6 +19,7 @@ import (
 	"github.com/Masterminds/semver"
 	cloudquery_api "github.com/cloudquery/cloudquery-api-go"
 	cqapiauth "github.com/cloudquery/cloudquery-api-go/auth"
+	cqconfig "github.com/cloudquery/cloudquery-api-go/config"
 	"github.com/cloudquery/cloudquery/cli/v6/internal/api"
 	cqauth "github.com/cloudquery/cloudquery/cli/v6/internal/auth"
 	"github.com/cloudquery/cloudquery/cli/v6/internal/env"
@@ -465,7 +466,12 @@ func GateSources(ctx context.Context, logger zerolog.Logger, cloudToken, teamNam
 // env read keeps sync and migrate from drifting.
 func DownloadAuth(ctx context.Context, logger zerolog.Logger, sources []*specs.Source, destinations []*specs.Destination, transformers []*specs.Transformer) (token, team string, err error) {
 	if t := platformToken(); t != "" {
-		return t, TeamFromToken(t), nil
+		tokenTeam := TeamFromToken(t)
+		if msg := teamMismatchWarning(tokenTeam); msg != "" {
+			logger.Warn().Msg(msg)
+			fmt.Fprintln(os.Stderr, msg)
+		}
+		return t, tokenTeam, nil
 	}
 	authToken, err := cqauth.GetAuthTokenIfNeeded(logger, sources, destinations, transformers)
 	if err != nil {
@@ -476,6 +482,23 @@ func DownloadAuth(ctx context.Context, logger zerolog.Logger, sources []*specs.S
 		return "", "", fmt.Errorf("failed to get team name from token: %w", err)
 	}
 	return authToken.Value, teamName, nil
+}
+
+// teamMismatchWarning reports when a headless platform token routes plugin
+// downloads and usage to a different team than the one the user is switched
+// to (`cloudquery switch`) — the token's tm claim wins silently otherwise.
+// Returns "" when there is nothing to warn about: no tm claim, no configured
+// team, or the two match.
+func teamMismatchWarning(tokenTeam string) string {
+	if tokenTeam == "" {
+		return ""
+	}
+	configTeam, err := cqconfig.GetValue("team")
+	if err != nil || configTeam == "" || configTeam == tokenTeam {
+		return ""
+	}
+	return fmt.Sprintf("Warning: the platform token in the environment (%s or a %s CLOUDQUERY_API_KEY) belongs to team %q; plugin downloads and usage will be attributed to that team, not your currently selected team %q",
+		EnvPlatformToken, cqpdPrefix, tokenTeam, configTeam)
 }
 
 // TeamFromToken returns the cloud team (`tm` claim) embedded in a cqpd_ token,

--- a/cli/internal/platform/inject.go
+++ b/cli/internal/platform/inject.go
@@ -406,7 +406,7 @@ var errPlatformUnauthorized = errors.New("platform rejected the token")
 // token, shared by init (DetectTenantForInit) and validate-config (GateSources)
 // so both report the same actionable fix.
 func unauthorizedTokenError() error {
-	return fmt.Errorf("the platform token in your environment (%s, or a %s CLOUDQUERY_API_KEY) was rejected — it is likely expired; mint a fresh token or unset it", EnvPlatformToken, cqpdPrefix)
+	return fmt.Errorf("the platform token in your environment (%s, or a %s %s) was rejected — it is likely expired; mint a fresh token or unset it", EnvPlatformToken, cqpdPrefix, cqapiauth.EnvVarCloudQueryAPIKey)
 }
 
 // fetchSupportedSourceVersions GETs /external-syncs/supported-source-versions
@@ -556,8 +556,8 @@ func teamMismatchWarning(tokenTeam string) string {
 	if err != nil || configTeam == "" || configTeam == tokenTeam {
 		return ""
 	}
-	return fmt.Sprintf("Warning: the platform token in the environment (%s or a %s CLOUDQUERY_API_KEY) belongs to team %q; plugin downloads and usage will be attributed to that team, not your currently selected team %q",
-		EnvPlatformToken, cqpdPrefix, tokenTeam, configTeam)
+	return fmt.Sprintf("Warning: the platform token in the environment (%s or a %s %s) belongs to team %q; plugin downloads and usage will be attributed to that team, not your currently selected team %q",
+		EnvPlatformToken, cqpdPrefix, cqapiauth.EnvVarCloudQueryAPIKey, tokenTeam, configTeam)
 }
 
 // TeamFromToken returns the cloud team (`tm` claim) embedded in a cqpd_ token,

--- a/cli/internal/platform/inject.go
+++ b/cli/internal/platform/inject.go
@@ -26,7 +26,6 @@ import (
 	"github.com/cloudquery/cloudquery/cli/v6/internal/env"
 	specs "github.com/cloudquery/cloudquery/cli/v6/internal/specs/v0"
 	"github.com/rs/zerolog"
-	zlog "github.com/rs/zerolog/log"
 	"google.golang.org/grpc/status"
 )
 
@@ -133,7 +132,7 @@ func DetectTenantForInit(ctx context.Context, logger zerolog.Logger, cloudToken,
 		// failures stay best-effort (nil pins → hub latest).
 		pins, err := fetchSupportedSourceVersions(ctx, logger, t, u)
 		if errors.Is(err, errPlatformUnauthorized) {
-			return nil, fmt.Errorf("the platform token in your environment (%s, or a %s CLOUDQUERY_API_KEY) is invalid or expired — mint a fresh token, unset it, or pass --disable-platform", EnvPlatformToken, cqpdPrefix)
+			return nil, unauthorizedTokenError()
 		}
 		return &TenantInit{
 			APIURL:               u,
@@ -262,8 +261,10 @@ var teamMismatchOnce gosync.Once
 
 func warnTeamMismatchOnce(token string) {
 	teamMismatchOnce.Do(func() {
+		// stderr only — a parallel zlog.Warn() would double-print when console
+		// logging is enabled (both land on the terminal). Matches login/logout,
+		// which print the credential warnings once via cmd.Printf.
 		if msg := teamMismatchWarning(TeamFromToken(token)); msg != "" {
-			zlog.Warn().Msg(msg)
 			fmt.Fprintln(os.Stderr, msg)
 		}
 	})
@@ -347,28 +348,34 @@ func externalSyncsURL(apiURL, path string) string {
 // its `u` claim. Logged in: mint a session for the team's resolved tenant. Returns
 // ok=false when there's no platform tenant or resolution fails, so callers fall
 // back to their normal behavior.
-func resolvePlatformSession(ctx context.Context, logger zerolog.Logger, cloudToken, teamName string) (cqpdToken, apiURL string, ok bool) {
+// resolvePlatformSession returns a cqpd_ token + api URL to reach
+// /external-syncs/*, and whether it's a direct env token (CQ_PLATFORM_TOKEN /
+// cqpd_ CLOUDQUERY_API_KEY) vs a freshly-minted session. `direct` matters for auth
+// failures: a rejected env token is user-fixable and the same token a sync reuses,
+// whereas a rejected fresh-minted token is a transient server anomaly (a sync
+// mints its own).
+func resolvePlatformSession(ctx context.Context, logger zerolog.Logger, cloudToken, teamName string) (cqpdToken, apiURL string, direct, ok bool) {
 	if os.Getenv(envDisable) == "1" {
-		return "", "", false
+		return "", "", false, false
 	}
 	if t := platformToken(); t != "" {
 		u := apiURLFromToken(t)
 		if u == "" {
 			logger.Debug().Msg("platform: direct token carries no api_url; cannot reach external-syncs endpoints")
-			return "", "", false
+			return "", "", false, false
 		}
-		return t, u, true
+		return t, u, true, true
 	}
 	cl, tenant, ok := resolveCloudTenant(ctx, logger, cloudToken, teamName)
 	if !ok {
-		return "", "", false
+		return "", "", false, false
 	}
 	session, _, err := mintSession(ctx, cl, tenant)
 	if err != nil {
 		logger.Debug().Err(err).Msg("platform: session mint failed; cannot fetch pinned versions")
-		return "", "", false
+		return "", "", false, false
 	}
-	return session.Token, session.ApiUrl, true
+	return session.Token, session.ApiUrl, false, true
 }
 
 // PinnedSourceVersions returns the platform-pinned source plugin versions
@@ -376,16 +383,21 @@ func resolvePlatformSession(ctx context.Context, logger zerolog.Logger, cloudTok
 // GET /external-syncs/supported-source-versions. `init` scaffolds these so the
 // generated spec matches what the tenant accepts, and `validate-config` gates
 // against them — the same window CreateExternalSync enforces at sync time.
-// Best-effort: (nil, false) when there's no platform tenant or the lookup fails.
-func PinnedSourceVersions(ctx context.Context, logger zerolog.Logger, cloudToken, teamName string) (map[string]string, bool) {
-	token, apiURL, ok := resolvePlatformSession(ctx, logger, cloudToken, teamName)
+//
+// Returns errPlatformUnauthorized only when a direct env token is rejected — the
+// same user-fixable failure `init` fails on, and one a sync would hit too, so the
+// gate shouldn't pass clean. Any other failure (no tenant, minted-session 401,
+// network) yields (nil, nil): best-effort, so the gate stays fail-open.
+func PinnedSourceVersions(ctx context.Context, logger zerolog.Logger, cloudToken, teamName string) (map[string]string, error) {
+	token, apiURL, direct, ok := resolvePlatformSession(ctx, logger, cloudToken, teamName)
 	if !ok {
-		return nil, false
+		return nil, nil
 	}
-	// Best-effort (fail-open) even on an auth rejection: the version gate is a UX
-	// check, not a security boundary.
-	versions, _ := fetchSupportedSourceVersions(ctx, logger, token, apiURL)
-	return versions, versions != nil
+	versions, err := fetchSupportedSourceVersions(ctx, logger, token, apiURL)
+	if errors.Is(err, errPlatformUnauthorized) && direct {
+		return nil, errPlatformUnauthorized
+	}
+	return versions, nil
 }
 
 // errPlatformUnauthorized means the platform rejected the token (401/403) —
@@ -393,6 +405,13 @@ func PinnedSourceVersions(ctx context.Context, logger zerolog.Logger, cloudToken
 // from other failures so an explicit CQ_PLATFORM_TOKEN can fail init early rather
 // than silently degrade; every other failure stays best-effort (nil, nil).
 var errPlatformUnauthorized = errors.New("platform rejected the token")
+
+// unauthorizedTokenError is the user-facing error for a rejected direct env
+// token, shared by init (DetectTenantForInit) and validate-config (GateSources)
+// so both report the same actionable fix.
+func unauthorizedTokenError() error {
+	return fmt.Errorf("the platform token in your environment (%s, or a %s CLOUDQUERY_API_KEY) was rejected — it is likely expired; mint a fresh token or unset it", EnvPlatformToken, cqpdPrefix)
+}
 
 // fetchSupportedSourceVersions GETs /external-syncs/supported-source-versions
 // with an already-minted cqpd_ token and returns the pinned path->version map.
@@ -477,8 +496,13 @@ func GateSources(ctx context.Context, logger zerolog.Logger, cloudToken, teamNam
 	if len(targeted) == 0 {
 		return nil
 	}
-	pinned, ok := PinnedSourceVersions(ctx, logger, cloudToken, teamName)
-	if !ok || len(pinned) == 0 {
+	pinned, err := PinnedSourceVersions(ctx, logger, cloudToken, teamName)
+	if errors.Is(err, errPlatformUnauthorized) {
+		// A rejected env token would 401 the sync too, so don't pass clean — this
+		// is exactly what validate-config promises to catch.
+		return unauthorizedTokenError()
+	}
+	if len(pinned) == 0 {
 		logger.Debug().Msg("platform: pinned source versions unavailable; skipping version gate")
 		return nil
 	}

--- a/cli/internal/platform/inject.go
+++ b/cli/internal/platform/inject.go
@@ -246,7 +246,7 @@ func platformToken() string {
 		warnTeamMismatchOnce(t)
 		return t
 	}
-	if k := os.Getenv("CLOUDQUERY_API_KEY"); strings.HasPrefix(k, cqpdPrefix) {
+	if k := os.Getenv(cqapiauth.EnvVarCloudQueryAPIKey); strings.HasPrefix(k, cqpdPrefix) {
 		warnTeamMismatchOnce(k)
 		return k
 	}
@@ -342,18 +342,14 @@ func externalSyncsURL(apiURL, path string) string {
 	return base + path
 }
 
-// resolvePlatformSession returns a cqpd_ token and the tenant's API base URL for
-// reaching the /external-syncs/* endpoints (which require an already-minted
-// token). Headless: a direct CQ_PLATFORM_TOKEN / cqpd_ CLOUDQUERY_API_KEY, using
-// its `u` claim. Logged in: mint a session for the team's resolved tenant. Returns
-// ok=false when there's no platform tenant or resolution fails, so callers fall
-// back to their normal behavior.
-// resolvePlatformSession returns a cqpd_ token + api URL to reach
-// /external-syncs/*, and whether it's a direct env token (CQ_PLATFORM_TOKEN /
-// cqpd_ CLOUDQUERY_API_KEY) vs a freshly-minted session. `direct` matters for auth
-// failures: a rejected env token is user-fixable and the same token a sync reuses,
-// whereas a rejected fresh-minted token is a transient server anomaly (a sync
-// mints its own).
+// resolvePlatformSession returns a cqpd_ token + tenant API base URL for reaching
+// the /external-syncs/* endpoints, and whether it's a direct env token
+// (CQ_PLATFORM_TOKEN / cqpd_ CLOUDQUERY_API_KEY, using its `u` claim) vs a
+// freshly-minted session for the logged-in team's tenant. ok=false when there's no
+// platform tenant or resolution fails, so callers fall back. `direct` matters for
+// auth failures: a rejected env token is user-fixable and is the same token a sync
+// reuses, whereas a rejected fresh-minted token is a transient server anomaly (a
+// sync mints its own).
 func resolvePlatformSession(ctx context.Context, logger zerolog.Logger, cloudToken, teamName string) (cqpdToken, apiURL string, direct, ok bool) {
 	if os.Getenv(envDisable) == "1" {
 		return "", "", false, false

--- a/cli/internal/platform/inject_test.go
+++ b/cli/internal/platform/inject_test.go
@@ -323,6 +323,59 @@ func TestDetectTenantForInit_MintOK_PinsUnavailable_NoError(t *testing.T) {
 	require.Nil(t, ti.PinnedSourceVersions, "pins unavailable → nil, init falls back to hub latest")
 }
 
+func TestDetectTenantForInit_DirectToken_Unauthorized_Errors(t *testing.T) {
+	// An expired/rejected env CQ_PLATFORM_TOKEN must fail init early rather than
+	// silently scaffold a spec that 401s at sync time.
+	es := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		http.Error(w, "unauthorized", http.StatusUnauthorized)
+	}))
+	defer es.Close()
+	t.Setenv(EnvPlatformToken, cqpdTokenWithClaims(t, map[string]any{"u": es.URL}))
+
+	ti, err := DetectTenantForInit(context.Background(), zerolog.Nop(), "", "")
+	require.Error(t, err, "a rejected env token fails init early")
+	require.ErrorContains(t, err, "invalid or expired")
+	require.Nil(t, ti)
+}
+
+func TestDetectTenantForInit_DirectToken_ServerError_BestEffort(t *testing.T) {
+	// A non-auth failure (500) stays best-effort — init proceeds without pins.
+	es := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		http.Error(w, "boom", http.StatusInternalServerError)
+	}))
+	defer es.Close()
+	t.Setenv(EnvPlatformToken, cqpdTokenWithClaims(t, map[string]any{"u": es.URL}))
+
+	ti, err := DetectTenantForInit(context.Background(), zerolog.Nop(), "", "")
+	require.NoError(t, err, "a non-auth failure doesn't fail init")
+	require.NotNil(t, ti)
+	require.Nil(t, ti.PinnedSourceVersions)
+}
+
+func TestDetectTenantForInit_MintOK_PinsUnauthorized_BestEffort(t *testing.T) {
+	// The session was just minted, so a 401 from the pins lookup is a server
+	// anomaly, not user-fixable — init still proceeds (unlike the direct-token
+	// path, which the user can fix by refreshing/unsetting the env token).
+	es := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		http.Error(w, "unauthorized", http.StatusUnauthorized)
+	}))
+	defer es.Close()
+	srv := fakeCloud(t, func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{"items": []map[string]any{
+			{"tenant_id": "11111111-1111-1111-1111-111111111111", "status": "active", "team_name": "team-x", "host": "acme.us.platform.cloudquery.io", "subdomain": "acme"},
+		}})
+	}, func(w http.ResponseWriter, _ *http.Request) {
+		writeSession(w, "cqpd_minted.sig", es.URL)
+	})
+	t.Setenv(envAPIURL, srv.URL)
+
+	ti, err := DetectTenantForInit(context.Background(), zerolog.Nop(), "tok", "team-x")
+	require.NoError(t, err, "a fresh-minted session's 401 doesn't fail init")
+	require.NotNil(t, ti)
+	require.Nil(t, ti.PinnedSourceVersions)
+}
+
 // DetectTenantForInit must make the SAME multi-tenant decision auto-injection
 // does: skip (report nothing) when a team has several active tenants and no
 // CQ_PLATFORM_TENANT_ID override — otherwise `init` would point the user at a

--- a/cli/internal/platform/inject_test.go
+++ b/cli/internal/platform/inject_test.go
@@ -11,6 +11,7 @@ import (
 	"sync/atomic"
 	"testing"
 
+	cqconfig "github.com/cloudquery/cloudquery-api-go/config"
 	specs "github.com/cloudquery/cloudquery/cli/v6/internal/specs/v0"
 	"github.com/rs/zerolog"
 	"github.com/stretchr/testify/require"
@@ -177,6 +178,35 @@ func TestPropagatePluginCredential(t *testing.T) {
 		t.Setenv("CLOUDQUERY_API_KEY", "")
 		PropagatePluginCredential("not-a-cqpd-token")
 		require.Empty(t, os.Getenv("CLOUDQUERY_API_KEY"))
+	})
+}
+
+func TestTeamMismatchWarning(t *testing.T) {
+	setConfigTeam := func(t *testing.T, team string) {
+		t.Helper()
+		require.NoError(t, cqconfig.SetConfigHome(t.TempDir()))
+		t.Cleanup(func() { _ = cqconfig.UnsetConfigHome() })
+		if team != "" {
+			require.NoError(t, cqconfig.SetValue("team", team))
+		}
+	}
+	t.Run("configured team differs from tm claim -> warns with both teams", func(t *testing.T) {
+		setConfigTeam(t, "team-a")
+		msg := teamMismatchWarning("acme")
+		require.Contains(t, msg, `"acme"`)
+		require.Contains(t, msg, `"team-a"`)
+	})
+	t.Run("configured team matches -> no warning", func(t *testing.T) {
+		setConfigTeam(t, "acme")
+		require.Empty(t, teamMismatchWarning("acme"))
+	})
+	t.Run("no configured team -> no warning", func(t *testing.T) {
+		setConfigTeam(t, "")
+		require.Empty(t, teamMismatchWarning("acme"))
+	})
+	t.Run("no tm claim -> no warning", func(t *testing.T) {
+		setConfigTeam(t, "team-a")
+		require.Empty(t, teamMismatchWarning(""))
 	})
 }
 

--- a/cli/internal/platform/inject_test.go
+++ b/cli/internal/platform/inject_test.go
@@ -334,7 +334,7 @@ func TestDetectTenantForInit_DirectToken_Unauthorized_Errors(t *testing.T) {
 
 	ti, err := DetectTenantForInit(context.Background(), zerolog.Nop(), "", "")
 	require.Error(t, err, "a rejected env token fails init early")
-	require.ErrorContains(t, err, "invalid or expired")
+	require.ErrorContains(t, err, "expired")
 	require.Nil(t, ti)
 }
 
@@ -794,9 +794,9 @@ func TestPinnedSourceVersions_DirectToken(t *testing.T) {
 	tok = cqpdTokenWithClaims(t, map[string]any{"u": es.URL})
 	t.Setenv(EnvPlatformToken, tok)
 
-	got, ok := PinnedSourceVersions(context.Background(), zerolog.Nop(), "", "")
-	require.True(t, ok, "a direct cqpd_ token resolves pinned versions without cloud")
-	require.Equal(t, pinned, got)
+	got, err := PinnedSourceVersions(context.Background(), zerolog.Nop(), "", "")
+	require.NoError(t, err)
+	require.Equal(t, pinned, got, "a direct cqpd_ token resolves pinned versions without cloud")
 }
 
 func TestPinnedSourceVersions_LoginMintsAndFetches(t *testing.T) {
@@ -808,14 +808,28 @@ func TestPinnedSourceVersions_LoginMintsAndFetches(t *testing.T) {
 	})
 	t.Setenv(envAPIURL, srv.URL)
 
-	got, ok := PinnedSourceVersions(context.Background(), zerolog.Nop(), "tok", "team-x")
-	require.True(t, ok, "logged-in flow mints a session then fetches pinned versions")
-	require.Equal(t, pinned, got)
+	got, err := PinnedSourceVersions(context.Background(), zerolog.Nop(), "tok", "team-x")
+	require.NoError(t, err)
+	require.Equal(t, pinned, got, "logged-in flow mints a session then fetches pinned versions")
 }
 
-func TestPinnedSourceVersions_NoTenant_NotOK(t *testing.T) {
-	got, ok := PinnedSourceVersions(context.Background(), zerolog.Nop(), "", "")
-	require.False(t, ok, "no token and no cloud creds → nothing to resolve")
+func TestPinnedSourceVersions_NoTenant_Nil(t *testing.T) {
+	got, err := PinnedSourceVersions(context.Background(), zerolog.Nop(), "", "")
+	require.NoError(t, err, "no token and no cloud creds → nothing to resolve, no error")
+	require.Nil(t, got)
+}
+
+func TestPinnedSourceVersions_DirectToken_Unauthorized(t *testing.T) {
+	// A rejected direct env token propagates errPlatformUnauthorized so the gate
+	// (validate-config) fails instead of silently passing.
+	es := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		http.Error(w, "unauthorized", http.StatusUnauthorized)
+	}))
+	defer es.Close()
+	t.Setenv(EnvPlatformToken, cqpdTokenWithClaims(t, map[string]any{"u": es.URL}))
+
+	got, err := PinnedSourceVersions(context.Background(), zerolog.Nop(), "", "")
+	require.ErrorIs(t, err, errPlatformUnauthorized)
 	require.Nil(t, got)
 }
 
@@ -892,6 +906,23 @@ func TestGateSources_VersionsUnavailable_FailOpen(t *testing.T) {
 		{Metadata: specs.Metadata{Name: "aws", Path: "cloudquery/aws", Version: "v99.0.0"}, Destinations: []string{"platform"}},
 	}
 	require.NoError(t, GateSources(context.Background(), zerolog.Nop(), "", "", sources))
+}
+
+func TestGateSources_RejectedToken_Errors(t *testing.T) {
+	// A rejected direct env token would 401 the sync too, so the gate must fail
+	// (not pass clean) — validate-config's "catch what sync would hit" contract.
+	es := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		http.Error(w, "unauthorized", http.StatusUnauthorized)
+	}))
+	defer es.Close()
+	t.Setenv(EnvPlatformToken, cqpdTokenWithClaims(t, map[string]any{"u": es.URL}))
+
+	sources := []*specs.Source{
+		{Metadata: specs.Metadata{Name: "aws", Path: "cloudquery/aws", Version: "v1.0.0"}, Destinations: []string{"platform"}},
+	}
+	err := GateSources(context.Background(), zerolog.Nop(), "", "", sources)
+	require.Error(t, err)
+	require.ErrorContains(t, err, "expired")
 }
 
 func TestInject_PlatformPinnedVersion(t *testing.T) {


### PR DESCRIPTION
Env credentials silently outrank the on-disk login (`GetToken` prefers `CLOUDQUERY_API_KEY`; the platform paths prefer `CQ_PLATFORM_TOKEN`). This PR makes that visible — and, where it can't work at all, fatal.

## Warn
- On `login` / `logout`, when `CLOUDQUERY_API_KEY` or `CQ_PLATFORM_TOKEN` is set — the env credential, not the login you just changed, is what authenticates.
- At the `platformToken()` chokepoint (so `init` / `validate-config` / `sync` / `migrate` all get it, once per run), when a headless platform token's `tm` claim targets a different team than the one you're switched to — plugin downloads/usage would be attributed to the token's team.

## Fail
- `cloudquery init`: when a set `CQ_PLATFORM_TOKEN` (or a `cqpd_` `CLOUDQUERY_API_KEY`) is **expired/rejected** by the tenant. Previously init used it headlessly and silently degraded — scaffolding a source-only config pointed at a tenant that only 401s later at `sync`. The `supported-source-versions` call init already makes now distinguishes a `401/403` (`errPlatformUnauthorized`) from other failures, so the direct-token path fails early with an actionable message (mint a fresh token / unset it / `--disable-platform`). No extra request.
  - Freshly-minted login sessions stay best-effort (a 401 there is a server anomaly, not user-fixable), and the `validate-config` version gate stays fail-open (it's a UX check, not a security boundary).

## Tests
`credential_warnings` (login/logout, team-mismatch), and `DetectTenantForInit` — direct-token 401 → error, direct-token 500 → best-effort, login 401 → best-effort. `go build` / `go vet` / gofmt clean.