### PR TITLE
fix: Skip sync_run_completed analytics event for platform-only syncs

### DIFF
--- a/cli/cmd/sync_v3.go
+++ b/cli/cmd/sync_v3.go
@@ -178,6 +178,12 @@ func syncConnectionV3(ctx context.Context, syncOptions syncV3Options) (syncErr e
 		statsPerTable  = utils.NewConcurrentMap[string, SyncRunTableProgressValue]()
 	)
 	defer func() {
+		// Platform-only syncs are external syncs: the platform emits the canonical
+		// sync_run_completed once ingestion settles, so sending it here too would
+		// double-count. See platform.OnlyPlatformDestinations.
+		if platform.OnlyPlatformDestinations(destinationSpecs) {
+			return
+		}
 		analytics.TrackSyncCompleted(ctx, invocationUUID.UUID, analytics.SyncFinishedEvent{
 			SyncStartedEvent:  syncStartedEvent,
 			Errors:            totals.Errors,

--- a/cli/internal/platform/inject.go
+++ b/cli/internal/platform/inject.go
@@ -713,6 +713,24 @@ func hasPlatformDestination(destinations []*specs.Destination) bool {
 	return false
 }
 
+// OnlyPlatformDestinations reports whether every destination of a sync is the
+// reserved `platform` destination. Such syncs are external syncs: the platform
+// emits its own canonical sync_run_completed event when the run's ingestion
+// settles, so the CLI suppresses its sync_run_completed to avoid double-counting.
+// sync_run_started is still sent — the platform emits no started event for
+// external syncs, and the CLI event carries the real user attribution.
+func OnlyPlatformDestinations(destinations []specs.Destination) bool {
+	if len(destinations) == 0 {
+		return false
+	}
+	for _, d := range destinations {
+		if d.Name != destinationName {
+			return false
+		}
+	}
+	return true
+}
+
 // injectPlatformDestination appends the reserved `platform` destination carrying
 // the cqpd_ token. The caller guarantees a source already targets it (the opt-in)
 // and that no user-defined `platform` destination exists. recommendedVersion,

--- a/cli/internal/platform/inject_test.go
+++ b/cli/internal/platform/inject_test.go
@@ -942,3 +942,13 @@ func TestInject_EnvVersionBeatsPlatformPin(t *testing.T) {
 	got := mustInject(t, "tok", "team-x", testSources(), testDestinations())
 	require.Equal(t, "v9.9.9", got[1].Version, "env override wins over the platform pin")
 }
+
+func TestOnlyPlatformDestinations(t *testing.T) {
+	platformDest := specs.Destination{Metadata: specs.Metadata{Name: destinationName, Path: "cloudquery/platform", Registry: specs.RegistryCloudQuery}}
+	pgDest := specs.Destination{Metadata: specs.Metadata{Name: "pg", Path: "cloudquery/postgresql", Registry: specs.RegistryCloudQuery}}
+
+	require.False(t, OnlyPlatformDestinations(nil), "no destinations is not a platform-only sync")
+	require.False(t, OnlyPlatformDestinations([]specs.Destination{pgDest}))
+	require.False(t, OnlyPlatformDestinations([]specs.Destination{platformDest, pgDest}), "mixed destinations keep the CLI event")
+	require.True(t, OnlyPlatformDestinations([]specs.Destination{platformDest}))
+}


### PR DESCRIPTION
Suppress the CLI `sync_run_completed` event when all destinations are the reserved `platform` destination, since the platform emits its own canonical completion event for external syncs and the CLI one double-counted them (`sync_run_started` is still sent — the platform has no external started event and it carries real user attribution).