### PR TITLE
chore: Pin typescript below v7 until typescript-eslint supports it

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -119,6 +119,12 @@
       matchPackageNames: ['mcr.microsoft.com/mssql/server'],
       allowedVersions: '2019',
     },
+    {
+      // typescript-eslint cannot support TS 7 until TS 7 exposes a public API; its peer
+      // range is still <6.1.0. Tracked upstream in typescript-eslint/typescript-eslint#10940.
+      matchPackageNames: ['typescript'],
+      allowedVersions: '<7',
+    },
   ],
   ignorePaths: [
     'plugins/source/aws/**',


### PR DESCRIPTION
## Why

Renovate's [#23225](https://github.com/cloudquery/cloudquery/pull/23225) bumps `typescript` to v7 and fails `plugins/source/airtable` with:

```
Error: typescript-eslint does not support TS 7.0.
```

This is not a transient failure and not something we can fix on our side. typescript-eslint's latest stable (8.65.0) and even its latest alpha declare `peerDependencies.typescript: >=4.8.4 <6.1.0`. Upstream closed the TS 7 support request as **not planned**, because there is no TS 7 compiler API to build against yet:

> typescript-eslint isn't compatible with TS 7 at this time, because there is no TS 7 API at this time. There is nothing we can do about this until TS 7 provides an API.

Tracked upstream in [typescript-eslint#10940](https://github.com/typescript-eslint/typescript-eslint/issues/10940). Microsoft's own guidance is to run TS 6 and TS 7 side by side.

## What

Adds an `allowedVersions: '<7'` rule for `typescript` so Renovate keeps tracking the 6.x line instead of reopening a PR that cannot pass CI.

`plugins/source/airtable` is the only Node-based plugin in the repo and already declares `typescript: ^6.0.0`, so nothing changes for the plugin today.

Once typescript-eslint ships TS 7 support, drop this rule.

## Follow-up

[#23225](https://github.com/cloudquery/cloudquery/pull/23225) should be closed; Renovate will stop recreating it once this lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)