### PR TITLE
feat: Add MongoDB Atlas Workload Identity Federation (OIDC) auth

### DIFF
--- a/plugins/destination/mongodb/client/client.go
+++ b/plugins/destination/mongodb/client/client.go
@@ -27,7 +27,7 @@ type Client struct {
 var errInvalidSpec = errors.New("invalid spec")
 var errConnectionFailed = errors.New("failed to connect to MongoDB")
 
-func oidcCredential(o *spec.OIDCCredentials) options.Credential {
+func oidcCredential(o *spec.WorkloadIdentityFederation) options.Credential {
 	props := map[string]string{auth.EnvironmentProp: o.Environment}
 	if o.TokenResource != "" {
 		props[auth.ResourceProp] = o.TokenResource
@@ -68,8 +68,8 @@ func New(ctx context.Context, logger zerolog.Logger, specByte []byte, _ plugin.N
 		}
 		// According to the docs: if ApplyURI is called before SetAuth, the Credential from SetAuth will overwrite the values from the connection string
 		mongoDBClientOptions = mongoDBClientOptions.SetAuth(assumeRoleCredential)
-	} else if c.spec.OIDC != nil {
-		mongoDBClientOptions = mongoDBClientOptions.SetAuth(oidcCredential(c.spec.OIDC))
+	} else if c.spec.WorkloadIdentityFederation != nil {
+		mongoDBClientOptions = mongoDBClientOptions.SetAuth(oidcCredential(c.spec.WorkloadIdentityFederation))
 	}
 
 	c.client, err = mongo.Connect(mongoDBClientOptions)

--- a/plugins/destination/mongodb/client/client.go
+++ b/plugins/destination/mongodb/client/client.go
@@ -27,6 +27,19 @@ type Client struct {
 var errInvalidSpec = errors.New("invalid spec")
 var errConnectionFailed = errors.New("failed to connect to MongoDB")
 
+func oidcCredential(o *spec.OIDCCredentials) options.Credential {
+	props := map[string]string{auth.EnvironmentProp: o.Environment}
+	if o.TokenResource != "" {
+		props[auth.ResourceProp] = o.TokenResource
+	}
+	return options.Credential{
+		AuthMechanism:           auth.MongoDBOIDC,
+		AuthMechanismProperties: props,
+		// Only used by the azure flow, where it is the managed-identity client ID.
+		Username: o.Username,
+	}
+}
+
 func New(ctx context.Context, logger zerolog.Logger, specByte []byte, _ plugin.NewClientOptions) (plugin.Client, error) {
 	var err error
 	c := &Client{
@@ -55,6 +68,8 @@ func New(ctx context.Context, logger zerolog.Logger, specByte []byte, _ plugin.N
 		}
 		// According to the docs: if ApplyURI is called before SetAuth, the Credential from SetAuth will overwrite the values from the connection string
 		mongoDBClientOptions = mongoDBClientOptions.SetAuth(assumeRoleCredential)
+	} else if c.spec.OIDC != nil {
+		mongoDBClientOptions = mongoDBClientOptions.SetAuth(oidcCredential(c.spec.OIDC))
 	}
 
 	c.client, err = mongo.Connect(mongoDBClientOptions)

--- a/plugins/destination/mongodb/client/client_test.go
+++ b/plugins/destination/mongodb/client/client_test.go
@@ -4,13 +4,55 @@ import (
 	"context"
 	"encoding/json"
 	"os"
+	"reflect"
 	"testing"
 	"time"
 
 	"github.com/cloudquery/cloudquery/plugins/destination/mongodb/v2/client/spec"
 	"github.com/cloudquery/plugin-sdk/v4/plugin"
 	"github.com/cloudquery/plugin-sdk/v4/schema"
+	"go.mongodb.org/mongo-driver/v2/x/mongo/driver/auth"
 )
+
+func TestOIDCCredential(t *testing.T) {
+	cases := []struct {
+		name      string
+		give      *spec.OIDCCredentials
+		wantProps map[string]string
+		wantUser  string
+	}{
+		{
+			name:      "k8s",
+			give:      &spec.OIDCCredentials{Environment: "k8s"},
+			wantProps: map[string]string{"ENVIRONMENT": "k8s"},
+		},
+		{
+			name:      "azure",
+			give:      &spec.OIDCCredentials{Environment: "azure", TokenResource: "aud", Username: "client-id"},
+			wantProps: map[string]string{"ENVIRONMENT": "azure", "TOKEN_RESOURCE": "aud"},
+			wantUser:  "client-id",
+		},
+		{
+			name:      "gcp",
+			give:      &spec.OIDCCredentials{Environment: "gcp", TokenResource: "aud"},
+			wantProps: map[string]string{"ENVIRONMENT": "gcp", "TOKEN_RESOURCE": "aud"},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			cred := oidcCredential(tc.give)
+			if cred.AuthMechanism != auth.MongoDBOIDC {
+				t.Fatalf("AuthMechanism = %q, want %q", cred.AuthMechanism, auth.MongoDBOIDC)
+			}
+			if cred.Username != tc.wantUser {
+				t.Fatalf("Username = %q, want %q", cred.Username, tc.wantUser)
+			}
+			if !reflect.DeepEqual(cred.AuthMechanismProperties, tc.wantProps) {
+				t.Fatalf("AuthMechanismProperties = %v, want %v", cred.AuthMechanismProperties, tc.wantProps)
+			}
+		})
+	}
+}
 
 func getTestConnection() string {
 	testConn := os.Getenv("CQ_DEST_MONGODB_TEST_CONN")

--- a/plugins/destination/mongodb/client/client_test.go
+++ b/plugins/destination/mongodb/client/client_test.go
@@ -17,24 +17,24 @@ import (
 func TestOIDCCredential(t *testing.T) {
 	cases := []struct {
 		name      string
-		give      *spec.OIDCCredentials
+		give      *spec.WorkloadIdentityFederation
 		wantProps map[string]string
 		wantUser  string
 	}{
 		{
 			name:      "k8s",
-			give:      &spec.OIDCCredentials{Environment: "k8s"},
+			give:      &spec.WorkloadIdentityFederation{Environment: "k8s"},
 			wantProps: map[string]string{"ENVIRONMENT": "k8s"},
 		},
 		{
 			name:      "azure",
-			give:      &spec.OIDCCredentials{Environment: "azure", TokenResource: "aud", Username: "client-id"},
+			give:      &spec.WorkloadIdentityFederation{Environment: "azure", TokenResource: "aud", Username: "client-id"},
 			wantProps: map[string]string{"ENVIRONMENT": "azure", "TOKEN_RESOURCE": "aud"},
 			wantUser:  "client-id",
 		},
 		{
 			name:      "gcp",
-			give:      &spec.OIDCCredentials{Environment: "gcp", TokenResource: "aud"},
+			give:      &spec.WorkloadIdentityFederation{Environment: "gcp", TokenResource: "aud"},
 			wantProps: map[string]string{"ENVIRONMENT": "gcp", "TOKEN_RESOURCE": "aud"},
 		},
 	}

--- a/plugins/destination/mongodb/client/spec/oidc.go
+++ b/plugins/destination/mongodb/client/spec/oidc.go
@@ -1,0 +1,27 @@
+package spec
+
+// OIDCCredentials configures MongoDB Atlas [Workload Identity Federation](https://www.mongodb.com/docs/atlas/workload-oidc/)
+// authentication using the built-in `MONGODB-OIDC` machine (workload) flows of the MongoDB driver.
+//
+// Requires an Atlas M10+ dedicated cluster running MongoDB 7.0.11 or later with Workload
+// Identity Federation configured for the matching identity provider.
+type OIDCCredentials struct {
+	// The workload environment the driver obtains an OIDC token from.
+	// One of `k8s` (Kubernetes / EKS service account), `azure` (Azure managed identity)
+	// or `gcp` (Google service account).
+	Environment string `json:"environment" jsonschema:"required,enum=k8s,enum=azure,enum=gcp,example=k8s"`
+
+	// The audience configured on the MongoDB deployment.
+	// Required when `environment` is `azure` or `gcp`; must not be set for `k8s`.
+	TokenResource string `json:"token_resource,omitempty" jsonschema:"example=api://my-audience"`
+
+	// The Azure managed-identity client ID (or application ID).
+	// Only valid when `environment` is `azure`; may be omitted if the VM has a single managed identity.
+	Username string `json:"username,omitempty" jsonschema:"example=00000000-0000-0000-0000-000000000000"`
+}
+
+const (
+	OIDCEnvironmentK8s   = "k8s"
+	OIDCEnvironmentAzure = "azure"
+	OIDCEnvironmentGCP   = "gcp"
+)

--- a/plugins/destination/mongodb/client/spec/schema.json
+++ b/plugins/destination/mongodb/client/spec/schema.json
@@ -39,38 +39,6 @@
       "pattern": "^[-+]?([0-9]*(\\.[0-9]*)?[a-z]+)+$",
       "title": "CloudQuery configtype.Duration"
     },
-    "OIDCCredentials": {
-      "properties": {
-        "environment": {
-          "type": "string",
-          "enum": [
-            "k8s",
-            "azure",
-            "gcp"
-          ],
-          "examples": [
-            "k8s"
-          ]
-        },
-        "token_resource": {
-          "type": "string",
-          "examples": [
-            "api://my-audience"
-          ]
-        },
-        "username": {
-          "type": "string",
-          "examples": [
-            "00000000-0000-0000-0000-000000000000"
-          ]
-        }
-      },
-      "additionalProperties": false,
-      "type": "object",
-      "required": [
-        "environment"
-      ]
-    },
     "Spec": {
       "properties": {
         "connection_string": {
@@ -111,10 +79,10 @@
             }
           ]
         },
-        "oidc": {
+        "workload_identity_federation": {
           "oneOf": [
             {
-              "$ref": "#/$defs/OIDCCredentials"
+              "$ref": "#/$defs/WorkloadIdentityFederation"
             },
             {
               "type": "null"
@@ -127,6 +95,38 @@
       "required": [
         "connection_string",
         "database"
+      ]
+    },
+    "WorkloadIdentityFederation": {
+      "properties": {
+        "environment": {
+          "type": "string",
+          "enum": [
+            "k8s",
+            "azure",
+            "gcp"
+          ],
+          "examples": [
+            "k8s"
+          ]
+        },
+        "token_resource": {
+          "type": "string",
+          "examples": [
+            "api://my-audience"
+          ]
+        },
+        "username": {
+          "type": "string",
+          "examples": [
+            "00000000-0000-0000-0000-000000000000"
+          ]
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "environment"
       ]
     },
     "WriteRetryConfig": {

--- a/plugins/destination/mongodb/client/spec/schema.json
+++ b/plugins/destination/mongodb/client/spec/schema.json
@@ -39,6 +39,38 @@
       "pattern": "^[-+]?([0-9]*(\\.[0-9]*)?[a-z]+)+$",
       "title": "CloudQuery configtype.Duration"
     },
+    "OIDCCredentials": {
+      "properties": {
+        "environment": {
+          "type": "string",
+          "enum": [
+            "k8s",
+            "azure",
+            "gcp"
+          ],
+          "examples": [
+            "k8s"
+          ]
+        },
+        "token_resource": {
+          "type": "string",
+          "examples": [
+            "api://my-audience"
+          ]
+        },
+        "username": {
+          "type": "string",
+          "examples": [
+            "00000000-0000-0000-0000-000000000000"
+          ]
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "environment"
+      ]
+    },
     "Spec": {
       "properties": {
         "connection_string": {
@@ -73,6 +105,16 @@
           "oneOf": [
             {
               "$ref": "#/$defs/WriteRetryConfig"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "oidc": {
+          "oneOf": [
+            {
+              "$ref": "#/$defs/OIDCCredentials"
             },
             {
               "type": "null"

--- a/plugins/destination/mongodb/client/spec/spec.go
+++ b/plugins/destination/mongodb/client/spec/spec.go
@@ -38,6 +38,10 @@ type Spec struct {
 	AWSCredentials *Credentials `json:"aws_credentials,omitempty"`
 
 	WriteRetry *WriteRetryConfig `json:"write_retry,omitempty"`
+
+	// Use MongoDB Atlas Workload Identity Federation (`MONGODB-OIDC`). Mutually exclusive with `aws_credentials`.
+	// If used this will override any credentials set in the connection_string.
+	OIDC *OIDCCredentials `json:"oidc,omitempty"`
 }
 
 type WriteRetryConfig struct {
@@ -96,6 +100,34 @@ func (s *Spec) Validate() error {
 		}
 		if s.WriteRetry.MaxBackoff != nil && s.WriteRetry.MaxBackoff.Duration() < 0 {
 			return errors.New("`write_retry.max_backoff` must be >= 0")
+		}
+	}
+
+	if s.OIDC != nil {
+		if s.AWSCredentials != nil {
+			return errors.New("`oidc` and `aws_credentials` are mutually exclusive")
+		}
+		switch s.OIDC.Environment {
+		case OIDCEnvironmentK8s:
+			if s.OIDC.TokenResource != "" {
+				return errors.New("`oidc.token_resource` must not be set when `oidc.environment` is `k8s`")
+			}
+			if s.OIDC.Username != "" {
+				return errors.New("`oidc.username` is only valid when `oidc.environment` is `azure`")
+			}
+		case OIDCEnvironmentAzure:
+			if s.OIDC.TokenResource == "" {
+				return errors.New("`oidc.token_resource` is required when `oidc.environment` is `azure`")
+			}
+		case OIDCEnvironmentGCP:
+			if s.OIDC.TokenResource == "" {
+				return errors.New("`oidc.token_resource` is required when `oidc.environment` is `gcp`")
+			}
+			if s.OIDC.Username != "" {
+				return errors.New("`oidc.username` is only valid when `oidc.environment` is `azure`")
+			}
+		default:
+			return errors.New("`oidc.environment` must be one of `k8s`, `azure`, or `gcp`")
 		}
 	}
 

--- a/plugins/destination/mongodb/client/spec/spec.go
+++ b/plugins/destination/mongodb/client/spec/spec.go
@@ -41,7 +41,7 @@ type Spec struct {
 
 	// Use MongoDB Atlas Workload Identity Federation (`MONGODB-OIDC`). Mutually exclusive with `aws_credentials`.
 	// If used this will override any credentials set in the connection_string.
-	OIDC *OIDCCredentials `json:"oidc,omitempty"`
+	WorkloadIdentityFederation *WorkloadIdentityFederation `json:"workload_identity_federation,omitempty"`
 }
 
 type WriteRetryConfig struct {
@@ -103,31 +103,31 @@ func (s *Spec) Validate() error {
 		}
 	}
 
-	if s.OIDC != nil {
+	if s.WorkloadIdentityFederation != nil {
 		if s.AWSCredentials != nil {
-			return errors.New("`oidc` and `aws_credentials` are mutually exclusive")
+			return errors.New("`workload_identity_federation` and `aws_credentials` are mutually exclusive")
 		}
-		switch s.OIDC.Environment {
+		switch s.WorkloadIdentityFederation.Environment {
 		case OIDCEnvironmentK8s:
-			if s.OIDC.TokenResource != "" {
-				return errors.New("`oidc.token_resource` must not be set when `oidc.environment` is `k8s`")
+			if s.WorkloadIdentityFederation.TokenResource != "" {
+				return errors.New("`workload_identity_federation.token_resource` must not be set when `workload_identity_federation.environment` is `k8s`")
 			}
-			if s.OIDC.Username != "" {
-				return errors.New("`oidc.username` is only valid when `oidc.environment` is `azure`")
+			if s.WorkloadIdentityFederation.Username != "" {
+				return errors.New("`workload_identity_federation.username` is only valid when `workload_identity_federation.environment` is `azure`")
 			}
 		case OIDCEnvironmentAzure:
-			if s.OIDC.TokenResource == "" {
-				return errors.New("`oidc.token_resource` is required when `oidc.environment` is `azure`")
+			if s.WorkloadIdentityFederation.TokenResource == "" {
+				return errors.New("`workload_identity_federation.token_resource` is required when `workload_identity_federation.environment` is `azure`")
 			}
 		case OIDCEnvironmentGCP:
-			if s.OIDC.TokenResource == "" {
-				return errors.New("`oidc.token_resource` is required when `oidc.environment` is `gcp`")
+			if s.WorkloadIdentityFederation.TokenResource == "" {
+				return errors.New("`workload_identity_federation.token_resource` is required when `workload_identity_federation.environment` is `gcp`")
 			}
-			if s.OIDC.Username != "" {
-				return errors.New("`oidc.username` is only valid when `oidc.environment` is `azure`")
+			if s.WorkloadIdentityFederation.Username != "" {
+				return errors.New("`workload_identity_federation.username` is only valid when `workload_identity_federation.environment` is `azure`")
 			}
 		default:
-			return errors.New("`oidc.environment` must be one of `k8s`, `azure`, or `gcp`")
+			return errors.New("`workload_identity_federation.environment` must be one of `k8s`, `azure`, or `gcp`")
 		}
 	}
 

--- a/plugins/destination/mongodb/client/spec/spec_test.go
+++ b/plugins/destination/mongodb/client/spec/spec_test.go
@@ -33,6 +33,16 @@ func TestSpec_Validate(t *testing.T) {
 		{Give: Spec{ConnectionString: "test-connection-string", Database: "database", WriteRetry: validRetry}, WantErr: false},
 		{Give: Spec{ConnectionString: "test-connection-string", Database: "database", WriteRetry: negativeMaxAttempts}, WantErr: true},
 		{Give: Spec{ConnectionString: "test-connection-string", Database: "database", WriteRetry: negativeBackoff}, WantErr: true},
+		// OIDC (Workload Identity Federation)
+		{Give: Spec{ConnectionString: "conn", Database: "database", OIDC: &OIDCCredentials{Environment: "k8s"}}, WantErr: false},
+		{Give: Spec{ConnectionString: "conn", Database: "database", OIDC: &OIDCCredentials{Environment: "azure", TokenResource: "aud", Username: "client-id"}}, WantErr: false},
+		{Give: Spec{ConnectionString: "conn", Database: "database", OIDC: &OIDCCredentials{Environment: "gcp", TokenResource: "aud"}}, WantErr: false},
+		{Give: Spec{ConnectionString: "conn", Database: "database", OIDC: &OIDCCredentials{Environment: "azure"}}, WantErr: true},                                    // azure missing token_resource
+		{Give: Spec{ConnectionString: "conn", Database: "database", OIDC: &OIDCCredentials{Environment: "gcp"}}, WantErr: true},                                      // gcp missing token_resource
+		{Give: Spec{ConnectionString: "conn", Database: "database", OIDC: &OIDCCredentials{Environment: "k8s", TokenResource: "aud"}}, WantErr: true},                // k8s must not set token_resource
+		{Give: Spec{ConnectionString: "conn", Database: "database", OIDC: &OIDCCredentials{Environment: "gcp", TokenResource: "aud", Username: "u"}}, WantErr: true}, // username only for azure
+		{Give: Spec{ConnectionString: "conn", Database: "database", OIDC: &OIDCCredentials{Environment: "unknown"}}, WantErr: true},
+		{Give: Spec{ConnectionString: "conn", Database: "database", OIDC: &OIDCCredentials{Environment: "k8s"}, AWSCredentials: &Credentials{Default: true}}, WantErr: true}, // mutually exclusive
 	}
 	for i, tc := range cases {
 		tc := tc
@@ -141,6 +151,31 @@ func TestJSONSchema(t *testing.T) {
 		{
 			Name: "spec with write_retry unknown field",
 			Spec: `{"connection_string": "abc", "database":"foo", "write_retry": {"max_attempts": 3, "unknown": true}}`,
+			Err:  true,
+		},
+		{
+			Name: "spec with valid k8s oidc",
+			Spec: `{"connection_string": "abc", "database":"foo", "oidc": {"environment": "k8s"}}`,
+			Err:  false,
+		},
+		{
+			Name: "spec with valid azure oidc",
+			Spec: `{"connection_string": "abc", "database":"foo", "oidc": {"environment": "azure", "token_resource": "aud", "username": "client-id"}}`,
+			Err:  false,
+		},
+		{
+			Name: "spec with valid gcp oidc",
+			Spec: `{"connection_string": "abc", "database":"foo", "oidc": {"environment": "gcp", "token_resource": "aud"}}`,
+			Err:  false,
+		},
+		{
+			Name: "spec with invalid oidc environment",
+			Spec: `{"connection_string": "abc", "database":"foo", "oidc": {"environment": "invalid"}}`,
+			Err:  true,
+		},
+		{
+			Name: "spec with unknown field in oidc",
+			Spec: `{"connection_string": "abc", "database":"foo", "oidc": {"environment": "k8s", "unknown": "x"}}`,
 			Err:  true,
 		},
 	})

--- a/plugins/destination/mongodb/client/spec/spec_test.go
+++ b/plugins/destination/mongodb/client/spec/spec_test.go
@@ -34,15 +34,15 @@ func TestSpec_Validate(t *testing.T) {
 		{Give: Spec{ConnectionString: "test-connection-string", Database: "database", WriteRetry: negativeMaxAttempts}, WantErr: true},
 		{Give: Spec{ConnectionString: "test-connection-string", Database: "database", WriteRetry: negativeBackoff}, WantErr: true},
 		// OIDC (Workload Identity Federation)
-		{Give: Spec{ConnectionString: "conn", Database: "database", OIDC: &OIDCCredentials{Environment: "k8s"}}, WantErr: false},
-		{Give: Spec{ConnectionString: "conn", Database: "database", OIDC: &OIDCCredentials{Environment: "azure", TokenResource: "aud", Username: "client-id"}}, WantErr: false},
-		{Give: Spec{ConnectionString: "conn", Database: "database", OIDC: &OIDCCredentials{Environment: "gcp", TokenResource: "aud"}}, WantErr: false},
-		{Give: Spec{ConnectionString: "conn", Database: "database", OIDC: &OIDCCredentials{Environment: "azure"}}, WantErr: true},                                    // azure missing token_resource
-		{Give: Spec{ConnectionString: "conn", Database: "database", OIDC: &OIDCCredentials{Environment: "gcp"}}, WantErr: true},                                      // gcp missing token_resource
-		{Give: Spec{ConnectionString: "conn", Database: "database", OIDC: &OIDCCredentials{Environment: "k8s", TokenResource: "aud"}}, WantErr: true},                // k8s must not set token_resource
-		{Give: Spec{ConnectionString: "conn", Database: "database", OIDC: &OIDCCredentials{Environment: "gcp", TokenResource: "aud", Username: "u"}}, WantErr: true}, // username only for azure
-		{Give: Spec{ConnectionString: "conn", Database: "database", OIDC: &OIDCCredentials{Environment: "unknown"}}, WantErr: true},
-		{Give: Spec{ConnectionString: "conn", Database: "database", OIDC: &OIDCCredentials{Environment: "k8s"}, AWSCredentials: &Credentials{Default: true}}, WantErr: true}, // mutually exclusive
+		{Give: Spec{ConnectionString: "conn", Database: "database", WorkloadIdentityFederation: &WorkloadIdentityFederation{Environment: "k8s"}}, WantErr: false},
+		{Give: Spec{ConnectionString: "conn", Database: "database", WorkloadIdentityFederation: &WorkloadIdentityFederation{Environment: "azure", TokenResource: "aud", Username: "client-id"}}, WantErr: false},
+		{Give: Spec{ConnectionString: "conn", Database: "database", WorkloadIdentityFederation: &WorkloadIdentityFederation{Environment: "gcp", TokenResource: "aud"}}, WantErr: false},
+		{Give: Spec{ConnectionString: "conn", Database: "database", WorkloadIdentityFederation: &WorkloadIdentityFederation{Environment: "azure"}}, WantErr: true},                                    // azure missing token_resource
+		{Give: Spec{ConnectionString: "conn", Database: "database", WorkloadIdentityFederation: &WorkloadIdentityFederation{Environment: "gcp"}}, WantErr: true},                                      // gcp missing token_resource
+		{Give: Spec{ConnectionString: "conn", Database: "database", WorkloadIdentityFederation: &WorkloadIdentityFederation{Environment: "k8s", TokenResource: "aud"}}, WantErr: true},                // k8s must not set token_resource
+		{Give: Spec{ConnectionString: "conn", Database: "database", WorkloadIdentityFederation: &WorkloadIdentityFederation{Environment: "gcp", TokenResource: "aud", Username: "u"}}, WantErr: true}, // username only for azure
+		{Give: Spec{ConnectionString: "conn", Database: "database", WorkloadIdentityFederation: &WorkloadIdentityFederation{Environment: "unknown"}}, WantErr: true},
+		{Give: Spec{ConnectionString: "conn", Database: "database", WorkloadIdentityFederation: &WorkloadIdentityFederation{Environment: "k8s"}, AWSCredentials: &Credentials{Default: true}}, WantErr: true}, // mutually exclusive
 	}
 	for i, tc := range cases {
 		tc := tc
@@ -155,27 +155,27 @@ func TestJSONSchema(t *testing.T) {
 		},
 		{
 			Name: "spec with valid k8s oidc",
-			Spec: `{"connection_string": "abc", "database":"foo", "oidc": {"environment": "k8s"}}`,
+			Spec: `{"connection_string": "abc", "database":"foo", "workload_identity_federation": {"environment": "k8s"}}`,
 			Err:  false,
 		},
 		{
 			Name: "spec with valid azure oidc",
-			Spec: `{"connection_string": "abc", "database":"foo", "oidc": {"environment": "azure", "token_resource": "aud", "username": "client-id"}}`,
+			Spec: `{"connection_string": "abc", "database":"foo", "workload_identity_federation": {"environment": "azure", "token_resource": "aud", "username": "client-id"}}`,
 			Err:  false,
 		},
 		{
 			Name: "spec with valid gcp oidc",
-			Spec: `{"connection_string": "abc", "database":"foo", "oidc": {"environment": "gcp", "token_resource": "aud"}}`,
+			Spec: `{"connection_string": "abc", "database":"foo", "workload_identity_federation": {"environment": "gcp", "token_resource": "aud"}}`,
 			Err:  false,
 		},
 		{
 			Name: "spec with invalid oidc environment",
-			Spec: `{"connection_string": "abc", "database":"foo", "oidc": {"environment": "invalid"}}`,
+			Spec: `{"connection_string": "abc", "database":"foo", "workload_identity_federation": {"environment": "invalid"}}`,
 			Err:  true,
 		},
 		{
 			Name: "spec with unknown field in oidc",
-			Spec: `{"connection_string": "abc", "database":"foo", "oidc": {"environment": "k8s", "unknown": "x"}}`,
+			Spec: `{"connection_string": "abc", "database":"foo", "workload_identity_federation": {"environment": "k8s", "unknown": "x"}}`,
 			Err:  true,
 		},
 	})

--- a/plugins/destination/mongodb/client/spec/workload_identity_federation.go
+++ b/plugins/destination/mongodb/client/spec/workload_identity_federation.go
@@ -1,11 +1,11 @@
 package spec
 
-// OIDCCredentials configures MongoDB Atlas [Workload Identity Federation](https://www.mongodb.com/docs/atlas/workload-oidc/)
+// WorkloadIdentityFederation configures MongoDB Atlas [Workload Identity Federation](https://www.mongodb.com/docs/atlas/workload-oidc/)
 // authentication using the built-in `MONGODB-OIDC` machine (workload) flows of the MongoDB driver.
 //
 // Requires an Atlas M10+ dedicated cluster running MongoDB 7.0.11 or later with Workload
 // Identity Federation configured for the matching identity provider.
-type OIDCCredentials struct {
+type WorkloadIdentityFederation struct {
 	// The workload environment the driver obtains an OIDC token from.
 	// One of `k8s` (Kubernetes / EKS service account), `azure` (Azure managed identity)
 	// or `gcp` (Google service account).

--- a/plugins/destination/mongodb/docs/_configuration.md
+++ b/plugins/destination/mongodb/docs/_configuration.md
@@ -26,5 +26,9 @@ spec:
     #   role_arn: "arn:aws:iam::123456789012:role/role_name" # Specify the role to assume
     #   external_id: "external_id" # Used when assuming a role
     #   role_session_name: "session_name" # Used when assuming a role
+    # workload_identity_federation: # <- Use MongoDB Atlas Workload Identity Federation (MONGODB-OIDC). Mutually exclusive with aws_credentials.
+    #   environment: "k8s" # One of k8s, azure or gcp
+    #   token_resource: "api://my-audience" # The audience configured on the MongoDB deployment. Required for azure and gcp, must not be set for k8s.
+    #   username: "00000000-0000-0000-0000-000000000000" # Azure managed-identity client ID. Only valid for azure.
 
 ```

--- a/plugins/destination/mongodb/docs/overview.md
+++ b/plugins/destination/mongodb/docs/overview.md
@@ -60,7 +60,9 @@ This is the (nested) spec used by the MongoDB destination Plugin.
 
   Opt-in exponential-backoff retry around each write batch to absorb transient network errors (e.g. `write tcp ...: broken pipe`) that the driver's single built-in retry can't recover from. Disabled by default.
 
+- `oidc` ([oidc](#oidc)) (optional)
 
+  Optional parameters to enable MongoDB Atlas [Workload Identity Federation](https://www.mongodb.com/docs/atlas/workload-oidc/) (`MONGODB-OIDC`). Mutually exclusive with `aws_credentials`.
 
 
 ### write_retry
@@ -123,3 +125,20 @@ Only enable retries (`max_attempts` >= 2) when the source uses `write_mode: over
 - `external_id` (`string`)
 
   If specified will use this when assuming role to `role_arn`.
+
+
+### oidc
+
+Enables MongoDB Atlas [Workload Identity Federation](https://www.mongodb.com/docs/atlas/workload-oidc/) using the built-in `MONGODB-OIDC` machine (workload) flows of the MongoDB driver. Requires an Atlas M10+ dedicated cluster running MongoDB 7.0.11 or later with Workload Identity Federation configured. Mutually exclusive with `aws_credentials`.
+
+- `environment` (`string`) (required)
+
+  The workload environment the driver obtains an OIDC token from. One of `k8s` (Kubernetes / EKS service account), `azure` (Azure managed identity) or `gcp` (Google service account).
+
+- `token_resource` (`string`)
+
+  The audience configured on the MongoDB deployment. Required when `environment` is `azure` or `gcp`; must not be set for `k8s`.
+
+- `username` (`string`)
+
+  The Azure managed-identity client ID (or application ID). Only valid when `environment` is `azure`; may be omitted if the VM has a single managed identity.

--- a/plugins/destination/mongodb/docs/overview.md
+++ b/plugins/destination/mongodb/docs/overview.md
@@ -60,7 +60,7 @@ This is the (nested) spec used by the MongoDB destination Plugin.
 
   Opt-in exponential-backoff retry around each write batch to absorb transient network errors (e.g. `write tcp ...: broken pipe`) that the driver's single built-in retry can't recover from. Disabled by default.
 
-- `oidc` ([oidc](#oidc)) (optional)
+- `workload_identity_federation` ([workload_identity_federation](#workload_identity_federation)) (optional)
 
   Optional parameters to enable MongoDB Atlas [Workload Identity Federation](https://www.mongodb.com/docs/atlas/workload-oidc/) (`MONGODB-OIDC`). Mutually exclusive with `aws_credentials`.
 
@@ -127,7 +127,7 @@ Only enable retries (`max_attempts` >= 2) when the source uses `write_mode: over
   If specified will use this when assuming role to `role_arn`.
 
 
-### oidc
+### workload_identity_federation
 
 Enables MongoDB Atlas [Workload Identity Federation](https://www.mongodb.com/docs/atlas/workload-oidc/) using the built-in `MONGODB-OIDC` machine (workload) flows of the MongoDB driver. Requires an Atlas M10+ dedicated cluster running MongoDB 7.0.11 or later with Workload Identity Federation configured. Mutually exclusive with `aws_credentials`.
 


### PR DESCRIPTION
#### Summary

Adds Workload Identity Federation (WIF) support to the MongoDB destination via the driver's built-in `MONGODB-OIDC` machine (workload) flows, so users on MongoDB Atlas can authenticate with a workload identity instead of embedding a username/password in the connection string. Complements the existing AWS IAM auth for users running on Kubernetes, Azure, or GCP.

Requires an Atlas M10+ dedicated cluster on MongoDB 7.0.11+ with Workload Identity Federation configured.

#### How

New optional `oidc` spec block, mutually exclusive with `aws_credentials`:

- `environment` (required): one of `k8s`, `azure`, `gcp`
- `token_resource`: the audience configured on the deployment — required for `azure`/`gcp`, must be unset for `k8s`
- `username`: Azure managed-identity client ID (only valid for `azure`)

When `oidc` is set, the client builds a `MONGODB-OIDC` credential and calls `SetAuth`, overriding any credentials in the connection string. Validation enforces the per-environment rules and the mutual exclusion with `aws_credentials`.

```yaml
kind: destination
spec:
  name: mongodb
  spec:
    connection_string: "mongodb+srv://<cluster-host>/"
    database: "my_db"
    oidc:
      environment: k8s
```

#### Testing

- Unit tests for spec validation (per-environment rules, mutual exclusion with `aws_credentials`) and JSON-schema cases.
- End-to-end: synced a source into MongoDB Atlas with no password in the URI, authenticating purely via a workload identity. Validated the `k8s` flow (Kubernetes service-account token) from an EKS cluster and the `gcp` flow (service-account identity token from the GCE metadata server) from a GKE cluster — each run in-cluster.
- `make gen` re-run so `schema.json` and docs match the spec.