### PR TITLE
fix: Restrict init source picker to platform-supported sources

### DIFF
--- a/cli/cmd/init.go
+++ b/cli/cmd/init.go
@@ -316,8 +316,8 @@ func configForDestinationPlugin(destination cqapi.ListPlugin, version *cqapi.Plu
 }
 
 // unsupportedPlatformSourceError returns an error when a platform tenant doesn't
-// support the given source path (team/name), else nil. nil supported set (no
-// platform tenant) never rejects.
+// support the given source path (team/name), else nil. An empty or nil supported
+// set (no platform tenant) never rejects.
 func unsupportedPlatformSourceError(source string, supported map[string]string) error {
 	if len(supported) == 0 {
 		return nil
@@ -332,7 +332,7 @@ func unsupportedPlatformSourceError(source string, supported map[string]string) 
 // (a CloudQuery Platform tenant — the caller requires a non-empty set there), the
 // list is restricted to the sources the platform supports (its `team/name` keys),
 // so the picker never offers plugins, e.g. database sources, a platform sync can't
-// use. nil supportedPaths (no platform tenant) leaves the list unfiltered.
+// use. An empty or nil supportedPaths (no platform tenant) leaves it unfiltered.
 func selectSource(allPlugins []cqapi.ListPlugin, acceptDefaults bool, supportedPaths map[string]string) (string, error) {
 	officialSources := lo.Filter(allPlugins, officialReleasedPluginsByKind(cqapi.PluginKindSource))
 	if len(supportedPaths) > 0 {

--- a/cli/cmd/init.go
+++ b/cli/cmd/init.go
@@ -329,6 +329,11 @@ func selectSource(allPlugins []cqapi.ListPlugin, acceptDefaults bool, supportedP
 		})
 	}
 	if len(officialSources) == 0 {
+		if len(supportedPaths) > 0 {
+			// Platform tenant, but none of its supported sources are official
+			// released plugins (near-impossible) — give the same escape hatch.
+			return "", errors.New("none of the source plugins your CloudQuery Platform supports are available — please try again, or pass --disable-platform to scaffold a regular source + destination config")
+		}
 		return "", errors.New("no source plugins available to select")
 	}
 	slices.SortStableFunc(officialSources, pluginsSorter(sourcesOrder))

--- a/cli/cmd/init.go
+++ b/cli/cmd/init.go
@@ -315,6 +315,19 @@ func configForDestinationPlugin(destination cqapi.ListPlugin, version *cqapi.Plu
 	return defaultConfig.String()
 }
 
+// unsupportedPlatformSourceError returns an error when a platform tenant doesn't
+// support the given source path (team/name), else nil. nil supported set (no
+// platform tenant) never rejects.
+func unsupportedPlatformSourceError(source string, supported map[string]string) error {
+	if len(supported) == 0 {
+		return nil
+	}
+	if _, ok := supported[source]; ok {
+		return nil
+	}
+	return fmt.Errorf("source plugin %q is not supported by your CloudQuery Platform", source)
+}
+
 // selectSource prompts for a source plugin. When supportedPaths is non-empty
 // (a CloudQuery Platform tenant — the caller requires a non-empty set there), the
 // list is restricted to the sources the platform supports (its `team/name` keys),
@@ -554,8 +567,13 @@ func initCmd(cmd *cobra.Command, args []string) (initCommandError error) {
 	// actionable error rather than silently listing everything.
 	var supportedSourcePaths map[string]string
 	if platformTenant {
-		if len(tenantInit.PinnedSourceVersions) == 0 {
+		switch {
+		case tenantInit.PinnedSourceVersions == nil:
+			// Lookup failed (nil, not an empty result) — likely transient.
 			return errors.New("couldn't determine which source plugins your CloudQuery Platform supports — please try again, or pass --disable-platform to scaffold a regular source + destination config")
+		case len(tenantInit.PinnedSourceVersions) == 0:
+			// Lookup succeeded but the platform reported no supported sources.
+			return errors.New("your CloudQuery Platform reports no supported source plugins — pass --disable-platform to scaffold a regular source + destination config")
 		}
 		supportedSourcePaths = tenantInit.PinnedSourceVersions
 	}
@@ -563,13 +581,10 @@ func initCmd(cmd *cobra.Command, args []string) (initCommandError error) {
 	var notFoundPluginsErrors error
 	if source != "" {
 		sourcePluginFilter := pluginFilter(source, cqapi.PluginKindSource)
-		sourceFound := lo.SomeBy(allPlugins, sourcePluginFilter)
-		if !sourceFound {
+		if !lo.SomeBy(allPlugins, sourcePluginFilter) {
 			notFoundPluginsErrors = errors.Join(notFoundPluginsErrors, fmt.Errorf("source plugin %q not found", source))
-		} else if len(supportedSourcePaths) > 0 {
-			if _, ok := supportedSourcePaths[source]; !ok {
-				notFoundPluginsErrors = errors.Join(notFoundPluginsErrors, fmt.Errorf("source plugin %q is not supported by your CloudQuery Platform", source))
-			}
+		} else if err := unsupportedPlatformSourceError(source, supportedSourcePaths); err != nil {
+			notFoundPluginsErrors = errors.Join(notFoundPluginsErrors, err)
 		}
 	}
 	if destination != "" {

--- a/cli/cmd/init.go
+++ b/cli/cmd/init.go
@@ -567,13 +567,8 @@ func initCmd(cmd *cobra.Command, args []string) (initCommandError error) {
 	// actionable error rather than silently listing everything.
 	var supportedSourcePaths map[string]string
 	if platformTenant {
-		switch {
-		case tenantInit.PinnedSourceVersions == nil:
-			// Lookup failed (nil, not an empty result) — likely transient.
+		if len(tenantInit.PinnedSourceVersions) == 0 {
 			return errors.New("couldn't determine which source plugins your CloudQuery Platform supports — please try again, or pass --disable-platform to scaffold a regular source + destination config")
-		case len(tenantInit.PinnedSourceVersions) == 0:
-			// Lookup succeeded but the platform reported no supported sources.
-			return errors.New("your CloudQuery Platform reports no supported source plugins — pass --disable-platform to scaffold a regular source + destination config")
 		}
 		supportedSourcePaths = tenantInit.PinnedSourceVersions
 	}

--- a/cli/cmd/init.go
+++ b/cli/cmd/init.go
@@ -316,11 +316,10 @@ func configForDestinationPlugin(destination cqapi.ListPlugin, version *cqapi.Plu
 }
 
 // selectSource prompts for a source plugin. When supportedPaths is non-empty
-// (a CloudQuery Platform tenant), the list is restricted to the sources the
-// platform supports (its `team/name` keys) — otherwise the picker would offer
-// plugins, e.g. database sources, a platform sync can't use. An empty/nil
-// supportedPaths means "unfiltered" (no platform, or the support list was
-// unavailable — don't over-filter on a best-effort lookup).
+// (a CloudQuery Platform tenant — the caller requires a non-empty set there), the
+// list is restricted to the sources the platform supports (its `team/name` keys),
+// so the picker never offers plugins, e.g. database sources, a platform sync can't
+// use. nil supportedPaths (no platform tenant) leaves the list unfiltered.
 func selectSource(allPlugins []cqapi.ListPlugin, acceptDefaults bool, supportedPaths map[string]string) (string, error) {
 	officialSources := lo.Filter(allPlugins, officialReleasedPluginsByKind(cqapi.PluginKindSource))
 	if len(supportedPaths) > 0 {
@@ -544,10 +543,15 @@ func initCmd(cmd *cobra.Command, args []string) (initCommandError error) {
 	}
 
 	// On a platform tenant, restrict sources to what the platform supports (its
-	// supported-source-versions). Empty/nil when there's no tenant or the lookup
-	// was unavailable — then it's unfiltered (best-effort).
+	// supported-source-versions). This is required, not best-effort: offering a
+	// source the platform can't ingest scaffolds a config that only fails later at
+	// the sync-time gate, so if the support list is unavailable, stop with an
+	// actionable error rather than silently listing everything.
 	var supportedSourcePaths map[string]string
 	if platformTenant {
+		if len(tenantInit.PinnedSourceVersions) == 0 {
+			return errors.New("couldn't determine which source plugins your CloudQuery Platform supports — please try again, or pass --disable-platform to scaffold a regular source + destination config")
+		}
 		supportedSourcePaths = tenantInit.PinnedSourceVersions
 	}
 

--- a/cli/cmd/init.go
+++ b/cli/cmd/init.go
@@ -315,8 +315,23 @@ func configForDestinationPlugin(destination cqapi.ListPlugin, version *cqapi.Plu
 	return defaultConfig.String()
 }
 
-func selectSource(allPlugins []cqapi.ListPlugin, acceptDefaults bool) (string, error) {
+// selectSource prompts for a source plugin. When supportedPaths is non-empty
+// (a CloudQuery Platform tenant), the list is restricted to the sources the
+// platform supports (its `team/name` keys) — otherwise the picker would offer
+// plugins, e.g. database sources, a platform sync can't use. An empty/nil
+// supportedPaths means "unfiltered" (no platform, or the support list was
+// unavailable — don't over-filter on a best-effort lookup).
+func selectSource(allPlugins []cqapi.ListPlugin, acceptDefaults bool, supportedPaths map[string]string) (string, error) {
 	officialSources := lo.Filter(allPlugins, officialReleasedPluginsByKind(cqapi.PluginKindSource))
+	if len(supportedPaths) > 0 {
+		officialSources = lo.Filter(officialSources, func(p cqapi.ListPlugin, _ int) bool {
+			_, ok := supportedPaths[p.TeamName+"/"+p.Name]
+			return ok
+		})
+	}
+	if len(officialSources) == 0 {
+		return "", errors.New("no source plugins available to select")
+	}
 	slices.SortStableFunc(officialSources, pluginsSorter(sourcesOrder))
 	if acceptDefaults {
 		return officialSources[0].Name, nil
@@ -528,12 +543,24 @@ func initCmd(cmd *cobra.Command, args []string) (initCommandError error) {
 		return err
 	}
 
+	// On a platform tenant, restrict sources to what the platform supports (its
+	// supported-source-versions). Empty/nil when there's no tenant or the lookup
+	// was unavailable — then it's unfiltered (best-effort).
+	var supportedSourcePaths map[string]string
+	if platformTenant {
+		supportedSourcePaths = tenantInit.PinnedSourceVersions
+	}
+
 	var notFoundPluginsErrors error
 	if source != "" {
 		sourcePluginFilter := pluginFilter(source, cqapi.PluginKindSource)
 		sourceFound := lo.SomeBy(allPlugins, sourcePluginFilter)
 		if !sourceFound {
 			notFoundPluginsErrors = errors.Join(notFoundPluginsErrors, fmt.Errorf("source plugin %q not found", source))
+		} else if len(supportedSourcePaths) > 0 {
+			if _, ok := supportedSourcePaths[source]; !ok {
+				notFoundPluginsErrors = errors.Join(notFoundPluginsErrors, fmt.Errorf("source plugin %q is not supported by your CloudQuery Platform", source))
+			}
 		}
 	}
 	if destination != "" {
@@ -549,7 +576,7 @@ func initCmd(cmd *cobra.Command, args []string) (initCommandError error) {
 	}
 
 	if source == "" {
-		source, err = selectSource(allPlugins, acceptDefaults)
+		source, err = selectSource(allPlugins, acceptDefaults, supportedSourcePaths)
 		if err != nil {
 			return err
 		}

--- a/cli/cmd/init_test.go
+++ b/cli/cmd/init_test.go
@@ -416,3 +416,15 @@ func Test_selectSource_PlatformFilter(t *testing.T) {
 		require.ErrorContains(t, err, "--disable-platform", "platform-filtered empty list keeps the actionable hint")
 	})
 }
+
+func Test_unsupportedPlatformSourceError(t *testing.T) {
+	supported := map[string]string{"cloudquery/aws": "v1.0.0"}
+
+	require.NoError(t, unsupportedPlatformSourceError("cloudquery/aws", supported), "a supported source is accepted")
+	require.NoError(t, unsupportedPlatformSourceError("cloudquery/postgresql", nil), "no platform tenant (nil set) never rejects")
+	require.NoError(t, unsupportedPlatformSourceError("cloudquery/postgresql", map[string]string{}), "empty set never rejects")
+
+	err := unsupportedPlatformSourceError("cloudquery/postgresql", supported)
+	require.Error(t, err)
+	require.ErrorContains(t, err, `"cloudquery/postgresql" is not supported by your CloudQuery Platform`)
+}

--- a/cli/cmd/init_test.go
+++ b/cli/cmd/init_test.go
@@ -389,3 +389,30 @@ func Test_withRecommendedTables(t *testing.T) {
 		require.Equal(t, rec, sr.Sources[0].Tables)
 	})
 }
+
+func Test_selectSource_PlatformFilter(t *testing.T) {
+	src := func(name string) cqapi.ListPlugin {
+		return cqapi.ListPlugin{Name: name, TeamName: "cloudquery", Kind: cqapi.PluginKindSource, Official: true, LatestVersion: lo.ToPtr("v1.0.0")}
+	}
+	plugins := []cqapi.ListPlugin{src("aws"), src("gcp"), src("postgresql")}
+
+	t.Run("platform tenant restricts to supported sources", func(t *testing.T) {
+		// postgresql (a DB source the platform doesn't support) must not be offered.
+		supported := map[string]string{"cloudquery/gcp": "v1.0.0"}
+		got, err := selectSource(plugins, true, supported)
+		require.NoError(t, err)
+		require.Equal(t, "gcp", got, "only the platform-supported source is selectable")
+	})
+
+	t.Run("no supported set is unfiltered", func(t *testing.T) {
+		got, err := selectSource(plugins, true, nil)
+		require.NoError(t, err)
+		require.Equal(t, "aws", got, "sourcesOrder puts aws first")
+	})
+
+	t.Run("errors when nothing supported matches the official list", func(t *testing.T) {
+		_, err := selectSource(plugins, true, map[string]string{"cloudquery/unlisted": "v1.0.0"})
+		require.Error(t, err)
+		require.ErrorContains(t, err, "no source plugins available")
+	})
+}

--- a/cli/cmd/init_test.go
+++ b/cli/cmd/init_test.go
@@ -410,9 +410,9 @@ func Test_selectSource_PlatformFilter(t *testing.T) {
 		require.Equal(t, "aws", got, "sourcesOrder puts aws first")
 	})
 
-	t.Run("errors when nothing supported matches the official list", func(t *testing.T) {
+	t.Run("errors actionably when nothing supported matches the official list", func(t *testing.T) {
 		_, err := selectSource(plugins, true, map[string]string{"cloudquery/unlisted": "v1.0.0"})
 		require.Error(t, err)
-		require.ErrorContains(t, err, "no source plugins available")
+		require.ErrorContains(t, err, "--disable-platform", "platform-filtered empty list keeps the actionable hint")
 	})
 }

--- a/cli/internal/platform/inject.go
+++ b/cli/internal/platform/inject.go
@@ -103,8 +103,7 @@ type TenantInit struct {
 	// PinnedSourceVersions maps source plugin path -> pinned version — the
 	// platform's supported-source-versions. init both scaffolds these versions and
 	// gates which sources it offers, so it treats this as required (failing when
-	// it's nil/empty on a platform tenant) rather than falling back. nil
-	// distinguishes a failed lookup from an empty (but successful) result.
+	// it's nil/empty on a platform tenant) rather than falling back.
 	PinnedSourceVersions map[string]string
 
 	// token + endpointBase reach /external-syncs/* for later per-plugin lookups,

--- a/cli/internal/platform/inject.go
+++ b/cli/internal/platform/inject.go
@@ -100,8 +100,11 @@ type TenantInit struct {
 	// APIURL is the tenant base URL to show the user (host only, no /api). May be
 	// empty if a directly supplied CQ_PLATFORM_TOKEN predates url-carrying tokens.
 	APIURL string
-	// PinnedSourceVersions maps source plugin path -> pinned version. Best-effort:
-	// nil when the lookup failed, so init falls back to the hub's latest.
+	// PinnedSourceVersions maps source plugin path -> pinned version — the
+	// platform's supported-source-versions. init both scaffolds these versions and
+	// gates which sources it offers, so it treats this as required (failing when
+	// it's nil/empty on a platform tenant) rather than falling back. nil
+	// distinguishes a failed lookup from an empty (but successful) result.
 	PinnedSourceVersions map[string]string
 
 	// token + endpointBase reach /external-syncs/* for later per-plugin lookups,


### PR DESCRIPTION
When you run `cloudquery init` authenticated against a CloudQuery Platform tenant, the source-plugin picker listed **every** official source — including ones the platform can't ingest (e.g. database sources). Selecting one produced a config the platform would reject at sync.

## Fix
On a platform tenant, restrict sources to what the platform supports — the tenant's `supported-source-versions` (already in `TenantInit.PinnedSourceVersions`):
- the interactive picker only offers supported sources;
- an explicit `--source` the platform doesn't support fails with `source plugin %q is not supported by your CloudQuery Platform`.

**Required, not best-effort.** Filtering is a correctness concern: silently listing every source when the support lookup is unavailable would reproduce the bug (a doomed config, caught only later at the sync-time gate). So if the support list is empty/unavailable on a platform tenant, init stops with an actionable error (`couldn't determine which source plugins your CloudQuery Platform supports — please try again, or pass --disable-platform ...`) rather than falling back to an unfiltered picker. This mirrors the mint-failure hard-fail already in `DetectTenantForInit`. Non-platform init is unaffected (unfiltered as before).

## Tests
`Test_selectSource_PlatformFilter`: supported set restricts the list (a DB source is excluded), nil (no platform) is unfiltered, and an all-excluded set errors. `go build` / `go vet` / gofmt clean.