### PR TITLE
fix: Make scaffolded source plugins pass their own CI

### DIFF
--- a/scaffold/sourcetpl/templates/source/.github/workflows/release.yaml.tpl
+++ b/scaffold/sourcetpl/templates/source/.github/workflows/release.yaml.tpl
@@ -76,7 +76,7 @@ jobs:
       - name: Setup CloudQuery
         uses: cloudquery/setup-cloudquery@757b19eb8496cf9e89a78de54f2c677253f54f6b # v5.0.3
         with:
-          version: v5.0.1
+          version: v6.42.2
 
       - name: Publish plugin to hub
         # See https://www.cloudquery.io/docs/deployment/generate-api-key for instructions how to generate this key.

--- a/scaffold/sourcetpl/templates/source/Makefile.tpl
+++ b/scaffold/sourcetpl/templates/source/Makefile.tpl
@@ -9,7 +9,7 @@ lint:
 .PHONY: gen-docs
 gen-docs:
 	rm -rf ./docs/tables/*
-	go run main.go doc ./docs/tables
+	go run main.go doc --format json ./docs/tables
 
 # All gen targets
 .PHONY: gen

--- a/scaffold/sourcetpl/templates/source/go.mod.tpl
+++ b/scaffold/sourcetpl/templates/source/go.mod.tpl
@@ -10,5 +10,5 @@ require (
 )
 
 require (
-	google.golang.org/genproto/googleapis/rpc 1f4bbc51befe // indirect
+	google.golang.org/genproto/googleapis/rpc v0.0.0-20260803160001-6ac0973c030d // indirect
 )

--- a/scaffold/sourcetpl/templates/source/resources/services/table.go.tpl
+++ b/scaffold/sourcetpl/templates/source/resources/services/table.go.tpl
@@ -24,5 +24,5 @@ func SampleTable() *schema.Table {
 
 func fetchSampleTable(ctx context.Context, meta schema.ClientMeta, parent *schema.Resource, res chan <- any) error {
   cl := meta.(*client.Client)
-  return fmt.Errorf("not implemented. client id: " + cl.ID())
+  return fmt.Errorf("not implemented. client id: %s", cl.ID())
 }


### PR DESCRIPTION
`scaffold source ...` runs fine, but the plugin it produces fails `make lint`, `make test` and `make gen` out of the box — all three of which the `test.yaml` it generates runs on every PR, so a new plugin is red on its first push.

- `table.go.tpl` — `fmt.Errorf` was called with a concatenated string; vet rejects it, so `make lint` and `make test` both failed to build
- `Makefile.tpl` — `go run main.go doc` defaults to markdown, which plugin-sdk v4 no longer supports (`only json format is supported`); switched to `--format json`, which is what the SDK's own help suggests
- `release.yaml.tpl` — the CloudQuery CLI pin was `v5.0.1`, which looks like the `setup-cloudquery` action version copied into the CLI field; now `v6.42.2`, matching the rest of the repo
- `go.mod.tpl` — `google.golang.org/genproto/googleapis/rpc 1f4bbc51befe` is a bare digest, not a version. `go get`/`go mod tidy` quietly rewrite it, but nothing else can read the file

`cmd/source_test.go` now also runs `go vet ./...` on the generated plugin. `go build` doesn't run vet, which is why the `fmt.Errorf` bug shipped.

## Test plan

Scaffolded `myorg/probe` into a temp dir before and after, on top of `origin/main`.

Before:
- [x] `make lint` -> `printf: non-constant format string in call to fmt.Errorf (govet)`, exit 1
- [x] `make test` -> `FAIL ... [build failed]`, exit 1
- [x] `make gen` -> `only json format is supported`, exit 1

After:
- [x] `make lint` -> `0 issues.`
- [x] `make test` -> pass
- [x] `make gen` -> exit 0, writes `docs/tables/__tables.json`
- [x] `go mod tidy && go build .` pass
- [x] In `scaffold/`: `make test` and `make lint` (0 issues) pass
- [x] Re-introduced the `fmt.Errorf` bug and confirmed the new `go vet` step fails `TestSource`